### PR TITLE
fix: resolve library visibility and recently added toggles mismatch

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -155,9 +155,23 @@ class MultiServerRepository {
     final results = await Future.wait(
       sessions.map(
         (session) => _withTimeout(() async {
-          final response = await session.client.userViewsApi.getUserViews();
+          final viewsFuture = session.client.userViewsApi.getUserViews();
+          final configFuture = session.client.usersApi
+              .getUserConfiguration()
+              .then<Set<String>>((config) => config.myMediaExcludes.toSet())
+              .catchError((_) => const <String>{});
+
+          final response = await viewsFuture;
+          final Set<String> excludes = await configFuture;
           final items = response['Items'] as List? ?? [];
-          return items.map((item) {
+
+          final filteredItems = items.where((item) {
+            final data = item as Map<String, dynamic>;
+            final id = data['Id']?.toString() ?? '';
+            return !excludes.contains(id);
+          });
+
+          return filteredItems.map((item) {
             final data = item as Map<String, dynamic>;
             final name = data['Name'] as String? ?? '';
             return AggregatedLibrary(
@@ -898,6 +912,55 @@ class MultiServerRepository {
     );
   }
 
+  Future<List<Map<String, dynamic>>> _getAllViewsIncludingHidden(MediaServerClient client) async {
+    try {
+      final foldersFuture = client.adminLibraryApi.getMediaFolders();
+      final userViewsFuture = client.userViewsApi.getUserViews();
+
+      final folders = await foldersFuture;
+      final userViewsResponse = await userViewsFuture;
+      final userViews = userViewsResponse['Items'] as List? ?? [];
+
+      final List<Map<String, dynamic>> result = folders.map<Map<String, dynamic>>((folder) {
+        final matchingView = userViews.where((v) {
+          final data = v as Map<String, dynamic>;
+          final cType = data['CollectionType'] as String?;
+          final name = data['Name'] as String?;
+          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
+            return cType == folder.collectionType;
+          }
+          return name == folder.name;
+        }).firstOrNull;
+
+        final matchingData = matchingView as Map<String, dynamic>?;
+
+        return {
+          'Id': matchingData?['Id']?.toString() ?? folder.itemId,
+          'Name': folder.name,
+          'CollectionType': folder.collectionType ?? '',
+        };
+      }).toList();
+
+      final existingIds = result.map((l) => l['Id']?.toString() ?? '').toSet();
+      for (final view in userViews) {
+        final data = view as Map<String, dynamic>;
+        final id = data['Id']?.toString() ?? '';
+        if (!existingIds.contains(id)) {
+          result.add(data);
+        }
+      }
+      return result;
+    } catch (_) {
+      try {
+        final response = await client.userViewsApi.getUserViews();
+        final items = response['Items'] as List? ?? [];
+        return items.cast<Map<String, dynamic>>();
+      } catch (_) {
+        return const [];
+      }
+    }
+  }
+
   Future<List<HomeRow>> getAggregatedLatestMediaRows() async {
     final sessions = await getLoggedInServers();
     final hasMultiple = sessions.length > 1;
@@ -905,11 +968,10 @@ class MultiServerRepository {
 
     for (final session in sessions) {
       try {
-        final viewsResponse = await _withTimeout(
-          () => session.client.userViewsApi.getUserViews(),
+        final views = await _withTimeout(
+          () => _getAllViewsIncludingHidden(session.client),
           label: 'views from ${session.server.name}',
         );
-        final views = viewsResponse['Items'] as List? ?? [];
 
         Set<String> latestExcludes = const {};
         try {

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -34,17 +34,35 @@ class UserViewsRepository extends ChangeNotifier {
 
   Future<List<AggregatedLibrary>> getAllViewsIncludingHidden() async {
     try {
-      final folders = await _client.adminLibraryApi.getMediaFolders();
-      return folders
-          .map(
-            (folder) => AggregatedLibrary(
-              id: folder.itemId,
-              name: folder.name,
-              collectionType: folder.collectionType ?? '',
-              serverId: '',
-            ),
-          )
-          .toList();
+      final foldersFuture = _client.adminLibraryApi.getMediaFolders();
+      final userViewsFuture = getAllViews();
+
+      final folders = await foldersFuture;
+      final userViews = await userViewsFuture;
+
+      final result = folders.map((folder) {
+        final matchingView = userViews.where((v) {
+          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
+            return v.collectionType == folder.collectionType;
+          }
+          return v.name == folder.name;
+        }).firstOrNull;
+
+        return AggregatedLibrary(
+          id: matchingView?.id ?? folder.itemId,
+          name: folder.name,
+          collectionType: folder.collectionType ?? '',
+          serverId: '',
+        );
+      }).toList();
+
+      final existingIds = result.map((l) => l.id).toSet();
+      for (final view in userViews) {
+        if (!existingIds.contains(view.id)) {
+          result.add(view);
+        }
+      }
+      return result;
     } catch (_) {
       return getAllViews();
     }

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -644,13 +644,31 @@ class RowDataSource {
     String serverId, [
     HomeRowType rowType = HomeRowType.libraryTiles,
   ]) async {
-    final response = await _client.userViewsApi.getUserViews();
+    final viewsFuture = _client.userViewsApi.getUserViews();
+    final configFuture = _client.usersApi
+        .getUserConfiguration()
+        .then<Set<String>>((config) => config.myMediaExcludes.toSet())
+        .catchError((_) => const <String>{});
+
+    final response = await viewsFuture;
+    final Set<String> excludes = await configFuture;
+    final items = response['Items'] as List? ?? [];
+
+    final filteredItems = items.where((item) {
+      final data = item as Map<String, dynamic>;
+      final id = data['Id']?.toString() ?? '';
+      return !excludes.contains(id);
+    }).toList();
+
     return _buildRow(
       id: rowType == HomeRowType.libraryTilesSmall
           ? 'libraryTilesSmall'
           : 'libraryTiles',
       title: _l10n.myMedia,
-      response: response,
+      response: {
+        ...response,
+        'Items': filteredItems,
+      },
       serverId: serverId,
       rowType: rowType,
     );

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -9,22 +9,22 @@ class AppLocalizationsAf extends AppLocalizations {
   AppLocalizationsAf([String locale = 'af']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Maanvin';
 
   @override
-  String get accountPreferences => 'REKENINGVOORKEURE';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Koppelvlaktaal';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Stelselverstek';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Meld aan';
 
   @override
-  String get empty => 'Leeg';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Vinnige verbinding';
 
   @override
   String get password => 'Wagwoord';
@@ -141,62 +141,62 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsAppearanceTheme => 'App Tema';
 
   @override
-  String get detailScreenStyle => 'Besonderhedeskermstyl';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassiek is die oorspronklike gesentreerde Moonfin-uitleg. Modern is \'n responsiewe filmiese uitleg.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassiek';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Uitgebreide oortjies';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Wys oortjie-inhoud outomaties terwyl jy deur die oortjies blaai. Skakel af om elke oortjie self oop en toe te maak.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Wys tegniese besonderhede?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Wys kodek-, resolusie- en stroominligting in die baniersamevatting';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Aanbevelingstelsel';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Gebruik die Moonfin Recommends-algoritme vir jou plaaslike biblioteek of TMDb se aanlyn ooreenkomsmetrieke. Let wel: aanlyn aanbevelings vereis Seerr-integrasie.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-ooreenkoms';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Beperk volgens ouderdomsgradering?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Beperk Moonfin Recommends-voorstelle volgens die ouderdomsgradering van die teikenmedia';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Koppelvlakstyl';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Outomaties pas by jou toestel aan. Kies Apple of Material om \'n spesifieke voorkoms af te dwing.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Outomaties';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsAf extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glaskwaliteit';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Outo kies die beste glaseffek vir hierdie toestel. Vol dwing werklike vervaging af; Verminderd gebruik \'n ligte glas wat GPU-krag spaar.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Outo';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Vol';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Verminderd';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Skakel tussen Moonfin en Neon Pulse sonder om die toepassing te herbegin';
 
   @override
-  String get customThemeTitle => 'Pasgemaakte tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Pasgemaakte temas verander visuele elemente regoor Moonfin. Kies een van hierdie opsies wat by jou styl pas.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Verkies stelselsleutelbord';
@@ -239,7 +239,7 @@ class AppLocalizationsAf extends AppLocalizations {
       'Gebruik jou toestelinvoermetode by verstek vir teksinvoer';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Maanvin';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsAf extends AppLocalizations {
       'Synthwave-stilering met magenta-gloed, siaan-teks en sterker chroomkontras';
 
   @override
-  String get themeGlass => 'Glas';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Vloeibare-glas-styl met \'n drywende gradiëntagtergrond, gevroste oppervlakke en \'n Apple-blou aksent';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit-held';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixelkuns-styl met \'n growwe palet, blokkerige rande, harde valskaduwees en \'n pixel-lettertipe';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,36 +327,35 @@ class AppLocalizationsAf extends AppLocalizations {
   String get exit => 'Verlaat';
 
   @override
-  String get gameMenu => 'Kieslys';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Gepouseer';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Stoor toestand';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Speletjies';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Laai toestand';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Vinnig vorentoe';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulator-instellings';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Hierdie kern het geen verstelbare opsies nie.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Hou in om die kieslys oop te maak';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Speletjies word nog nie op hierdie toestel ondersteun nie.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Geen tuisrye kon gelaai word nie';
@@ -378,7 +377,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get schedule => 'Skedule';
 
   @override
-  String get series => 'Reekse';
+  String get series => 'Reeks';
 
   @override
   String get noItemsFound => 'Geen items gevind nie';
@@ -554,7 +553,7 @@ class AppLocalizationsAf extends AppLocalizations {
       'Kies watter onderwerpstrome om in Ontdek te wys.';
 
   @override
-  String get apply => 'Pas toe';
+  String get apply => 'Doen aansoek';
 
   @override
   String get openLink => 'Maak skakel oop';
@@ -734,7 +733,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get folder => 'Vouer';
+  String get folder => 'Folder';
 
   @override
   String get filters => 'Filters';
@@ -767,43 +766,43 @@ class AppLocalizationsAf extends AppLocalizations {
   String get books => 'Boeke';
 
   @override
-  String get latestBooks => 'Nuutste boeke';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Nuutste oudioboeke';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count boeke',
-      one: '1 boek',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Boek';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Oudioboek';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% gelees';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time oor';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lees';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Luister';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Skrywer';
@@ -881,8 +880,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count oudioboeke',
-      one: '1 oudioboek',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -897,7 +896,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get failedToLoad => 'Kon nie laai nie';
 
   @override
-  String get delete => 'Skrap';
+  String get delete => 'Vee uit';
 
   @override
   String get save => 'Stoor';
@@ -906,7 +905,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get moreLikeThis => 'Meer soos hierdie';
 
   @override
-  String get castAndCrew => 'Rolverdeling en span';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Versameling';
@@ -986,8 +985,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Seisoene',
-      one: '1 Seisoen',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1001,37 +1000,37 @@ class AppLocalizationsAf extends AppLocalizations {
   String get items => 'Items';
 
   @override
-  String get extras => 'Ekstras';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Agter die skerms';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Geskrapte tonele';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Onderhoude';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Tonele';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kortfilms';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Lokprente';
+  String get trailers => 'Sleepwaens';
 
   @override
   String timeRemaining(String time) {
-    return '$time oor';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Eindig oor $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1076,7 +1075,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get cast => 'Cast';
 
   @override
-  String get trailer => 'Lokprent';
+  String get trailer => 'Sleepwa';
 
   @override
   String get finished => 'Klaar';
@@ -1270,10 +1269,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get director => 'DIREKTEUR';
 
   @override
-  String get directors => 'REGISSEURS';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SKRYWER';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'SKRYWERS';
@@ -1311,8 +1310,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count snitte',
-      one: '1 snit',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1322,8 +1321,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hoofstukke',
-      one: '1 hoofstuk',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1353,13 +1352,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get shuffle => 'Skommel';
 
   @override
-  String get shuffleAllMusic => 'Skommel alle musiek';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Meld op jou foon by Moonfin aan';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Kan nie jou bediener bereik nie';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1457,7 +1456,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get unavailable => 'Onbeskikbaar';
 
   @override
-  String get pause => 'Onderbreek';
+  String get pause => 'Pouse';
 
   @override
   String get syncPosition => 'Sinkroniseer posisie';
@@ -1531,7 +1530,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get subtitleDelay => 'Subtitel vertraging';
 
   @override
-  String get reset => 'Herstel';
+  String get reset => 'Stel terug';
 
   @override
   String get unknown => 'Onbekend';
@@ -1582,7 +1581,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get videoBitrate => 'Video bitrate';
 
   @override
-  String get track => 'Snit';
+  String get track => 'Spoor';
 
   @override
   String get channels => 'Kanale';
@@ -1591,7 +1590,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audioBitrate => 'Oudio-bitsnelheid';
 
   @override
-  String get sampleRate => 'Monsterkoers';
+  String get sampleRate => 'Sample Rate';
 
   @override
   String get format => 'Formaat';
@@ -1797,22 +1796,22 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Volgende: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m oor';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}u oor';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}u ${minutes}m oor';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1835,7 +1834,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get favoriteChannel => 'Gunsteling kanaal';
 
   @override
-  String get record => 'Neem op';
+  String get record => 'Rekord';
 
   @override
   String get cancelRecordingAction => 'Kanselleer opname';
@@ -2255,7 +2254,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get inMenus => 'In spyskaarte';
 
   @override
-  String get inVideo => 'In video';
+  String get inVideo => 'In Video';
 
   @override
   String get seasonalEffects => 'Seisoenale effekte';
@@ -2287,7 +2286,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Besonderhedebladsye, tuisrye en volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2301,11 +2300,11 @@ class AppLocalizationsAf extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Speel wanneer u tuisskerm blaai';
 
   @override
-  String get loopThemeMusic => 'Herhaal temamusiek';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Herhaal die snit in plaas daarvan om dit net een keer te speel';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Besonderhede Agtergrond vervaag';
@@ -2328,17 +2327,17 @@ class AppLocalizationsAf extends AppLocalizations {
   String get playerZoomMode => 'Spelerzoemmodus';
 
   @override
-  String get settingsScrollWheelAction => 'Muis-rolwiel';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Kies wat gebeur wanneer jy die muiswiel tydens terugspeel oor die video rol.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Af';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Spring (vorentoe / terug)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2350,7 +2349,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get fit => 'Gepas';
 
   @override
-  String get autoCrop => 'Outo-snoei';
+  String get autoCrop => 'Auto Crop';
 
   @override
   String get stretch => 'Strek';
@@ -2398,37 +2397,37 @@ class AppLocalizationsAf extends AppLocalizations {
   String get defaultAudioLanguage => 'Standaard oudiotaal';
 
   @override
-  String get fallbackAudioLanguage => 'Terugvaltaal vir oudio';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Verkies verstek-oudiosnit';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Verkies die oorspronklike oudiosnit bo \'n gelokaliseerde oorklanking.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Verkies oudiobeskrywingsnitte';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Verkies oudiobeskrywingsnitte bo gewone snitte.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodering (oudio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Direkte stroom (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodering (bistempo of resolusie)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodering (video en oudio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodering (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Outo (bedienerverstek)';
@@ -2458,7 +2457,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get korean => 'Koreaans';
 
   @override
-  String get chinese => 'Sjinees';
+  String get chinese => 'Chinese';
 
   @override
   String get russian => 'Russies';
@@ -2509,7 +2508,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Kies hoe oudio gedekodeer word. AVR-deurgee stuur rou Dolby/DTS-strome na jou ontvanger; Outo of Afmeng dekodeer plaaslik.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR deurlaat';
@@ -2519,13 +2518,13 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Kies die teikenformaat waarna multikanaal-oudio getranskodeer word wanneer die bronstroom nie direk gespeel of deurgegee kan word nie.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Outospeur\n(Aanbeveel)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Verstek)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2534,26 +2533,26 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Verliesloos)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Slegs stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Doeltreffend)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Verliesloos)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maksimum oudiokanale';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Stel die maksimum kanale van jou oudio-opstelling. Multikanaalstrome wat hierdie limiet oorskry, word afgemeng of getranskodeer.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'Outospeur\n(Hardeware-verstek)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2562,22 +2561,22 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Omringklank';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kwadrofonies';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Omringklank';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Omringklank';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Omringklank';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Omringklank';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Deurloop (Gevorderd)';
@@ -2658,7 +2657,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Spreker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kopfone';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2837,45 +2836,45 @@ class AppLocalizationsAf extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Pas subtitel voorkoms aan';
 
   @override
-  String get subtitleMode => 'Onderskrifmodus';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Gemerk';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Altyd';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Vreemdtalig';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Geforseer';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Speel snitte wat in die medialêer se metadata intern as \"default\" of \"forced\" gemerk is.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Laai en wys onderskrifte outomaties elke keer wanneer \'n video begin.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Skakel onderskrifte outomaties aan as die verstek-oudiosnit in \'n vreemde taal is.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Laai slegs onderskrifte wat uitdruklik met die \"forced\"-metadatamerker gemerk is.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Skakel outomatiese laai van onderskrifte heeltemal af.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Terugvaltaal vir onderskrifte';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Onderskrifstroom';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2924,7 +2923,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get global => 'Wêreldwyd';
 
   @override
-  String get desktop => 'Rekenaar';
+  String get desktop => 'Desktop';
 
   @override
   String get mobile => 'Selfoon';
@@ -3062,7 +3061,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get navigationStyle => 'Navigasie styl';
 
   @override
-  String get topBar => 'Boonste balk';
+  String get topBar => 'Top Bar';
 
   @override
   String get leftSidebar => 'Linkersybalk';
@@ -3080,10 +3079,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showLibrariesInToolbar => 'Wys biblioteke in Toolbar';
 
   @override
-  String get navbarAlwaysExpanded => 'Wys navigasie-etikette altyd';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Wys Seerr-knoppie';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar Ondeursigtigheid';
@@ -3158,19 +3157,18 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showFolderBrowsingOption => 'Wys gidsblaai-opsie';
 
   @override
-  String get groupItemsIntoCollections => 'Groepeer items in versamelings';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Versteek biblioteekitems wat aan \'n versameling behoort wanneer jy deur biblioteke blaai';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Kennisgewing oor biblioteekgroepering';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Om hierdie instelling te gebruik, maak seker dat die biblioteekinstellings \"Groepeer flieks in versamelings\" en/of \"Groepeer reekse in versamelings\" onder jou biblioteek se Vertoon-instellings op jou Jellyfin- of Emby-bediener geaktiveer is.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Biblioteeksigbaarheid';
@@ -3229,7 +3227,7 @@ class AppLocalizationsAf extends AppLocalizations {
       'Kies tussen verskeie mediabalkstyle, of skakel die mediabalk af';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Maanvin';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3266,13 +3264,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get noneExcluded => 'Geen uitgesluit nie';
 
   @override
-  String get autoAdvance => 'Outo-wissel';
+  String get autoAdvance => 'Auto Advance';
 
   @override
   String get autoAdvanceSlides => 'Gaan outomaties na die volgende skyfie';
 
   @override
-  String get autoAdvanceInterval => 'Outo-wisselinterval';
+  String get autoAdvanceInterval => 'Auto Advance Interval';
 
   @override
   String get trailerPreview => 'Voorskou van die sleepwa';
@@ -3282,11 +3280,10 @@ class AppLocalizationsAf extends AppLocalizations {
       'Speel sleepwaens outomaties in die mediabalk na 3 sekondes';
 
   @override
-  String get trailerAudio => 'Lokprent-oudio';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Aktiveer oudio vir lokprente in die mediabalk';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Episode Voorskou';
@@ -3316,7 +3313,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get recentlyReleased => 'Onlangs vrygestel';
 
   @override
-  String get myMedia => 'My media';
+  String get myMedia => 'My Media';
 
   @override
   String get myMediaSmall => 'My media (klein)';
@@ -3364,10 +3361,10 @@ class AppLocalizationsAf extends AppLocalizations {
       'Kombineer albei rye in \'n enkele huisafdeling';
 
   @override
-  String get fullScreenRows => 'Uitgebreide tuisrye';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => 'Beperk tuisrye tot 1 ry per skerm';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Per ry tipe beeld';
@@ -3382,7 +3379,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get lastUser => 'Laaste gebruiker';
 
   @override
-  String get currentUser => 'Huidige gebruiker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Verifieer altyd';
@@ -3491,10 +3488,10 @@ class AppLocalizationsAf extends AppLocalizations {
       'Vertoon klok tydens skermbewaarder';
 
   @override
-  String get clockModeStatic => 'Staties';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Bonsend';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Vrot tamaties (kritici)';
@@ -3565,7 +3562,7 @@ class AppLocalizationsAf extends AppLocalizations {
       'Aktiveer en herrangskik die graderingsbronne wat regdeur die toepassing gewys word';
 
   @override
-  String get pluginLabel => 'Moonbase-inprop';
+  String get pluginLabel => 'Inprop';
 
   @override
   String get pluginDetected => 'Inprop bespeur';
@@ -3610,7 +3607,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get recentlyAdded => 'Onlangs bygevoeg';
 
   @override
-  String get trending => 'Tans gewild';
+  String get trending => 'Trending';
 
   @override
   String get popularMovies => 'Gewilde flieks';
@@ -3622,7 +3619,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get upcomingMovies => 'Komende flieks';
 
   @override
-  String get studios => 'Ateljees';
+  String get studios => 'Studios';
 
   @override
   String get popularSeries => 'Gewilde reeks';
@@ -3637,13 +3634,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get networks => 'Netwerke';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-ontdekkingsrye';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Stel rye terug na verstek';
 
   @override
-  String get enableSeerr => 'Aktiveer Seerr';
+  String get enableSeerr => 'Aktiveer Siener';
 
   @override
   String get showSeerrInNavigation =>
@@ -3660,28 +3657,28 @@ class AppLocalizationsAf extends AppLocalizations {
   String get hideAdultContent => 'Versteek volwasse inhoud in resultate';
 
   @override
-  String get seerrNotificationsSection => 'Kennisgewings';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Kennisgewings vir nuwe versoeke';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Stel my in kennis wanneer iemand \'n versoek indien';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Versoekopdaterings';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Goedgekeur, afgekeur en by jou biblioteek gevoeg';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Kwessie-opdaterings';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nuwe kwessies, antwoorde en oplossings';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3689,15 +3686,15 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr-ontdekkingsbladsy';
+  String get discoverRows => 'Ontdek rye';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktiveer rye om op die Seerr-hoofblad te sien. Sleep om te herrangskik. Pasgemaakte volgorde sinkroniseer met Moonbase.';
+      'Sleep om te herrangskik. Aktiveer of deaktiveer rye. Geaktiveerde ryvolgorde sinchroniseer met die Moonfin-inprop.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktiveer rye om op die Seerr-hoofblad te sien. Sleep om te herrangskik. Pasgemaakte volgorde sinkroniseer met Moonbase.';
+      'Sleep om te herrangskik. Aktiveer of deaktiveer rye.';
 
   @override
   String get enabled => 'Geaktiveer';
@@ -3833,7 +3830,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get imageCacheCleared => 'Beeldkas skoongemaak';
 
   @override
-  String get clear => 'Vee uit';
+  String get clear => 'Duidelik';
 
   @override
   String get browse => 'Blaai deur';
@@ -3849,11 +3846,11 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Laai af · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Voer in';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3861,7 +3858,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Seerr-instellings';
+  String get seerrSettings => 'Siener-instellings';
 
   @override
   String get requestMore => 'Versoek meer';
@@ -3996,148 +3993,148 @@ class AppLocalizationsAf extends AppLocalizations {
   String get deletedStatus => 'Geskrap';
 
   @override
-  String get failedStatus => 'Misluk';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Verwerk tans';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Gewysig deur $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Voltooi';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Hierdie titel is reeds versoek';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Versoeklimiet bereik';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Hierdie titel is geblokkeer';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Geen seisoene oor om te versoek nie';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Jy het nie toestemming om hierdie versoek te maak nie';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Versoeke';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Kwessies';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nuutste';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Laas gewysig';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Geen kwessies nie';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining van $limit fliekversoeke oor';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining van $limit seisoenversoeke oor';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Deel van $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Bekyk versameling';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Versoek versameling';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total flieks · $available beskikbaar';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Versoek $count flieks';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Versoek tans $current van $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count flieks versoek';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok van $total flieks versoek';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alle flieks is reeds beskikbaar of versoek';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Rapporteer kwessie';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Oudio';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Wat is verkeerd?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alle episodes';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Oop';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Opgelos';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Los op';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Heropen';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Gerapporteer deur $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommentare';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Voeg \'n kommentaar by';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Vee hierdie kwessie uit?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Dien verslag in';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-telling';
@@ -4254,7 +4251,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get refresh => 'Verfris';
 
   @override
-  String get remote => 'Afstandsbeheer';
+  String get remote => 'Afgeleë';
 
   @override
   String get rename => 'Hernoem';
@@ -4299,7 +4296,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get time => 'Tyd';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Truukspel';
 
   @override
   String get uninstall => 'Deïnstalleer';
@@ -4323,7 +4320,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get branding => 'Handelsmerk';
 
   @override
-  String get adminDrawerDashboard => 'Kontrolepaneel';
+  String get adminDrawerDashboard => 'Dashboard';
 
   @override
   String get adminDrawerAnalytics => 'Ontleding';
@@ -4341,13 +4338,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteke';
 
   @override
-  String get adminDrawerDisplay => 'Vertoon';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-instellings';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodering';
@@ -4359,7 +4356,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminDrawerStreaming => 'Stroom';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Truukspel';
 
   @override
   String get adminDrawerDevices => 'Toestelle';
@@ -4377,7 +4374,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminDrawerBackups => 'Rugsteun';
 
   @override
-  String get adminDrawerLogs => 'Logboeke';
+  String get adminDrawerLogs => 'Logs';
 
   @override
   String get adminDrawerScheduledTasks => 'Geskeduleerde take';
@@ -4440,7 +4437,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get analyticsContainers => 'Houers';
 
   @override
-  String get analyticsTopGenres => 'Topgenres';
+  String get analyticsTopGenres => 'Top Genres';
 
   @override
   String get analyticsReleaseYears => 'Vrystellingsjare';
@@ -4559,7 +4556,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audioCodec => 'Oudio-kodek';
 
   @override
-  String get hwAccel => 'HW-versnelling';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Voltooiing';
@@ -4574,10 +4571,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminClearDates => 'Duidelike datums';
 
   @override
-  String get adminActivitySeverityAll => 'Alle ernsgrade';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datumreeks';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4614,23 +4611,23 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Verwyder toestel \'$name\'? Die gebruiker sal weer op hierdie toestel moet aanmeld.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Vee alle toestelle uit';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Verwyder $count toestelle? Geaffekteerde gebruikers sal weer moet aanmeld. Jou huidige toestel word nie geraak nie.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Toestelle verwyder';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Sommige toestelle is verwyder; $count kon nie verwyder word nie.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4745,252 +4742,244 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminMetadataCountryHint => 'bv. VSA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Paaie';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opsies';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Aflaaiers';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadata-stoorders';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Onderskrif-aflaaiers';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Lirieke-aflaaiers';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadata-aflaaiers: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Beeldophalers: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Hierdie bediener bied geen aflaaiers vir hierdie biblioteektipe nie.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Algemeen';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Ingebedde inligting';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Onderskrifte';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Beelde';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Reekse';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musiek';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Flieks';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktiveer intydse monitering';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Bespeur lêerveranderinge en verwerk hulle outomaties.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Hanteer argiewe as medialêers';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Wys foto\'s';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Stoor kunswerk in mediavouers';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Outomatiese metadata-verfrissing';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nooit';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Verstek';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Vertoon';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Biblioteekvertoning';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Wys \'n vouer-aansig om gewone mediavouers te vertoon';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Wys spesiale episodes binne die seisoene waarin hulle uitgesaai is';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Groepeer flieks in versamelings';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Groepeer reekse in versamelings';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Wys eksterne inhoud in voorstelle';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Gedrag van datum bygevoeg';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Gebruik datum bygevoeg vanaf';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Datum waarop dit in die biblioteek geskandeer is';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum waarop die lêer geskep is';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata en beelde';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Voorkeurtaal vir metadata';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Hoofstukke';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Duur van plekhouer-hoofstukke (sekondes)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Lengte van hoofstukke wat geskep word vir media wat geen het nie. Stel op 0 om af te skakel.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Resolusie van hoofstukbeelde';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-instellings';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metadata is versoenbaar met Kodi en soortgelyke kliënte. Instellings geld vir alle biblioteke wat NFO-metadata stoor.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Gebruiker vir wie kykdata in NFO-lêers gestoor word';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Stoor beeldpaaie in NFO-lêers';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktiveer padvervanging vir NFO-beeldpaaie';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopieer extrafanart-beelde na \'n extrathumbs-vouer';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Geen';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dae';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Gebruik ingebedde titels';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Gebruik ingebedde titels vir ekstras';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Gebruik ingebedde episode-inligting';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Laat ingebedde onderskrifte toe';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Laat alles toe';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Slegs teks';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Slegs beeld';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Geen';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Slaan aflaai oor as ingebedde onderskrifte teenwoordig is';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Slaan aflaai oor as die oudiosnit met die aflaaitaal ooreenstem';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Vereis \'n perfekte onderskrif-passing';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Stoor onderskrifte in mediavouers';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Onttrek hoofstukbeelde';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Onttrek hoofstukbeelde tydens die biblioteekskandering';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktiveer onttrekking van Trickplay-beelde';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Onttrek Trickplay-beelde tydens die biblioteekskandering';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Stoor Trickplay-beelde in mediavouers';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Voeg reekse wat oor verskeie vouers versprei is outomaties saam';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Vertoonnaam vir seisoen nul';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Aktiveer LUFS-skandering vir oudionormalisering';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Verkies nie-standaard kunstenaarsetiket';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Voeg flieks outomaties by versamelings';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Biblioteeknaam word vereis';
@@ -5228,144 +5217,143 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktiveer toegang tot alle kanale';
 
   @override
-  String get adminParentalControl => 'Ouerbeheer';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Maksimum toegelate ouderdomsgradering';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Inhoud met \'n hoër gradering word vir hierdie gebruiker versteek.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Geen';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokkeer items sonder of met onherkenbare graderingsinligting';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Boeke';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanale';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Regstreekse TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Flieks';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musiek';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Lokprente';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Reekse';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Toegangskedules';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Laat toegang slegs gedurende die geskeduleerde tye hieronder toe. Wanneer geen skedule gestel is nie, word toegang die hele dag toegelaat.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Voeg skedule by';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dag';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Begin';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Einde';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Elke dag';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Weeksdag';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Naweek';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Sondag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Maandag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Dinsdag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Woensdag';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Donderdag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Vrydag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Saterdag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Toegelate etikette';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Slegs inhoud met hierdie etikette word gewys. Los leeg om alles toe te laat.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Geblokkeerde etikette';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Inhoud met hierdie etikette word vir hierdie gebruiker versteek.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Voeg etiket by';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Geaktiveerde toestelle';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Geaktiveerde kanale';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Verifikasieverskaffer';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Verskaffer vir wagwoordherstel';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksimum mislukte aanmeldpogings voor uitsluiting';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Stel op 0 vir die verstek, of -1 om uitsluiting af te skakel.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-toegang';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Laat toe om groepe te skep en by groepe aan te sluit';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Laat toe om by groepe aan te sluit';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Geen toegang';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Laat inhoud uitgevee word uit';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5453,26 +5441,25 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Skep rugsteun';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Kies wat in die rugsteun ingesluit moet word.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Databasis';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Altyd ingesluit';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Onderskrifte';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-beelde';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Skep tans rugsteun …';
@@ -5897,7 +5884,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminSegmentKeepSeconds => 'Segment hou (sekondes)';
 
   @override
-  String get adminThrottleBuffering => 'Beperk buffering';
+  String get adminThrottleBuffering => 'Throttle buffering';
 
   @override
   String get adminTrickplaySaved => 'Trickplay-instellings gestoor';
@@ -6014,7 +6001,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminBaseUrl => 'Basis URL';
 
   @override
-  String get adminBaseUrlHint => 'bv. /jellyfin';
+  String get adminBaseUrlHint => 'bv. /jellietjie';
 
   @override
   String get https => 'HTTPS';
@@ -6176,60 +6163,60 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminAddTuner => 'Voeg Tuner by';
 
   @override
-  String get adminEditTuner => 'Wysig tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Lêer of URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Tuner se IP-adres';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Vriendelike naam';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Gebruikeragent';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limiet vir gelyktydige verbindings';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Die maksimum aantal strome wat die tuner gelyktydig toelaat. Stel op 0 vir onbeperk.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Terugval-maksimum stroom-bistempo';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Voer slegs gunsteling-kanale in';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Laat hardeware-transkodering toe';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Laat fMP4-transkoderingshouer toe';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Laat stroomdeling toe';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Aktiveer stroomherhaling';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignoreer DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Lees inset teen inheemse raamtempo';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Wysig verskaffer';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6238,50 +6225,50 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Lêer of URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Fliekvoorvoegsel';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Fliekkategorieë';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Skei veelvuldige kategorieë met \'n vertikale streep.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kinderkategorieë';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nuuskategorieë';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportkategorieë';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Gebruikersnaam';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Wagwoord';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Kies \'n land';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Poskode';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Kry lyste';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Lyste';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktiveer alle tuners';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuner Tipe';
@@ -6323,7 +6310,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Hierdie tunertipe ondersteun nie terugstelling nie.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6346,43 +6333,43 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Reeks opname pad';
 
   @override
-  String get adminMovieRecordingPath => 'Opnamepad vir flieks';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Dae se gidsdata';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Outomaties';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dae';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Pad na naverwerkingstoepassing';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Naverwerker-argumente';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Stoor NFO-metadata vir opnames';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Stoor opnamebeelde';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tydsberekening';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Opnamepaaie';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Naverwerking';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Gidsdata: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6424,14 +6411,14 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminGuideProviders => 'Gidsverskaffers';
 
   @override
-  String get adminRefreshGuideData => 'Verfris gidsdata';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Verfrissing van gidsdata het begin';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Die taak om die gids te verfris is nie op hierdie bediener beskikbaar nie.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Voeg verskaffer by';
@@ -6460,7 +6447,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get adminTunerDiscovery => 'Tuner-ontdekking';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Kanaalkaarte';
@@ -6512,13 +6499,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminLiveTvTitle => 'Regstreekse TV-administrasie';
 
   @override
-  String get adminApply => 'Pas toe';
+  String get adminApply => 'Doen aansoek';
 
   @override
   String get adminNotSet => 'Nie gestel nie';
 
   @override
-  String get adminReset => 'Herstel';
+  String get adminReset => 'Stel terug';
 
   @override
   String get adminLogsTitle => 'Bediener logs';
@@ -6564,7 +6551,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadata-redigeerder';
 
   @override
-  String get adminMetadataIdentify => 'Identifiseer';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tik';
@@ -6618,7 +6605,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminMetadataTags => 'Merkers';
 
   @override
-  String get adminMetadataStudios => 'Ateljees';
+  String get adminMetadataStudios => 'Studios';
 
   @override
   String get adminMetadataPeople => 'Mense';
@@ -6978,19 +6965,19 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktiveer plonsskerm';
 
   @override
-  String get adminBrandingSplashUpload => 'Laai beeld op';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Plonsskerm opgedateer';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'Kon nie plonsskerm oplaai nie';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Plonsskerm verwyder';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Geen pasgemaakte plonsskerm';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardeware versnelling';
@@ -7006,124 +6993,121 @@ class AppLocalizationsAf extends AppLocalizations {
       'Aktiveer hardeware-dekodering vir:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-toestel';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Aktiveer verbeterde NVDEC-dekodeerder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Verkies die stelsel se inheemse hardeware-dekodeerder';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Kleurdiepte vir hardeware-dekodering';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bis HEVC-dekodering';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bis VP9-dekodering';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bis-dekodering';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bis-dekodering';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardeware-enkodering';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Laat HEVC-enkodering toe';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Laat AV1-enkodering toe';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktiveer Intel se laekrag-H.264-enkodeerder';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktiveer Intel se laekrag-HEVC-enkodeerder';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Toonkartering';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktiveer toonkartering';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Aktiveer VPP-toonkartering';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktiveer VideoToolbox-toonkartering';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Toonkarteringsalgoritme';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Toonkarteringsmodus';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Toonkarteringsbereik';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Toonkartering-ontversadiging';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Toonkarteringspiek';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Toonkarteringsparameter';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP-toonkartering se helderheid';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP-toonkartering se kontras';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Voorinstellings en kwaliteit';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Enkodeerder-voorinstelling';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264-enkodering se CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC)-enkodering se CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Ontvlegtingsmetode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Verdubbel die raamtempo tydens ontvlegting';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Oudio';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktiveer VBR-enkodering vir oudio';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Versterking vir oudio-afmenging';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritme vir stereo-afmenging';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Maksimum grootte van muxing-tou';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Outo';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Enkodering';
@@ -7246,7 +7230,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Lopende take';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Hardloop';
@@ -7316,8 +7300,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ure',
-      one: '1 uur',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7368,7 +7352,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '${hours}u';
+    return '${hours}h';
   }
 
   @override
@@ -7378,7 +7362,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7392,50 +7376,49 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Basis URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'bv. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'bv. /jellietjie';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Openbare HTTP-poort';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Vereis HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Herlei alle afgeleë versoeke na HTTPS. Het geen effek as die bediener nie \'n geldige sertifikaat het nie.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Sertifikaatwagwoord';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-instellings';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktiveer IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktiveer IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Aktiveer outomatiese poortkartering';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-netwerke';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Komma- of reëlgeskeide lys van IP-adresse of CIDR-subnette wat as deel van die plaaslike netwerk hanteer word.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Gepubliseerde bediener-URI\'s';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Karteer \'n subnet of adres na \'n gepubliseerde URL, bv. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Sertifikaat pad';
@@ -7462,14 +7445,14 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminPlaybackSegmentKeep => 'Segment hou (sekondes)';
 
   @override
-  String get adminPlaybackThrottleBuffering => 'Beperk buffering';
+  String get adminPlaybackThrottleBuffering => 'Throttle buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Beperkingsvertraging (sekondes)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Laat intydse onttrekking van onderskrifte toe';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimum hervat persentasie';
@@ -7526,23 +7509,22 @@ class AppLocalizationsAf extends AppLocalizations {
       'Stadige reaksie drempel (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktiveer waarskuwings oor stadige response';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktiveer Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Bediener';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Paaie';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Werkverrigting';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Kas pad';
@@ -7554,7 +7536,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminGeneralServerName => 'Bediener naam';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Voorkeurtaal vir vertoning';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Kon nie instellings laai nie';
@@ -7607,8 +7589,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# deelnemers',
-      one: '# deelnemer',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7755,8 +7737,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rye ontdek',
-      one: '# ry ontdek',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7797,20 +7779,20 @@ class AppLocalizationsAf extends AppLocalizations {
   String get offlineSavedMedia => 'Gestoorde media';
 
   @override
-  String get offlineBannerTitle => 'Jy is aflyn';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Wys jou aflaaie';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Aflaaie';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Kan nie jou bediener bereik nie';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Speel uit jou aflaaie totdat dit terug is';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7883,10 +7865,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get pinForgot => 'PIN vergeet?';
 
   @override
-  String get pinClear => 'Vee uit';
+  String get pinClear => 'Duidelik';
 
   @override
-  String get pinBackspace => 'Terugvee';
+  String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized => 'Quick Connect-versoek gemagtig.';
@@ -7897,7 +7879,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect word nie op hierdie bediener ondersteun nie.';
+      'Vinnige verbinding word nie op hierdie bediener ondersteun nie.';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7905,7 +7887,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect is op hierdie bediener gedeaktiveer.';
+      'Vinnige verbinding is op hierdie bediener gedeaktiveer.';
 
   @override
   String get quickConnectForbidden =>
@@ -7917,7 +7899,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect het misluk: $message';
+    return 'Vinnige verbinding het misluk: $message';
   }
 
   @override
@@ -8168,13 +8150,14 @@ class AppLocalizationsAf extends AppLocalizations {
   String get contextMenuGoToSeries => 'Gaan na Reeks';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Versteek uit Hou aan kyk';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Versteek uit Volgende';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Voeg by versameling';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8229,15 +8212,14 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabeties';
 
   @override
-  String get settingsConnectionSection => 'VERBINDING';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Laat selfondertekende sertifikate toe';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Vertrou bedieners wat selfondertekende of privaat-CA TLS-sertifikate gebruik. Aktiveer dit slegs vir bedieners wat jy self beheer. Dit skakel sertifikaatvalidering vir alle verbindings af.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVAATHEID EN VEILIGHEID';
@@ -8253,11 +8235,11 @@ class AppLocalizationsAf extends AppLocalizations {
       'Tema-aksente, agtergronde, gekykte aanwysers en temamusiek';
 
   @override
-  String get settingsDetailsScreen => 'Besonderhedeskerm';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Styl, agtergrondvervaging en oortjiegedrag';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Tuisblad';
@@ -8295,11 +8277,11 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Wys die Seerr-knoppie in die navigasiebalk';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Wys altyd teksetikette in die boonste navigasiebalk';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8401,8 +8383,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# lisensiekennisgewings',
-      one: '# lisensiekennisgewing',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8450,16 +8432,16 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Slaan Intro\'s en Outros oor?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Aftelling vir mediasegmente';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Vorderingsbalk';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Tydteller';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Geen';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Vinnige gebruiker';
@@ -8686,7 +8668,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Onlangs vrygestelde $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8719,11 +8701,11 @@ class AppLocalizationsAf extends AppLocalizations {
       'Forseer nie-getonnelde afspeel. Nuttig op toestelle met klank-/videodiskontinuïteite.';
 
   @override
-  String get enableTunnelingTitle => 'Aktiveer tonneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Gevorderd. Stuur oudio en video deur \'n gekoppelde hardewarepad. Standaard af, want dit veroorsaak oudio-/videowegvalle op sommige toestelle.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Kaart Dolby Vision profiel 7 aan HEVC';
@@ -8748,14 +8730,14 @@ class AppLocalizationsAf extends AppLocalizations {
       'Pas lettergrootte-wenke toe wat in die onderskrifsnit ingebed is. Deaktiveer om die ondertitelgrootte van jou stylvoorkeure te gebruik.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Wys mediabesonderhede';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Wys besonderhede van die gekose item boaan biblioteekbladsye.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Versteek agtergronde tydens blaai?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Gebruik gedetailleerde subopskrifte';
@@ -8773,38 +8755,37 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Temawinkel';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Blaai deur en stoor gemeenskapstemas';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Stoor \'n tema om dit soos jou ander gestoorde temas te gebruik.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Geen temas is tans beskikbaar nie.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Kon nie die Temawinkel laai nie. Gaan jou verbinding na en probeer weer.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Stoor';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Stoor en pas toe';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Gestoor';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage =>
-      'Hierdie tema kon nie gelaai word nie.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" gestoor.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8863,21 +8844,21 @@ class AppLocalizationsAf extends AppLocalizations {
   String get homeRowsSection => 'Tuis Rye';
 
   @override
-  String get homeRowDisplay => 'Vertoon van tuisrye';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Tuisry-afdelings';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Tuisry-skakelaars';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Aktiveer of deaktiveer biblioteekgebaseerde tuisry-kategorieë';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktiveer die volgende skakelaars om die rye in Tuis-afdelings te wys.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Tipe rye';
@@ -8935,55 +8916,55 @@ class AppLocalizationsAf extends AppLocalizations {
       'Wys flieks, reekse of albei in genres-rye.';
 
   @override
-  String get displayPlaylistsRows => 'Wys snitlysrye';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Wys snitlysrye in Tuis-afdelings.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortering van snitlysrye';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sorteer snitlysrye volgens datum bygevoeg, vrystellingsdatum, alfabeties en meer.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Wys oudiorye';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'Wys oudiorye in Tuis-afdelings.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortering van oudiorye';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sorteer oudiorye volgens datum bygevoeg, vrystellingsdatum, alfabeties en meer.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Oudio-snitlyste';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Voorkoms';
 
   @override
-  String get layout => 'Uitleg';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Sleutelbord';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Knoppies';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Weergee';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-konfigurasie';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kaart grootte';
@@ -8993,7 +8974,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Stel \'n eksterne speler om die lang-druk-speel-opsie te aktiveer';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9131,7 +9112,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get webDiagnosticsDefaultServerUrl => 'Verstek bediener URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL vir ontdekkingsproksi';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
   String get notConfigured => 'nie gekonfigureer nie';
@@ -9256,10 +9237,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get guestAppearances => 'Gasverskynings';
 
   @override
-  String get appearancesSeerr => 'Verskynings (Seerr)';
+  String get appearancesSeerr => 'Voorkoms (Siener)';
 
   @override
-  String get crewContributionsSeerr => 'Spanbydraes (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Kyk saam met die groep';
@@ -9345,8 +9326,8 @@ class AppLocalizationsAf extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Biblioteke',
-      one: '1 Biblioteek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9378,7 +9359,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminServerPathCache => 'Kas';
 
   @override
-  String get adminServerPathLogs => 'Logboeke';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
@@ -9505,13 +9486,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get loadingShuffle => 'Laai tans shuffle …';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTEEK-SKOMMEL';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'LUKRAAK SKOMMEL';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'GENRE-SKOMMEL';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Outo-HDR-skakeling';
@@ -9524,222 +9505,222 @@ class AppLocalizationsAf extends AppLocalizations {
   String get whenFullscreen => 'Wanneer volskerm';
 
   @override
-  String get changeArtwork => 'Verander kunswerk';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Ontbreek';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Transkoderingslimiete';
 
   @override
-  String get clearAllArtworkButton => 'Vee alle kunswerk uit?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Is jy seker jy wil alle afgelaaide kunswerk uitvee?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Bevestig uitvee';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Is jy seker jy wil hierdie $itemType uitvee?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Laai op?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolusie: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Wys slegs kunswerk in die koppelvlaktaal';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Bevestig om alles uit te vee';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Beeld suksesvol opgelaai!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Kon nie beeld oplaai nie: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Kon nie beeld stel nie: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Kon nie beeld uitvee nie: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kon nie alle kunswerk uitvee nie: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakkaat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Agtergronde';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Banier';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Duimnael';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Kuns';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Skyfkuns';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Skermkiekie';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Voorblad';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Agterblad';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Kieslyskuns';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakkaat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'agtergrond';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'banier';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'duimnael';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'kuns';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'skyfkuns';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'skermkiekie';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'voorblad';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'agterblad';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'kieslyskuns';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alle';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Hoog (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
   String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Laag (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Bronne';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Hoofstukke';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Boekmerke';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notas';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Tou';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Tydlyn';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Die tydlyn is leeg';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Hele boek';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Gefokusde tydlyn';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Voer boekmerke uit';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Voer notas uit';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Voer alles uit';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Uitgevoer na $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Uitvoer het misluk: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Lirieke';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Voeg boekmerk by';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Voeg nota by';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Wysig nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Skryf \'n nota vir hierdie oomblik';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Slaaptydteller';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Af';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Einde van hoofstuk';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Pasgemaak';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining oor';
+    return '$remaining left';
   }
 
   @override
@@ -9754,51 +9735,51 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Terugspeelspoed';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Oor';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Verloop';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '${seconds}s terug';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '${seconds}s vorentoe';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Vorige hoofstuk';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Volgende hoofstuk';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Hoofstuk $current van $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Geen hoofstukke';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Nog geen boekmerke nie';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Nog geen notas nie';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Boekmerk by $position bygevoeg';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Stel terug na 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9806,253 +9787,249 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Stoor';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Kanselleer';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Skrap';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Onderskrifvoorkeure';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Verander onderskrifmodusse, verstektale, voorkoms en weergee-opsies.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Weergee van onderskrifte';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Vertoonopsies';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Vrystellingsdatum (opgaande)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Vrystellingsdatum (afgaande)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Groepeer bydraes';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Groepeer veelvuldige rolle';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Waarskuwing oor skryftoegang tot biblioteek';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Hoe om dit reg te stel:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Gee skryfregte aan die Jellyfin-diensgebruiker (bv. jellyfin of Docker PUID/PGID) vir jou mediabiblioteek-vouers op die bediener.\n\n2. Of gaan na jou Jellyfin-kontrolepaneel -> Biblioteke, wysig hierdie biblioteek en deaktiveer \'Stoor kunswerk in mediavouers\' om kunswerk in Jellyfin se interne databasis te stoor.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Maak toe';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Jou \'$libraryName\'-biblioteek is opgestel om kunswerk direk in die mediavouers te stoor (\'Stoor kunswerk in mediavouers\' is geaktiveer). Jellyfin het egter skryftoegang getoets en het nie toestemming om lêers na hierdie gids te skryf nie:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Dit lyk of Jellyfin nie die kunswerk kon opdateer nie. Jou biblioteek is opgestel om kunswerk direk in die mediavouers te stoor (\'Stoor kunswerk in mediavouers\' is geaktiveer). Hierdie fout gebeur gewoonlik wanneer die Jellyfin-bedienerproses nie toestemming het om lêers na jou mediagidse te skryf nie.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Eksterne lyste';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Speel weer';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Lêerinligting';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Grootte: $size  •  Formaat: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Wys al ($count) die oudiosnitte';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Wys al ($count) die onderskrifsnitte';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Kontroleer Direct Play-vermoë...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play-vermoë: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Geforseer';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Die houerformaat word nie deur die speler ondersteun nie.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Die videokodek word nie ondersteun nie.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Die oudiokodek word nie ondersteun nie.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Die onderskrifformaat word nie ondersteun nie (moet ingebrand word).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Die oudioprofiel word nie ondersteun nie.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Die videoprofiel word nie ondersteun nie.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Die videovlak word nie ondersteun nie.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Die videoresolusie word nie deur hierdie toestel ondersteun nie.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Die video se bisdiepte word nie ondersteun nie.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Die video se raamtempo word nie ondersteun nie.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Die lêer se bistempo oorskry die speler se stroomlimiet.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Die video se bistempo oorskry die stroomlimiet.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Die oudio se bistempo oorskry die stroomlimiet.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Die aantal oudiokanale word nie ondersteun nie.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabeties';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Vrystellingsvolgorde (opgaande)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Vrystellingsvolgorde (afgaande)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Pasgemaak (sleep-en-los)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Snitlys-sorteeropsies';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Stel sortering terug';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Kyk S$season:E$episode weer';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Kyk snitlys weer';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Geen onderskrifte gevind nie.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Adminkontroles';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Weergee-enjin (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller is Flutter se moderne GPU-weergeër vir gladder animasies en minder hakkel. Op sommige TV-bokse en ouer GPU\'s kan dit foute of swart video veroorsaak; skakel dit af as jy dit sien. Outomaties kies die beste verstek vir jou toestel. Herbegin Moonfin om dit toe te pas.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Outomaties';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Aan';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Af';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Herbegin vereis';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin moet herbegin om die weergee-enjin te verander. Maak die app nou toe en heropen dit om die verandering toe te pas.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Maak app nou toe';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Verfris biblioteek';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Verfris alle biblioteke';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Datum bygevoeg (oudste eerste)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Datum bygevoeg (nuutste eerste)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabeties (A tot Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabeties (Z tot A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Laai bediener-analise... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Pas by bron';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb se top 250 flieks';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb se top 250 TV-reekse';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb se gewildste flieks';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb se gewildste TV-reekse';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb se laagsgegradeerde flieks';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb se topgegradeerde Engelse flieks';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -9,22 +9,22 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'مونفين';
 
   @override
-  String get accountPreferences => 'تفضيلات الحساب';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'لغة الواجهة';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'افتراضي النظام';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'تسجيل الدخول';
 
   @override
-  String get empty => 'فارغ';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'اتصال سريع';
 
   @override
   String get password => 'كلمة المرور';
@@ -51,7 +51,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get waitingForAuthorization => 'في انتظار الترخيص...';
 
   @override
-  String get back => 'رجوع';
+  String get back => 'خلف';
 
   @override
   String get serverUnavailable => 'الخادم غير متوفر';
@@ -113,7 +113,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get cancel => 'يلغي';
 
   @override
-  String get remove => 'إزالة';
+  String get remove => 'يزيل';
 
   @override
   String get connectToServer => 'الاتصال بالخادم';
@@ -141,62 +141,62 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsAppearanceTheme => 'موضوع التطبيق';
 
   @override
-  String get detailScreenStyle => 'نمط شاشة التفاصيل';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'الكلاسيكي هو تخطيط Moonfin الأصلي المتمركز. الحديث تخطيط سينمائي متجاوب.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'كلاسيكي';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'حديث';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'علامات تبويب موسّعة';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'عرض محتوى علامة التبويب تلقائيًا أثناء تصفّح العلامات. عطّل الخيار لفتح كل علامة تبويب وإغلاقها يدويًا.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'عرض التفاصيل التقنية؟';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'عرض معلومات الترميز والدقة والبث في ملخص اللافتة';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'نظام التوصيات';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'استخدم خوارزمية المكتبة المحلية Moonfin Recommends أو مقاييس التشابه من TMDb عبر الإنترنت. ملاحظة: تتطلب التوصيات عبر الإنترنت تكامل Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'تشابه TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'تطبيق حد التصنيف العمري؟';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'تقييد اقتراحات Moonfin Recommends حسب التصنيف العمري للوسائط المستهدفة';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'نمط الواجهة';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'يطابق الوضع التلقائي جهازك. اختر Apple أو Material لفرض مظهر معيّن.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'تلقائي';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsAr extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'جودة الزجاج';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'يختار الوضع التلقائي أفضل تأثير زجاجي لهذا الجهاز. يفرض الوضع الكامل ضبابية حقيقية، بينما يستخدم الوضع المخفّض زجاجًا خفيفًا يوفّر طاقة GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'تلقائي';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'كامل';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'مخفّض';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'قم بالتبديل بين Moonfin وNeon Pulse دون إعادة تشغيل التطبيق';
 
   @override
-  String get customThemeTitle => 'سمة مخصصة';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'تغيّر السمات المخصصة العناصر المرئية في Moonfin. اختر أحد هذه الخيارات بما يناسب ذوقك.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'تفضل لوحة مفاتيح النظام';
@@ -239,7 +239,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'استخدم طريقة إدخال جهازك بشكل افتراضي لإدخال النص';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'مونفين';
 
   @override
   String get themeMoonfinSubtitle => 'المظهر الحالي Moonfin الذي أحببته جميعًا';
@@ -252,18 +252,18 @@ class AppLocalizationsAr extends AppLocalizations {
       'تصميم Synthwave مع توهج أرجواني ونص سماوي وتباين أقوى للكروم';
 
   @override
-  String get themeGlass => 'زجاجي';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'تصميم زجاجي سائل مع خلفية متدرّجة متحرّكة وأسطح مصنفرة ولون تمييز أزرق بأسلوب Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'بطل 8 بت';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'تصميم بكسل كلاسيكي بلوحة ألوان جريئة وحدود مربّعة وظلال حادة وخط بكسلي';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -325,36 +325,35 @@ class AppLocalizationsAr extends AppLocalizations {
   String get exit => 'مخرج';
 
   @override
-  String get gameMenu => 'القائمة';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'متوقف مؤقتًا';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'حفظ الحالة';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'الألعاب';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'تحميل الحالة';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'تقديم سريع';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'إعدادات المحاكي';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'لا تتوفّر خيارات قابلة للتعديل في هذه النواة.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'استمر بالضغط لفتح القائمة';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'تشغيل الألعاب غير مدعوم على هذا الجهاز بعد.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'لا يمكن تحميل أي صفوف رئيسية';
@@ -375,13 +374,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get schedule => 'جدول';
 
   @override
-  String get series => 'المسلسلات';
+  String get series => 'مسلسل';
 
   @override
   String get noItemsFound => 'لم يتم العثور على أي عناصر';
 
   @override
-  String get home => 'الرئيسية';
+  String get home => 'بيت';
 
   @override
   String get browseAll => 'تصفح الكل';
@@ -411,7 +410,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get noLibrariesFound => 'لم يتم العثور على مكتبات';
 
   @override
-  String get library => 'المكتبة';
+  String get library => 'مكتبة';
 
   @override
   String get displaySettings => 'إعدادات العرض';
@@ -503,7 +502,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get albumArtists => 'فنانين الالبوم';
 
   @override
-  String get artists => 'الفنانون';
+  String get artists => 'الفنانين';
 
   @override
   String get bookmarks => 'الإشارات المرجعية';
@@ -550,7 +549,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'اختر خلاصات الموضوع التي سيتم عرضها في Discover.';
 
   @override
-  String get apply => 'تطبيق';
+  String get apply => 'يتقدم';
 
   @override
   String get openLink => 'افتح الرابط';
@@ -598,7 +597,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get listen => 'يستمع';
 
   @override
-  String get resume => 'استئناف';
+  String get resume => 'سيرة ذاتية';
 
   @override
   String get failedToLoadLibrary => 'فشل تحميل المكتبة';
@@ -741,13 +740,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get readStatus => 'يقرأ';
 
   @override
-  String get watched => 'تمت مشاهدته';
+  String get watched => 'شاهد';
 
   @override
   String get unread => 'غير مقروءة';
 
   @override
-  String get unwatched => 'لم تتم مشاهدته';
+  String get unwatched => 'غير مراقب';
 
   @override
   String get seriesStatus => 'حالة السلسلة';
@@ -759,47 +758,43 @@ class AppLocalizationsAr extends AppLocalizations {
   String get books => 'كتب';
 
   @override
-  String get latestBooks => 'أحدث الكتب';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'أحدث الكتب الصوتية';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count كتاب',
-      many: '$count كتابًا',
-      few: '$count كتب',
-      two: 'كتابان',
-      zero: 'لا توجد كتب',
-      one: 'كتاب واحد',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'كتاب';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'كتاب صوتي';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% مقروء';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'متبقٍ $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'قراءة';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'استماع';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'مؤلف';
@@ -876,12 +871,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count كتاب صوتي',
-      many: '$count كتابًا صوتيًا',
-      few: '$count كتب صوتية',
-      two: 'كتابان صوتيان',
-      zero: 'لا توجد كتب صوتية',
-      one: 'كتاب صوتي واحد',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -896,10 +887,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get failedToLoad => 'فشل التحميل';
 
   @override
-  String get delete => 'حذف';
+  String get delete => 'يمسح';
 
   @override
-  String get save => 'حفظ';
+  String get save => 'يحفظ';
 
   @override
   String get moreLikeThis => 'المزيد مثل هذا';
@@ -984,12 +975,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count موسم',
-      many: '$count موسمًا',
-      few: '$count مواسم',
-      two: 'موسمان',
-      zero: 'لا توجد مواسم',
-      one: 'موسم واحد',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1000,40 +987,40 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get items => 'العناصر';
+  String get items => 'Items';
 
   @override
-  String get extras => 'إضافات';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'خلف الكواليس';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'مشاهد محذوفة';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'مقاطع تعريفية';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'مقابلات';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'مشاهد';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'أفلام قصيرة';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'الإعلانات التشويقية';
+  String get trailers => 'مقطورات';
 
   @override
   String timeRemaining(String time) {
-    return 'متبقٍ $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'ينتهي خلال $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1051,7 +1038,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get play => 'تشغيل';
+  String get play => 'يلعب';
 
   @override
   String get startOver => 'البدء من جديد';
@@ -1075,10 +1062,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get version => 'إصدار';
 
   @override
-  String get cast => 'إرسال';
+  String get cast => 'يقذف';
 
   @override
-  String get trailer => 'الإعلان التشويقي';
+  String get trailer => 'جَرَّار';
 
   @override
   String get finished => 'انتهى';
@@ -1193,7 +1180,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get subtitleTrack => 'مسار الترجمة';
 
   @override
-  String get none => 'بدون';
+  String get none => 'لا أحد';
 
   @override
   String get downloadSubtitlesLabel => 'تحميل ترجمات...';
@@ -1271,13 +1258,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get director => 'مخرج';
 
   @override
-  String get directors => 'المخرجون';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'الكاتب';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'الكتّاب';
+  String get writers => 'الكتاب';
 
   @override
   String get studio => 'استوديو';
@@ -1312,12 +1299,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count مسار',
-      many: '$count مسارًا',
-      few: '$count مسارات',
-      two: 'مساران',
-      zero: 'لا توجد مسارات',
-      one: 'مسار واحد',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1327,12 +1310,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count فصل',
-      many: '$count فصلًا',
-      few: '$count فصول',
-      two: 'فصلان',
-      zero: 'لا توجد فصول',
-      one: 'فصل واحد',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1359,16 +1338,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get readMore => 'اقرأ المزيد';
 
   @override
-  String get shuffle => 'تشغيل عشوائي';
+  String get shuffle => 'خلط';
 
   @override
-  String get shuffleAllMusic => 'تشغيل كل الموسيقى عشوائيًا';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'سجّل الدخول إلى Moonfin من هاتفك';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'تعذّر الوصول إلى الخادم';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1380,11 +1359,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count قناة';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'أحادي';
+  String get mono => 'كثرة الوحيدات';
 
   @override
   String get stereo => 'ستيريو';
@@ -1465,7 +1444,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get unavailable => 'غير متاح';
 
   @override
-  String get pause => 'إيقاف مؤقت';
+  String get pause => 'يوقف';
 
   @override
   String get syncPosition => 'موقف المزامنة';
@@ -1504,7 +1483,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get longPressToUnlock => 'اضغط لفترة طويلة لفتح';
 
   @override
-  String get off => 'إيقاف';
+  String get off => 'عن';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1539,7 +1518,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get subtitleDelay => 'تأخير الترجمة';
 
   @override
-  String get reset => 'إعادة تعيين';
+  String get reset => 'إعادة ضبط';
 
   @override
   String get unknown => 'مجهول';
@@ -1566,7 +1545,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get transcodeReasons => 'أسباب التحويل';
 
   @override
-  String get player => 'المشغّل';
+  String get player => 'لاعب';
 
   @override
   String get container => 'حاوية';
@@ -1590,7 +1569,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoBitrate => 'معدل البت للفيديو';
 
   @override
-  String get track => 'المسار';
+  String get track => 'مسار';
 
   @override
   String get channels => 'القنوات';
@@ -1804,22 +1783,22 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'التالي: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'متبقٍ $minutes د';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'متبقٍ $hours س';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'متبقٍ $hours س $minutes د';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1841,7 +1820,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get favoriteChannel => 'القناة المفضلة';
 
   @override
-  String get record => 'تسجيل';
+  String get record => 'سِجِلّ';
 
   @override
   String get cancelRecordingAction => 'إلغاء التسجيل';
@@ -1856,10 +1835,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get unableToCreateRecording => 'غير قادر على إنشاء التسجيل';
 
   @override
-  String get watch => 'مشاهدة';
+  String get watch => 'يشاهد';
 
   @override
-  String get close => 'إغلاق';
+  String get close => 'يغلق';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1941,7 +1920,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'نوع حساب Seerr';
+  String get seerrAccountType => 'نوع حساب السير';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2023,7 +2002,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'م$season ح$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2047,7 +2026,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'م$number';
+    return 'S$number';
   }
 
   @override
@@ -2066,12 +2045,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count حلقة',
-      many: '$count حلقة',
-      few: '$count حلقات',
-      two: 'حلقتان',
-      zero: 'لا توجد حلقات',
-      one: 'حلقة واحدة',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2298,7 +2273,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'صفحات التفاصيل وصفوف الرئيسية ومستوى الصوت';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2312,10 +2287,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'العب عند تصفح الشاشة الرئيسية';
 
   @override
-  String get loopThemeMusic => 'تكرار الموسيقى التعريفية';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'تكرار المسار بدلًا من تشغيله مرة واحدة';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'تفاصيل طمس الخلفية';
@@ -2338,23 +2314,23 @@ class AppLocalizationsAr extends AppLocalizations {
   String get playerZoomMode => 'وضع تكبير المشغل';
 
   @override
-  String get settingsScrollWheelAction => 'عجلة تمرير الماوس';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'اختر ما تفعله عجلة الماوس عند التمرير فوق الفيديو أثناء التشغيل.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'إيقاف';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'التنقل (تقديم / إرجاع)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'مستوى الصوت';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'مستوى الصوت';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'ملائم';
@@ -2369,7 +2345,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get refreshRateSwitching => 'تبديل معدل التحديث';
 
   @override
-  String get disabled => 'معطّل';
+  String get disabled => 'عاجز';
 
   @override
   String get scaleOnTv => 'مقياس على شاشة التلفزيون';
@@ -2408,37 +2384,37 @@ class AppLocalizationsAr extends AppLocalizations {
   String get defaultAudioLanguage => 'لغة الصوت الافتراضية';
 
   @override
-  String get fallbackAudioLanguage => 'لغة الصوت الاحتياطية';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'تفضيل مسار الصوت الافتراضي';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'تفضيل مسار الصوت الأصلي على الدبلجة المحلية.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'تفضيل مسارات الوصف الصوتي';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'تفضيل مسارات الوصف الصوتي على المسارات العادية.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'إعادة ترميز (الصوت)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'بث مباشر (إعادة تغليف)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'إعادة ترميز (معدل البت أو الدقة)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'إعادة ترميز (الفيديو والصوت)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'إعادة ترميز (الفيديو)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'تلقائي (الخادم الافتراضي)';
@@ -2519,7 +2495,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'اختر طريقة فك ترميز الصوت. يرسل وضع AVR Passthrough تدفقات Dolby/DTS الخام إلى جهاز الاستقبال، بينما يفك الوضع التلقائي أو المزج التنازلي الترميز محليًا.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'عبور AVR';
@@ -2529,13 +2505,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'حدّد التنسيق الهدف لإعادة ترميز الصوت متعدد القنوات عندما يتعذّر تشغيل تدفق المصدر مباشرةً أو تمريره.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'اكتشاف تلقائي\n(موصى به)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(افتراضي)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2544,50 +2520,50 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(بلا فقدان)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ستيريو فقط)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(فعّال)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(بلا فقدان)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'الحد الأقصى لقنوات الصوت';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'اضبط الحد الأقصى لقنوات نظامك الصوتي. سيتم مزج التدفقات متعددة القنوات التي تتجاوز هذا الحد أو إعادة ترميزها.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'اكتشاف تلقائي\n(افتراضي العتاد)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 أحادي';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ستيريو';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 محيطي';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 رباعي';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 محيطي';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 محيطي';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 محيطي';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 محيطي';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'العبور (متقدم)';
@@ -2668,11 +2644,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'المتحدث';
 
   @override
-  String get settingsAudioRouteHeadphones => 'سماعات الرأس';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count قناة PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2757,7 +2733,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value ث';
+    return '${value}s';
   }
 
   @override
@@ -2848,45 +2824,45 @@ class AppLocalizationsAr extends AppLocalizations {
   String get subtitleCustomizationDescription => 'تخصيص مظهر الترجمة';
 
   @override
-  String get subtitleMode => 'وضع الترجمة';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'المُعلَّمة';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'دائمًا';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'الأجنبية';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'المفروضة';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'يشغّل المسارات المُعلَّمة داخليًا في بيانات ملف الوسائط على أنها \"افتراضية\" أو \"مفروضة\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'يحمّل الترجمات ويعرضها تلقائيًا في كل مرة يبدأ فيها الفيديو.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'يفعّل الترجمات تلقائيًا إذا كان مسار الصوت الافتراضي بلغة أجنبية.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'يحمّل الترجمات المُعلَّمة صراحةً بعلامة \"مفروضة\" فقط.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'يعطّل التحميل التلقائي للترجمات تمامًا.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'لغة الترجمة الاحتياطية';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'مسار الترجمة';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'يقفز الثعلب البني السريع فوق الكلب الكسول';
@@ -3090,10 +3066,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showLibrariesInToolbar => 'إظهار المكتبات في شريط الأدوات';
 
   @override
-  String get navbarAlwaysExpanded => 'توسيع تسميات شريط التنقل دائمًا';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'عرض زر Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'عتامة نافبار';
@@ -3167,18 +3143,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showFolderBrowsingOption => 'إظهار خيار تصفح المجلد';
 
   @override
-  String get groupItemsIntoCollections => 'تجميع العناصر في مجموعات';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'إخفاء عناصر المكتبة المرتبطة بمجموعة عند تصفّح المكتبات';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'تنبيه بشأن تجميع المكتبة';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'لاستخدام هذا الإعداد، تأكّد من تفعيل إعدادَي المكتبة \"تجميع الأفلام في مجموعات\" و/أو \"تجميع المسلسلات في مجموعات\" ضمن إعدادات العرض لمكتبتك على خادم Jellyfin أو Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'رؤية المكتبة';
@@ -3237,13 +3213,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'اختر من بين أنماط متنوعة لشريط الوسائط، أو قم بإيقاف تشغيل شريط الوسائط';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'مونفين';
 
   @override
   String get mediaBarModeMakd => 'ماكد';
 
   @override
-  String get mediaBarModeOff => 'إيقاف';
+  String get mediaBarModeOff => 'عن';
 
   @override
   String get enableMediaBar => 'تمكين شريط الوسائط';
@@ -3290,11 +3266,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'تشغيل المقطورات تلقائيًا في شريط الوسائط بعد 3 ثوانٍ';
 
   @override
-  String get trailerAudio => 'صوت المقاطع الدعائية';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'تفعيل الصوت للمقاطع الدعائية في شريط الوسائط';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'معاينة الحلقة';
@@ -3370,11 +3345,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get combineBothRows => 'ادمج كلا الصفين في قسم رئيسي واحد';
 
   @override
-  String get fullScreenRows => 'صفوف الرئيسية الموسّعة';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'قصر صفوف الرئيسية على صف واحد لكل شاشة';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'نوع الصورة لكل صف';
@@ -3389,7 +3363,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get lastUser => 'المستخدم الأخير';
 
   @override
-  String get currentUser => 'المستخدم الحالي';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'المصادقة دائما';
@@ -3447,7 +3421,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get enableBuiltInScreensaver => 'تمكين شاشة التوقف المدمجة';
 
   @override
-  String get mode => 'الوضع';
+  String get mode => 'وضع';
 
   @override
   String get libraryArt => 'فن المكتبة';
@@ -3493,10 +3467,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get displayClockDuringScreensaver => 'عرض الساعة أثناء شاشة التوقف';
 
   @override
-  String get clockModeStatic => 'ثابت';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'مرتد';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'الطماطم الفاسدة (النقاد)';
@@ -3505,7 +3479,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get rottenTomatoesAudience => 'الطماطم الفاسدة (الجمهور)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'شجونه';
 
   @override
   String get tmdb => 'TMDB';
@@ -3517,7 +3491,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get metacriticUser => 'ميتاكريتيك (مستخدم)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'تراكت';
 
   @override
   String get letterboxd => 'ليتربوكسد';
@@ -3566,7 +3540,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'تمكين وإعادة ترتيب مصادر التقييم المعروضة في التطبيق';
 
   @override
-  String get pluginLabel => 'إضافة Moonbase';
+  String get pluginLabel => 'البرنامج المساعد';
 
   @override
   String get pluginDetected => 'تم اكتشاف البرنامج المساعد';
@@ -3638,18 +3612,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get networks => 'الشبكات';
 
   @override
-  String get seerrDiscoveryRows => 'صفوف استكشاف Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
       'إعادة تعيين الصفوف إلى الإعدادات الافتراضية';
 
   @override
-  String get enableSeerr => 'تفعيل Seerr';
+  String get enableSeerr => 'تمكين السير';
 
   @override
   String get showSeerrInNavigation =>
-      'عرض Seerr في شريط التنقل (يتطلب إضافة الخادم)';
+      'إظهار Serr في التنقل (يتطلب مكونًا إضافيًا للخادم)';
 
   @override
   String get seerrUnavailable =>
@@ -3662,26 +3636,28 @@ class AppLocalizationsAr extends AppLocalizations {
   String get hideAdultContent => 'إخفاء محتوى البالغين في النتائج';
 
   @override
-  String get seerrNotificationsSection => 'الإشعارات';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'إشعارات الطلبات الجديدة';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => 'تنبيهي عندما يقدّم أحدهم طلبًا';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'تحديثات الطلبات';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'المقبولة والمرفوضة والمضافة إلى مكتبتك';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'تحديثات المشكلات';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'المشكلات الجديدة والردود والحلول';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3689,18 +3665,18 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'صفحة استكشاف Seerr';
+  String get discoverRows => 'اكتشف الصفوف';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'فعّل الصفوف التي تريد رؤيتها في صفحة Seerr الرئيسية. اسحب لإعادة الترتيب. تتم مزامنة الترتيب المخصص مع Moonbase.';
+      'اسحب لإعادة الترتيب. تمكين أو تعطيل الصفوف. يتم مزامنة ترتيب الصفوف الممكّن مع المكون الإضافي Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'فعّل الصفوف التي تريد رؤيتها في صفحة Seerr الرئيسية. اسحب لإعادة الترتيب. تتم مزامنة الترتيب المخصص مع Moonbase.';
+      'اسحب لإعادة الترتيب. تمكين أو تعطيل الصفوف.';
 
   @override
-  String get enabled => 'مفعّل';
+  String get enabled => 'ممكّن';
 
   @override
   String get hidden => 'مختفي';
@@ -3809,7 +3785,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'حجم الملصق، نوع الصورة، عرض المجلد';
 
   @override
-  String get mdbListTmdbRatingSources => 'MDBList وTMDB ومصادر التقييم';
+  String get mdbListTmdbRatingSources => 'قائمة MDB وTMDB ومصادر التصنيف';
 
   @override
   String gbValue(String value) {
@@ -3831,7 +3807,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get imageCacheCleared => 'تم مسح ذاكرة التخزين المؤقت للصور';
 
   @override
-  String get clear => 'مسح';
+  String get clear => 'واضح';
 
   @override
   String get browse => 'تصفح';
@@ -3847,11 +3823,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'جارٍ التحميل · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'جارٍ الاستيراد';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3859,7 +3835,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'إعدادات Seerr';
+  String get seerrSettings => 'إعدادات السير';
 
   @override
   String get requestMore => 'اطلب المزيد';
@@ -3955,7 +3931,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showMore => 'عرض المزيد';
 
   @override
-  String get appearances => 'الظهور';
+  String get appearances => 'المظاهر';
 
   @override
   String get crewSection => 'طاقم';
@@ -3993,146 +3969,148 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deletedStatus => 'تم الحذف';
 
   @override
-  String get failedStatus => 'فشل';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'قيد المعالجة';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'عُدّل بواسطة $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'مكتمل';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'تم طلب هذا العنوان بالفعل';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'تم بلوغ حد الطلبات';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'هذا العنوان محظور';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'لا توجد مواسم متبقية للطلب';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'ليس لديك إذن لتقديم هذا الطلب';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'الطلبات';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'المشكلات';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'الأحدث';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'آخر تعديل';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'لا توجد مشكلات';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'متبقٍ $remaining من أصل $limit من طلبات الأفلام';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'متبقٍ $remaining من أصل $limit من طلبات المواسم';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'جزء من $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'عرض المجموعة';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'طلب المجموعة';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total فيلم · $available متاح';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'طلب $count فيلم';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'جارٍ طلب $current من $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'تم طلب $count فيلم';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'تم طلب $ok من أصل $total فيلم';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'جميع الأفلام متاحة أو مطلوبة بالفعل';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'الإبلاغ عن مشكلة';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'فيديو';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'صوت';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'ما المشكلة؟';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'كل الحلقات';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'حلقة';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'مفتوحة';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'محلولة';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'حل';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'إعادة فتح';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'أبلغ عنها $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count تعليق';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'أضف تعليقًا';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'حذف هذه المشكلة؟';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'إرسال البلاغ';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'نقاط TMDB';
@@ -4165,7 +4143,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get access => 'وصول';
 
   @override
-  String get add => 'إضافة';
+  String get add => 'يضيف';
 
   @override
   String get address => 'عنوان';
@@ -4189,10 +4167,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get disable => 'إبطال';
 
   @override
-  String get done => 'تم';
+  String get done => 'منتهي';
 
   @override
-  String get edit => 'تعديل';
+  String get edit => 'يحرر';
 
   @override
   String get encoding => 'الترميز';
@@ -4201,7 +4179,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get error => 'خطأ';
 
   @override
-  String get forward => 'تقديم';
+  String get forward => 'إلى الأمام';
 
   @override
   String get general => 'عام';
@@ -4249,7 +4227,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get refresh => 'ينعش';
 
   @override
-  String get remote => 'التحكم عن بُعد';
+  String get remote => 'بعيد';
 
   @override
   String get rename => 'إعادة تسمية';
@@ -4267,7 +4245,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get run => 'يجري';
 
   @override
-  String get search => 'بحث';
+  String get search => 'يبحث';
 
   @override
   String get select => 'يختار';
@@ -4285,7 +4263,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get status => 'حالة';
 
   @override
-  String get stop => 'إيقاف';
+  String get stop => 'قف';
 
   @override
   String get streaming => 'جاري';
@@ -4294,7 +4272,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get time => 'وقت';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'خدعة';
 
   @override
   String get uninstall => 'إلغاء التثبيت';
@@ -4312,7 +4290,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get unmute => 'إلغاء كتم الصوت';
 
   @override
-  String get mute => 'كتم الصوت';
+  String get mute => 'صامت';
 
   @override
   String get branding => 'العلامة التجارية';
@@ -4336,25 +4314,25 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminDrawerLibraries => 'المكتبات';
 
   @override
-  String get adminDrawerDisplay => 'العرض';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'البيانات الوصفية';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'إعدادات NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'تحويل الشفرة';
 
   @override
-  String get adminDrawerResume => 'استئناف';
+  String get adminDrawerResume => 'سيرة ذاتية';
 
   @override
   String get adminDrawerStreaming => 'جاري';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'خدعة';
 
   @override
   String get adminDrawerDevices => 'الأجهزة';
@@ -4524,7 +4502,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get sessionRewind => 'الترجيع';
 
   @override
-  String get sessionForward => 'تقديم';
+  String get sessionForward => 'إلى الأمام';
 
   @override
   String get sessionNext => 'التالي';
@@ -4542,7 +4520,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get nowPlaying => 'التشغيل الآن';
 
   @override
-  String get volume => 'مستوى الصوت';
+  String get volume => 'مقدار';
 
   @override
   String get actions => 'الإجراءات';
@@ -4569,10 +4547,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminClearDates => 'تواريخ واضحة';
 
   @override
-  String get adminActivitySeverityAll => 'كل مستويات الخطورة';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'النطاق الزمني';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4609,23 +4587,23 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'إزالة الجهاز \'$name\'؟ سيحتاج المستخدم إلى تسجيل الدخول مرة أخرى على هذا الجهاز.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'حذف كل الأجهزة';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'إزالة $count جهاز؟ سيحتاج المستخدمون المتأثرون إلى تسجيل الدخول مرة أخرى. جهازك الحالي غير متأثر.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'تمت إزالة الأجهزة';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'تمت إزالة بعض الأجهزة، وتعذّر إزالة $count منها.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4741,244 +4719,244 @@ class AppLocalizationsAr extends AppLocalizations {
       'على سبيل المثال الولايات المتحدة، ألمانيا، فرنسا';
 
   @override
-  String get adminLibraryTabPaths => 'المسارات';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'الخيارات';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'أدوات التحميل';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'أدوات حفظ البيانات الوصفية';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'أدوات تحميل الترجمات';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'أدوات تحميل كلمات الأغاني';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'أدوات تحميل البيانات الوصفية: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'أدوات جلب الصور: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'لا يوفّر هذا الخادم أي أدوات تحميل لهذا النوع من المكتبات.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'عام';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'البيانات الوصفية';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'المعلومات المضمّنة';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'الترجمات';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'الصور';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'المسلسلات';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'الموسيقى';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'الأفلام';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'تفعيل المراقبة الفورية';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'اكتشاف تغييرات الملفات ومعالجتها تلقائيًا.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'معاملة الأرشيفات كملفات وسائط';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'عرض الصور';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'حفظ الصور الفنية في مجلدات الوسائط';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'التحديث التلقائي للبيانات الوصفية';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'أبدًا';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'افتراضي';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'العرض';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'عرض المكتبة';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'عرض واجهة المجلدات لإظهار مجلدات الوسائط العادية';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'عرض الحلقات الخاصة ضمن المواسم التي عُرضت فيها';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'تجميع الأفلام في مجموعات';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'تجميع المسلسلات في مجموعات';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'عرض المحتوى الخارجي ضمن الاقتراحات';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'سلوك تاريخ الإضافة';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'استخدام تاريخ الإضافة من';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'تاريخ فحص العنصر وإضافته إلى المكتبة';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'تاريخ إنشاء الملف';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'البيانات الوصفية والصور';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'لغة البيانات الوصفية المفضّلة';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'الفصول';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'مدة الفصل الوهمي (بالثواني)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'مدة الفصول التي تُنشأ للوسائط التي لا تحتوي على فصول. اضبطها على 0 للتعطيل.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'دقة صور الفصول';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'إعدادات NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'بيانات NFO الوصفية متوافقة مع Kodi والتطبيقات المشابهة. تنطبق الإعدادات على جميع المكتبات التي تحفظ بيانات NFO الوصفية.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'المستخدم الذي تُحفظ بيانات مشاهدته في ملفات NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'حفظ مسارات الصور داخل ملفات NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'تفعيل استبدال المسارات لمسارات صور NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
-  String get adminLibExtraThumbs => 'نسخ صور extrafanart إلى مجلد extrathumbs';
+  String get adminLibExtraThumbs =>
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'لا شيء';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days يومًا';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'استخدام العناوين المضمّنة';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'استخدام العناوين المضمّنة للإضافات';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'استخدام معلومات الحلقات المضمّنة';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'السماح بالترجمات المضمّنة';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'السماح بالكل';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'النصية فقط';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'الصورية فقط';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'لا شيء';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'تخطي التحميل عند وجود ترجمات مضمّنة';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'تخطي التحميل إذا كان مسار الصوت مطابقًا للغة التحميل';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'اشتراط تطابق تام للترجمة';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => 'حفظ الترجمات في مجلدات الوسائط';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'استخراج صور الفصول';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'استخراج صور الفصول أثناء فحص المكتبة';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'تفعيل استخراج صور Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'استخراج صور Trickplay أثناء فحص المكتبة';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'حفظ صور Trickplay في مجلدات الوسائط';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'دمج المسلسلات الموزّعة على عدة مجلدات تلقائيًا';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'اسم عرض الموسم صفر';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'تفعيل فحص LUFS لتسوية مستوى الصوت';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'تفضيل وسم الفنانين غير القياسي';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'إضافة الأفلام إلى المجموعات تلقائيًا';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'اسم المكتبة مطلوب';
@@ -5216,144 +5194,143 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminEnableAllChannels => 'تمكين الوصول إلى كافة القنوات';
 
   @override
-  String get adminParentalControl => 'الرقابة الأبوية';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'الحد الأقصى المسموح به للتصنيف العمري';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'سيُخفى المحتوى ذو التصنيف الأعلى عن هذا المستخدم.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'لا شيء';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'حظر العناصر التي لا تحمل معلومات تصنيف أو التي تحمل تصنيفًا غير معروف';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'الكتب';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'القنوات';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'البث التلفزيوني المباشر';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'الأفلام';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'الموسيقى';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'الإعلانات التشويقية';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'المسلسلات';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'جداول الوصول';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'السماح بالوصول خلال الأوقات المجدولة أدناه فقط. يُسمح بالوصول طوال اليوم عند عدم ضبط أي جدول.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'إضافة جدول';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'اليوم';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'البداية';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'النهاية';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'كل يوم';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'أيام الأسبوع';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'عطلة نهاية الأسبوع';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'الأحد';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'الاثنين';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'الثلاثاء';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'الأربعاء';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'الخميس';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'الجمعة';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'السبت';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'الوسوم المسموح بها';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'يُعرض المحتوى الذي يحمل هذه الوسوم فقط. اتركه فارغًا للسماح بالكل.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'الوسوم المحظورة';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'يُخفى المحتوى الذي يحمل هذه الوسوم عن هذا المستخدم.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'إضافة وسم';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'الأجهزة المُفعّلة';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'القنوات المُفعّلة';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'موفّر المصادقة';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'موفّر إعادة تعيين كلمة المرور';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'الحد الأقصى لمحاولات تسجيل الدخول الفاشلة قبل الحظر';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'اضبطها على 0 للقيمة الافتراضية، أو على -1 لتعطيل الحظر.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'الوصول إلى SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'السماح بإنشاء المجموعات والانضمام إليها';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'السماح بالانضمام إلى المجموعات';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'لا يوجد وصول';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'السماح بحذف المحتوى من';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5440,25 +5417,25 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'إنشاء نسخة احتياطية';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'اختر ما تريد تضمينه في النسخة الاحتياطية.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'قاعدة البيانات';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'مُضمّنة دائمًا';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'البيانات الوصفية';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'الترجمات';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'صور Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'جارٍ إنشاء نسخة احتياطية...';
@@ -5883,7 +5860,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminTrickplaySaved => 'تم حفظ إعدادات Trickplay';
 
   @override
-  String get adminTrickplayLoadFailed => 'فشل تحميل إعدادات Trickplay';
+  String get adminTrickplayLoadFailed => 'فشل تحميل إعدادات الخدعة';
 
   @override
   String get adminEnableHardwareAcceleration => 'تمكين تسريع الأجهزة';
@@ -6155,60 +6132,60 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminAddTuner => 'أضف موالف';
 
   @override
-  String get adminEditTuner => 'تعديل الموالف';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'موالف M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ملف أو URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'عنوان IP للموالف';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'الاسم الظاهر';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'وكيل المستخدم';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'حد الاتصالات المتزامنة';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'الحد الأقصى لعدد عمليات البث التي يسمح بها الموالف في وقت واحد. اضبطه على 0 لجعله بلا حدود.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'الحد الأقصى الاحتياطي لمعدل بت البث';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'استيراد القنوات المفضلة فقط';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'السماح بتحويل الشفرة بالعتاد';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'السماح بحاوية تحويل الشفرة fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'السماح بمشاركة البث';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'تفعيل تكرار البث';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'تجاهل DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'قراءة المُدخل بمعدل الإطارات الأصلي';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'تعديل الموفّر';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6217,50 +6194,50 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ملف أو URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'بادئة الأفلام';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'فئات الأفلام';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'افصل بين الفئات المتعددة بشَرطة عمودية.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'فئات الأطفال';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'فئات الأخبار';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'فئات الرياضة';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'اسم المستخدم';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'كلمة المرور';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'الدولة';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'اختر دولة';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'الرمز البريدي';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'جلب القوائم';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'القوائم';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'تفعيل جميع الموالفات';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'نوع الموالف';
@@ -6302,7 +6279,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'لا يدعم هذا النوع من الموالفات إعادة الضبط.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6325,43 +6302,43 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminSeriesRecordingPath => 'مسار تسجيل السلسلة';
 
   @override
-  String get adminMovieRecordingPath => 'مسار تسجيل الأفلام';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'أيام بيانات الدليل';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'تلقائي';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days يومًا';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'مسار تطبيق المعالجة اللاحقة';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'معاملات المعالج اللاحق';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'حفظ بيانات NFO الوصفية للتسجيلات';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'حفظ صور التسجيلات';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'التوقيت';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'مسارات التسجيل';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'المعالجة اللاحقة';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'بيانات الدليل: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6402,14 +6379,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminGuideProviders => 'مقدمو الدليل';
 
   @override
-  String get adminRefreshGuideData => 'تحديث بيانات الدليل';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'بدأ تحديث بيانات الدليل';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'مهمة تحديث الدليل غير متوفرة على هذا الخادم.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'إضافة موفر';
@@ -6490,13 +6467,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminLiveTvTitle => 'إدارة البث التلفزيوني المباشر';
 
   @override
-  String get adminApply => 'تطبيق';
+  String get adminApply => 'يتقدم';
 
   @override
   String get adminNotSet => 'لم يتم ضبطه';
 
   @override
-  String get adminReset => 'إعادة تعيين';
+  String get adminReset => 'إعادة ضبط';
 
   @override
   String get adminLogsTitle => 'سجلات الخادم';
@@ -6542,7 +6519,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminMetadataEditorTitle => 'محرر البيانات الوصفية';
 
   @override
-  String get adminMetadataIdentify => 'تحديد الهوية';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'يكتب';
@@ -6557,7 +6534,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminMetadataImages => 'الصور';
 
   @override
-  String get adminMetadataFieldTitle => 'العنوان';
+  String get adminMetadataFieldTitle => 'عنوان';
 
   @override
   String get adminMetadataFieldSortTitle => 'فرز العنوان';
@@ -6823,7 +6800,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'إزالة';
+  String get adminReposRemove => 'يزيل';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6954,19 +6931,19 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminBrandingEnableSplash => 'تمكين شاشة البداية';
 
   @override
-  String get adminBrandingSplashUpload => 'رفع صورة';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'تم تحديث شاشة البداية';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'فشل رفع شاشة البداية';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'تمت إزالة شاشة البداية';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'لا توجد شاشة بداية مخصّصة';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'تسريع الأجهزة';
@@ -6981,127 +6958,121 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'تمكين فك تشفير الأجهزة لـ:';
 
   @override
-  String get adminPlaybackQsvDevice => 'جهاز QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'تفعيل مفكك ترميز NVDEC المحسّن';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'تفضيل مفكك الترميز العتادي الأصلي للنظام';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'عمق ألوان فك الترميز بالعتاد';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'فك ترميز HEVC بعمق 10 بت';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'فك ترميز VP9 بعمق 10 بت';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'فك ترميز HEVC RExt بعمق 8/10 بت';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'فك ترميز HEVC RExt بعمق 12 بت';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'الترميز بالعتاد';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'السماح بترميز HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'السماح بترميز AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'تفعيل مُرمِّز H.264 منخفض الطاقة من Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'تفعيل مُرمِّز HEVC منخفض الطاقة من Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'تعيين درجات الألوان';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'تفعيل تعيين درجات الألوان';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'تفعيل تعيين درجات الألوان بـVPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'تفعيل تعيين درجات الألوان بـVideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'خوارزمية تعيين درجات الألوان';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'وضع تعيين درجات الألوان';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'نطاق تعيين درجات الألوان';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'إزالة تشبّع تعيين درجات الألوان';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ذروة تعيين درجات الألوان';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'مُعامل تعيين درجات الألوان';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'سطوع تعيين درجات الألوان بـVPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'تباين تعيين درجات الألوان بـVPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'الإعدادات المسبقة والجودة';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'الإعداد المسبق للمُرمِّز';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'قيمة CRF لترميز H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'قيمة CRF لترميز H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'طريقة إزالة التشابك';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'مضاعفة معدل الإطارات عند إزالة التشابك';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'الصوت';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'تفعيل ترميز الصوت بمعدل بت متغير (VBR)';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'تعزيز خفض مزج الصوت';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'خوارزمية خفض المزج إلى ستيريو';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'الحد الأقصى لحجم طابور المزج';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'تلقائي';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'الترميز';
@@ -7219,10 +7190,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminTaskNeverRun => 'لا تركض أبدًا';
 
   @override
-  String get adminTaskStop => 'إيقاف';
+  String get adminTaskStop => 'قف';
 
   @override
-  String get adminRunningTasks => 'المهام قيد التشغيل';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'يجري';
@@ -7292,12 +7263,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ساعة',
-      many: '$count ساعة',
-      few: '$count ساعات',
-      two: 'ساعتان',
-      one: 'ساعة واحدة',
-      zero: '$count ساعة',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7343,17 +7310,17 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes د';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours س';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days ي';
+    return '${days}d';
   }
 
   @override
@@ -7363,7 +7330,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'اضبط إنشاء صور Trickplay لمعاينات التقديم المصغّرة.';
+      'قم بتكوين إنشاء الصور الخادعة للبحث عن الصور المصغرة للمعاينة.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'منفذ HTTPS العام';
@@ -7378,43 +7345,43 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'منفذ HTTP العام';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'اشتراط HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'إعادة توجيه جميع الطلبات البعيدة إلى HTTPS. لا تأثير لذلك إذا لم يكن لدى الخادم شهادة صالحة.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'كلمة مرور الشهادة';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'إعدادات IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'تفعيل IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'تفعيل IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'تفعيل التعيين التلقائي للمنافذ';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'شبكات LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'قائمة بعناوين IP أو شبكات CIDR الفرعية، مفصولة بفواصل أو أسطر، تُعامَل على أنها ضمن الشبكة المحلية.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'عناوين URI المنشورة للخادم';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'عيّن شبكة فرعية أو عنوانًا إلى URL منشور، مثال: all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'مسار الشهادة';
@@ -7444,11 +7411,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'خنق التخزين المؤقت';
 
   @override
-  String get adminPlaybackThrottleDelay => 'مهلة التقييد (بالثواني)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'السماح باستخراج الترجمات أثناء التشغيل';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'الحد الأدنى لنسبة السيرة الذاتية';
@@ -7505,23 +7472,22 @@ class AppLocalizationsAr extends AppLocalizations {
       'عتبة الاستجابة البطيئة (مللي ثانية)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'تفعيل تحذيرات الاستجابة البطيئة';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'تفعيل Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'الخادم';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'البيانات الوصفية';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'المسارات';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'الأداء';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'مسار ذاكرة التخزين المؤقت';
@@ -7533,7 +7499,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminGeneralServerName => 'اسم الخادم';
 
   @override
-  String get adminGeneralDisplayLanguage => 'لغة العرض المفضّلة';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'فشل تحميل الإعدادات';
@@ -7585,12 +7551,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# مشارك',
-      many: '# مشاركًا',
-      few: '# مشاركين',
-      two: '# مشاركان',
-      one: '# مشارك',
-      zero: '# مشاركين',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7736,12 +7698,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'تم اكتشاف # صف',
-      many: 'تم اكتشاف # صفًا',
-      few: 'تم اكتشاف # صفوف',
-      two: 'تم اكتشاف # صفّين',
-      one: 'تم اكتشاف # صف',
-      zero: 'تم اكتشاف # صفوف',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7782,20 +7740,20 @@ class AppLocalizationsAr extends AppLocalizations {
   String get offlineSavedMedia => 'الوسائط المحفوظة';
 
   @override
-  String get offlineBannerTitle => 'أنت غير متصل بالإنترنت';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'عرض التحميلات الخاصة بك';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'التحميلات';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'تعذّر الوصول إلى الخادم';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'التشغيل من التحميلات حتى عودة الخادم';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7869,40 +7827,39 @@ class AppLocalizationsAr extends AppLocalizations {
   String get pinForgot => 'هل نسيت رقم التعريف الشخصي؟';
 
   @override
-  String get pinClear => 'مسح';
+  String get pinClear => 'واضح';
 
   @override
   String get pinBackspace => 'مسافة للخلف';
 
   @override
-  String get quickConnectAuthorized => 'تمت الموافقة على طلب Quick Connect.';
+  String get quickConnectAuthorized => 'طلب الاتصال السريع معتمد.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'رمز Quick Connect غير صالح أو منتهي الصلاحية.';
+      'رمز الاتصال السريع غير صالح أو منتهي الصلاحية.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect غير مدعوم على هذا الخادم.';
+      'الاتصال السريع غير مدعوم على هذا الخادم.';
 
   @override
-  String get quickConnectAuthorizeFailed =>
-      'تعذّرت الموافقة على رمز Quick Connect.';
+  String get quickConnectAuthorizeFailed => 'فشل في اعتماد رمز الاتصال السريع.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect معطّل على هذا الخادم.';
+  String get quickConnectDisabled => 'تم تعطيل الاتصال السريع على هذا الخادم.';
 
   @override
   String get quickConnectForbidden =>
-      'لا يمكن لحسابك الموافقة على طلب Quick Connect هذا.';
+      'لا يمكن لحسابك السماح بطلب الاتصال السريع هذا.';
 
   @override
   String get quickConnectNotFound =>
-      'لم يُعثر على رمز Quick Connect. جرّب رمزًا جديدًا.';
+      'لم يتم العثور على رمز الاتصال السريع. جرب رمزًا جديدًا.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'فشل Quick Connect: $message';
+    return 'فشل الاتصال السريع: $message';
   }
 
   @override
@@ -8006,7 +7963,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shuffleSelectGenre => 'حدد النوع';
 
   @override
-  String get shuffleLibrary => 'المكتبة';
+  String get shuffleLibrary => 'مكتبة';
 
   @override
   String get shuffleGenre => 'النوع';
@@ -8066,7 +8023,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get stillWatchingContent => 'تم إيقاف التشغيل مؤقتًا. هل مازلت تشاهد؟';
 
   @override
-  String get stillWatchingStop => 'إيقاف';
+  String get stillWatchingStop => 'قف';
 
   @override
   String get stillWatchingContinue => 'يكمل';
@@ -8126,7 +8083,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'السماح بالتناوب';
 
   @override
-  String get playerTooltipPrevious => 'السابق';
+  String get playerTooltipPrevious => 'سابق';
 
   @override
   String get playerTooltipSeekBack => 'اطلب العودة';
@@ -8150,13 +8107,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get contextMenuGoToSeries => 'اذهب إلى السلسلة';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'إخفاء من مواصلة المشاهدة';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'إخفاء من التالي';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'إضافة إلى مجموعة';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'الوصول إلى لوحة إدارة الخادم';
@@ -8210,14 +8168,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsAlphabetical => 'أبجديا';
 
   @override
-  String get settingsConnectionSection => 'الاتصال';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'السماح بالشهادات الموقّعة ذاتيًا';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'الوثوق بالخوادم التي تستخدم شهادات TLS موقّعة ذاتيًا أو صادرة عن مرجع خاص. فعّل هذا الخيار للخوادم التي تتحكم بها فقط. يؤدي ذلك إلى تعطيل التحقق من الشهادات لجميع الاتصالات.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'الخصوصية والأمان';
@@ -8233,11 +8191,11 @@ class AppLocalizationsAr extends AppLocalizations {
       'لهجات السمات والخلفيات والمؤشرات التي تمت مشاهدتها وموسيقى السمات';
 
   @override
-  String get settingsDetailsScreen => 'شاشة التفاصيل';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'النمط وتمويه الخلفية وسلوك علامات التبويب';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'الصفحة الرئيسية';
@@ -8275,11 +8233,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'إظهار زر Seerr في شريط التنقل';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'إظهار التسميات النصية دائمًا في شريط التنقل العلوي';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8380,12 +8338,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# إشعار ترخيص',
-      many: '# إشعار ترخيص',
-      few: '# إشعارات ترخيص',
-      two: '# إشعارا ترخيص',
-      one: '# إشعار ترخيص',
-      zero: '# إشعارات ترخيص',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8431,16 +8385,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'تخطي المقدمات والنهايات؟';
 
   @override
-  String get settingsMediaSegmentCountdown => 'العد التنازلي لمقاطع الوسائط';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'شريط التقدم';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'المؤقّت';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'بدون';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'المستخدم الفوري';
@@ -8665,7 +8619,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'صدر حديثًا في $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8698,11 +8652,11 @@ class AppLocalizationsAr extends AppLocalizations {
       'فرض التشغيل غير النفقي. مفيد على الأجهزة التي بها انقطاعات في الصوت/الفيديو.';
 
   @override
-  String get enableTunnelingTitle => 'تفعيل النفق';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'متقدم. يوجّه الصوت والفيديو عبر مسار عتادي مقترن. مُعطّل افتراضيًا لأنه يسبب انقطاعات في الصوت والفيديو على بعض الأجهزة.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8728,14 +8682,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'قم بتطبيق تلميحات حجم الخط المضمنة في مسار الترجمة. قم بتعطيل استخدام حجم الترجمة من تفضيلات النمط الخاص بك.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'إظهار تفاصيل الوسائط';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'إظهار تفاصيل العنصر المحدد في أعلى صفحات المكتبة.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'إخفاء الخلفيات أثناء التصفح؟';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'استخدم العناوين الفرعية التفصيلية';
@@ -8753,37 +8707,37 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'متجر السمات';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'تصفّح سمات المجتمع واحفظها';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'احفظ سمة لاستخدامها مثل سماتك المحفوظة الأخرى.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'لا تتوفر أي سمات في الوقت الحالي.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'تعذّر تحميل متجر السمات. تحقق من اتصالك وحاول مرة أخرى.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'حفظ';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'حفظ وتطبيق';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'تم الحفظ';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'تعذّر تحميل هذه السمة.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'تم حفظ \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8840,21 +8794,21 @@ class AppLocalizationsAr extends AppLocalizations {
   String get homeRowsSection => 'صفوف المنزل';
 
   @override
-  String get homeRowDisplay => 'عرض صفوف الرئيسية';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'أقسام صفوف الرئيسية';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'مفاتيح صفوف الرئيسية';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'تفعيل أو تعطيل فئات صفوف الرئيسية المستندة إلى المكتبات';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'فعّل المفاتيح التالية لعرض الصفوف في أقسام الرئيسية.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'نوع الصفوف';
@@ -8913,55 +8867,55 @@ class AppLocalizationsAr extends AppLocalizations {
       'عرض الأفلام أو المسلسلات أو كليهما في صفوف الأنواع.';
 
   @override
-  String get displayPlaylistsRows => 'عرض صفوف قوائم التشغيل';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'إظهار صفوف قوائم التشغيل في أقسام الرئيسية.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'ترتيب صفوف قوائم التشغيل';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'رتّب صفوف قوائم التشغيل حسب تاريخ الإضافة أو تاريخ الإصدار أو أبجديًا وغير ذلك.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'عرض صفوف الصوت';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'إظهار صفوف الصوت في أقسام الرئيسية.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ترتيب صفوف الصوت';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'رتّب صفوف الصوت حسب تاريخ الإضافة أو تاريخ الإصدار أو أبجديًا وغير ذلك.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'قوائم تشغيل الصوت';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'المظهر';
+  String get appearance => 'مظهر';
 
   @override
-  String get layout => 'التخطيط';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'السمة';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'لوحة المفاتيح';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'الأزرار';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'التصيير';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'تهيئة MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'حجم البطاقة';
@@ -8971,7 +8925,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'عيّن مشغّلاً خارجيًا لتفعيل خيار التشغيل بالضغط المطوّل';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9232,10 +9186,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get guestAppearances => 'ظهورات الضيوف';
 
   @override
-  String get appearancesSeerr => 'الظهور (Seerr)';
+  String get appearancesSeerr => 'المظاهر (العراف)';
 
   @override
-  String get crewContributionsSeerr => 'مساهمات طاقم العمل (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'شاهد مع المجموعة';
@@ -9319,12 +9273,8 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count مكتبة',
-      many: '$count مكتبة',
-      few: '$count مكتبات',
-      two: 'مكتبتان',
-      zero: 'لا توجد مكتبات',
-      one: 'مكتبة واحدة',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9415,7 +9365,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mixedMoviesAndShows => 'أفلام وعروض مختلطة';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'إنتل مزامنة سريعة';
 
   @override
   String get rockchipMpp => 'روكشيب MPP';
@@ -9482,13 +9432,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get loadingShuffle => 'جارٍ التحميل العشوائي...';
 
   @override
-  String get libraryShuffleLabel => 'تشغيل عشوائي للمكتبة';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'تشغيل عشوائي';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'تشغيل عشوائي حسب النوع';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'التبديل التلقائي لتقنية HDR';
@@ -9501,221 +9451,222 @@ class AppLocalizationsAr extends AppLocalizations {
   String get whenFullscreen => 'عندما ملء الشاشة';
 
   @override
-  String get changeArtwork => 'تغيير الصور الفنية';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'مفقود';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'حدود تحويل الترميز';
 
   @override
-  String get clearAllArtworkButton => 'مسح جميع الصور الفنية؟';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'هل أنت متأكد أنك تريد مسح جميع الصور الفنية التي تم تحميلها؟';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'تأكيد المسح';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'هل أنت متأكد أنك تريد مسح $itemType؟';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'رفع؟';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'الدقة: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => 'إظهار الصور الفنية بلغة الواجهة فقط';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'تأكيد مسح الكل';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'تم رفع الصورة بنجاح!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'تعذّر رفع الصورة: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'تعذّر تعيين الصورة: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'تعذّر حذف الصورة: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'تعذّر مسح جميع الصور الفنية: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'نعم';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'ملصق';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'خلفيات';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'لافتة';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'شعار';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'صورة مصغّرة';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'صورة فنية';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'صورة القرص';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'لقطة شاشة';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'غلاف العلبة';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'غلاف العلبة الخلفي';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'صورة القائمة';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'الملصق';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'الخلفية';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'اللافتة';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'الشعار';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'الصورة المصغّرة';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'الصورة الفنية';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'صورة القرص';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'لقطة الشاشة';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'غلاف العلبة';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'غلاف العلبة الخلفي';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'صورة القائمة';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'الكل';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'عالية (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'متوسطة (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'منخفضة (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'المصادر';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'الفصول';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'الإشارات المرجعية';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'الملاحظات';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'قائمة الانتظار';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'المخطط الزمني';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'المخطط الزمني فارغ';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'الكتاب كاملاً';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'المخطط الزمني المركّز';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'تصدير الإشارات المرجعية';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'تصدير الملاحظات';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'تصدير الكل';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'تم التصدير إلى $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'فشل التصدير: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'الكلمات';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'إضافة إشارة مرجعية';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'إضافة ملاحظة';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'تعديل الملاحظة';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'اكتب ملاحظة لهذه اللحظة';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'مؤقّت النوم';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'إيقاف';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'نهاية الفصل';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'مخصص';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'متبقٍ $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9723,62 +9674,58 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count دقيقة',
-      many: '$count دقيقة',
-      few: '$count دقائق',
-      two: 'دقيقتان',
-      zero: '$count دقيقة',
-      one: 'دقيقة واحدة',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'سرعة التشغيل';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'المتبقي';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'المنقضي';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'للخلف $seconds ث';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'للأمام $seconds ث';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'الفصل السابق';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'الفصل التالي';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'الفصل $current من $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'لا توجد فصول';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'لا توجد إشارات مرجعية بعد';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'لا توجد ملاحظات بعد';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'تمت إضافة إشارة مرجعية عند $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'إعادة الضبط إلى 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9786,249 +9733,249 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'حفظ';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'إلغاء';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'حذف';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'تفضيلات الترجمة';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'غيّر أوضاع الترجمة واللغات الافتراضية والمظهر وخيارات التصيير.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'تصيير الترجمة';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'خيارات العرض';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'تاريخ الإصدار (تصاعديًا)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'تاريخ الإصدار (تنازليًا)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'تجميع المساهمات';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'تجميع الأدوار المتعددة';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'تحذير بشأن صلاحية الكتابة في المكتبة';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'كيفية إصلاح ذلك:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. امنح صلاحيات الكتابة لمستخدم خدمة Jellyfin (مثل jellyfin أو PUID/PGID في Docker) على مجلدات مكتبة الوسائط في الخادم.\n\n2. أو انتقل إلى لوحة تحكم Jellyfin ← المكتبات، وعدّل هذه المكتبة، وعطّل خيار \'حفظ الصور الفنية في مجلدات الوسائط\' لتخزين الصور الفنية في قاعدة بيانات Jellyfin الداخلية.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'تجاهل';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'مكتبة \'$libraryName\' مضبوطة على حفظ الصور الفنية مباشرة في مجلدات الوسائط (خيار \'حفظ الصور الفنية في مجلدات الوسائط\' مُفعّل). لكن Jellyfin اختبر صلاحية الكتابة ولا يملك إذنًا بكتابة الملفات في هذا المجلد:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'يبدو أن Jellyfin فشل في تحديث الصور الفنية. مكتبتك مضبوطة على حفظ الصور الفنية مباشرة في مجلدات الوسائط (خيار \'حفظ الصور الفنية في مجلدات الوسائط\' مُفعّل). يحدث هذا الخطأ عادةً عندما لا يملك خادم Jellyfin إذنًا بكتابة الملفات في مجلدات الوسائط.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'القوائم الخارجية';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'إعادة التشغيل';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'معلومات الملف';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'الحجم: $size  •  الصيغة: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'إظهار جميع مسارات الصوت ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'إظهار جميع مسارات الترجمة ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'جارٍ التحقق من إمكانية التشغيل المباشر...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'إمكانية التشغيل المباشر: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'إجباري';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'صيغة الحاوية غير مدعومة من المشغّل.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'مرمّز الفيديو غير مدعوم.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'مرمّز الصوت غير مدعوم.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'صيغة الترجمة غير مدعومة (تتطلب الدمج).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'الملف التعريفي للصوت غير مدعوم.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'الملف التعريفي للفيديو غير مدعوم.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'مستوى الفيديو غير مدعوم.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'دقة الفيديو غير مدعومة على هذا الجهاز.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'عمق ألوان الفيديو غير مدعوم.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'معدل إطارات الفيديو غير مدعوم.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'معدل بت الملف يتجاوز حد البث في المشغّل.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'معدل بت الفيديو يتجاوز حد البث.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'معدل بت الصوت يتجاوز حد البث.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioChannelsNotSupported => 'عدد قنوات الصوت غير مدعوم.';
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'أبجديًا';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'ترتيب الإصدار (تصاعديًا)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'ترتيب الإصدار (تنازليًا)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'مخصص (سحب وإفلات)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'خيارات ترتيب قائمة التشغيل';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'إعادة ضبط الترتيب';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'إعادة مشاهدة م$season:ح$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'إعادة مشاهدة قائمة التشغيل';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'لم يُعثر على ترجمات.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'أدوات المسؤول';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'محرك التصيير (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller هو محرك التصيير الحديث في Flutter الذي يعتمد على GPU لحركات أكثر سلاسة وتقطّع أقل. قد يسبب خللاً في الصورة أو فيديو أسود على بعض أجهزة التلفزيون وبطاقات GPU الأقدم؛ اضبطه على إيقاف إذا واجهت ذلك. يختار الوضع التلقائي أفضل إعداد افتراضي لجهازك. أعد تشغيل Moonfin للتطبيق.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'تلقائي';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'تشغيل';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'إيقاف';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'يلزم إعادة التشغيل';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'يحتاج Moonfin إلى إعادة التشغيل لتغيير محرك التصيير. أغلق التطبيق الآن ثم أعد فتحه للتطبيق.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'إغلاق التطبيق الآن';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'تحديث المكتبة';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'تحديث جميع المكتبات';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'تاريخ الإضافة (الأقدم أولاً)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'تاريخ الإضافة (الأحدث أولاً)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'أبجديًا (من A إلى Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'أبجديًا (من Z إلى A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'جارٍ تحميل تحليلات الخادم... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'مطابقة المصدر';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'أفضل 250 فيلمًا على IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'أفضل 250 مسلسلاً على IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'أكثر الأفلام شعبية على IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'أكثر المسلسلات شعبية على IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'الأفلام الأقل تقييمًا على IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'أفضل الأفلام الإنجليزية تقييمًا على IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -9,22 +9,22 @@ class AppLocalizationsBe extends AppLocalizations {
   AppLocalizationsBe([String locale = 'be']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Месяцовы плаўнік';
 
   @override
-  String get accountPreferences => 'НАЛАДЫ ЎЛІКОВАГА ЗАПІСУ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Мова інтэрфейсу';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Як у сістэме';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Увайдзіце';
 
   @override
-  String get empty => 'Пуста';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Хуткае падключэнне';
 
   @override
   String get password => 'Пароль';
@@ -113,7 +113,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get cancel => 'Адмяніць';
 
   @override
-  String get remove => 'Прыбраць';
+  String get remove => 'Зняць';
 
   @override
   String get connectToServer => 'Падлучыцца да сервера';
@@ -141,62 +141,62 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsAppearanceTheme => 'Тэма прыкладання';
 
   @override
-  String get detailScreenStyle => 'Стыль экрана звестак';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '«Класічны» — арыгінальная цэнтраваная кампаноўка Moonfin. «Сучасны» — адаптыўная кінематаграфічная кампаноўка.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Класічны';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Сучасны';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Разгорнутыя ўкладкі';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Аўтаматычна паказваць змесціва ўкладак пры пераглядзе. Выключыце, каб адкрываць і закрываць кожную ўкладку ўручную.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Паказваць тэхнічныя звесткі?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Паказваць кодэк, раздзяляльнасць і звесткі пра паток у кароткім апісанні банера';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Сістэма рэкамендацый';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Выкарыстоўвайце алгарытм лакальнай бібліятэкі «Moonfin рэкамендуе» або сеціўныя метрыкі падабенства TMDb. Заўвага: сеціўныя рэкамендацыі патрабуюць інтэграцыі з Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin рэкамендуе';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Падабенства TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Ужываць абмежаванне па ўзроставым рэйтынгу?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Абмяжоўваць прапановы «Moonfin рэкамендуе» паводле ўзроставага рэйтынгу выбранага медыя';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стыль інтэрфейсу';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '«Аўтаматычна» адпавядае вашай прыладзе. Выберыце Apple або Material, каб задаць выгляд прымусова.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Аўтаматычна';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsBe extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Якасць шкла';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '«Аўта» выбірае найлепшы эфект шкла для гэтай прылады. «Поўная» уключае сапраўднае размыццё, «Зніжаная» выкарыстоўвае лёгкае шкло, якое эканоміць рэсурсы GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Аўта';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Поўная';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Зніжаная';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Пераключайцеся паміж Moonfin і Neon Pulse без перазапуску праграмы';
 
   @override
-  String get customThemeTitle => 'Уласная тэма';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Уласныя тэмы змяняюць візуальныя элементы ва ўсім Moonfin. Выберыце адзін з варыянтаў пад свой густ.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Аддаць перавагу сістэмнай клавіятуры';
@@ -239,7 +239,7 @@ class AppLocalizationsBe extends AppLocalizations {
       'Для ўводу тэксту па змаўчанні выкарыстоўвайце метад уводу сваёй прылады';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Месяцовы плаўнік';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsBe extends AppLocalizations {
       'Стыль Synthwave з пурпурным ззяннем, блакітным тэкстам і больш моцным храмаваным кантрастам';
 
   @override
-  String get themeGlass => 'Шкло';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Аздабленне ў стылі вадкага шкла з плыўным градыентным фонам, матавымі паверхнямі і сінім акцэнтам Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-бітны герой';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Рэтра-аздабленне ў стылі піксель-арт з грубай палітрай, блочнымі рамкамі, рэзкімі ценямі і піксельным шрыфтом';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,35 +327,35 @@ class AppLocalizationsBe extends AppLocalizations {
   String get exit => 'Выхад';
 
   @override
-  String get gameMenu => 'Меню';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Паўза';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Захаваць стан';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Гульні';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Загрузіць стан';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Паскарэнне';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Налады эмулятара';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Гэтае ядро не мае наладжвальных параметраў.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Утрымлівайце, каб адкрыць меню';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Гульні пакуль не падтрымліваюцца на гэтай прыладзе.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Не ўдалося загрузіць хатнія радкі';
@@ -377,13 +377,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get schedule => 'Расклад';
 
   @override
-  String get series => 'Серыялы';
+  String get series => 'серыял';
 
   @override
   String get noItemsFound => 'Элементы не знойдзены';
 
   @override
-  String get home => 'Галоўная';
+  String get home => 'дадому';
 
   @override
   String get browseAll => 'Праглядзець усе';
@@ -506,7 +506,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get albumArtists => 'Выканаўцы альбома';
 
   @override
-  String get artists => 'Выканаўцы';
+  String get artists => 'Мастакі';
 
   @override
   String get bookmarks => 'Закладкі';
@@ -602,7 +602,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get listen => 'Слухай';
 
   @override
-  String get resume => 'Працягнуць';
+  String get resume => 'Рэзюмэ';
 
   @override
   String get failedToLoadLibrary => 'Не ўдалося загрузіць бібліятэку';
@@ -746,13 +746,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get readStatus => 'Прачытайце';
 
   @override
-  String get watched => 'Прагледжана';
+  String get watched => 'Глядзеў';
 
   @override
   String get unread => 'Непрачытанае';
 
   @override
-  String get unwatched => 'Непрагледжана';
+  String get unwatched => 'Непрагледжаны';
 
   @override
   String get seriesStatus => 'Статус серыі';
@@ -764,45 +764,43 @@ class AppLocalizationsBe extends AppLocalizations {
   String get books => 'Кнігі';
 
   @override
-  String get latestBooks => 'Апошнія кнігі';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Апошнія аўдыякнігі';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count кнігі',
-      many: '$count кніг',
-      few: '$count кнігі',
-      one: '$count кніга',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Кніга';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аўдыякніга';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Прачытана $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Засталося $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Чытаць';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слухаць';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Аўтар';
@@ -879,10 +877,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аўдыякнігі',
-      many: '$count аўдыякніг',
-      few: '$count аўдыякнігі',
-      one: '$count аўдыякніга',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -918,7 +914,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get nextUp => 'Далей';
 
   @override
-  String get seasons => 'Сезоны';
+  String get seasons => 'Поры года';
 
   @override
   String get chapters => 'раздзелы';
@@ -985,10 +981,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Сезона',
-      many: '$count Сезонаў',
-      few: '$count Сезоны',
-      one: '$count Сезон',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -999,40 +993,40 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get items => 'Элементы';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Дадаткі';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'За кадрам';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Выдаленыя сцэны';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Кароткія сюжэты';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Інтэрв\'ю';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцэны';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Кароткаметражкі';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Трэйлеры';
 
   @override
   String timeRemaining(String time) {
-    return 'Засталося $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Скончыцца праз $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1050,7 +1044,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get play => 'Прайграць';
+  String get play => 'гуляць';
 
   @override
   String get startOver => 'Пачаць спачатку';
@@ -1074,7 +1068,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get version => 'Версія';
 
   @override
-  String get cast => 'Трансляваць';
+  String get cast => 'У ролях';
 
   @override
   String get trailer => 'Трэйлер';
@@ -1269,13 +1263,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get director => 'ДЫРЭКТАР';
 
   @override
-  String get directors => 'РЭЖЫСЁРЫ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЭНАРЫСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЭНАРЫСТЫ';
+  String get writers => 'ПІСЬМЕННІКІ';
 
   @override
   String get studio => 'СТУДЫЯ';
@@ -1310,10 +1304,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count трэка',
-      many: '$count трэкаў',
-      few: '$count трэкі',
-      one: '$count трэк',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1323,10 +1315,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count раздзела',
-      many: '$count раздзелаў',
-      few: '$count раздзелы',
-      one: '$count раздзел',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1353,16 +1343,16 @@ class AppLocalizationsBe extends AppLocalizations {
   String get readMore => 'Больш падрабязна';
 
   @override
-  String get shuffle => 'Перамяшаць';
+  String get shuffle => 'Ператасаваць';
 
   @override
-  String get shuffleAllMusic => 'Перамяшаць усю музыку';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Увайдзіце ў Moonfin на тэлефоне';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Не ўдаецца звязацца з серверам';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1374,7 +1364,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count кан.';
+    return '${count}ch';
   }
 
   @override
@@ -1499,7 +1489,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get longPressToUnlock => 'Доўгі націск, каб разблакіраваць';
 
   @override
-  String get off => 'Выкл.';
+  String get off => 'Выкл';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1522,12 +1512,12 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value мс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value мс';
+    return '+${value}ms';
   }
 
   @override
@@ -1561,7 +1551,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get transcodeReasons => 'Прычыны перакадзіравання';
 
   @override
-  String get player => 'Прайгравальнік';
+  String get player => 'Гулец';
 
   @override
   String get container => 'Кантэйнер';
@@ -1585,7 +1575,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get videoBitrate => 'Бітрэйт відэа';
 
   @override
-  String get track => 'Дарожка';
+  String get track => 'Трэк';
 
   @override
   String get channels => 'Каналы';
@@ -1802,22 +1792,22 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Далей: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Засталося $minutes хв';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Засталося $hours гадз';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Засталося $hours гадз $minutes хв';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1840,7 +1830,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get favoriteChannel => 'Любімы канал';
 
   @override
-  String get record => 'Запісаць';
+  String get record => 'Запіс';
 
   @override
   String get cancelRecordingAction => 'Адмяніць запіс';
@@ -1858,7 +1848,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get watch => 'Глядзець';
 
   @override
-  String get close => 'Закрыць';
+  String get close => 'Блізка';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1892,7 +1882,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get no => 'Не';
+  String get no => 'няма';
 
   @override
   String get yesCancel => 'Так, адмяніць';
@@ -2023,7 +2013,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Э$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2047,7 +2037,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2066,10 +2056,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count эпізода',
-      many: '$count эпізодаў',
-      few: '$count эпізоды',
-      one: '$count эпізод',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2296,7 +2284,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Старонкі звестак, радкі на галоўнай і гучнасць';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2311,18 +2299,18 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прайграванне падчас прагляду галоўнага экрана';
 
   @override
-  String get loopThemeMusic => 'Паўтараць музычную тэму';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Прайграваць трэк цыклічна, а не адзін раз';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Размыццё фону дэталяў';
 
   @override
   String pixelValue(int value) {
-    return '$value пкс';
+    return '${value}px';
   }
 
   @override
@@ -2338,23 +2326,23 @@ class AppLocalizationsBe extends AppLocalizations {
   String get playerZoomMode => 'Рэжым маштабавання прайгравальніка';
 
   @override
-  String get settingsScrollWheelAction => 'Кола пракруткі мышы';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Выберыце, што робіць пракрутка кола мышы над відэа падчас прайгравання.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Выкл.';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Перамотка (наперад / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Гучнасць';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Гучнасць';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Прыстасаваны';
@@ -2369,7 +2357,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get refreshRateSwitching => 'Пераключэнне частоты абнаўлення';
 
   @override
-  String get disabled => 'Адключана';
+  String get disabled => 'Інваліды';
 
   @override
   String get scaleOnTv => 'Шкала на ТБ';
@@ -2408,39 +2396,37 @@ class AppLocalizationsBe extends AppLocalizations {
   String get defaultAudioLanguage => 'Мова гуку па змаўчанні';
 
   @override
-  String get fallbackAudioLanguage => 'Рэзервовая мова аўдыё';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Аддаваць перавагу стандартнай аўдыядарожцы';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Аддаваць перавагу арыгінальнай аўдыядарожцы замест лакалізаванага дубляжу.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'Аддаваць перавагу дарожкам з аўдыяапісаннем';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Аддаваць перавагу дарожкам з аўдыяапісаннем замест звычайных.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскадаванне (аўдыё)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Прамы паток (рэмультыплексаванне)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскадаванне (бітрэйт або раздзяляльнасць)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскадаванне (відэа і аўдыё)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскадаванне (відэа)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Аўта (па змаўчанні сервера)';
@@ -2521,7 +2507,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Выберыце, як дэкадуецца гук. Транзіт праз AVR адпраўляе неапрацаваныя патокі Dolby/DTS на ваш рэсівер, а «Аўта» і «Звядзенне» дэкадуюць лакальна.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Праходжанне AVR';
@@ -2531,14 +2517,13 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Выберыце фармат для транскадавання шматканальнага гуку, калі зыходны паток нельга прайграць напрамую або перадаць транзітам.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Аўтавызначэнне\n(рэкамендуецца)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(стандартна)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2547,51 +2532,50 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(без страт)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(толькі стэрэа)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(эканомны)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(без страт)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максімум аўдыяканалаў';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Задайце максімальную колькасць каналаў вашай аўдыясістэмы. Шматканальныя патокі звыш гэтага ліміту будуць зведзены або транскадаваны.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Аўтавызначэнне\n(стандарт абсталявання)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Мона';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Стэрэа';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Аб\'ёмны гук';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Квадрафанічны';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Аб\'ёмны гук';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Аб\'ёмны гук';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Аб\'ёмны гук';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Аб\'ёмны гук';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Праходжанне (пашыраны)';
@@ -2610,7 +2594,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsAudioEac3JocPassthrough => 'Праход EAC3 JOC (Atmos).';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Транзіт ядра DTS';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'Праходжанне DTS-HD MA';
@@ -2672,11 +2656,11 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Дакладчык';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Навушнікі';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count кан. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2761,7 +2745,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value с';
+    return '${value}s';
   }
 
   @override
@@ -2850,45 +2834,45 @@ class AppLocalizationsBe extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Наладзьце выгляд субтытраў';
 
   @override
-  String get subtitleMode => 'Рэжым субтытраў';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Пазначаныя';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Заўсёды';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Замежныя';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Прымусовыя';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Прайграе дарожкі, пазначаныя ў метаданых медыяфайла як «default» або «forced».';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Аўтаматычна загружае і паказвае субтытры пры кожным запуску відэа.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Аўтаматычна ўключае субтытры, калі стандартная аўдыядарожка на замежнай мове.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Загружае толькі субтытры з яўнай пазнакай forced у метаданых.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Цалкам адключае аўтаматычную загрузку субтытраў.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Рэзервовая мова субтытраў';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Паток субтытраў';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3095,11 +3079,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказаць бібліятэкі на панэлі інструментаў';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Заўсёды паказваць подпісы панэлі навігацыі';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Паказваць кнопку Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Непразрыстасць панэлі навігацыі';
@@ -3174,19 +3157,18 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showFolderBrowsingOption => 'Паказаць параметр прагляду тэчак';
 
   @override
-  String get groupItemsIntoCollections => 'Групаваць элементы ў калекцыі';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Хаваць элементы бібліятэкі, звязаныя з калекцыямі, пры праглядзе бібліятэк';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Заўвага пра групаванне бібліятэкі';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Каб выкарыстоўваць гэтую наладу, пераканайцеся, што ў наладах адлюстравання вашай бібліятэкі на серверы Jellyfin або Emby ўключаны параметры «Групаваць фільмы ў калекцыі» і/або «Групаваць серыялы ў калекцыі».';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Бачнасць бібліятэкі';
@@ -3245,13 +3227,13 @@ class AppLocalizationsBe extends AppLocalizations {
       'Выбірайце паміж рознымі стылямі медыяпанэлі або адключайце медыяпанэль';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Месяцовы плаўнік';
 
   @override
   String get mediaBarModeMakd => 'МакД';
 
   @override
-  String get mediaBarModeOff => 'Выкл.';
+  String get mediaBarModeOff => 'Выкл';
 
   @override
   String get enableMediaBar => 'Уключыць медыяпанэль';
@@ -3298,10 +3280,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Аўтаматычнае прайграванне трэйлераў на панэлі мультымедыя праз 3 секунды';
 
   @override
-  String get trailerAudio => 'Гук трэйлераў';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Уключыць гук трэйлераў у медыяпанэлі';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Папярэдні прагляд эпізоду';
@@ -3379,11 +3361,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Аб\'яднайце абодва шэрагу ў адну хатнюю секцыю';
 
   @override
-  String get fullScreenRows => 'Разгорнутыя радкі галоўнай';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Паказваць не больш за адзін радок галоўнай на экран';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тып выявы ў радку';
@@ -3398,7 +3379,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get lastUser => 'Апошні карыстальнік';
 
   @override
-  String get currentUser => 'Бягучы карыстальнік';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Заўсёды правяраць сапраўднасць';
@@ -3506,10 +3487,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказаць гадзіннік падчас застаўкі';
 
   @override
-  String get clockModeStatic => 'Нерухомы';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Скачучы';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (крытыкі)';
@@ -3530,7 +3511,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get metacriticUser => 'Metacritic (Карыстальнік)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'Letterboxd';
@@ -3581,7 +3562,7 @@ class AppLocalizationsBe extends AppLocalizations {
       'Уключыце і змяніце парадак крыніц рэйтынгаў, паказаных ва ўсім дадатку';
 
   @override
-  String get pluginLabel => 'Плагін Moonbase';
+  String get pluginLabel => 'Убудова';
 
   @override
   String get pluginDetected => 'Убудова выяўлены';
@@ -3652,7 +3633,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get networks => 'Сеткі';
 
   @override
-  String get seerrDiscoveryRows => 'Радкі агляду Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Скінуць радкі да значэнняў па змаўчанні';
@@ -3675,27 +3656,28 @@ class AppLocalizationsBe extends AppLocalizations {
   String get hideAdultContent => 'Схаваць змесціва для дарослых у выніках';
 
   @override
-  String get seerrNotificationsSection => 'Апавяшчэнні';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Апавяшчэнні пра новыя запыты';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Паведамляць, калі хтосьці адпраўляе запыт';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Абнаўленні запытаў';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Ухвалена, адхілена і дададзена ў вашу бібліятэку';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Абнаўленні праблем';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Новыя праблемы, адказы і рашэнні';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3703,15 +3685,15 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Старонка агляду Seerr';
+  String get discoverRows => 'Адкрыйце для сябе радкі';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Уключыце радкі, якія трэба паказваць на галоўнай старонцы Seerr. Перацягвайце, каб змяніць парадак. Уласны парадак сінхранізуецца з Moonbase.';
+      'Перацягнуць, каб змяніць парадак. Уключыць або выключыць радкі. Уключаны парадак радкоў сінхранізуецца з убудовай Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Уключыце радкі, якія трэба паказваць на галоўнай старонцы Seerr. Перацягвайце, каб змяніць парадак. Уласны парадак сінхранізуецца з Moonbase.';
+      'Перацягнуць, каб змяніць парадак. Уключыць або выключыць радкі.';
 
   @override
   String get enabled => 'Уключана';
@@ -3831,7 +3813,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value ГБ';
+    return '$value GB';
   }
 
   @override
@@ -3849,7 +3831,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get imageCacheCleared => 'Кэш відарысаў ачышчаны';
 
   @override
-  String get clear => 'Ачысціць';
+  String get clear => 'Ясна';
 
   @override
   String get browse => 'Праглядзіце';
@@ -3865,11 +3847,11 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Спампоўванне · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Імпартаванне';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3973,7 +3955,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showMore => 'Паказаць больш';
 
   @override
-  String get appearances => 'Ролі';
+  String get appearances => 'З\'яўленне';
 
   @override
   String get crewSection => 'Экіпаж';
@@ -4011,146 +3993,148 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deletedStatus => 'Выдалены';
 
   @override
-  String get failedStatus => 'Не ўдалося';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Апрацоўка';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Зменена: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завершана';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Гэтая назва ўжо запытана';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Дасягнуты ліміт запытаў';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Гэтая назва ў чорным спісе';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Не засталося сезонаў для запыту';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'У вас няма дазволу на гэты запыт';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Запыты';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Праблемы';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Найноўшыя';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Апошнія змены';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Няма праблем';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Засталося $remaining з $limit запытаў на фільмы';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Засталося $remaining з $limit запытаў на сезоны';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Уваходзіць у $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Адкрыць калекцыю';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Запытаць калекцыю';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total фільмаў · $available даступна';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Запытаць $count фільмаў';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Запыт $current з $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Запытана $count фільмаў';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Запытана $ok з $total фільмаў';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'Усе фільмы ўжо даступныя або запытаныя';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Паведаміць пра праблему';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Відэа';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Аўдыё';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Што не так?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Усе эпізоды';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Эпізод';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Адкрыта';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Вырашана';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Вырашыць';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Адкрыць зноў';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Паведаміў $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count каментарыяў';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Дадаць каментарый';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Выдаліць гэтую праблему?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Адправіць паведамленне';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Ацэнка TMDB';
@@ -4174,7 +4158,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get originalLanguageLabel => 'Мова арыгінала';
 
   @override
-  String get seasonsLabel => 'Сезоны';
+  String get seasonsLabel => 'Поры года';
 
   @override
   String get episodesLabel => 'Эпізоды';
@@ -4222,7 +4206,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get forward => 'Наперад';
 
   @override
-  String get general => 'Агульныя';
+  String get general => 'Генерал';
 
   @override
   String get go => 'Ідзі';
@@ -4267,7 +4251,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get refresh => 'Абнавіць';
 
   @override
-  String get remote => 'Пульт';
+  String get remote => 'Дыстанцыйнае';
 
   @override
   String get rename => 'Перайменаваць';
@@ -4303,7 +4287,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Спыніць';
+  String get stop => 'Стоп';
 
   @override
   String get streaming => 'Паток';
@@ -4312,7 +4296,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get time => 'Час';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Выкрут';
 
   @override
   String get uninstall => 'Выдаліць';
@@ -4330,7 +4314,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get unmute => 'Уключыць гук';
 
   @override
-  String get mute => 'Без гуку';
+  String get mute => 'Адключыць гук';
 
   @override
   String get branding => 'Брэндынг';
@@ -4354,25 +4338,25 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminDrawerLibraries => 'Бібліятэкі';
 
   @override
-  String get adminDrawerDisplay => 'Адлюстраванне';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метаданыя';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Налады NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Перакадзіроўка';
 
   @override
-  String get adminDrawerResume => 'Працягнуць';
+  String get adminDrawerResume => 'Рэзюмэ';
 
   @override
   String get adminDrawerStreaming => 'Паток';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Выкрут';
 
   @override
   String get adminDrawerDevices => 'прылады';
@@ -4562,7 +4546,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get nowPlaying => 'Зараз іграе';
 
   @override
-  String get volume => 'Гучнасць';
+  String get volume => 'Аб\'ём';
 
   @override
   String get actions => 'Дзеянні';
@@ -4574,7 +4558,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audioCodec => 'Аўдыё кодэк';
 
   @override
-  String get hwAccel => 'Апаратнае паскарэнне';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Завяршэнне';
@@ -4589,10 +4573,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminClearDates => 'Выразныя даты';
 
   @override
-  String get adminActivitySeverityAll => 'Усе ўзроўні';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Дыяпазон дат';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4629,23 +4613,23 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Выдаліць прыладу «$name»? Карыстальніку спатрэбіцца ўвайсці зноў на гэтай прыладзе.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Выдаліць усе прылады';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Выдаліць $count прылад? Закранутым карыстальнікам спатрэбіцца ўвайсці зноў. Вашай бягучай прылады гэта не тычыцца.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Прылады выдалены';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Некаторыя прылады выдалены; $count выдаліць не ўдалося.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4760,252 +4744,244 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminMetadataCountryHint => 'напр. ЗША, Германія, Францыя';
 
   @override
-  String get adminLibraryTabPaths => 'Шляхі';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Параметры';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Спампоўшчыкі';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Захавальнікі метаданых';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Спампоўшчыкі субтытраў';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Спампоўшчыкі тэкстаў песень';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Спампоўшчыкі метаданых: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Крыніцы відарысаў: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Гэты сервер не прапануе спампоўшчыкаў для гэтага тыпу бібліятэкі.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Агульныя';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метаданыя';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Убудаваныя звесткі';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Субтытры';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Відарысы';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Серыялы';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музыка';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Фільмы';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Уключыць маніторынг у рэальным часе';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Выяўляць змены файлаў і апрацоўваць іх аўтаматычна.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Лічыць архівы медыяфайламі';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Паказваць фота';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Захоўваць ілюстрацыі ў медыяпапках';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Аўтаматычнае абнаўленне метаданых';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Ніколі';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Стандартна';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Адлюстраванне';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Адлюстраванне бібліятэкі';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Паказваць выгляд папак для звычайных медыяпапак';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Паказваць спецвыпускі ў сезонах, дзе яны выйшлі';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Групаваць фільмы ў калекцыі';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Групаваць серыялы ў калекцыі';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Паказваць знешняе змесціва ў прапановах';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Паводзіны даты дадання';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Браць дату дадання з';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Дата сканавання ў бібліятэку';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Дата стварэння файла';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метаданыя і відарысы';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Пажаданая мова метаданых';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Раздзелы';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Працягласць фіктыўнага раздзела (секунды)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Даўжыня раздзелаў, якія ствараюцца для медыя без іх. Задайце 0, каб адключыць.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Раздзяляльнасць відарысаў раздзелаў';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Налады NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Метаданыя NFO сумяшчальныя з Kodi і падобнымі кліентамі. Налады прымяняюцца да ўсіх бібліятэк, якія захоўваюць метаданыя NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Карыстальнік, чые звесткі пра прагляд захоўваюцца ў файлах NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Захоўваць шляхі відарысаў у файлах NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Уключыць падмену шляхоў для відарысаў NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Капіраваць відарысы extrafanart у папку extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Няма';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days дзён';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Выкарыстоўваць убудаваныя назвы';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Выкарыстоўваць убудаваныя назвы для дадаткаў';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Выкарыстоўваць убудаваныя звесткі пра эпізоды';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Дазволіць убудаваныя субтытры';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Дазволіць усе';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Толькі тэкставыя';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Толькі відарысы';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Няма';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Прапускаць спампоўку, калі ёсць убудаваныя субтытры';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Прапускаць спампоўку, калі аўдыядарожка адпавядае мове спампоўкі';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Патрабаваць дакладнае супадзенне субтытраў';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Захоўваць субтытры ў медыяпапках';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Здабываць відарысы раздзелаў';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Здабываць відарысы раздзелаў падчас сканавання бібліятэкі';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Уключыць здабыванне відарысаў trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Здабываць відарысы trickplay падчас сканавання бібліятэкі';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Захоўваць відарысы trickplay у медыяпапках';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Аўтаматычна аб\'ядноўваць серыялы, размеркаваныя па некалькіх папках';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Назва нулявога сезона';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Уключыць сканаванне LUFS для нармалізацыі гуку';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Аддаваць перавагу нестандартнаму тэгу выканаўцаў';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Аўтаматычна дадаваць фільмы ў калекцыі';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Увядзіце назву бібліятэкі';
@@ -5244,145 +5220,143 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminEnableAllChannels => 'Уключыць доступ да ўсіх каналаў';
 
   @override
-  String get adminParentalControl => 'Бацькоўскі кантроль';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Максімальны дазволены ўзроставы рэйтынг';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Змесціва з вышэйшым рэйтынгам будзе схавана ад гэтага карыстальніка.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Няма';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блакаваць элементы без рэйтынгу або з нераспазнаным рэйтынгам';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Кнігі';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Каналы';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Жывое тэлебачанне';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Фільмы';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музыка';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трэйлеры';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Серыялы';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Расклады доступу';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Дазваляць доступ толькі ў пазначаны ніжэй час. Калі расклад не зададзены, доступ дазволены цэлы дзень.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Дадаць расклад';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Дзень';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Пачатак';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Канец';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Кожны дзень';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Будні дзень';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Выхадныя';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Нядзеля';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Панядзелак';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Аўторак';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Серада';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Чацвер';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Пятніца';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Субота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Дазволеныя тэгі';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Паказваецца толькі змесціва з гэтымі тэгамі. Пакіньце пустым, каб дазволіць усё.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Заблакаваныя тэгі';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Змесціва з гэтымі тэгамі схавана ад гэтага карыстальніка.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Дадаць тэг';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Уключаныя прылады';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Уключаныя каналы';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Пастаўшчык аўтэнтыфікацыі';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Пастаўшчык скіду пароля';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максімум няўдалых спроб уваходу да блакіроўкі';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Задайце 0 для стандартнага значэння або -1, каб адключыць блакіроўку.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Доступ да SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Дазволіць ствараць групы і далучацца да іх';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Дазволіць далучацца да груп';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Няма доступу';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Дазволіць выдаленне змесціва з';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5469,25 +5443,25 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Стварыць рэзервовую копію';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Выберыце, што ўключыць у рэзервовую копію.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База даных';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Уключаецца заўсёды';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метаданыя';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Субтытры';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Відарысы Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Стварэнне рэзервовай копіі...';
@@ -6032,7 +6006,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminBaseUrl => 'Базавы URL';
 
   @override
-  String get adminBaseUrlHint => 'напр. /jellyfin';
+  String get adminBaseUrlHint => 'напр. /жэле';
 
   @override
   String get https => 'HTTPS';
@@ -6194,64 +6168,60 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminAddTuner => 'Дадаць цюнэр';
 
   @override
-  String get adminEditTuner => 'Змяніць цюнер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Цюнер M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл або URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-адрас цюнера';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Зручная назва';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Ліміт адначасовых злучэнняў';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максімальная колькасць патокаў, якія цюнер дазваляе адначасова. Задайце 0 для неабмежаванай колькасці.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Рэзервовы максімальны бітрэйт патоку';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Імпартаваць толькі выбраныя каналы';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Дазволіць апаратнае транскадаванне';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Дазволіць кантэйнер транскадавання fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Дазволіць сумеснае выкарыстанне патоку';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Уключыць зацыкліванне патоку';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ігнараваць DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Чытаць уваход з зыходнай частатой кадраў';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Змяніць пастаўшчыка';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6260,50 +6230,50 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл або URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Прэфікс фільмаў';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Катэгорыі фільмаў';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Раздзяляйце некалькі катэгорый вертыкальнай рыскай.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Дзіцячыя катэгорыі';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Катэгорыі навін';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Спартыўныя катэгорыі';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Імя карыстальніка';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Пароль';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Краіна';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Выберыце краіну';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Паштовы індэкс';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Атрымаць праграму';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Праграма перадач';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Уключыць усе цюнеры';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тып цюнэра';
@@ -6345,7 +6315,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Гэты тып цюнера не падтрымлівае скід.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6368,43 +6338,43 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Шлях запісу серыі';
 
   @override
-  String get adminMovieRecordingPath => 'Шлях для запісу фільмаў';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Дзён даных праграмы';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Аўтаматычна';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days дзён';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Шлях да праграмы постапрацоўкі';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Аргументы постапрацоўшчыка';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Захоўваць метаданыя NFO для запісаў';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Захоўваць відарысы запісаў';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Час';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Шляхі запісу';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Постапрацоўка';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Даныя праграмы: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6447,14 +6417,14 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminGuideProviders => 'Пастаўшчыкі гідаў';
 
   @override
-  String get adminRefreshGuideData => 'Абнавіць даныя праграмы';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Абнаўленне даных праграмы пачалося';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Задача абнаўлення праграмы недаступная на гэтым серверы.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Дадаць пастаўшчыка';
@@ -6587,7 +6557,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Рэдактар ​​метададзеных';
 
   @override
-  String get adminMetadataIdentify => 'Апазнаць';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тып';
@@ -6870,7 +6840,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Прыбраць';
+  String get adminReposRemove => 'Зняць';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7001,19 +6971,19 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Уключыць застаўку';
 
   @override
-  String get adminBrandingSplashUpload => 'Загрузіць відарыс';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Застаўка абноўлена';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'Не ўдалося загрузіць застаўку';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Застаўка выдалена';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Няма ўласнай застаўкі';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Апаратнае паскарэнне';
@@ -7029,131 +6999,121 @@ class AppLocalizationsBe extends AppLocalizations {
       'Уключыць апаратнае дэкадаванне для:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Прылада QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Уключыць пашыраны дэкодэр NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Аддаваць перавагу сістэмнаму апаратнаму дэкодэру';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Глыбіня колеру апаратнага дэкадавання';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-бітнае дэкадаванне HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-бітнае дэкадаванне VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      '8/10-бітнае дэкадаванне HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      '12-бітнае дэкадаванне HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Апаратнае кадаванне';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Дазволіць кадаванне HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Дазволіць кадаванне AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Уключыць нізкаспажывальны кадавальнік Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Уключыць нізкаспажывальны кадавальнік Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Танальнае адлюстраванне';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'Уключыць танальнае адлюстраванне';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Уключыць танальнае адлюстраванне VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Уключыць танальнае адлюстраванне VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Алгарытм танальнага адлюстравання';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Рэжым танальнага адлюстравання';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange =>
-      'Дыяпазон танальнага адлюстравання';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Дэсатурацыя танальнага адлюстравання';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Пік танальнага адлюстравання';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam =>
-      'Параметр танальнага адлюстравання';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Яркасць танальнага адлюстравання VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Кантраст танальнага адлюстравання VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Прэсеты і якасць';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Прэсет кадавальніка';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF кадавання H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF кадавання H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метад дэінтэрлейсінгу';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Падвойваць частату кадраў пры дэінтэрлейсінгу';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Аўдыё';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Уключыць кадаванне аўдыё VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Узмацненне пры звядзенні аўдыё';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгарытм звядзення ў стэрэа';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максімальны памер чаргі мультыплексавання';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Аўта';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кадзіроўка';
@@ -7273,10 +7233,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminTaskNeverRun => 'Ніколі не бегайце';
 
   @override
-  String get adminTaskStop => 'Спыніць';
+  String get adminTaskStop => 'Стоп';
 
   @override
-  String get adminRunningTasks => 'Задачы, што выконваюцца';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Бегчы';
@@ -7346,10 +7306,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count гадзіны',
-      many: '$count гадзін',
-      few: '$count гадзіны',
-      one: '$count гадзіна',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7395,27 +7353,27 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes хв';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours гадз';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days дз';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Наладзьце генерацыю відарысаў trickplay для эскізаў папярэдняга прагляду пры перамотцы.';
+      'Наладзьце генерацыю відарысаў падману для эскізаў папярэдняга прагляду.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Публічны порт HTTPS';
@@ -7424,50 +7382,49 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Базавы URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'напр. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'напр. /жэле';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Публічны порт HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Патрабаваць HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Перанакіроўваць усе аддаленыя запыты на HTTPS. Не дзейнічае, калі ў сервера няма сапраўднага сертыфіката.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Пароль сертыфіката';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Налады IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Уключыць IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Уключыць IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Уключыць аўтаматычнае супастаўленне портаў';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Сеткі LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Спіс IP-адрасоў або падсетак CIDR праз коску ці з новага радка, якія лічацца лакальнай сеткай.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Апублікаваныя URI сервера';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Супаставіце падсетку або адрас з апублікаваным URL, напр. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Шлях сертыфіката';
@@ -7498,12 +7455,11 @@ class AppLocalizationsBe extends AppLocalizations {
       'Буферызацыя дросельнай засланкі';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Затрымка абмежавання патоку (секунды)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Дазволіць здабыванне субтытраў на ляту';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Мінімальны працэнт рэзюмэ';
@@ -7561,23 +7517,22 @@ class AppLocalizationsBe extends AppLocalizations {
       'Парог павольнай рэакцыі (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Уключыць папярэджанні пра павольны адказ';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Уключыць Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метаданыя';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Шляхі';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Прадукцыйнасць';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Шлях кэша';
@@ -7589,7 +7544,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminGeneralServerName => 'Імя сервера';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Пажаданая мова адлюстравання';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Не ўдалося загрузіць налады';
@@ -7641,10 +7596,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# удзельніка',
-      many: '# удзельнікаў',
-      few: '# удзельнікі',
-      one: '# удзельнік',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7791,10 +7744,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'знойдзена # радка',
-      many: 'знойдзена # радкоў',
-      few: 'знойдзена # радкі',
-      one: 'знойдзены # радок',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7835,20 +7786,20 @@ class AppLocalizationsBe extends AppLocalizations {
   String get offlineSavedMedia => 'Захаваныя носьбіты';
 
   @override
-  String get offlineBannerTitle => 'Вы па-за сеткай';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Паказваем вашы спампоўкі';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Спампоўкі';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Не ўдаецца звязацца з серверам';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Прайграванне са спамповак, пакуль ён не вернецца';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7922,10 +7873,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pinForgot => 'Забыўся PIN-код?';
 
   @override
-  String get pinClear => 'Ачысціць';
+  String get pinClear => 'Ясна';
 
   @override
-  String get pinBackspace => 'Выдаліць';
+  String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized => 'Запыт Quick Connect дазволены.';
@@ -7936,15 +7887,15 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect не падтрымліваецца на гэтым серверы.';
+      'Хуткае злучэнне не падтрымліваецца на гэтым серверы.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Не ўдалося аўтарызаваць код Quick Connect.';
+      'Не ўдалося аўтарызаваць код хуткага злучэння.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect адключаны на гэтым серверы.';
+      'Хуткае падключэнне адключана на гэтым серверы.';
 
   @override
   String get quickConnectForbidden =>
@@ -7952,11 +7903,11 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get quickConnectNotFound =>
-      'Код Quick Connect не знойдзены. Паспрабуйце новы код.';
+      'Код хуткага злучэння не знойдзены. Паспрабуйце новы код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Памылка Quick Connect: $message';
+    return 'Памылка хуткага злучэння: $message';
   }
 
   @override
@@ -8124,7 +8075,7 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прайграванне прыпынена. Вы ўсё яшчэ глядзіце?';
 
   @override
-  String get stillWatchingStop => 'Спыніць';
+  String get stillWatchingStop => 'Стоп';
 
   @override
   String get stillWatchingContinue => 'Працягнуць';
@@ -8209,13 +8160,13 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Схаваць з «Працягнуць прагляд»';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Схаваць з «Далей»';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Дадаць у калекцыю';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8270,15 +8221,14 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsAlphabetical => 'Алфавітны';
 
   @override
-  String get settingsConnectionSection => 'ЗЛУЧЭННЕ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Дазволіць самападпісаныя сертыфікаты';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Давяраць серверам з самападпісанымі сертыфікатамі TLS або сертыфікатамі прыватнага ЦС. Уключайце толькі для сервераў, якімі вы кіруеце. Гэта адключае праверку сертыфікатаў для ўсіх злучэнняў.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'КАНФІДЭНЦЫЯЛЬНАСЦЬ І БЯСПЕКА';
@@ -8294,11 +8244,11 @@ class AppLocalizationsBe extends AppLocalizations {
       'Тэматычныя акцэнты, фоны, назіраныя індыкатары і тэматычная музыка';
 
   @override
-  String get settingsDetailsScreen => 'Экран звестак';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стыль, размыццё фону і паводзіны ўкладак';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Галоўная старонка';
@@ -8336,11 +8286,11 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Паказваць кнопку Seerr на панэлі навігацыі';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Заўсёды паказваць тэкставыя подпісы на верхняй панэлі навігацыі';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8443,10 +8393,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ліцэнзійнай заўвагі',
-      many: '# ліцэнзійных заўваг',
-      few: '# ліцэнзійныя заўвагі',
-      one: '# ліцэнзійная заўвага',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8496,16 +8444,16 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прапусціць уводныя і канчатковыя часткі?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Адлік медыясегмента';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Панэль прагрэсу';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Няма';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Запрасіць карыстальніка';
@@ -8642,7 +8590,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8740,7 +8688,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Нядаўна выйшлі: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8773,11 +8721,11 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прымусовае нетунэляванае прайграванне. Карысна на прыладах з разрывамі тунэлявання аўдыё/відэа.';
 
   @override
-  String get enableTunnelingTitle => 'Уключыць тунэляванне';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Для дасведчаных. Накіроўвае аўдыё і відэа праз звязаны апаратны шлях. Стандартна выключана, бо на некаторых прыладах выклікае перапынкі гуку і відэа.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8804,15 +8752,14 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прымяніць падказкі памеру шрыфта, убудаваныя ў дарожку субтытраў. Адключыце выкарыстанне памеру субтытраў з вашых налад стылю.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Паказваць звесткі пра медыя';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Паказваць звесткі пра выбраны элемент угары старонак бібліятэкі.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Хаваць фонавыя відарысы пры праглядзе?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings =>
@@ -8831,37 +8778,37 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Крама тэм';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Праглядайце і захоўвайце тэмы супольнасці';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Захавайце тэму, каб карыстацца ёй, як іншымі захаванымі тэмамі.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Зараз няма даступных тэм.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Не ўдалося загрузіць Краму тэм. Праверце злучэнне і паспрабуйце зноў.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Захаваць';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Захаваць і ўжыць';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Захавана';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Не ўдалося загрузіць гэтую тэму.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Захавана «$themeName».';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8920,21 +8867,21 @@ class AppLocalizationsBe extends AppLocalizations {
   String get homeRowsSection => 'Хатнія шэрагі';
 
   @override
-  String get homeRowDisplay => 'Адлюстраванне радкоў галоўнай';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Раздзелы радкоў галоўнай';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Пераключальнікі радкоў галоўнай';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Уключыце або адключыце катэгорыі радкоў галоўнай на аснове бібліятэк';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Уключыце наступныя пераключальнікі, каб паказваць радкі ў раздзелах галоўнай.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Тып радкоў';
@@ -8993,56 +8940,55 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказаць фільмы, серыялы або абодва ў радках жанраў.';
 
   @override
-  String get displayPlaylistsRows => 'Паказваць радкі плэйлістоў';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Паказваць радкі плэйлістоў у раздзелах галоўнай.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Сартаванне радкоў плэйлістоў';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Сартуйце радкі плэйлістоў па даце дадання, даце выхаду, алфавіце і іншым.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Паказваць радкі аўдыё';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Паказваць радкі аўдыё ў раздзелах галоўнай.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Сартаванне радкоў аўдыё';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Сартуйце радкі аўдыё па даце дадання, даце выхаду, алфавіце і іншым.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аўдыяплэйлісты';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Знешні выгляд';
 
   @override
-  String get layout => 'Кампаноўка';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тэма';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Клавіятура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Кнопкі';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Рэндэрынг';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Канфігурацыя MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Памер карты';
@@ -9052,7 +8998,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Задайце знешні плэер, каб уключыць прайграванне праз доўгае націсканне';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9322,7 +9268,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get appearancesSeerr => 'З\'яўленне (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Удзел здымачнай групы (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Глядзіце з групай';
@@ -9408,10 +9354,8 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Бібліятэкі',
-      many: '$count Бібліятэк',
-      few: '$count Бібліятэкі',
-      one: '$count Бібліятэка',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9569,13 +9513,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get loadingShuffle => 'Загрузка перамешвання...';
 
   @override
-  String get libraryShuffleLabel => 'ПЕРАМЯШАЦЬ БІБЛІЯТЭКУ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ВЫПАДКОВЫ ПАРАДАК';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ПЕРАМЯШАЦЬ ЖАНРЫ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Аўтаматычнае пераключэнне HDR';
@@ -9588,222 +9532,222 @@ class AppLocalizationsBe extends AppLocalizations {
   String get whenFullscreen => 'У поўнаэкранным рэжыме';
 
   @override
-  String get changeArtwork => 'Змяніць ілюстрацыю';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Адсутнічае';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Абмежаванні перакадавання';
 
   @override
-  String get clearAllArtworkButton => 'Ачысціць усе ілюстрацыі?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Вы сапраўды хочаце ачысціць усе спампаваныя ілюстрацыі?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Пацвердзіць ачыстку';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Вы сапраўды хочаце ачысціць элемент «$itemType»?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Загрузіць?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Раздзяляльнасць: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Паказваць ілюстрацыі толькі на мове інтэрфейсу';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Пацвердзіць ачыстку ўсяго';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Відарыс паспяхова загружаны!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Не ўдалося загрузіць відарыс: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Не ўдалося задаць відарыс: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Не ўдалося выдаліць відарыс: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Не ўдалося ачысціць усе ілюстрацыі: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Так';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Плакат';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Фонавыя відарысы';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Банер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Лагатып';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Эскіз';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Ілюстрацыя';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Ілюстрацыя дыска';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Здымак экрана';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Вокладка';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задняя вокладка';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Ілюстрацыя меню';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'плакат';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'фонавы відарыс';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'банер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'лагатып';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'эскіз';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ілюстрацыя';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ілюстрацыя дыска';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'здымак экрана';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'вокладка';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задняя вокладка';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ілюстрацыя меню';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Усе';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Высокая (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Сярэдняя (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Нізкая (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Крыніцы';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Раздзелы';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Закладкі';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Нататкі';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Чарга';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Шкала часу';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Шкала часу пустая';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Уся кніга';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Сфакусаваная шкала';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Экспартаваць закладкі';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Экспартаваць нататкі';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Экспартаваць усё';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Экспартавана ў $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Не ўдалося экспартаваць: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Тэкст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Дадаць закладку';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Дадаць нататку';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Змяніць нататку';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напішыце нататку для гэтага моманту';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Таймер сну';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Выкл.';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Канец раздзела';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Свой';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Засталося $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9811,58 +9755,58 @@ class AppLocalizationsBe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count хв',
-      one: '1 хв',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Хуткасць прайгравання';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Засталося';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Прайшло';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $seconds с';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Наперад $seconds с';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Папярэдні раздзел';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Наступны раздзел';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Раздзел $current з $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Няма раздзелаў';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Пакуль няма закладак';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Пакуль няма нататак';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Закладка дададзена на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Скінуць да 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9870,254 +9814,249 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Захаваць';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Адмяніць';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Выдаліць';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Налады субтытраў';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Змяніце рэжымы субтытраў, стандартныя мовы, выгляд і параметры адлюстравання.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Адлюстраванне субтытраў';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Параметры адлюстравання';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Дата выхаду (па ўзрастанні)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Дата выхаду (па спаданні)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Групаваць удзел';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Групаваць некалькі роляў';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Папярэджанне пра доступ на запіс у бібліятэку';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Як гэта выправіць:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Дайце дазвол на запіс службоваму карыстальніку Jellyfin (напр., jellyfin або Docker PUID/PGID) для папак вашай медыябібліятэкі на серверы.\n\n2. Або перайдзіце ў Панэль кіравання Jellyfin -> Бібліятэкі, адрэдагуйце гэтую бібліятэку і адключыце «Захоўваць ілюстрацыі ў медыяпапках», каб захоўваць ілюстрацыі ва ўнутранай базе даных Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Закрыць';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Ваша бібліятэка «$libraryName» настроена захоўваць ілюстрацыі непасрэдна ў медыяпапках (уключана «Захоўваць ілюстрацыі ў медыяпапках»). Аднак Jellyfin праверыў доступ на запіс і не мае дазволу запісваць файлы ў гэты каталог:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Здаецца, Jellyfin не змог абнавіць ілюстрацыю. Ваша бібліятэка настроена захоўваць ілюстрацыі непасрэдна ў медыяпапках (уключана «Захоўваць ілюстрацыі ў медыяпапках»). Гэтая памылка звычайна ўзнікае, калі працэс сервера Jellyfin не мае дазволу запісваць файлы ў вашы медыякаталогі.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Знешнія спісы';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Прайграць зноў';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Звесткі пра файл';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Памер: $size  •  Фармат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Паказаць усе аўдыядарожкі ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Паказаць усе дарожкі субтытраў ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Праверка магчымасці прамога прайгравання...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Магчымасць прамога прайгравання: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Прымусовыя';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Фармат кантэйнера не падтрымліваецца плэерам.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Відэакодэк не падтрымліваецца.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Аўдыякодэк не падтрымліваецца.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Фармат субтытраў не падтрымліваецца (патрабуе ўпальвання).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Аўдыяпрофіль не падтрымліваецца.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Відэапрофіль не падтрымліваецца.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Узровень відэа не падтрымліваецца.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Раздзяляльнасць відэа не падтрымліваецца гэтай прыладай.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Глыбіня колеру відэа не падтрымліваецца.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Частата кадраў відэа не падтрымліваецца.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Бітрэйт файла перавышае ліміт патоку плэера.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Бітрэйт відэа перавышае ліміт патоку.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Бітрэйт аўдыё перавышае ліміт патоку.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Колькасць аўдыяканалаў не падтрымліваецца.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Па алфавіце';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Парадак выхаду (па ўзрастанні)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Парадак выхаду (па спаданні)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Уласны (перацягванне)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Параметры сартавання плэйліста';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Скінуць сартаванне';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Перагледзець С$season:Э$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Перагледзець плэйліст';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Субтытры не знойдзены.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Кіраванне адміністратара';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Рухавік рэндэрынгу (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller — сучасны GPU-рэндэрар Flutter для плаўнейшых анімацый і меншых падтармажванняў. На некаторых ТБ-прыстаўках і старых GPU ён можа выклікаць артэфакты або чорнае відэа; выключыце яго, калі бачыце такое. «Аўтаматычна» выбірае найлепшы варыянт для вашай прылады. Перазапусціце Moonfin, каб ужыць.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Аўтаматычна';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Укл.';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Выкл.';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Патрэбны перазапуск';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Каб змяніць рухавік рэндэрынгу, Moonfin трэба перазапусціць. Закрыйце праграму, а потым адкрыйце яе зноў, каб ужыць змены.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Закрыць праграму зараз';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Абнавіць бібліятэку';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Абнавіць усе бібліятэкі';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Дата дадання (спачатку старыя)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Дата дадання (спачатку новыя)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Па алфавіце (ад А да Я)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Па алфавіце (ад Я да А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Загрузка аналітыкі сервера... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Як у крыніцы';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Топ-250 фільмаў';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Топ-250 серыялаў';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Самыя папулярныя фільмы IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Самыя папулярныя серыялы IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Фільмы з найніжэйшым рэйтынгам IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Найлепшыя англамоўныя фільмы IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -9,22 +9,22 @@ class AppLocalizationsBg extends AppLocalizations {
   AppLocalizationsBg([String locale = 'bg']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Лунна перка';
 
   @override
-  String get accountPreferences => 'ПРЕДПОЧИТАНИЯ ЗА АКАУНТА';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Език на интерфейса';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Системен по подразбиране';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Вход';
 
   @override
-  String get empty => 'Празно';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Бързо свързване';
 
   @override
   String get password => 'Парола';
@@ -113,7 +113,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cancel => 'Отказ';
 
   @override
-  String get remove => 'Премахване';
+  String get remove => 'Премахнете';
 
   @override
   String get connectToServer => 'Свържете се със сървъра';
@@ -141,62 +141,62 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsAppearanceTheme => 'Тема на приложението';
 
   @override
-  String get detailScreenStyle => 'Стил на екрана с детайли';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Класически е оригиналното центрирано оформление на Moonfin. Модерен е адаптивно кинематографично оформление.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Класически';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Модерен';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Разгънати раздели';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Автоматично показване на съдържанието на разделите при разглеждане. Изключете, за да отваряте и затваряте всеки раздел ръчно.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Показване на технически детайли?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Показване на кодек, резолюция и информация за потока в обобщението на банера';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Система за препоръки';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Използвайте алгоритъма Moonfin Recommends за локалната библиотека или онлайн показателите за сходство на TMDb. Забележка: онлайн препоръките изискват интеграция със Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Сходство по TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Прилагане на ограничение по родителска оценка?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ограничаване на предложенията на Moonfin Recommends според родителската оценка на целевата медия';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стил на интерфейса';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Автоматично съответства на вашето устройство. Изберете Apple или Material, за да наложите определен облик.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автоматично';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsBg extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Качество на стъклото';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Автоматично избира най-добрия стъклен ефект за това устройство. Пълно налага истинско размиване; Намалено използва олекотено стъкло, което пести GPU ресурси.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Автоматично';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Пълно';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Намалено';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Превключвайте между Moonfin и Neon Pulse без рестартиране на приложението';
 
   @override
-  String get customThemeTitle => 'Персонализирана тема';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Персонализираните теми променят визуалните елементи в Moonfin. Изберете една от тези опции според вашия стил.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Предпочитам системна клавиатура';
@@ -239,7 +239,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Използвайте метода на въвеждане на вашето устройство по подразбиране за въвеждане на текст';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Лунна перка';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -257,14 +257,14 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Стил с течно стъкло, плавно движещ се градиентен фон, матирани повърхности и акцент в Apple синьо';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретро пиксел-арт стил с плътна палитра, блокови рамки, резки сенки и пикселен шрифт';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Влезте с вашия акаунт Emby Connect';
@@ -326,35 +326,35 @@ class AppLocalizationsBg extends AppLocalizations {
   String get exit => 'Изход';
 
   @override
-  String get gameMenu => 'Меню';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'На пауза';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Запазване на състоянието';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Игри';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Зареждане на състоянието';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Превъртане напред';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Настройки на емулатора';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Това ядро няма настройваеми опции.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Задръжте за меню';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Възпроизвеждането на игри още не се поддържа на това устройство.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Не можаха да бъдат заредени начални редове';
@@ -376,7 +376,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get schedule => 'График';
 
   @override
-  String get series => 'Сериали';
+  String get series => 'Серия';
 
   @override
   String get noItemsFound => 'Няма намерени елементи';
@@ -505,7 +505,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get albumArtists => 'Изпълнители на албуми';
 
   @override
-  String get artists => 'Изпълнители';
+  String get artists => 'Художници';
 
   @override
   String get bookmarks => 'Отметки';
@@ -552,7 +552,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Изберете кои тематични емисии да се показват в Discover.';
 
   @override
-  String get apply => 'Прилагане';
+  String get apply => 'Кандидатствайте';
 
   @override
   String get openLink => 'Отворете връзката';
@@ -601,7 +601,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get listen => 'слушай';
 
   @override
-  String get resume => 'Продължи';
+  String get resume => 'Резюме';
 
   @override
   String get failedToLoadLibrary => 'Неуспешно зареждане на библиотеката';
@@ -745,13 +745,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get readStatus => 'Прочетете';
 
   @override
-  String get watched => 'Гледани';
+  String get watched => 'Гледах';
 
   @override
   String get unread => 'Непрочетено';
 
   @override
-  String get unwatched => 'Негледани';
+  String get unwatched => 'Ненаблюдавано';
 
   @override
   String get seriesStatus => 'Състояние на серията';
@@ -763,43 +763,43 @@ class AppLocalizationsBg extends AppLocalizations {
   String get books => 'Книги';
 
   @override
-  String get latestBooks => 'Последни книги';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Последни аудиокниги';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count книги',
-      one: '1 книга',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Книга';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудиокнига';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% прочетено';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'остават $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Четене';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слушане';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Автор';
@@ -876,8 +876,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудиокниги',
-      one: '1 аудиокнига',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -980,8 +980,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Сезона',
-      one: '1 Сезон',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -992,40 +992,40 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get items => 'Елементи';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Допълнения';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Зад кулисите';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Изтрити сцени';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Кратки материали';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Интервюта';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцени';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Късометражни филми';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Трейлъри';
 
   @override
   String timeRemaining(String time) {
-    return 'остават $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Завършва след $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1043,7 +1043,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get play => 'Пусни';
+  String get play => 'Играйте';
 
   @override
   String get startOver => 'Започнете отначало';
@@ -1067,7 +1067,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get version => 'Версия';
 
   @override
-  String get cast => 'Предаване';
+  String get cast => 'Актьорски състав';
 
   @override
   String get trailer => 'Трейлър';
@@ -1185,7 +1185,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get subtitleTrack => 'Запис със субтитри';
 
   @override
-  String get none => 'Без';
+  String get none => 'Няма';
 
   @override
   String get downloadSubtitlesLabel => 'Изтегляне на субтитри...';
@@ -1265,13 +1265,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕЖИСЬОРИ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТИ';
+  String get writers => 'ПИСАТЕЛИ';
 
   @override
   String get studio => 'СТУДИО';
@@ -1306,8 +1306,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count песни',
-      one: '1 песен',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1317,8 +1317,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count глави',
-      one: '1 глава',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1345,16 +1345,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get readMore => 'Прочетете повече';
 
   @override
-  String get shuffle => 'Разбъркай';
+  String get shuffle => 'Разбъркайте';
 
   @override
-  String get shuffleAllMusic => 'Разбъркване на цялата музика';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Влезте в Moonfin на телефона си';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Сървърът не е достъпен';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1493,7 +1493,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get longPressToUnlock => 'Натиснете дълго за отключване';
 
   @override
-  String get off => 'Изкл.';
+  String get off => 'Изкл';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1516,12 +1516,12 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$valueмс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$valueмс';
+    return '+${value}ms';
   }
 
   @override
@@ -1555,7 +1555,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get transcodeReasons => 'Причини за прекодиране';
 
   @override
-  String get player => 'Плейър';
+  String get player => 'Играч';
 
   @override
   String get container => 'Контейнер';
@@ -1796,22 +1796,22 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Следва: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'остават $minutes мин';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'остават $hours ч';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'остават $hours ч $minutes мин';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1834,7 +1834,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get favoriteChannel => 'Любим канал';
 
   @override
-  String get record => 'Запис';
+  String get record => 'Записвайте';
 
   @override
   String get cancelRecordingAction => 'Отказ от записване';
@@ -1852,7 +1852,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get watch => 'Гледай';
 
   @override
-  String get close => 'Затвори';
+  String get close => 'затвори';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1886,7 +1886,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get no => 'Не';
+  String get no => 'не';
 
   @override
   String get yesCancel => 'Да, Отказ';
@@ -2018,7 +2018,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Е$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2042,7 +2042,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2061,8 +2061,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count епизода',
-      one: '1 епизод',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2292,7 +2292,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Страници с детайли, начални редове и сила на звука';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2307,11 +2307,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Играйте, докато сърфирате в началния екран';
 
   @override
-  String get loopThemeMusic => 'Повтаряне на тематичната музика';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Повтаряне на записа вместо еднократно възпроизвеждане';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Замъгляване на фона на детайлите';
@@ -2334,23 +2334,23 @@ class AppLocalizationsBg extends AppLocalizations {
   String get playerZoomMode => 'Режим на мащабиране на играча';
 
   @override
-  String get settingsScrollWheelAction => 'Колелце на мишката';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Изберете какво прави превъртането с колелцето на мишката върху видеото по време на възпроизвеждане.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Изкл.';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Превъртане (напред / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Сила на звука';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Сила на звука';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2365,7 +2365,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get refreshRateSwitching => 'Превключване на скоростта на опресняване';
 
   @override
-  String get disabled => 'Изключено';
+  String get disabled => 'Забранено';
 
   @override
   String get scaleOnTv => 'Мащаб по телевизията';
@@ -2404,38 +2404,37 @@ class AppLocalizationsBg extends AppLocalizations {
   String get defaultAudioLanguage => 'Аудио език по подразбиране';
 
   @override
-  String get fallbackAudioLanguage => 'Резервен език на звука';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Предпочитане на аудиозаписа по подразбиране';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Предпочитайте оригиналния аудиозапис пред локализирания дублаж.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Предпочитане на записи с аудиоописание';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Предпочитайте записите с аудиоописание пред обикновените.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Прекодиране (звук)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Директен поток (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Прекодиране (битрейт или резолюция)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Прекодиране (видео и звук)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Прекодиране (видео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Автоматично (по подразбиране на сървъра)';
@@ -2516,7 +2515,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Изберете как се декодира звукът. AVR Passthrough изпраща необработени Dolby/DTS потоци към вашия ресийвър; Автоматично или Downmix декодира локално.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
@@ -2526,14 +2525,13 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Изберете целевия формат за прекодиране на многоканален звук, когато изходният поток не може да се възпроизведе директно или да премине без обработка.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Автоматично разпознаване\n(Препоръчително)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(По подразбиране)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2542,51 +2540,50 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Без загуби)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Само стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Ефективен)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Без загуби)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максимален брой аудиоканали';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Задайте максималния брой канали на вашата аудиосистема. Многоканалните потоци над този лимит ще бъдат смесени или прекодирани.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Автоматично разпознаване\n(Хардуер по подразбиране)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Съраунд';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Квадрофоничен';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Съраунд';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Съраунд';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Съраунд';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Съраунд';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Преминаване (разширено)';
@@ -2667,7 +2664,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Говорител';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Слушалки';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2757,7 +2754,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueс';
+    return '${value}s';
   }
 
   @override
@@ -2849,45 +2846,45 @@ class AppLocalizationsBg extends AppLocalizations {
       'Персонализирайте външния вид на субтитрите';
 
   @override
-  String get subtitleMode => 'Режим на субтитрите';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Маркирани';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Винаги';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Чуждоезични';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Принудителни';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Възпроизвежда записите, маркирани в метаданните на медийния файл като „по подразбиране“ или „принудителни“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Автоматично зарежда и показва субтитри при всяко пускане на видео.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Автоматично включва субтитрите, ако аудиозаписът по подразбиране е на чужд език.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Зарежда само субтитрите, изрично маркирани с флага „принудителни“ в метаданните.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Напълно изключва автоматичното зареждане на субтитри.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Резервен език на субтитрите';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Поток на субтитрите';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3095,10 +3092,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на библиотеки в лентата с инструменти';
 
   @override
-  String get navbarAlwaysExpanded => 'Винаги разгънати надписи в навигацията';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Показване на бутона Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Непрозрачност на навигационната лента';
@@ -3174,19 +3171,18 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на опцията за разглеждане на папки';
 
   @override
-  String get groupItemsIntoCollections => 'Групиране на елементите в колекции';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Скриване на елементите, свързани с колекция, при разглеждане на библиотеките';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Бележка за групирането на библиотеката';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'За да използвате тази настройка, уверете се, че настройките на библиотеката „Групиране на филмите в колекции“ и/или „Групиране на сериалите в колекции“ са включени в настройките за показване на вашата библиотека на вашия Jellyfin или Emby сървър.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Видимост на библиотеката';
@@ -3245,13 +3241,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Изберете между различни стилове на медийната лента или я изключете';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Лунна перка';
 
   @override
   String get mediaBarModeMakd => 'МакД';
 
   @override
-  String get mediaBarModeOff => 'Изкл.';
+  String get mediaBarModeOff => 'Изкл';
 
   @override
   String get enableMediaBar => 'Активиране на медийната лента';
@@ -3298,11 +3294,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Автоматично пускане на трейлъри в медийната лента след 3 секунди';
 
   @override
-  String get trailerAudio => 'Звук на трейлърите';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Включване на звука за трейлърите в медийната лента';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Преглед на епизод';
@@ -3379,11 +3374,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get combineBothRows => 'Комбинирайте двата реда в една начална секция';
 
   @override
-  String get fullScreenRows => 'Разгънати начални редове';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Ограничаване до 1 начален ред на екран';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тип изображение на ред';
@@ -3398,7 +3392,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get lastUser => 'Последен потребител';
 
   @override
-  String get currentUser => 'Текущ потребител';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Винаги удостоверявай';
@@ -3505,10 +3499,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на часовник по време на скрийнсейвър';
 
   @override
-  String get clockModeStatic => 'Статичен';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Подскачащ';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Критика)';
@@ -3529,7 +3523,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get metacriticUser => 'Metacritic (потребител)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'Пощенска кутияd';
@@ -3580,7 +3574,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Активирайте и пренаредете източниците на оценка, показани в приложението';
 
   @override
-  String get pluginLabel => 'Приставка Moonbase';
+  String get pluginLabel => 'Плъгин';
 
   @override
   String get pluginDetected => 'Добавката е открита';
@@ -3652,7 +3646,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get networks => 'мрежи';
 
   @override
-  String get seerrDiscoveryRows => 'Редове за откриване в Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3677,27 +3671,28 @@ class AppLocalizationsBg extends AppLocalizations {
       'Скриване на съдържание за възрастни в резултатите';
 
   @override
-  String get seerrNotificationsSection => 'Известия';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Известия за нови заявки';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Известие, когато някой подаде заявка';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Актуализации на заявките';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Одобрени, отхвърлени и добавени в библиотеката ви';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Актуализации на проблемите';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Нови проблеми, отговори и решения';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3705,18 +3700,18 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Страница за откриване в Seerr';
+  String get discoverRows => 'Открийте редове';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Включете редовете, които да виждате на началната страница на Seerr. Плъзнете, за да пренаредите. Персонализираният ред се синхронизира с Moonbase.';
+      'Плъзнете, за да пренаредите. Активиране или деактивиране на редове. Активираният ред на редовете се синхронизира с плъгина Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Включете редовете, които да виждате на началната страница на Seerr. Плъзнете, за да пренаредите. Персонализираният ред се синхронизира с Moonbase.';
+      'Плъзнете, за да пренаредите. Активиране или деактивиране на редове.';
 
   @override
-  String get enabled => 'Включено';
+  String get enabled => 'Активирано';
 
   @override
   String get hidden => 'Скрити';
@@ -3852,7 +3847,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get imageCacheCleared => 'Кешът за изображения е изчистен';
 
   @override
-  String get clear => 'Изчисти';
+  String get clear => 'ясно';
 
   @override
   String get browse => 'Прегледайте';
@@ -3868,11 +3863,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Изтегляне · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Импортиране';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3977,7 +3972,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get showMore => 'Покажи повече';
 
   @override
-  String get appearances => 'Участия';
+  String get appearances => 'Изяви';
 
   @override
   String get crewSection => 'Екипаж';
@@ -4015,148 +4010,148 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deletedStatus => 'Изтрито';
 
   @override
-  String get failedStatus => 'Неуспешно';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Обработва се';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Променено от $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завършено';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Това заглавие вече е заявено';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Достигнат е лимитът на заявките';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Това заглавие е в списъка с блокирани';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Няма останали сезони за заявяване';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Нямате разрешение да направите тази заявка';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Заявки';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Проблеми';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Най-нови';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Последно променени';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Няма проблеми';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Остават $remaining от $limit заявки за филми';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Остават $remaining от $limit заявки за сезони';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Част от $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Преглед на колекцията';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Заявяване на колекцията';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total филма · $available налични';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Заявяване на $count филма';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Заявяване на $current от $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Заявени са $count филма';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Заявени са $ok от $total филма';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Всички филми вече са налични или заявени';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Докладване на проблем';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Видео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Звук';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Какъв е проблемът?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Всички епизоди';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Епизод';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Отворен';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Решен';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Разрешаване';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Отваряне отново';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Докладвано от $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count коментара';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Добавете коментар';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Изтриване на този проблем?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Изпращане на доклада';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB резултат';
@@ -4189,7 +4184,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get access => 'Достъп';
 
   @override
-  String get add => 'Добавяне';
+  String get add => 'Добавете';
 
   @override
   String get address => 'Адрес';
@@ -4228,7 +4223,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get forward => 'Напред';
 
   @override
-  String get general => 'Общи';
+  String get general => 'генерал';
 
   @override
   String get go => 'върви';
@@ -4249,7 +4244,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get networking => 'Работа в мрежа';
 
   @override
-  String get next => 'Следващ';
+  String get next => 'Следваща';
 
   @override
   String get path => 'Пътека';
@@ -4309,7 +4304,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Спри';
+  String get stop => 'Спрете';
 
   @override
   String get streaming => 'Поточно предаване';
@@ -4357,22 +4352,22 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminDrawerUsers => 'Потребители';
 
   @override
-  String get adminDrawerLibraries => 'Библиотеки';
+  String get adminDrawerLibraries => 'библиотеки';
 
   @override
-  String get adminDrawerDisplay => 'Показване';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метаданни';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO настройки';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Транскодиране';
 
   @override
-  String get adminDrawerResume => 'Продължаване';
+  String get adminDrawerResume => 'Резюме';
 
   @override
   String get adminDrawerStreaming => 'Поточно предаване';
@@ -4554,13 +4549,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get sessionForward => 'Напред';
 
   @override
-  String get sessionNext => 'Следващ';
+  String get sessionNext => 'Следваща';
 
   @override
   String get sessionVolumeDown => 'том –';
 
   @override
-  String get sessionVolumeUp => 'Звук +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4569,7 +4564,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nowPlaying => 'Сега се играе';
 
   @override
-  String get volume => 'Сила на звука';
+  String get volume => 'Обем';
 
   @override
   String get actions => 'Действия';
@@ -4581,7 +4576,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audioCodec => 'Аудио кодек';
 
   @override
-  String get hwAccel => 'Хард. ускорение';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Завършване';
@@ -4596,10 +4591,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminClearDates => 'Ясни дати';
 
   @override
-  String get adminActivitySeverityAll => 'Всички нива';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Период';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4636,23 +4631,23 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Да се премахне ли устройството „$name“? Потребителят ще трябва да влезе отново на това устройство.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Изтриване на всички устройства';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Да се премахнат ли $count устройства? Засегнатите потребители ще трябва да влязат отново. Текущото ви устройство не е засегнато.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Устройствата са премахнати';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Някои устройства бяха премахнати; $count не можаха да бъдат премахнати.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4768,256 +4763,244 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminMetadataCountryHint => 'напр. САЩ, Германия, Франция';
 
   @override
-  String get adminLibraryTabPaths => 'Пътища';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Опции';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Модули за изтегляне';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Модули за запис на метаданни';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Модули за изтегляне на субтитри';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Модули за изтегляне на текстове';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Модули за изтегляне на метаданни: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Модули за изображения: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Този сървър не предоставя модули за изтегляне за този тип библиотека.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Общи';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метаданни';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Вградена информация';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Субтитри';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Изображения';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Сериали';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музика';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Филми';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Наблюдение в реално време';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Откриване на промени във файловете и автоматичната им обработка.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Третиране на архивите като медийни файлове';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Показване на снимки';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Запазване на обложките в медийните папки';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Автоматично обновяване на метаданните';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Никога';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'По подразбиране';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Показване';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Показване на библиотеката';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Показване на изглед с папки за обикновените медийни папки';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Показване на специалните епизоди в сезоните, в които са излъчени';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Групиране на филмите в колекции';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Групиране на сериалите в колекции';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Показване на външно съдържание в предложенията';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Поведение на датата на добавяне';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Използване на дата на добавяне от';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Датата на сканиране в библиотеката';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Датата на създаване на файла';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метаданни и изображения';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Предпочитан език на метаданните';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Глави';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Продължителност на фиктивните глави (секунди)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Дължина на главите, генерирани за медия, която няма такива. Задайте 0, за да изключите.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Резолюция на изображенията за главите';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO настройки';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO метаданните са съвместими с Kodi и подобни клиенти. Настройките важат за всички библиотеки, които записват NFO метаданни.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Потребител, за когото да се записват данните за гледане в NFO файловете';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Запазване на пътищата към изображенията в NFO файловете';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Заместване на пътищата за изображенията в NFO файловете';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Копиране на extrafanart изображенията в папка extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Няма';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days дни';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Използване на вградените заглавия';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Използване на вградените заглавия за допълненията';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Използване на вградената информация за епизодите';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Разрешаване на вградените субтитри';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Всички';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Само текст';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Само изображения';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Няма';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Пропускане на изтеглянето, ако има вградени субтитри';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Пропускане на изтеглянето, ако аудиозаписът съвпада с езика за изтегляне';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Изискване на пълно съвпадение на субтитрите';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Запазване на субтитрите в медийните папки';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Извличане на изображения за главите';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Извличане на изображенията за главите по време на сканирането на библиотеката';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Извличане на Trickplay изображения';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Извличане на Trickplay изображенията по време на сканирането на библиотеката';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Запазване на Trickplay изображенията в медийните папки';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Автоматично обединяване на сериалите, разпределени в няколко папки';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Име на нулевия сезон';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'LUFS сканиране за нормализиране на звука';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Предпочитане на нестандартния таг за изпълнител';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Автоматично добавяне на филмите към колекции';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Името на библиотеката е задължително';
@@ -5262,145 +5245,143 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminEnableAllChannels => 'Разрешете достъпа до всички канали';
 
   @override
-  String get adminParentalControl => 'Родителски контрол';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Максимална разрешена родителска оценка';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Съдържанието с по-висока оценка ще бъде скрито от този потребител.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Няма';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блокиране на елементите без или с неразпозната информация за оценка';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Книги';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Канали';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Телевизия на живо';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Филми';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музика';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трейлъри';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Сериали';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Графици за достъп';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Разрешаване на достъп само в посочените по-долу часове. Когато не е зададен график, достъпът е разрешен през целия ден.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Добавяне на график';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Ден';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Начало';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Край';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Всеки ден';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Делничен ден';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Уикенд';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Неделя';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Понеделник';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Вторник';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Сряда';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Четвъртък';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Петък';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Събота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Разрешени тагове';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Показва се само съдържание с тези тагове. Оставете празно, за да разрешите всички.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Блокирани тагове';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Съдържанието с тези тагове е скрито от този потребител.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Добавяне на таг';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Разрешени устройства';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Разрешени канали';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Доставчик на удостоверяване';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Доставчик за нулиране на паролата';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максимален брой неуспешни опити за вход преди заключване';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Задайте 0 за стойността по подразбиране или -1, за да изключите заключването.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Достъп до SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Разрешаване на създаване и присъединяване към групи';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Разрешаване на присъединяване към групи';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Без достъп';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Разрешаване на изтриване на съдържание от';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5488,26 +5469,25 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Създаване на резервно копие';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Изберете какво да бъде включено в резервното копие.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База данни';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Винаги включена';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метаданни';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Субтитри';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay изображения';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Създава се резервно копие...';
@@ -5945,7 +5925,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Неуспешно зареждане на настройките за Trickplay';
+      'Неуспешно зареждане на настройките за трикплей';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6061,7 +6041,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminBaseUrl => 'Основен URL адрес';
 
   @override
-  String get adminBaseUrlHint => 'напр. /jellyfin';
+  String get adminBaseUrlHint => 'напр. / желе';
 
   @override
   String get https => 'HTTPS';
@@ -6226,66 +6206,60 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminAddTuner => 'Добавете тунер';
 
   @override
-  String get adminEditTuner => 'Редактиране на тунер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U тунер';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл или URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP адрес на тунера';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Показвано име';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Лимит на едновременните връзки';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максималният брой потоци, които тунерът позволява едновременно. Задайте 0 за неограничено.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Резервен максимален битрейт за стрийминг';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Импортиране само на любимите канали';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Разрешаване на хардуерно прекодиране';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Разрешаване на fMP4 контейнер за прекодиране';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Разрешаване на споделяне на потока';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Включване на зацикляне на потока';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Игнориране на DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Четене на входа с оригиналната честота на кадрите';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Редактиране на доставчик';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6294,50 +6268,50 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл или URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Префикс за филми';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Категории за филми';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Разделяйте няколко категории с вертикална черта.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Категории за деца';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Категории за новини';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Категории за спорт';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Потребителско име';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Парола';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Държава';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Изберете държава';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Пощенски код';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Извличане на програмата';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Програма';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Включване на всички тунери';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тип тунер';
@@ -6379,7 +6353,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Този тип тунер не поддържа нулиране.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6402,45 +6376,43 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Път за запис на серия';
 
   @override
-  String get adminMovieRecordingPath => 'Път за записите на филми';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Дни с данни за програмата';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автоматично';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days дни';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Път до приложението за последваща обработка';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Аргументи за последващата обработка';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Запазване на NFO метаданни за записите';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Запазване на изображения за записите';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Време';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Пътища за записите';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Последваща обработка';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Данни за програмата: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6484,15 +6456,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminGuideProviders => 'Доставчици на ръководства';
 
   @override
-  String get adminRefreshGuideData => 'Обновяване на данните за програмата';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Обновяването на данните за програмата започна';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Задачата за обновяване на програмата не е налична на този сървър.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Добавяне на доставчик';
@@ -6575,7 +6546,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminLiveTvTitle => 'Администрация на телевизия на живо';
 
   @override
-  String get adminApply => 'Прилагане';
+  String get adminApply => 'Кандидатствайте';
 
   @override
   String get adminNotSet => 'Не е зададено';
@@ -6627,7 +6598,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Редактор на метаданни';
 
   @override
-  String get adminMetadataIdentify => 'Идентифициране';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тип';
@@ -6911,7 +6882,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Премахване';
+  String get adminReposRemove => 'Премахнете';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7042,20 +7013,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Активиране на началния екран';
 
   @override
-  String get adminBrandingSplashUpload => 'Качване на изображение';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Началният екран е обновен';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Неуспешно качване на началния екран';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Началният екран е премахнат';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Няма персонализиран начален екран';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Хардуерно ускорение';
@@ -7072,134 +7042,121 @@ class AppLocalizationsBg extends AppLocalizations {
       'Активирайте хардуерното декодиране за:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV устройство';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Включване на подобрения NVDEC декодер';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Предпочитане на системния хардуерен декодер';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Дълбочина на цвета при хардуерно декодиране';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-битово HEVC декодиране';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-битово VP9 декодиране';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-битово декодиране';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-битово декодиране';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Хардуерно кодиране';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Разрешаване на HEVC кодиране';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Разрешаване на AV1 кодиране';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Включване на Intel нискоенергийния H.264 кодер';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Включване на Intel нискоенергийния HEVC кодер';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тонално преобразуване';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'Включване на тонално преобразуване';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Включване на VPP тонално преобразуване';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Включване на VideoToolbox тонално преобразуване';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Алгоритъм за тонално преобразуване';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Режим на тонално преобразуване';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange =>
-      'Обхват на тоналното преобразуване';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Обезцветяване при тоналното преобразуване';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Пик на тоналното преобразуване';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam =>
-      'Параметър на тоналното преобразуване';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Яркост при VPP тонално преобразуване';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Контраст при VPP тонално преобразуване';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Профили и качество';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Профил на кодера';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF при H.264 кодиране';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF при H.265 (HEVC) кодиране';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метод на деинтерлейсинг';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Удвояване на честотата на кадрите при деинтерлейсинг';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Звук';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Включване на VBR кодиране на звука';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Усилване при смесване на звука';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгоритъм за стерео смесване';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максимален размер на опашката за мултиплексиране';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Автоматично';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодиране';
@@ -7320,10 +7277,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminTaskNeverRun => 'Никога не бягайте';
 
   @override
-  String get adminTaskStop => 'Спри';
+  String get adminTaskStop => 'Спрете';
 
   @override
-  String get adminRunningTasks => 'Изпълнявани задачи';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Бягай';
@@ -7393,8 +7350,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count часа',
-      one: '1 час',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7440,27 +7397,27 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesм';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursч';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysд';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Конфигурирайте генерирането на Trickplay изображения за миниатюрите при превъртане.';
+      'Конфигурирайте генериране на трикплей изображения за миниатюри за преглед при търсене.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Обществен HTTPS порт';
@@ -7469,51 +7426,49 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Основен URL адрес';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'напр. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'напр. / желе';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Публичен HTTP порт';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Изискване на HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Пренасочва всички отдалечени заявки към HTTPS. Няма ефект, ако сървърът няма валиден сертификат.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Парола на сертификата';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP настройки';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Включване на IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Включване на IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Включване на автоматично съпоставяне на портовете';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN мрежи';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Списък с IP адреси или CIDR подмрежи, разделени със запетая или нов ред, които се третират като част от локалната мрежа.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris =>
-      'Публикувани URI адреси на сървъра';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Съпоставете подмрежа или адрес с публикуван URL, напр. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Път на сертификата';
@@ -7543,12 +7498,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Буфериране на газта';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Забавяне при ограничаване (секунди)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Разрешаване на извличане на субтитри в движение';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Минимален процент на резюме';
@@ -7605,23 +7559,22 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Праг на бавна реакция (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Включване на предупрежденията за бавен отговор';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Включване на Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сървър';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метаданни';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Пътища';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Производителност';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Път на кеша';
@@ -7633,7 +7586,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminGeneralServerName => 'Име на сървъра';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Предпочитан език на показване';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Неуспешно зареждане на настройките';
@@ -7655,7 +7608,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get folders => 'Папки';
 
   @override
-  String get libraries => 'Библиотеки';
+  String get libraries => 'библиотеки';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7685,8 +7638,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# участници',
-      one: '# участник',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7833,8 +7786,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'открити # реда',
-      one: 'открит # ред',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7875,20 +7828,20 @@ class AppLocalizationsBg extends AppLocalizations {
   String get offlineSavedMedia => 'Запазени медии';
 
   @override
-  String get offlineBannerTitle => 'Нямате връзка';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Показват се изтеглянията ви';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Изтегляния';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Сървърът не е достъпен';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Възпроизвеждане от изтеглянията, докато се възстанови';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7961,40 +7914,42 @@ class AppLocalizationsBg extends AppLocalizations {
   String get pinForgot => 'Забравен ПИН?';
 
   @override
-  String get pinClear => 'Изчисти';
+  String get pinClear => 'ясно';
 
   @override
-  String get pinBackspace => 'Изтриване';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Заявката за Quick Connect е одобрена.';
+  String get quickConnectAuthorized =>
+      'Заявката за бързо свързване е разрешена.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Кодът за Quick Connect е невалиден или изтекъл.';
+      'Кодът за бързо свързване е невалиден или изтекъл.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect не се поддържа на този сървър.';
+      'Бързото свързване не се поддържа на този сървър.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Неуспешно одобряване на кода за Quick Connect.';
+      'Неуспешно оторизиране на кода за бързо свързване.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect е изключен на този сървър.';
+  String get quickConnectDisabled =>
+      'Бързото свързване е деактивирано на този сървър.';
 
   @override
   String get quickConnectForbidden =>
-      'Вашият акаунт не може да одобри тази заявка за Quick Connect.';
+      'Вашият акаунт не може да разреши тази заявка за бързо свързване.';
 
   @override
   String get quickConnectNotFound =>
-      'Кодът за Quick Connect не е намерен. Опитайте с нов код.';
+      'Кодът за бързо свързване не беше намерен. Опитайте нов код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect беше неуспешен: $message';
+    return 'Неуспешно бързо свързване: $message';
   }
 
   @override
@@ -8163,7 +8118,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Възпроизвеждането е поставено на пауза. Гледате ли още?';
 
   @override
-  String get stillWatchingStop => 'Спри';
+  String get stillWatchingStop => 'Спрете';
 
   @override
   String get stillWatchingContinue => 'Продължи';
@@ -8249,13 +8204,13 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Скриване от „Продължете да гледате“';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Скриване от „Следва“';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Добавяне към колекция';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8310,15 +8265,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsAlphabetical => 'Азбучен ред';
 
   @override
-  String get settingsConnectionSection => 'ВРЪЗКА';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Разрешаване на самоподписани сертификати';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Доверявайте се на сървъри, използващи самоподписани TLS сертификати или такива от частен сертифициращ орган. Включвайте само за сървъри, които контролирате. Това изключва проверката на сертификатите за всички връзки.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ПОВЕРИТЕЛНОСТ И БЕЗОПАСНОСТ';
@@ -8334,11 +8288,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Тематични акценти, фонове, наблюдавани индикатори и тематична музика';
 
   @override
-  String get settingsDetailsScreen => 'Екран с детайли';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стил, размиване на фона и поведение на разделите';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Начална страница';
@@ -8376,11 +8330,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Показване на бутона Seerr в навигационната лента';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Винаги показване на текстовите надписи в горната навигационна лента';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8483,8 +8437,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лицензионни известия',
-      one: '# лицензионно известие',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8535,17 +8489,16 @@ class AppLocalizationsBg extends AppLocalizations {
       'Пропускане на въведения и изключения?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Обратно броене за медийните сегменти';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Лента за напредъка';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Няма';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Подкана на потребител';
@@ -8682,7 +8635,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8780,7 +8733,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Наскоро издадени $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8813,11 +8766,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Принудително нетунелирано възпроизвеждане. Полезно за устройства с прекъсвания на аудио/видео при тунелиране.';
 
   @override
-  String get enableTunnelingTitle => 'Включване на тунелиране';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'За напреднали. Насочва звука и видеото през свързан хардуерен път. Изключено по подразбиране, защото причинява прекъсвания на звука/видеото на някои устройства.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Карта Dolby Vision профил 7 към HEVC';
@@ -8843,15 +8796,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'Прилагане на съвети за размера на шрифта, вградени в пистата със субтитри. Деактивирайте, за да използвате размера на субтитрите от вашите стилови предпочитания.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Показване на детайли за медията';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Показване на детайли за избрания елемент в горната част на страниците с библиотеки.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Скриване на фоновете при разглеждане?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Използвайте подробни подзаглавия';
@@ -8870,38 +8822,37 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Магазин за теми';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Разглеждайте и запазвайте теми от общността';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Запазете дадена тема, за да я използвате като другите си запазени теми.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'В момента няма налични теми.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Магазинът за теми не можа да се зареди. Проверете връзката си и опитайте отново.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Запазване';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Запазване и прилагане';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Запазена';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Тази тема не можа да бъде заредена.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '„$themeName“ е запазена.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8959,21 +8910,21 @@ class AppLocalizationsBg extends AppLocalizations {
   String get homeRowsSection => 'Домашни редове';
 
   @override
-  String get homeRowDisplay => 'Показване на началните редове';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Секции на началните редове';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Превключватели за началните редове';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Включване или изключване на категориите начални редове, базирани на библиотеки';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Включете следните превключватели, за да се показват редовете в началните секции.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Тип редове';
@@ -9032,56 +8983,55 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на филми, сериали или и двете в редовете за жанрове.';
 
   @override
-  String get displayPlaylistsRows => 'Показване на редовете с плейлисти';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Показване на редовете с плейлисти в началните секции.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Подреждане на редовете с плейлисти';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Подреждайте редовете с плейлисти по дата на добавяне, дата на издаване, по азбучен ред и други.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Показване на аудиоредовете';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Показване на аудиоредовете в началните секции.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Подреждане на аудиоредовете';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Подреждайте аудиоредовете по дата на добавяне, дата на издаване, по азбучен ред и други.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудиоплейлисти';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Външен вид';
 
   @override
-  String get layout => 'Оформление';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тема';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Клавиатура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Бутони';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Рендиране';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV конфигурация';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Размер на картата';
@@ -9091,7 +9041,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Задайте външен плейър, за да включите опцията за възпроизвеждане при задържане';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9363,7 +9313,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appearancesSeerr => 'Изяви (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Участие на екипа (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Гледайте с група';
@@ -9449,8 +9399,8 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Библиотеки',
-      one: '1 Библиотека',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9608,13 +9558,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get loadingShuffle => 'Разбъркването се зарежда...';
 
   @override
-  String get libraryShuffleLabel => 'РАЗБЪРКВАНЕ НА БИБЛИОТЕКАТА';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'СЛУЧАЙНО РАЗБЪРКВАНЕ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'РАЗБЪРКВАНЕ ПО ЖАНРОВЕ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Автоматично превключване на HDR';
@@ -9627,222 +9577,222 @@ class AppLocalizationsBg extends AppLocalizations {
   String get whenFullscreen => 'Когато е на цял екран';
 
   @override
-  String get changeArtwork => 'Смяна на изображението';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Липсва';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Ограничения за транскодиране';
 
   @override
-  String get clearAllArtworkButton => 'Изчистване на всички изображения?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Сигурни ли сте, че искате да изчистите всички изтеглени изображения?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Потвърдете изчистването';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Сигурни ли сте, че искате да изчистите $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Качване?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Резолюция: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Показване само на изображения на езика на интерфейса';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Потвърдете изчистването на всичко';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Изображението е качено успешно!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Неуспешно качване на изображението: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Неуспешно задаване на изображението: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Неуспешно изтриване на изображението: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Неуспешно изчистване на всички изображения: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Да';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Фонове';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Банер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Лого';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Миниатюра';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Изображение';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Изображение на диска';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Екранна снимка';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Предна корица';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задна корица';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Изображение на менюто';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постера';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'фона';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'банера';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'логото';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'миниатюрата';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'изображението';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'изображението на диска';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'екранната снимка';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'предната корица';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задната корица';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'изображението на менюто';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Всички';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Висока (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Средна (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Ниска (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Източници';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Глави';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Отметки';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Бележки';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Опашка';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Хронология';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Хронологията е празна';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Цялата книга';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Фокусирана хронология';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Експортиране на отметките';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Експортиране на бележките';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Експортиране на всичко';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Експортирано в $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Неуспешно експортиране: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Текст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Добавяне на отметка';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Добавяне на бележка';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Редактиране на бележката';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напишете бележка за този момент';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Таймер за заспиване';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Изкл.';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'В края на главата';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Персонализиран';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'остават $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9850,58 +9800,58 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Скорост на възпроизвеждане';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Оставащо';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Изминало';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $secondsс';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Напред $secondsс';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Предишна глава';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Следваща глава';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Глава $current от $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Няма глави';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Все още няма отметки';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Все още няма бележки';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Добавена е отметка на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Връщане на 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9909,253 +9859,249 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Запазване';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Отказ';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Изтриване';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Настройки на субтитрите';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Променете режимите на субтитрите, езиците по подразбиране, външния вид и опциите за изобразяване.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Изобразяване на субтитрите';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Опции за показване';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Дата на издаване (възходящо)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Дата на издаване (низходящо)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Групиране на участията';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Групиране на няколко роли';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Предупреждение за достъп за запис в библиотеката';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Как да поправите това:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Дайте права за запис на потребителя на услугата Jellyfin (напр. jellyfin или Docker PUID/PGID) върху папките с медийната ви библиотека на сървъра.\n\n2. Или отидете в таблото за управление на Jellyfin -> Библиотеки, редактирайте тази библиотека и изключете „Запазване на обложките в медийните папки“, за да се съхраняват обложките във вътрешната база данни на Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Отхвърляне';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Вашата библиотека „$libraryName“ е конфигурирана да запазва обложките директно в медийните папки (включено е „Запазване на обложките в медийните папки“). Jellyfin обаче провери достъпа за запис и няма права да записва файлове в тази директория:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Изглежда, че Jellyfin не успя да обнови обложката. Вашата библиотека е конфигурирана да запазва обложките директно в медийните папки (включено е „Запазване на обложките в медийните папки“). Тази грешка обикновено възниква, когато процесът на сървъра Jellyfin няма права да записва файлове в медийните ви директории.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Външни списъци';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Възпроизвеждане отново';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Информация за файла';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Размер: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Показване на всички ($count) аудиозаписи';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Показване на всички ($count) субтитри';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Проверка на възможността за директно възпроизвеждане...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel =>
-      'Възможност за директно възпроизвеждане: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Принудителни';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Форматът на контейнера не се поддържа от плейъра.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видеокодекът не се поддържа.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудиокодекът не се поддържа.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Форматът на субтитрите не се поддържа (изисква вграждане).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Аудиопрофилът не се поддържа.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Видеопрофилът не се поддържа.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Видеонивото не се поддържа.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Видеорезолюцията не се поддържа от това устройство.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Битовата дълбочина на видеото не се поддържа.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Честотата на кадрите не се поддържа.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Битрейтът на файла надвишава лимита за стрийминг на плейъра.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Битрейтът на видеото надвишава лимита за стрийминг.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Битрейтът на звука надвишава лимита за стрийминг.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Броят на аудиоканалите не се поддържа.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'По азбучен ред';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ред на издаване (възходящо)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Ред на издаване (низходящо)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Персонализиран (с плъзгане)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Опции за подреждане на плейлиста';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Нулиране на подреждането';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Гледай отново С$season:Е$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Гледай отново плейлиста';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Не са намерени субтитри.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Административни контроли';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Двигател за изобразяване (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller е модерният GPU рендер на Flutter за по-плавни анимации и по-малко забавяния. На някои TV устройства и по-стари GPU може да причини дефекти или черно видео; изключете го, ако забележите такива. „Автоматично“ избира най-добрата настройка за вашето устройство. Рестартирайте Moonfin, за да приложите промяната.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автоматично';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Вкл.';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Изкл.';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Изисква се рестартиране';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin трябва да се рестартира, за да смени двигателя за изобразяване. Затворете приложението сега и след това го отворете отново, за да приложите промяната.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Затвори приложението сега';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Обновяване на библиотеката';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Обновяване на всички библиотеки';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Дата на добавяне (първо най-старите)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Дата на добавяне (първо най-новите)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'По азбучен ред (А до Я)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'По азбучен ред (Я до А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Зареждане на анализите на сървъра... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Като източника';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Топ 250 филми';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Топ 250 сериали';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Най-популярни филми';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Най-популярни сериали';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Най-ниско оценени филми';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb Най-високо оценени филми на английски';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -9,22 +9,22 @@ class AppLocalizationsBn extends AppLocalizations {
   AppLocalizationsBn([String locale = 'bn']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'মুনফিন';
 
   @override
-  String get accountPreferences => 'অ্যাকাউন্ট পছন্দসমূহ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ইন্টারফেসের ভাষা';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'সিস্টেম ডিফল্ট';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'সাইন ইন করুন';
 
   @override
-  String get empty => 'খালি';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'দ্রুত সংযোগ';
 
   @override
   String get password => 'পাসওয়ার্ড';
@@ -51,7 +51,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get waitingForAuthorization => 'অনুমোদনের জন্য অপেক্ষা করা হচ্ছে...';
 
   @override
-  String get back => 'ফিরে যান';
+  String get back => 'ব্যাক';
 
   @override
   String get serverUnavailable => 'সার্ভার অনুপলব্ধ';
@@ -141,62 +141,62 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsAppearanceTheme => 'অ্যাপ থিম';
 
   @override
-  String get detailScreenStyle => 'বিস্তারিত স্ক্রিনের স্টাইল';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'ক্লাসিক হলো Moonfin-এর মূল কেন্দ্রীভূত লেআউট। মডার্ন হলো একটি রেসপনসিভ সিনেম্যাটিক লেআউট।';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'ক্লাসিক';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'মডার্ন';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'বিস্তৃত ট্যাব';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ট্যাব ব্রাউজ করার সময় স্বয়ংক্রিয়ভাবে ট্যাবের বিষয়বস্তু দেখান। প্রতিটি ট্যাব নিজে খুলতে ও বন্ধ করতে চাইলে বন্ধ রাখুন।';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'টেকনিক্যাল বিবরণ দেখাবেন?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'ব্যানার সারাংশে কোডেক, রেজোলিউশন এবং স্ট্রিমের তথ্য দেখান';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'সুপারিশ সিস্টেম';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends-এর লোকাল-লাইব্রেরি অ্যালগরিদম অথবা অনলাইন TMDb-এর সাদৃশ্য মেট্রিক ব্যবহার করুন। দ্রষ্টব্য: অনলাইন সুপারিশের জন্য Seerr ইন্টিগ্রেশন প্রয়োজন।';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb সাদৃশ্য';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'প্যারেন্টাল রেটিং সীমা প্রয়োগ করবেন?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'লক্ষ্য মিডিয়ার প্যারেন্টাল রেটিং অনুযায়ী Moonfin Recommends-এর সাজেশন সীমিত করুন';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'ইন্টারফেস স্টাইল';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'স্বয়ংক্রিয় আপনার ডিভাইসের সাথে মিলিয়ে নেয়। নির্দিষ্ট চেহারা বেছে নিতে Apple বা Material নির্বাচন করুন।';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'স্বয়ংক্রিয়';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsBn extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glass কোয়ালিটি';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'অটো এই ডিভাইসের জন্য সেরা glass ইফেক্ট বেছে নেয়। ফুল আসল ব্লার ব্যবহার করে; রিডিউসড হালকা glass ব্যবহার করে যা GPU শক্তি বাঁচায়।';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'অটো';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'ফুল';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'রিডিউসড';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'অ্যাপ রিস্টার্ট না করে Moonfin এবং Neon Pulse এর মধ্যে পাল্টান';
 
   @override
-  String get customThemeTitle => 'কাস্টম থিম';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'কাস্টম থিম Moonfin জুড়ে ভিজ্যুয়াল উপাদান বদলে দেয়। আপনার পছন্দ অনুযায়ী একটি বেছে নিন।';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'সিস্টেম কীবোর্ড পছন্দ করুন';
@@ -239,7 +239,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'পাঠ্য এন্ট্রির জন্য ডিফল্টরূপে আপনার ডিভাইস ইনপুট পদ্ধতি ব্যবহার করুন৷';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'মুনফিন';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -257,14 +257,14 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'ভাসমান গ্রেডিয়েন্ট ব্যাকড্রপ, ফ্রস্টেড সারফেস এবং Apple-নীল অ্যাকসেন্ট সহ liquid-glass স্টাইলিং';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '৮-বিট হিরো';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'মোটা প্যালেট, ব্লকি বর্ডার, কড়া ড্রপ-শ্যাডো এবং পিক্সেল ফন্ট সহ রেট্রো পিক্সেল-আর্ট স্টাইলিং';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -326,34 +326,35 @@ class AppLocalizationsBn extends AppLocalizations {
   String get exit => 'প্রস্থান করুন';
 
   @override
-  String get gameMenu => 'মেনু';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'পজ করা হয়েছে';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'স্টেট সংরক্ষণ করুন';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'গেম';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'স্টেট লোড করুন';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'ফাস্ট-ফরওয়ার্ড';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'এমুলেটর সেটিংস';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'এই কোরে পরিবর্তনযোগ্য কোনো অপশন নেই।';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'মেনু খুলতে চেপে ধরে রাখুন';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
-  String get gamePlaybackUnsupported => 'এই ডিভাইসে এখনও গেম খেলা সমর্থিত নয়।';
+  String get gamePlaybackUnsupported =>
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'কোন হোম সারি লোড করা যাবে না';
@@ -381,7 +382,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get noItemsFound => 'কোন আইটেম পাওয়া যায়নি';
 
   @override
-  String get home => 'হোম';
+  String get home => 'বাড়ি';
 
   @override
   String get browseAll => 'সব ব্রাউজ করুন';
@@ -551,7 +552,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'ডিসকভারে কোন বিষয়ের ফিড দেখানো হবে তা বেছে নিন।';
 
   @override
-  String get apply => 'প্রয়োগ করুন';
+  String get apply => 'আবেদন করুন';
 
   @override
   String get openLink => 'লিঙ্ক খুলুন';
@@ -742,13 +743,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get readStatus => 'পড়ুন';
 
   @override
-  String get watched => 'দেখা হয়েছে';
+  String get watched => 'দেখেছে';
 
   @override
   String get unread => 'অপঠিত';
 
   @override
-  String get unwatched => 'দেখা হয়নি';
+  String get unwatched => 'অদেখা';
 
   @override
   String get seriesStatus => 'সিরিজ স্ট্যাটাস';
@@ -760,43 +761,43 @@ class AppLocalizationsBn extends AppLocalizations {
   String get books => 'বই';
 
   @override
-  String get latestBooks => 'সর্বশেষ বই';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'সর্বশেষ অডিওবুক';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি বই',
-      one: '১টি বই',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'বই';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'অডিওবুক';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% পড়া হয়েছে';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time বাকি';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'পড়ুন';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'শুনুন';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'লেখক';
@@ -873,8 +874,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি অডিওবুক',
-      one: '১টি অডিওবুক',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -910,7 +911,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get nextUp => 'পরবর্তী আপ';
 
   @override
-  String get seasons => 'সিজন';
+  String get seasons => 'ঋতু';
 
   @override
   String get chapters => 'অধ্যায়';
@@ -977,8 +978,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি সিজন',
-      one: '১টি সিজন',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -989,40 +990,40 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get items => 'আইটেম';
+  String get items => 'Items';
 
   @override
-  String get extras => 'এক্সট্রা';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'নেপথ্যের দৃশ্য';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'বাদ দেওয়া দৃশ্য';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ফিচারেট';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'সাক্ষাৎকার';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'দৃশ্য';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'শর্টস';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'ট্রেলার';
 
   @override
   String timeRemaining(String time) {
-    return '$time বাকি';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time-এ শেষ হবে';
+    return 'Ends in $time';
   }
 
   @override
@@ -1040,7 +1041,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get play => 'প্লে করুন';
+  String get play => 'খেলা';
 
   @override
   String get startOver => 'ওভার শুরু করুন';
@@ -1064,7 +1065,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get version => 'সংস্করণ';
 
   @override
-  String get cast => 'কাস্ট করুন';
+  String get cast => 'কাস্ট';
 
   @override
   String get trailer => 'ট্রেলার';
@@ -1259,10 +1260,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get director => 'পরিচালক';
 
   @override
-  String get directors => 'পরিচালক';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'লেখক';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'লেখক';
@@ -1300,8 +1301,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি ট্র্যাক',
-      one: '১টি ট্র্যাক',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1311,8 +1312,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি অধ্যায়',
-      one: '১টি অধ্যায়',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1339,16 +1340,16 @@ class AppLocalizationsBn extends AppLocalizations {
   String get readMore => 'আরও পড়ুন';
 
   @override
-  String get shuffle => 'শাফেল';
+  String get shuffle => 'এলোমেলো';
 
   @override
-  String get shuffleAllMusic => 'সব মিউজিক শাফল করুন';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'আপনার ফোনে Moonfin-এ সাইন ইন করুন';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'আপনার সার্ভারে পৌঁছানো যাচ্ছে না';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1364,7 +1365,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get mono => 'মোনো';
+  String get mono => 'মনো';
 
   @override
   String get stereo => 'স্টেরিও';
@@ -1446,7 +1447,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get unavailable => 'অনুপলব্ধ';
 
   @override
-  String get pause => 'পজ করুন';
+  String get pause => 'বিরতি';
 
   @override
   String get syncPosition => 'সিঙ্ক অবস্থান';
@@ -1786,22 +1787,22 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'পরবর্তী: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesমি বাকি';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursঘ বাকি';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursঘ $minutesমি বাকি';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1824,7 +1825,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get favoriteChannel => 'প্রিয় চ্যানেল';
 
   @override
-  String get record => 'রেকর্ড করুন';
+  String get record => 'রেকর্ড';
 
   @override
   String get cancelRecordingAction => 'রেকর্ডিং বাতিল করুন';
@@ -1839,10 +1840,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get unableToCreateRecording => 'রেকর্ডিং তৈরি করতে অক্ষম৷';
 
   @override
-  String get watch => 'দেখুন';
+  String get watch => 'ঘড়ি';
 
   @override
-  String get close => 'বন্ধ করুন';
+  String get close => 'বন্ধ';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1984,7 +1985,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get season => 'সিজন';
+  String get season => 'ঋতু';
 
   @override
   String get errorLoadingEpisodes => 'পর্বগুলি লোড করার সময় ত্রুটি৷';
@@ -2050,8 +2051,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি পর্ব',
-      one: '১টি পর্ব',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2274,7 +2275,8 @@ class AppLocalizationsBn extends AppLocalizations {
   String get themeMusicVolume => 'থিম মিউজিক ভলিউম';
 
   @override
-  String get themeMusicSettingsSubtitle => 'বিস্তারিত পেজ, হোম সারি এবং ভলিউম';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2288,11 +2290,11 @@ class AppLocalizationsBn extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'হোম স্ক্রীন ব্রাউজ করার সময় খেলুন';
 
   @override
-  String get loopThemeMusic => 'থিম মিউজিক লুপ করুন';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'একবার চালানোর বদলে ট্র্যাকটি বারবার চালান';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'বিশদ বিবরণ পটভূমি ঝাপসা';
@@ -2315,23 +2317,23 @@ class AppLocalizationsBn extends AppLocalizations {
   String get playerZoomMode => 'প্লেয়ার জুম মোড';
 
   @override
-  String get settingsScrollWheelAction => 'মাউস স্ক্রল হুইল';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'প্লেব্যাকের সময় ভিডিওর উপর মাউস হুইল স্ক্রল করলে কী হবে তা বেছে নিন।';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'বন্ধ';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'সিক (সামনে / পিছনে)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ভলিউম';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ভলিউম';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'ফিট';
@@ -2346,7 +2348,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get refreshRateSwitching => 'রিফ্রেশ হার সুইচিং';
 
   @override
-  String get disabled => 'নিষ্ক্রিয়';
+  String get disabled => 'অক্ষম';
 
   @override
   String get scaleOnTv => 'টিভিতে স্কেল';
@@ -2385,38 +2387,37 @@ class AppLocalizationsBn extends AppLocalizations {
   String get defaultAudioLanguage => 'ডিফল্ট অডিও ভাষা';
 
   @override
-  String get fallbackAudioLanguage => 'ফলব্যাক অডিও ভাষা';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'ডিফল্ট অডিও ট্র্যাককে অগ্রাধিকার দিন';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'স্থানীয় ডাবের বদলে মূল অডিও ট্র্যাককে অগ্রাধিকার দিন।';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'অডিও ডেসক্রিপশন ট্র্যাককে অগ্রাধিকার দিন';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'সাধারণ ট্র্যাকের বদলে অডিও ডেসক্রিপশন ট্র্যাককে অগ্রাধিকার দিন।';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ট্রান্সকোডিং (অডিও)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'ডাইরেক্ট স্ট্রিম (রিমাক্স)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ট্রান্সকোডিং (বিটরেট বা রেজোলিউশন)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ট্রান্সকোডিং (ভিডিও ও অডিও)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ট্রান্সকোডিং (ভিডিও)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'স্বয়ংক্রিয় (সার্ভার ডিফল্ট)';
@@ -2497,7 +2498,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'অডিও কীভাবে ডিকোড হবে তা বেছে নিন। AVR Passthrough আপনার রিসিভারে সরাসরি Dolby/DTS স্ট্রিম পাঠায়; অটো বা ডাউনমিক্স ডিভাইসেই ডিকোড করে।';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR পাসথ্রু';
@@ -2507,13 +2508,13 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'সোর্স স্ট্রিম ডাইরেক্ট-প্লে বা পাসথ্রু করা না গেলে মাল্টি-চ্যানেল অডিও কোন ফরম্যাটে ট্রান্সকোড হবে তা নির্বাচন করুন।';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'অটো শনাক্ত\n(প্রস্তাবিত)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ডিফল্ট)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2522,51 +2523,50 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(লসলেস)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(শুধু স্টেরিও)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(সাশ্রয়ী)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(লসলেস)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'সর্বোচ্চ অডিও চ্যানেল';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'আপনার অডিও সেটআপের সর্বোচ্চ চ্যানেল সংখ্যা নির্ধারণ করুন। এই সীমা ছাড়ানো মাল্টিচ্যানেল স্ট্রিম ডাউনমিক্স বা ট্রান্সকোড হবে।';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'অটো শনাক্ত\n(হার্ডওয়্যার ডিফল্ট)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 মনো';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 স্টেরিও';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 সারাউন্ড';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 কোয়াড্রাফোনিক';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 সারাউন্ড';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 সারাউন্ড';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 সারাউন্ড';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 সারাউন্ড';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'পাসথ্রু (উন্নত)';
@@ -2602,7 +2602,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC)-এর মাধ্যমে বাহ্যিক ডিকোডারে Dolby Atmos বিটস্ট্রিম পাঠান।';
+      'বিটস্ট্রিম ডলবি অ্যাটমোস ওভার EAC3 (JOC) থেকে এক্সটার্নাল ডিকোডার।';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
@@ -2647,7 +2647,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'স্পিকার';
 
   @override
-  String get settingsAudioRouteHeadphones => 'হেডফোন';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2736,7 +2736,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueসে';
+    return '${value}s';
   }
 
   @override
@@ -2826,45 +2826,45 @@ class AppLocalizationsBn extends AppLocalizations {
       'সাবটাইটেল চেহারা কাস্টমাইজ করুন';
 
   @override
-  String get subtitleMode => 'সাবটাইটেল মোড';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ফ্ল্যাগ করা';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'সর্বদা';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'বিদেশি';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'ফোর্সড';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'মিডিয়া ফাইলের মেটাডেটায় \"default\" বা \"forced\" হিসেবে ফ্ল্যাগ করা ট্র্যাক চালায়।';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'প্রতিবার ভিডিও শুরু হলে স্বয়ংক্রিয়ভাবে সাবটাইটেল লোড করে দেখায়।';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'ডিফল্ট অডিও ট্র্যাক বিদেশি ভাষায় হলে স্বয়ংক্রিয়ভাবে সাবটাইটেল চালু করে।';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'শুধু forced মেটাডেটা ফ্ল্যাগ দেওয়া সাবটাইটেল লোড করে।';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'স্বয়ংক্রিয় সাবটাইটেল লোডিং সম্পূর্ণ বন্ধ করে দেয়।';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ফলব্যাক সাবটাইটেল ভাষা';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'সাবটাইটেল স্ট্রিম';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3069,10 +3069,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showLibrariesInToolbar => 'টুলবারে লাইব্রেরি দেখান';
 
   @override
-  String get navbarAlwaysExpanded => 'নেভিগেশন বারের লেবেল সবসময় দেখান';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr বোতাম দেখান';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'নববার অস্বচ্ছতা';
@@ -3147,19 +3147,18 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showFolderBrowsingOption => 'ফোল্ডার ব্রাউজিং অপশন দেখান';
 
   @override
-  String get groupItemsIntoCollections => 'আইটেমগুলো কালেকশনে গোষ্ঠীবদ্ধ করুন';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'লাইব্রেরি ব্রাউজ করার সময় কালেকশনভুক্ত লাইব্রেরি আইটেম লুকান';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'লাইব্রেরি গ্রুপিং বিজ্ঞপ্তি';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'এই সেটিংটি ব্যবহার করতে, আপনার Jellyfin বা Emby সার্ভারে লাইব্রেরির Display সেটিংসে \"Group movies into collections\" এবং/অথবা \"Group shows into collections\" লাইব্রেরি সেটিং চালু আছে কিনা নিশ্চিত করুন।';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'লাইব্রেরি দৃশ্যমানতা';
@@ -3218,7 +3217,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'Moonfin, MakD এর মধ্যে বেছে নিন অথবা মিডিয়া বার বন্ধ করুন';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'মুনফিন';
 
   @override
   String get mediaBarModeMakd => 'ম্যাকডি';
@@ -3271,10 +3270,10 @@ class AppLocalizationsBn extends AppLocalizations {
       '3 সেকেন্ড পরে মিডিয়া বারে অটো-প্লে ট্রেলারগুলি৷';
 
   @override
-  String get trailerAudio => 'ট্রেলার অডিও';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'মিডিয়া বারে ট্রেলারের অডিও চালু করুন';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'পর্বের পূর্বরূপ';
@@ -3351,11 +3350,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get combineBothRows => 'একটি একক হোম বিভাগে উভয় সারি একত্রিত করুন';
 
   @override
-  String get fullScreenRows => 'বিস্তৃত হোম সারি';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'প্রতি স্ক্রিনে হোম সারি ১টিতে সীমাবদ্ধ করুন';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'প্রতি সারি ইমেজ টাইপ';
@@ -3370,7 +3368,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get lastUser => 'শেষ ব্যবহারকারী';
 
   @override
-  String get currentUser => 'বর্তমান ব্যবহারকারী';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'সর্বদা প্রমাণীকরণ';
@@ -3479,10 +3477,10 @@ class AppLocalizationsBn extends AppLocalizations {
       'স্ক্রিনসেভার চলাকালীন ঘড়ি প্রদর্শন করুন';
 
   @override
-  String get clockModeStatic => 'স্থির';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'বাউন্সিং';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'পচা টমেটো (সমালোচক)';
@@ -3491,10 +3489,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get rottenTomatoesAudience => 'পচা টমেটো (শ্রোতা)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'আইএমডিবি';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'টিএমডিবি';
 
   @override
   String get metacritic => 'মেটাক্রিটিক';
@@ -3503,7 +3501,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get metacriticUser => 'মেটাক্রিটিক (ব্যবহারকারী)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ট্র্যাক্ট';
 
   @override
   String get letterboxd => 'লেটারবক্সডি';
@@ -3552,7 +3550,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'অ্যাপ্লিকেশান জুড়ে দেখানো রেটিং উত্সগুলি সক্ষম করুন এবং পুনরায় সাজান৷';
 
   @override
-  String get pluginLabel => 'Moonbase প্লাগইন';
+  String get pluginLabel => 'প্লাগইন';
 
   @override
   String get pluginDetected => 'প্লাগইন শনাক্ত হয়েছে';
@@ -3623,7 +3621,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get networks => 'নেটওয়ার্ক';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr ডিসকভারি সারি';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'সারি ডিফল্টে রিসেট করুন';
@@ -3646,27 +3644,28 @@ class AppLocalizationsBn extends AppLocalizations {
   String get hideAdultContent => 'ফলাফলে প্রাপ্তবয়স্কদের সামগ্রী লুকান';
 
   @override
-  String get seerrNotificationsSection => 'বিজ্ঞপ্তি';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'নতুন অনুরোধের বিজ্ঞপ্তি';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'কেউ অনুরোধ জমা দিলে আমাকে জানান';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'অনুরোধের আপডেট';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'অনুমোদিত, প্রত্যাখ্যাত এবং লাইব্রেরিতে যোগ হওয়া';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'ইস্যুর আপডেট';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'নতুন ইস্যু, উত্তর এবং সমাধান';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3674,15 +3673,15 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr ডিসকভারি পেজ';
+  String get discoverRows => 'সারি আবিষ্কার করুন';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr-এর মূল পেজে যে সারিগুলো দেখতে চান সেগুলো চালু করুন। ক্রম বদলাতে টেনে নিন। কাস্টম ক্রম Moonbase-এর সাথে সিঙ্ক হয়।';
+      'পুনরায় সাজাতে টেনে আনুন। সারিগুলি সক্ষম বা অক্ষম করুন৷ সক্ষম সারি অর্ডার Moonfin প্লাগইনের সাথে সিঙ্ক করে।';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr-এর মূল পেজে যে সারিগুলো দেখতে চান সেগুলো চালু করুন। ক্রম বদলাতে টেনে নিন। কাস্টম ক্রম Moonbase-এর সাথে সিঙ্ক হয়।';
+      'পুনরায় সাজাতে টেনে আনুন। সারিগুলি সক্ষম বা অক্ষম করুন৷';
 
   @override
   String get enabled => 'সক্রিয়';
@@ -3820,7 +3819,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get imageCacheCleared => 'ইমেজ ক্যাশ পরিষ্কার করা হয়েছে';
 
   @override
-  String get clear => 'সাফ করুন';
+  String get clear => 'পরিষ্কার';
 
   @override
   String get browse => 'ব্রাউজ করুন';
@@ -3836,11 +3835,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'ডাউনলোড হচ্ছে · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ইমপোর্ট হচ্ছে';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3983,147 +3982,148 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deletedStatus => 'মুছে ফেলা হয়েছে';
 
   @override
-  String get failedStatus => 'ব্যর্থ';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'প্রক্রিয়াধীন';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name পরিবর্তন করেছেন';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'সম্পন্ন';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'এই টাইটেলটি ইতিমধ্যে অনুরোধ করা হয়েছে';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'অনুরোধের সীমা শেষ';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'এই টাইটেলটি ব্লকলিস্টে আছে';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'অনুরোধ করার মতো আর কোনো সিজন নেই';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'এই অনুরোধ করার অনুমতি আপনার নেই';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'অনুরোধ';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'ইস্যু';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'নতুন';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'সর্বশেষ পরিবর্তিত';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'কোনো ইস্যু নেই';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limitটির মধ্যে $remainingটি মুভি অনুরোধ বাকি';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limitটির মধ্যে $remainingটি সিজন অনুরোধ বাকি';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name-এর অংশ';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'কালেকশন দেখুন';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'কালেকশন অনুরোধ করুন';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$totalটি মুভি · $availableটি উপলব্ধ';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$countটি মুভি অনুরোধ করুন';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$totalটির মধ্যে $currentটি অনুরোধ করা হচ্ছে...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$countটি মুভি অনুরোধ করা হয়েছে';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$totalটির মধ্যে $okটি মুভি অনুরোধ করা হয়েছে';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'সব মুভি ইতিমধ্যে উপলব্ধ বা অনুরোধ করা হয়েছে';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'ইস্যু রিপোর্ট করুন';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'ভিডিও';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'অডিও';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'সমস্যাটি কী?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'সব পর্ব';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'পর্ব';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'খোলা';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'সমাধান হয়েছে';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'সমাধান করুন';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'আবার খুলুন';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name রিপোর্ট করেছেন';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$countটি মন্তব্য';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'একটি মন্তব্য যোগ করুন';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'এই ইস্যুটি মুছবেন?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'রিপোর্ট জমা দিন';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB স্কোর';
@@ -4147,7 +4147,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get originalLanguageLabel => 'মূল ভাষা';
 
   @override
-  String get seasonsLabel => 'সিজন';
+  String get seasonsLabel => 'ঋতু';
 
   @override
   String get episodesLabel => 'পর্বগুলি';
@@ -4240,7 +4240,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get refresh => 'রিফ্রেশ';
 
   @override
-  String get remote => 'রিমোট';
+  String get remote => 'দূরবর্তী';
 
   @override
   String get rename => 'নাম পরিবর্তন করুন';
@@ -4258,7 +4258,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get run => 'চালান';
 
   @override
-  String get search => 'অনুসন্ধান';
+  String get search => 'অনুসন্ধান করুন';
 
   @override
   String get select => 'নির্বাচন করুন';
@@ -4276,7 +4276,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get status => 'স্ট্যাটাস';
 
   @override
-  String get stop => 'থামান';
+  String get stop => 'থামো';
 
   @override
   String get streaming => 'স্ট্রিমিং';
@@ -4285,7 +4285,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get time => 'সময়';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ট্রিকপ্লে';
 
   @override
   String get uninstall => 'আনইনস্টল করুন';
@@ -4303,7 +4303,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get unmute => 'আনমিউট করুন';
 
   @override
-  String get mute => 'মিউট';
+  String get mute => 'নিঃশব্দ';
 
   @override
   String get branding => 'ব্র্যান্ডিং';
@@ -4327,25 +4327,25 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminDrawerLibraries => 'লাইব্রেরি';
 
   @override
-  String get adminDrawerDisplay => 'ডিসপ্লে';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'মেটাডেটা';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO সেটিংস';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ট্রান্সকোডিং';
 
   @override
-  String get adminDrawerResume => 'পুনরায় শুরু';
+  String get adminDrawerResume => 'পুনরায় শুরু করুন';
 
   @override
   String get adminDrawerStreaming => 'স্ট্রিমিং';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ট্রিকপ্লে';
 
   @override
   String get adminDrawerDevices => 'ডিভাইস';
@@ -4533,7 +4533,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get nowPlaying => 'এখন চলছে';
 
   @override
-  String get volume => 'ভলিউম';
+  String get volume => 'আয়তন';
 
   @override
   String get actions => 'কর্ম';
@@ -4545,7 +4545,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audioCodec => 'অডিও কোডেক';
 
   @override
-  String get hwAccel => 'হার্ডওয়্যার অ্যাক্সেল';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'সমাপ্তি';
@@ -4560,10 +4560,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminClearDates => 'তারিখগুলি পরিষ্কার করুন';
 
   @override
-  String get adminActivitySeverityAll => 'সব তীব্রতা';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'তারিখের পরিসর';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4600,23 +4600,23 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' ডিভাইসটি সরাবেন? ব্যবহারকারীকে এই ডিভাইসে আবার সাইন ইন করতে হবে।';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'সব ডিভাইস মুছুন';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$countটি ডিভাইস সরাবেন? প্রভাবিত ব্যবহারকারীদের আবার সাইন ইন করতে হবে। আপনার বর্তমান ডিভাইস প্রভাবিত হবে না।';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'ডিভাইস সরানো হয়েছে';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'কিছু ডিভাইস সরানো হয়েছে; $countটি সরানো যায়নি।';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4731,251 +4731,244 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminMetadataCountryHint => 'যেমন US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'পাথ';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'অপশন';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ডাউনলোডার';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'মেটাডেটা সেভার';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'সাবটাইটেল ডাউনলোডার';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'লিরিক ডাউনলোডার';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'মেটাডেটা ডাউনলোডার: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ছবি ফেচার: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'এই সার্ভারে এই লাইব্রেরি ধরনের জন্য কোনও ডাউনলোডার নেই।';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'সাধারণ';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'মেটাডেটা';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'এমবেড করা তথ্য';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'সাবটাইটেল';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'ছবি';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'সিরিজ';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'মিউজিক';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'সিনেমা';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'রিয়েল-টাইম মনিটরিং চালু করুন';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ফাইলের পরিবর্তন শনাক্ত করে স্বয়ংক্রিয়ভাবে প্রক্রিয়া করুন।';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'আর্কাইভকে মিডিয়া ফাইল হিসেবে গণ্য করুন';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ছবি দেখান';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'মিডিয়া ফোল্ডারে আর্টওয়ার্ক সংরক্ষণ করুন';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'স্বয়ংক্রিয় মেটাডেটা রিফ্রেশ';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'কখনও নয়';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ডিফল্ট';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'প্রদর্শন';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'লাইব্রেরি প্রদর্শন';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'সাধারণ মিডিয়া ফোল্ডার দেখাতে একটি ফোল্ডার ভিউ দেখান';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'স্পেশালগুলি যে সিজনে প্রচারিত হয়েছিল সেই সিজনেই দেখান';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'সিনেমাগুলি কালেকশনে গ্রুপ করুন';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'শোগুলি কালেকশনে গ্রুপ করুন';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'সাজেশনে বাইরের কনটেন্ট দেখান';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'যোগ করার তারিখের আচরণ';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'যোগ করার তারিখ নিন';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'লাইব্রেরিতে স্ক্যান করার তারিখ';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ফাইল তৈরির তারিখ';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'মেটাডেটা ও ছবি';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'পছন্দের মেটাডেটা ভাষা';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'অধ্যায়';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ডামি অধ্যায়ের দৈর্ঘ্য (সেকেন্ড)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'যেসব মিডিয়ায় অধ্যায় নেই, তার জন্য তৈরি করা অধ্যায়ের দৈর্ঘ্য। বন্ধ করতে 0 দিন।';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'অধ্যায়ের ছবির রেজোলিউশন';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO সেটিংস';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO মেটাডেটা Kodi ও অনুরূপ ক্লায়েন্টের সঙ্গে সামঞ্জস্যপূর্ণ। যেসব লাইব্রেরি NFO মেটাডেটা সংরক্ষণ করে, এই সেটিংস সেগুলির সবগুলিতেই প্রযোজ্য।';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ফাইলে যে ব্যবহারকারীর দেখার তথ্য রাখা হবে';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO ফাইলে ছবির পাথ সংরক্ষণ করুন';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO ছবির পাথের জন্য পাথ প্রতিস্থাপন চালু করুন';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart ছবিগুলি extrathumbs ফোল্ডারে কপি করুন';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'কোনোটিই নয়';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days দিন';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'এমবেড করা টাইটেল ব্যবহার করুন';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'এক্সট্রার জন্য এমবেড করা টাইটেল ব্যবহার করুন';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'এমবেড করা পর্বের তথ্য ব্যবহার করুন';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'এমবেড করা সাবটাইটেল অনুমোদন করুন';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'সব অনুমোদন করুন';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'শুধু টেক্সট';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'শুধু ছবি';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'কোনোটিই নয়';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'এমবেড করা সাবটাইটেল থাকলে ডাউনলোড এড়িয়ে যান';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'অডিও ট্র্যাক ডাউনলোডের ভাষার সঙ্গে মিললে ডাউনলোড এড়িয়ে যান';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'নিখুঁত সাবটাইটেল মিল আবশ্যক করুন';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'মিডিয়া ফোল্ডারে সাবটাইটেল সংরক্ষণ করুন';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'অধ্যায়ের ছবি বের করুন';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'লাইব্রেরি স্ক্যানের সময় অধ্যায়ের ছবি বের করুন';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay ছবি এক্সট্র্যাকশন চালু করুন';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'লাইব্রেরি স্ক্যানের সময় Trickplay ছবি বের করুন';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'মিডিয়া ফোল্ডারে Trickplay ছবি সংরক্ষণ করুন';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'একাধিক ফোল্ডারে ছড়িয়ে থাকা সিরিজ স্বয়ংক্রিয়ভাবে একত্র করুন';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'সিজন শূন্যের প্রদর্শন নাম';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'অডিও নরমালাইজেশনের জন্য LUFS স্ক্যান চালু করুন';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'নন-স্ট্যান্ডার্ড আর্টিস্ট ট্যাগ অগ্রাধিকার দিন';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'সিনেমাগুলি স্বয়ংক্রিয়ভাবে কালেকশনে যোগ করুন';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'লাইব্রেরির নাম প্রয়োজন';
@@ -5211,143 +5204,143 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminEnableAllChannels => 'সমস্ত চ্যানেলে অ্যাক্সেস সক্ষম করুন৷';
 
   @override
-  String get adminParentalControl => 'অভিভাবকীয় নিয়ন্ত্রণ';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'সর্বোচ্চ অনুমোদিত অভিভাবকীয় রেটিং';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'এর চেয়ে বেশি রেটিংয়ের কনটেন্ট এই ব্যবহারকারীর কাছে লুকানো থাকবে।';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'কোনোটিই নয়';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'রেটিং তথ্য নেই বা অচেনা, এমন আইটেম ব্লক করুন';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'বই';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'চ্যানেল';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'লাইভ টিভি';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'সিনেমা';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'মিউজিক';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ট্রেলার';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'শো';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'অ্যাক্সেসের সময়সূচি';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'শুধু নিচের নির্ধারিত সময়ে অ্যাক্সেস অনুমোদন করুন। কোনও সময়সূচি না থাকলে সারাদিনই অ্যাক্সেস অনুমোদিত।';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'সময়সূচি যোগ করুন';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'দিন';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'শুরু';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'শেষ';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'প্রতিদিন';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'কর্মদিবস';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'সপ্তাহান্ত';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'রবিবার';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'সোমবার';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'মঙ্গলবার';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'বুধবার';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'বৃহস্পতিবার';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'শুক্রবার';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'শনিবার';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'অনুমোদিত ট্যাগ';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'শুধু এই ট্যাগযুক্ত কনটেন্ট দেখানো হবে। সব অনুমোদন করতে খালি রাখুন।';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'ব্লক করা ট্যাগ';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'এই ট্যাগযুক্ত কনটেন্ট এই ব্যবহারকারীর কাছে লুকানো থাকবে।';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ট্যাগ যোগ করুন';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'চালু থাকা ডিভাইস';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'চালু থাকা চ্যানেল';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'অথেনটিকেশন প্রোভাইডার';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'পাসওয়ার্ড রিসেট প্রোভাইডার';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'লকআউটের আগে সর্বোচ্চ ব্যর্থ লগইন চেষ্টা';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'ডিফল্টের জন্য 0 দিন, অথবা লকআউট বন্ধ করতে -1 দিন।';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay অ্যাক্সেস';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'গ্রুপ তৈরি ও যোগদানের অনুমতি দিন';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'গ্রুপে যোগদানের অনুমতি দিন';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'অ্যাক্সেস নেই';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'কনটেন্ট মুছে ফেলার অনুমতি দিন';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5435,25 +5428,25 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'ব্যাকআপ তৈরি করুন';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'ব্যাকআপে কী কী রাখবেন তা বেছে নিন।';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ডেটাবেস';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'সবসময় অন্তর্ভুক্ত';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'মেটাডেটা';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'সাবটাইটেল';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay ছবি';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'ব্যাকআপ তৈরি করা হচ্ছে...';
@@ -5882,10 +5875,11 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminThrottleBuffering => 'থ্রটল বাফারিং';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay সেটিংস সংরক্ষণ করা হয়েছে';
+  String get adminTrickplaySaved => 'ট্রিকপ্লে সেটিংস সংরক্ষিত';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay সেটিংস লোড করা যায়নি';
+  String get adminTrickplayLoadFailed =>
+      'ট্রিকপ্লে সেটিংস লোড করতে ব্যর্থ হয়েছে৷';
 
   @override
   String get adminEnableHardwareAcceleration => 'হার্ডওয়্যার ত্বরণ সক্ষম করুন';
@@ -5997,7 +5991,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminBaseUrl => 'বেস URL';
 
   @override
-  String get adminBaseUrlHint => 'যেমন /jellyfin';
+  String get adminBaseUrlHint => 'যেমন /জেলিফিন';
 
   @override
   String get https => 'HTTPS';
@@ -6161,61 +6155,60 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminAddTuner => 'টিউনার যোগ করুন';
 
   @override
-  String get adminEditTuner => 'টিউনার সম্পাদনা করুন';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U টিউনার';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ফাইল বা URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'টিউনারের IP ঠিকানা';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'সহজবোধ্য নাম';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'ইউজার এজেন্ট';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'একযোগে সংযোগের সীমা';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'টিউনার একসঙ্গে সর্বাধিক যতগুলি স্ট্রিম অনুমোদন করে। সীমাহীন করতে 0 দিন।';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'ফলব্যাক সর্বোচ্চ স্ট্রিমিং বিটরেট';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'শুধু পছন্দের চ্যানেল ইমপোর্ট করুন';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'হার্ডওয়্যার ট্রান্সকোডিং অনুমোদন করুন';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 ট্রান্সকোডিং কনটেইনার অনুমোদন করুন';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'স্ট্রিম শেয়ারিং অনুমোদন করুন';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'স্ট্রিম লুপিং চালু করুন';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS উপেক্ষা করুন';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
-  String get adminTunerReadAtNativeFramerate => 'নেটিভ ফ্রেম রেটে ইনপুট পড়ুন';
+  String get adminTunerReadAtNativeFramerate =>
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'প্রোভাইডার সম্পাদনা করুন';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6224,50 +6217,50 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ফাইল বা URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'সিনেমার প্রিফিক্স';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'সিনেমার বিভাগ';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'একাধিক বিভাগ ভার্টিক্যাল বার দিয়ে আলাদা করুন।';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'শিশুদের বিভাগ';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'সংবাদের বিভাগ';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'খেলাধুলার বিভাগ';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ব্যবহারকারীর নাম';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'পাসওয়ার্ড';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'দেশ';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'একটি দেশ বেছে নিন';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'পোস্টাল কোড';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'লিস্টিং আনুন';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'লিস্টিং';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'সব টিউনার চালু করুন';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'টিউনার প্রকার';
@@ -6309,7 +6302,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'এই ধরনের টিউনার রিসেট করা যায় না।';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6332,43 +6325,43 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminSeriesRecordingPath => 'সিরিজ রেকর্ডিং পাথ';
 
   @override
-  String get adminMovieRecordingPath => 'সিনেমা রেকর্ডিংয়ের পাথ';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'গাইড ডেটার দিন';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'স্বয়ংক্রিয়';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days দিন';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'পোস্ট-প্রসেসিং অ্যাপ্লিকেশনের পাথ';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'পোস্ট-প্রসেসরের আর্গুমেন্ট';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'রেকর্ডিংয়ের NFO মেটাডেটা সংরক্ষণ করুন';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'রেকর্ডিংয়ের ছবি সংরক্ষণ করুন';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'সময়';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'রেকর্ডিংয়ের পাথ';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'পোস্ট-প্রসেসিং';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'গাইড ডেটা: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6410,14 +6403,14 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminGuideProviders => 'গাইড প্রদানকারী';
 
   @override
-  String get adminRefreshGuideData => 'গাইড ডেটা রিফ্রেশ করুন';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'গাইড ডেটা রিফ্রেশ শুরু হয়েছে';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'এই সার্ভারে গাইড রিফ্রেশ টাস্কটি নেই।';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'প্রদানকারী যোগ করুন';
@@ -6500,7 +6493,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminLiveTvTitle => 'লাইভ টিভি প্রশাসন';
 
   @override
-  String get adminApply => 'প্রয়োগ করুন';
+  String get adminApply => 'আবেদন করুন';
 
   @override
   String get adminNotSet => 'সেট করা হয়নি';
@@ -6552,7 +6545,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminMetadataEditorTitle => 'মেটাডেটা সম্পাদক';
 
   @override
-  String get adminMetadataIdentify => 'শনাক্ত করুন';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'টাইপ';
@@ -6966,20 +6959,19 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminBrandingEnableSplash => 'স্প্ল্যাশ স্ক্রিন সক্ষম করুন';
 
   @override
-  String get adminBrandingSplashUpload => 'ছবি আপলোড করুন';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'স্প্ল্যাশস্ক্রিন আপডেট হয়েছে';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'স্প্ল্যাশস্ক্রিন আপলোড করা যায়নি';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'স্প্ল্যাশস্ক্রিন সরানো হয়েছে';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'কোনও কাস্টম স্প্ল্যাশস্ক্রিন নেই';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'হার্ডওয়্যার ত্বরণ';
@@ -6995,121 +6987,121 @@ class AppLocalizationsBn extends AppLocalizations {
       'এর জন্য হার্ডওয়্যার ডিকোডিং সক্ষম করুন:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ডিভাইস';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'উন্নত NVDEC ডিকোডার চালু করুন';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'সিস্টেমের নেটিভ হার্ডওয়্যার ডিকোডার অগ্রাধিকার দিন';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'হার্ডওয়্যার ডিকোডিংয়ের কালার ডেপথ';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-বিট HEVC ডিকোডিং';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-বিট VP9 ডিকোডিং';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-বিট ডিকোডিং';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-বিট ডিকোডিং';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'হার্ডওয়্যার এনকোডিং';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC এনকোডিং অনুমোদন করুন';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 এনকোডিং অনুমোদন করুন';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel লো-পাওয়ার H.264 এনকোডার চালু করুন';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel লো-পাওয়ার HEVC এনকোডার চালু করুন';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'টোন ম্যাপিং';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'টোন ম্যাপিং চালু করুন';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP টোন ম্যাপিং চালু করুন';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox টোন ম্যাপিং চালু করুন';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'টোন ম্যাপিং অ্যালগরিদম';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'টোন ম্যাপিং মোড';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'টোন ম্যাপিং রেঞ্জ';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'টোন ম্যাপিং ডিস্যাচুরেশন';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'টোন ম্যাপিং পিক';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'টোন ম্যাপিং প্যারামিটার';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP টোন ম্যাপিং উজ্জ্বলতা';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP টোন ম্যাপিং কনট্রাস্ট';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'প্রিসেট ও মান';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'এনকোডার প্রিসেট';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 এনকোডিং CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) এনকোডিং CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'ডিইন্টারলেস পদ্ধতি';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ডিইন্টারলেস করার সময় ফ্রেম রেট দ্বিগুণ করুন';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'অডিও';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'অডিও VBR এনকোডিং চালু করুন';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'অডিও ডাউনমিক্স বুস্ট';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'স্টেরিও ডাউনমিক্স অ্যালগরিদম';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'সর্বোচ্চ মাক্সিং কিউ সাইজ';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'স্বয়ংক্রিয়';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'এনকোডিং';
@@ -7225,10 +7217,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminTaskNeverRun => 'কখনো দৌড়াবেন না';
 
   @override
-  String get adminTaskStop => 'থামান';
+  String get adminTaskStop => 'থামো';
 
   @override
-  String get adminRunningTasks => 'চলমান টাস্ক';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'চালান';
@@ -7298,8 +7290,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ঘণ্টা',
-      one: '১ ঘণ্টা',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7345,17 +7337,17 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesমি';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursঘ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysদি';
+    return '${days}d';
   }
 
   @override
@@ -7365,7 +7357,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'সিক প্রিভিউ থাম্বনেইলের জন্য Trickplay ছবি তৈরি কনফিগার করুন।';
+      'প্রিভিউ থাম্বনেল খোঁজার জন্য ট্রিকপ্লে ইমেজ জেনারেশন কনফিগার করুন।';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'পাবলিক HTTPS পোর্ট';
@@ -7374,50 +7366,49 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'বেস URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'যেমন /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'যেমন /জেলিফিন';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'পাবলিক HTTP পোর্ট';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS আবশ্যক করুন';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'সব রিমোট রিকোয়েস্ট HTTPS-এ পাঠান। সার্ভারে বৈধ সার্টিফিকেট না থাকলে এটি কার্যকর হবে না।';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'সার্টিফিকেটের পাসওয়ার্ড';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP সেটিংস';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 চালু করুন';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 চালু করুন';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'স্বয়ংক্রিয় পোর্ট ম্যাপিং চালু করুন';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN নেটওয়ার্ক';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'কমা বা লাইন দিয়ে আলাদা করা IP ঠিকানা বা CIDR সাবনেটের তালিকা, যেগুলিকে লোকাল নেটওয়ার্কের অংশ হিসেবে গণ্য করা হবে।';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'প্রকাশিত সার্ভার URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'একটি সাবনেট বা ঠিকানাকে প্রকাশিত URL-এ ম্যাপ করুন, যেমন all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'শংসাপত্রের পথ';
@@ -7447,11 +7438,11 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'থ্রটল বাফারিং';
 
   @override
-  String get adminPlaybackThrottleDelay => 'থ্রটল বিলম্ব (সেকেন্ড)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'চলার সময় সাবটাইটেল এক্সট্র্যাকশন অনুমোদন করুন';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'ন্যূনতম জীবনবৃত্তান্ত শতাংশ';
@@ -7510,23 +7501,22 @@ class AppLocalizationsBn extends AppLocalizations {
       'ধীর প্রতিক্রিয়া থ্রেশহোল্ড (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'ধীর রেসপন্সের সতর্কতা চালু করুন';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect চালু করুন';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'সার্ভার';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'মেটাডেটা';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'পাথ';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'পারফরম্যান্স';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'ক্যাশে পথ';
@@ -7538,7 +7528,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminGeneralServerName => 'সার্ভারের নাম';
 
   @override
-  String get adminGeneralDisplayLanguage => 'পছন্দের প্রদর্শন ভাষা';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'সেটিংস লোড করতে ব্যর্থ হয়েছে৷';
@@ -7590,8 +7580,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# জন অংশগ্রহণকারী',
-      one: '# জন অংশগ্রহণকারী',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7737,8 +7727,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# টি সারি পাওয়া গেছে',
-      one: '# টি সারি পাওয়া গেছে',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7779,20 +7769,20 @@ class AppLocalizationsBn extends AppLocalizations {
   String get offlineSavedMedia => 'সংরক্ষিত মিডিয়া';
 
   @override
-  String get offlineBannerTitle => 'আপনি অফলাইনে আছেন';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'আপনার ডাউনলোড দেখানো হচ্ছে';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ডাউনলোড';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'আপনার সার্ভারে পৌঁছানো যাচ্ছে না';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'সার্ভার ফিরে না আসা পর্যন্ত ডাউনলোড থেকে চালানো হচ্ছে';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7865,40 +7855,40 @@ class AppLocalizationsBn extends AppLocalizations {
   String get pinForgot => 'পিন ভুলে গেছেন?';
 
   @override
-  String get pinClear => 'সাফ করুন';
+  String get pinClear => 'পরিষ্কার';
 
   @override
   String get pinBackspace => 'ব্যাকস্পেস';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect অনুরোধ অনুমোদিত হয়েছে।';
+  String get quickConnectAuthorized => 'দ্রুত সংযোগের অনুরোধ অনুমোদিত।';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect কোডটি ভুল বা মেয়াদোত্তীর্ণ।';
+      'দ্রুত সংযোগ কোড অবৈধ বা মেয়াদ উত্তীর্ণ.';
 
   @override
-  String get quickConnectNotSupported =>
-      'এই সার্ভারে Quick Connect সমর্থিত নয়।';
+  String get quickConnectNotSupported => 'এই সার্ভারে দ্রুত সংযোগ সমর্থিত নয়৷';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect কোড অনুমোদন করা যায়নি।';
+      'দ্রুত সংযোগ কোড অনুমোদন করতে ব্যর্থ হয়েছে.';
 
   @override
-  String get quickConnectDisabled => 'এই সার্ভারে Quick Connect বন্ধ আছে।';
+  String get quickConnectDisabled =>
+      'এই সার্ভারে দ্রুত সংযোগ নিষ্ক্রিয় করা হয়েছে৷';
 
   @override
   String get quickConnectForbidden =>
-      'আপনার অ্যাকাউন্ট এই Quick Connect অনুরোধ অনুমোদন করতে পারবে না।';
+      'আপনার অ্যাকাউন্ট এই দ্রুত সংযোগের অনুরোধ অনুমোদন করতে পারে না৷';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect কোড পাওয়া যায়নি। নতুন একটি কোড দিয়ে চেষ্টা করুন।';
+      'দ্রুত সংযোগ কোড পাওয়া যায়নি. একটি নতুন কোড চেষ্টা করুন.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ব্যর্থ হয়েছে: $message';
+    return 'দ্রুত সংযোগ ব্যর্থ হয়েছে: $message';
   }
 
   @override
@@ -8063,7 +8053,7 @@ class AppLocalizationsBn extends AppLocalizations {
       'প্লেব্যাক বিরাম দেওয়া হয়েছে. আপনি কি এখনও দেখছেন?';
 
   @override
-  String get stillWatchingStop => 'থামান';
+  String get stillWatchingStop => 'থামো';
 
   @override
   String get stillWatchingContinue => 'চালিয়ে যান';
@@ -8123,7 +8113,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'ঘূর্ণনের অনুমতি দিন';
 
   @override
-  String get playerTooltipPrevious => 'পূর্ববর্তী';
+  String get playerTooltipPrevious => 'আগের';
 
   @override
   String get playerTooltipSeekBack => 'ফিরে চাও';
@@ -8148,13 +8138,13 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Continue Watching থেকে লুকান';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Next Up থেকে লুকান';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'কালেকশনে যোগ করুন';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8208,15 +8198,14 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsAlphabetical => 'বর্ণানুক্রমিক';
 
   @override
-  String get settingsConnectionSection => 'সংযোগ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'সেলফ-সাইনড সার্টিফিকেট অনুমোদন করুন';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'সেলফ-সাইনড বা প্রাইভেট-CA TLS সার্টিফিকেট ব্যবহার করা সার্ভারকে বিশ্বাস করুন। শুধু আপনার নিজের নিয়ন্ত্রণে থাকা সার্ভারের জন্য চালু করুন। এটি সব সংযোগের সার্টিফিকেট যাচাই বন্ধ করে দেয়।';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'গোপনীয়তা এবং নিরাপত্তা';
@@ -8232,11 +8221,11 @@ class AppLocalizationsBn extends AppLocalizations {
       'থিম অ্যাকসেন্ট, ব্যাকড্রপ, দেখা সূচক এবং থিম মিউজিক';
 
   @override
-  String get settingsDetailsScreen => 'বিস্তারিত স্ক্রিন';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'স্টাইল, ব্যাকগ্রাউন্ড ব্লার এবং ট্যাবের আচরণ';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'হোম পেজ';
@@ -8274,11 +8263,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'নেভিগেশন বারে Seerr বোতাম দেখান';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'উপরের নেভিগেশন বারে সবসময় টেক্সট লেবেল দেখান';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8379,8 +8368,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# লাইসেন্স নোটিশ',
-      one: '# লাইসেন্স নোটিশ',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8429,16 +8418,16 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros এবং Outros এড়িয়ে যান?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'মিডিয়া সেগমেন্ট কাউন্টডাউন';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'প্রোগ্রেস বার';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'টাইমার';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'কোনোটিই নয়';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'প্রম্পট ব্যবহারকারী';
@@ -8666,7 +8655,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'সম্প্রতি মুক্তিপ্রাপ্ত $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8699,11 +8688,11 @@ class AppLocalizationsBn extends AppLocalizations {
       'অ-টানেল প্লেব্যাক জোর করুন। টানেলিং অডিও/ভিডিও বন্ধ থাকা ডিভাইসগুলিতে দরকারী।';
 
   @override
-  String get enableTunnelingTitle => 'টানেলিং চালু করুন';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'উন্নত। অডিও ও ভিডিওকে একটি যুক্ত হার্ডওয়্যার পথে পাঠায়। কিছু ডিভাইসে অডিও/ভিডিও কেটে যাওয়ার কারণে ডিফল্টভাবে বন্ধ রাখা হয়েছে।';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8730,14 +8719,14 @@ class AppLocalizationsBn extends AppLocalizations {
       'সাবটাইটেল ট্র্যাকে এমবেড করা ফন্ট-আকারের ইঙ্গিতগুলি প্রয়োগ করুন৷ আপনার শৈলী পছন্দগুলি থেকে সাবটাইটেল আকার ব্যবহার করতে অক্ষম করুন৷';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'মিডিয়ার বিস্তারিত দেখান';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'লাইব্রেরি পেজের উপরে নির্বাচিত আইটেমের বিস্তারিত দেখান।';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'ব্রাউজ করার সময় ব্যাকড্রপ লুকাবেন?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'বিস্তারিত উপ-শিরোনাম ব্যবহার করুন';
@@ -8755,37 +8744,37 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'থিম স্টোর';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'কমিউনিটি থিম দেখুন ও সংরক্ষণ করুন';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'থিমটি সংরক্ষণ করলে আপনার অন্যান্য সংরক্ষিত থিমের মতোই ব্যবহার করতে পারবেন।';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'এই মুহূর্তে কোনো থিম নেই।';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'থিম স্টোর লোড করা যায়নি। আপনার সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'সংরক্ষণ করুন';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'সংরক্ষণ ও প্রয়োগ করুন';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'সংরক্ষিত';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'এই থিমটি লোড করা যায়নি।';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" সংরক্ষিত হয়েছে।';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8843,21 +8832,21 @@ class AppLocalizationsBn extends AppLocalizations {
   String get homeRowsSection => 'বাড়ির সারি';
 
   @override
-  String get homeRowDisplay => 'হোম রো প্রদর্শন';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'হোম রো সেকশন';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'হোম রো টগল';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'লাইব্রেরি-ভিত্তিক হোম রো ক্যাটাগরি চালু বা বন্ধ করুন';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'হোম সেকশনে রো দেখাতে নিচের টগলগুলো চালু করুন।';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'সারি টাইপ';
@@ -8915,54 +8904,55 @@ class AppLocalizationsBn extends AppLocalizations {
       'সিনেমা, সিরিজ বা উভয় প্রকারের সারিতে দেখান।';
 
   @override
-  String get displayPlaylistsRows => 'প্লেলিস্ট রো দেখান';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
-  String get displayPlaylistsRowsSubtitle => 'হোম সেকশনে প্লেলিস্ট রো দেখান।';
+  String get displayPlaylistsRowsSubtitle =>
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'প্লেলিস্ট রো সাজানো';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'প্লেলিস্ট রো যোগ করার তারিখ, মুক্তির তারিখ, বর্ণানুক্রম এবং আরও নানাভাবে সাজান।';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'অডিও রো দেখান';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'হোম সেকশনে অডিও রো দেখান।';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'অডিও রো সাজানো';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'অডিও রো যোগ করার তারিখ, মুক্তির তারিখ, বর্ণানুক্রম এবং আরও নানাভাবে সাজান।';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'অডিও প্লেলিস্ট';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'চেহারা';
 
   @override
-  String get layout => 'লেআউট';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'থিম';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'কীবোর্ড';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'বোতাম';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'রেন্ডারিং';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV কনফিগারেশন';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'কার্ড সাইজ';
@@ -8972,7 +8962,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'লং-প্রেস করে চালানোর অপশন পেতে এক্সটার্নাল প্লেয়ার সেট করুন';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9235,10 +9225,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get guestAppearances => 'অতিথি উপস্থিতি';
 
   @override
-  String get appearancesSeerr => 'উপস্থিতি (Seerr)';
+  String get appearancesSeerr => 'উপস্থিতি (দ্রষ্টা)';
 
   @override
-  String get crewContributionsSeerr => 'কলাকুশলীর অবদান (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'গ্রুপের সাথে দেখুন';
@@ -9324,8 +9314,8 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$countটি লাইব্রেরি',
-      one: '১টি লাইব্রেরি',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9416,7 +9406,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mixedMoviesAndShows => 'মিশ্র চলচ্চিত্র ও শো';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'ইন্টেল কুইক সিঙ্ক';
 
   @override
   String get rockchipMpp => 'রকচিপ এমপিপি';
@@ -9484,13 +9474,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get loadingShuffle => 'শাফেল লোড হচ্ছে...';
 
   @override
-  String get libraryShuffleLabel => 'লাইব্রেরি শাফল';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'এলোমেলো শাফল';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'জনরা শাফল';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'অটো এইচডিআর সুইচিং';
@@ -9503,222 +9493,222 @@ class AppLocalizationsBn extends AppLocalizations {
   String get whenFullscreen => 'যখন ফুলস্ক্রিন';
 
   @override
-  String get changeArtwork => 'আর্টওয়ার্ক পরিবর্তন করুন';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'অনুপস্থিত';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'ট্রান্সকোডিং সীমা';
 
   @override
-  String get clearAllArtworkButton => 'সব আর্টওয়ার্ক মুছবেন?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'আপনি কি ডাউনলোড করা সব আর্টওয়ার্ক মুছে ফেলতে চান?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'মোছার নিশ্চিতকরণ';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'আপনি কি এই $itemType মুছে ফেলতে চান?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'আপলোড করবেন?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'রেজোলিউশন: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'শুধু ইন্টারফেসের ভাষার আর্টওয়ার্ক দেখান';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'সব মোছার নিশ্চিতকরণ';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'ছবি সফলভাবে আপলোড হয়েছে!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'ছবি আপলোড করা যায়নি: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ছবি সেট করা যায়নি: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ছবি মুছে ফেলা যায়নি: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'সব আর্টওয়ার্ক মোছা যায়নি: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'হ্যাঁ';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'পোস্টার';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'ব্যাকড্রপ';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'ব্যানার';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'লোগো';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'থাম্বনেইল';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'আর্ট';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ডিস্ক আর্ট';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'স্ক্রিনশট';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'বক্স কভার';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'বক্সের পেছনের কভার';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'মেনু আর্ট';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'পোস্টার';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ব্যাকড্রপ';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'ব্যানার';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'লোগো';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'থাম্বনেইল';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'আর্ট';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ডিস্ক আর্ট';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'স্ক্রিনশট';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'বক্স কভার';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'বক্সের পেছনের কভার';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'মেনু আর্ট';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'সব';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'উচ্চ (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'মাঝারি (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'নিম্ন (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'উৎস';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'অধ্যায়';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'বুকমার্ক';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'নোট';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'কিউ';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'টাইমলাইন';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'টাইমলাইন খালি';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'সম্পূর্ণ বই';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'নির্দিষ্ট টাইমলাইন';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'বুকমার্ক এক্সপোর্ট করুন';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'নোট এক্সপোর্ট করুন';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'সব এক্সপোর্ট করুন';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path-এ এক্সপোর্ট হয়েছে';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'এক্সপোর্ট ব্যর্থ হয়েছে: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'লিরিক্স';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'বুকমার্ক যোগ করুন';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'নোট যোগ করুন';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'নোট সম্পাদনা করুন';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'এই মুহূর্তটির জন্য একটি নোট লিখুন';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'স্লিপ টাইমার';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'বন্ধ';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'অধ্যায়ের শেষে';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'কাস্টম';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining বাকি';
+    return '$remaining left';
   }
 
   @override
@@ -9726,58 +9716,58 @@ class AppLocalizationsBn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count মিনিট',
-      one: '১ মিনিট',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'প্লেব্যাকের গতি';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'বাকি';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'অতিবাহিত';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds সেকেন্ড পেছনে';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds সেকেন্ড সামনে';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'পূর্ববর্তী অধ্যায়';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'পরবর্তী অধ্যায়';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'অধ্যায় $current / $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'কোনো অধ্যায় নেই';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'এখনও কোনো বুকমার্ক নেই';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'এখনও কোনো নোট নেই';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position-এ বুকমার্ক যোগ হয়েছে';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x-এ রিসেট করুন';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9785,248 +9775,249 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'সংরক্ষণ করুন';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'বাতিল করুন';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'মুছুন';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'সাবটাইটেল পছন্দসমূহ';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'সাবটাইটেলের মোড, ডিফল্ট ভাষা, চেহারা এবং রেন্ডারিং অপশন পরিবর্তন করুন।';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'সাবটাইটেল রেন্ডারিং';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'প্রদর্শন অপশন';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'মুক্তির তারিখ (ঊর্ধ্বক্রম)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'মুক্তির তারিখ (নিম্নক্রম)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'অবদান গ্রুপ করুন';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'একাধিক ভূমিকা একসাথে গ্রুপ করুন';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'লাইব্রেরি রাইট অ্যাক্সেস সতর্কতা';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'যেভাবে সমাধান করবেন:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '১. সার্ভারে আপনার মিডিয়া লাইব্রেরি ফোল্ডারগুলোর জন্য Jellyfin সার্ভিস ইউজারকে (যেমন jellyfin বা Docker PUID/PGID) রাইট পারমিশন দিন।\n\n২. অথবা, আপনার Jellyfin Dashboard -> Libraries-এ যান, এই লাইব্রেরিটি সম্পাদনা করুন এবং \'Save artwork into media folders\' বন্ধ করে দিন, যাতে আর্টওয়ার্ক Jellyfin-এর নিজস্ব ডেটাবেসে সংরক্ষিত হয়।';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'বন্ধ করুন';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'আপনার \'$libraryName\' লাইব্রেরিটি আর্টওয়ার্ক সরাসরি মিডিয়া ফোল্ডারে সংরক্ষণ করার জন্য কনফিগার করা আছে (\'Save artwork into media folders\' চালু রয়েছে)। কিন্তু Jellyfin রাইট অ্যাক্সেস পরীক্ষা করে দেখেছে যে এই ডিরেক্টরিতে ফাইল লেখার অনুমতি নেই:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'মনে হচ্ছে Jellyfin আর্টওয়ার্ক আপডেট করতে পারেনি। আপনার লাইব্রেরিটি আর্টওয়ার্ক সরাসরি মিডিয়া ফোল্ডারে সংরক্ষণ করার জন্য কনফিগার করা আছে (\'Save artwork into media folders\' চালু রয়েছে)। সাধারণত Jellyfin সার্ভার প্রসেসের আপনার মিডিয়া ডিরেক্টরিতে ফাইল লেখার অনুমতি না থাকলে এই ত্রুটি হয়।';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'বাহ্যিক তালিকা';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'আবার চালান';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ফাইলের তথ্য';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'আকার: $size  •  ফরম্যাট: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'সব ($count) অডিও ট্র্যাক দেখান';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'সব ($count) সাবটাইটেল ট্র্যাক দেখান';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Direct Play সক্ষমতা পরীক্ষা করা হচ্ছে...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play সক্ষমতা: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'ফোর্সড';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'কন্টেইনার ফরম্যাটটি প্লেয়ারে সমর্থিত নয়।';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'ভিডিও কোডেক সমর্থিত নয়।';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'অডিও কোডেক সমর্থিত নয়।';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'সাবটাইটেল ফরম্যাট সমর্থিত নয় (বার্ন করা প্রয়োজন)।';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'অডিও প্রোফাইল সমর্থিত নয়।';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'ভিডিও প্রোফাইল সমর্থিত নয়।';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'ভিডিও লেভেল সমর্থিত নয়।';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'এই ডিভাইসে ভিডিও রেজোলিউশনটি সমর্থিত নয়।';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'ভিডিও বিট ডেপথ সমর্থিত নয়।';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'ভিডিও ফ্রেমরেট সমর্থিত নয়।';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ফাইলের বিটরেট প্লেয়ারের স্ট্রিমিং সীমা ছাড়িয়ে গেছে।';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'ভিডিও বিটরেট স্ট্রিমিং সীমা ছাড়িয়ে গেছে।';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'অডিও বিটরেট স্ট্রিমিং সীমা ছাড়িয়ে গেছে।';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'অডিও চ্যানেলের সংখ্যা সমর্থিত নয়।';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'বর্ণানুক্রমিক';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'মুক্তির ক্রম (ঊর্ধ্বক্রম)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'মুক্তির ক্রম (নিম্নক্রম)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'কাস্টম (ড্র্যাগ-অ্যান্ড-ড্রপ)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'প্লেলিস্ট সাজানোর অপশন';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'সাজানো রিসেট করুন';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode আবার দেখুন';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'প্লেলিস্ট আবার দেখুন';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'কোনো সাবটাইটেল পাওয়া যায়নি।';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'অ্যাডমিন নিয়ন্ত্রণ';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'রেন্ডারিং ইঞ্জিন (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller হলো Flutter-এর আধুনিক GPU রেন্ডারার, যা আরও মসৃণ অ্যানিমেশন ও কম আটকানো নিশ্চিত করে। কিছু টিভি বক্স ও পুরোনো GPU-তে এটি গ্লিচ বা কালো ভিডিওর কারণ হতে পারে; এমন হলে এটি বন্ধ করে দিন। স্বয়ংক্রিয় আপনার ডিভাইসের জন্য সেরা ডিফল্টটি বেছে নেয়। প্রয়োগ করতে Moonfin রিস্টার্ট করুন।';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'স্বয়ংক্রিয়';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'চালু';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'বন্ধ';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'রিস্টার্ট প্রয়োজন';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'রেন্ডারিং ইঞ্জিন পরিবর্তন করতে Moonfin রিস্টার্ট করা প্রয়োজন। এখন অ্যাপটি বন্ধ করে আবার চালু করলে পরিবর্তনটি প্রয়োগ হবে।';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'এখনই অ্যাপ বন্ধ করুন';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'লাইব্রেরি রিফ্রেশ করুন';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'সব লাইব্রেরি রিফ্রেশ করুন';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'যোগ করার তারিখ (পুরোনো আগে)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'যোগ করার তারিখ (নতুন আগে)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'বর্ণানুক্রমিক (A থেকে Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'বর্ণানুক্রমিক (Z থেকে A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'সার্ভার অ্যানালিটিক্স লোড হচ্ছে... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'উৎসের সাথে মিলিয়ে';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb-র সেরা ২৫০ সিনেমা';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb-র সেরা ২৫০ টিভি শো';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb-র সবচেয়ে জনপ্রিয় সিনেমা';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb-র সবচেয়ে জনপ্রিয় টিভি শো';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb-র সর্বনিম্ন রেটিং পাওয়া সিনেমা';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb-র সেরা রেটিং পাওয়া ইংরেজি সিনেমা';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -32,7 +32,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Connexió ràpida';
 
   @override
   String get password => 'Contrasenya';
@@ -113,7 +113,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get cancel => 'Cancel·la';
 
   @override
-  String get remove => 'Elimina';
+  String get remove => 'Eliminar';
 
   @override
   String get connectToServer => 'Connecteu-vos al servidor';
@@ -122,7 +122,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get serverAddress => 'Adreça del servidor';
 
   @override
-  String get serverAddressHint => 'https://el-teu-servidor.exemple.com';
+  String get serverAddressHint => 'https://your-server.example.com';
 
   @override
   String get connect => 'Connecta\'t';
@@ -154,18 +154,18 @@ class AppLocalizationsCa extends AppLocalizations {
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Pestanyes desplegades';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Mostra automàticament el contingut de les pestanyes mentre hi navegues. Desactiva-ho per obrir i tancar cada pestanya manualment.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Mostrar els detalls tècnics?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Mostra el còdec, la resolució i la informació del flux al resum del bàner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
   String get recommendationSystem => 'Sistema de recomanacions';
@@ -178,22 +178,22 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Recomanacions Moonfin';
 
   @override
-  String get recommendationSystemTmdb => 'Similitud de TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Aplicar el límit de classificació parental?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limita els suggeriments de Recomanacions Moonfin segons la classificació parental del contingut de destinació';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
   String get interfaceStyle => 'Estil de l\'interfaç';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automàtic s\'adapta al teu dispositiu. Tria Apple o Material per forçar un aspecte concret.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
   String get interfaceStyleAutomatic => 'Automàtic';
@@ -205,11 +205,11 @@ class AppLocalizationsCa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Qualitat de Glass';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto tria el millor efecte Glass per a aquest dispositiu. Complet força un desenfocament real; Reduït utilitza un efecte lleuger que estalvia energia de la GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
@@ -225,11 +225,11 @@ class AppLocalizationsCa extends AppLocalizations {
       'Canvia entre Moonfin i Neon Pulse sense reiniciar l\'aplicació';
 
   @override
-  String get customThemeTitle => 'Tema personalitzat';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Els temes personalitzats modifiquen els elements visuals de tot Moonfin. Tria una d\'aquestes opcions segons el teu estil.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Preferiu el teclat del sistema';
@@ -263,7 +263,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Estil retro de pixel art amb una paleta contundent, vores quadrades, ombres marcades i una tipografia de píxels';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -337,7 +337,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get gameSaveState => 'Desa l’estat actual';
 
   @override
-  String get games => 'Jocs';
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Carregar estat';
@@ -349,14 +349,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get gameEmulatorSettings => 'Paràmetres de l\'emulador';
 
   @override
-  String get gameNoCoreOptions => 'Aquest nucli no té opcions ajustables.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Mantén premut per obrir el menú';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Encara no es poden executar jocs en aquest dispositiu.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'No s\'ha pogut carregar cap fila inicial';
@@ -378,7 +378,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get schedule => 'Horari';
 
   @override
-  String get series => 'Sèries';
+  String get series => 'Sèrie';
 
   @override
   String get noItemsFound => 'No s\'han trobat elements';
@@ -557,7 +557,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Trieu quins feeds de temes voleu mostrar a Discover.';
 
   @override
-  String get apply => 'Aplica';
+  String get apply => 'Aplicar';
 
   @override
   String get openLink => 'Obriu l\'enllaç';
@@ -607,7 +607,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get listen => 'Escolta';
 
   @override
-  String get resume => 'Reprèn';
+  String get resume => 'Reprendre';
 
   @override
   String get failedToLoadLibrary => 'No s\'ha pogut carregar la biblioteca';
@@ -752,13 +752,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get readStatus => 'Llegeix';
 
   @override
-  String get watched => 'Vist';
+  String get watched => 'Mirat';
 
   @override
   String get unread => 'Sense llegir';
 
   @override
-  String get unwatched => 'No vist';
+  String get unwatched => 'Sense mirar';
 
   @override
   String get seriesStatus => 'Estat de la sèrie';
@@ -780,33 +780,33 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count llibres',
-      one: '1 llibre',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Llibre';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiollibre';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% llegit';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Queden $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Llegeix';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Escolta';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -884,8 +884,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiollibres',
-      one: '1 audiollibre',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -989,8 +989,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count temporades',
-      one: '1 temporada',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1001,35 +1001,35 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get items => 'Elements';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Extres';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Darrere les càmeres';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Escenes eliminades';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Reportatges';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Entrevistes';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Escenes';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Curtmetratges';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Tràilers';
+  String get trailers => 'Remolcs';
 
   @override
   String timeRemaining(String time) {
-    return 'Queden $time';
+    return '$time remaining';
   }
 
   @override
@@ -1052,7 +1052,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get play => 'Reprodueix';
+  String get play => 'Reproduir';
 
   @override
   String get startOver => 'Torna a començar';
@@ -1076,7 +1076,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get version => 'Versió';
 
   @override
-  String get cast => 'Emet';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Tràiler';
@@ -1279,7 +1279,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get writer => 'GUIONISTA';
 
   @override
-  String get writers => 'GUIONISTES';
+  String get writers => 'ESCRIPTORS';
 
   @override
   String get studio => 'ESTUDI';
@@ -1314,8 +1314,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pistes',
-      one: '1 pista',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1325,8 +1325,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count capítols',
-      one: '1 capítol',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1353,16 +1353,16 @@ class AppLocalizationsCa extends AppLocalizations {
   String get readMore => 'Llegeix més';
 
   @override
-  String get shuffle => 'Aleatori';
+  String get shuffle => 'Barrejar';
 
   @override
-  String get shuffleAllMusic => 'Barreja tota la música';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Inicia la sessió a Moonfin al teu telèfon';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'No es pot connectar amb el teu servidor';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1374,14 +1374,14 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count can.';
+    return '${count}ch';
   }
 
   @override
   String get mono => 'Mono';
 
   @override
-  String get stereo => 'Estèreo';
+  String get stereo => 'estèreo';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1452,7 +1452,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String castControlsTitle(String label) {
-    return 'Controls de $label';
+    return '$label Controls';
   }
 
   @override
@@ -1501,7 +1501,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get longPressToUnlock => 'Mantingueu per a desbloquejar';
 
   @override
-  String get off => 'Desactivat';
+  String get off => 'Apagat';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1805,22 +1805,22 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'A continuació: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min restants';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours h restants';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours h $minutes min restants';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1844,7 +1844,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get favoriteChannel => 'Canal preferit';
 
   @override
-  String get record => 'Enregistra';
+  String get record => 'Registre';
 
   @override
   String get cancelRecordingAction => 'Cancel·la la gravació';
@@ -1862,7 +1862,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get watch => 'Mira';
 
   @override
-  String get close => 'Tanca';
+  String get close => 'Tancar';
 
   @override
   String failedToPlayChannel(String name) {
@@ -2032,7 +2032,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2057,7 +2057,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -2076,8 +2076,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episodis',
-      one: '1 episodi',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2290,7 +2290,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get fireworks => 'Focs artificials';
 
   @override
-  String get confetti => 'Confeti';
+  String get confetti => 'Confetti';
 
   @override
   String get fallingLeaves => 'Fulles que cauen';
@@ -2307,7 +2307,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Pàgines de detall, files d\'inici i volum';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2322,11 +2322,11 @@ class AppLocalizationsCa extends AppLocalizations {
       'Reprodueix quan navegues per la pantalla d\'inici';
 
   @override
-  String get loopThemeMusic => 'Música del tema en bucle';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repeteix la pista en comptes de reproduir-la un sol cop';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detalls Desenfocament de fons';
@@ -2356,7 +2356,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Escolliu què fa la rodeta del ratolí durant la reproducció del vídeo.';
 
   @override
-  String get scrollWheelActionOff => 'Desactivat';
+  String get scrollWheelActionOff => 'Desactivar';
 
   @override
   String get scrollWheelActionSeek => 'Salta (endavant / enrere)';
@@ -2380,7 +2380,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get refreshRateSwitching => 'Canvi de freqüència d\'actualització';
 
   @override
-  String get disabled => 'Desactivat';
+  String get disabled => 'Inhabilitat';
 
   @override
   String get scaleOnTv => 'Escala a la televisió';
@@ -2419,39 +2419,37 @@ class AppLocalizationsCa extends AppLocalizations {
   String get defaultAudioLanguage => 'Idioma d\'àudio per defecte';
 
   @override
-  String get fallbackAudioLanguage => 'Idioma d\'àudio alternatiu';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Prefereix la pista d\'àudio predeterminada';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Prefereix la pista d\'àudio original en comptes del doblatge localitzat.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'Prefereix les pistes d\'audiodescripció';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Prefereix les pistes d\'audiodescripció en comptes de les normals.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcodificació (àudio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Transmissió directa (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodificació (taxa de bits o resolució)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodificació (vídeo i àudio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodificació (vídeo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automàtic (Servidor per defecte)';
@@ -2542,11 +2540,10 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Tria el format de destinació per transcodificar l\'àudio multicanal quan el flux d\'origen no es pot reproduir de manera nativa ni transmetre directament.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detecció automàtica\n(Recomanat)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
   String get settingsAudioFallbackCodecAac => 'AAC\n(Predeterminat)';
@@ -2561,36 +2558,35 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sense perdues)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Només estèreo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficient)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
   String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sense perdua)';
 
   @override
-  String get settingsMaxAudioChannels => 'Màxim de canals d\'àudio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
       'Configura el nombre màxim de canals de la teva configuració d’àudio. Els fluxos multicanal que superin aquest límit es reduiran a una versió mesclada o es transcodificaran.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detecció automàtica\n(Predeterminat del maquinari)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estèreo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrafònic';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2618,7 +2614,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
   String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
@@ -2627,10 +2623,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2684,11 +2680,11 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Altaveu';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Auriculars';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count can. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2865,10 +2861,10 @@ class AppLocalizationsCa extends AppLocalizations {
       'Personalitza l\'aspecte dels subtítols';
 
   @override
-  String get subtitleMode => 'Mode de subtítols';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Marcats';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
   String get subtitleModeAlways => 'Sempre';
@@ -2881,29 +2877,29 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Reprodueix les pistes marcades internament a les metadades del fitxer com a \"predeterminada\" o \"forçada\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Carrega i mostra automàticament els subtítols cada vegada que comença un vídeo.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Activa automàticament els subtítols si la pista d\'àudio predeterminada és en un idioma estranger.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Només carrega els subtítols marcats explícitament amb l\'indicador de metadades \"forçat\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Desactiva completament la càrrega automàtica de subtítols.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Idioma de subtítols alternatiu';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Flux de subtítols';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2913,13 +2909,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get verticalOffset => 'Desplaçament vertical';
 
   @override
-  String get pgsDirectPlay => 'Reproducció nativa de PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Reproducció directa de subtítols PGS';
 
   @override
-  String get assSsaDirectPlay => 'Reproducció nativa d\'ASS/SSA';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles =>
@@ -3110,8 +3106,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra les biblioteques a la barra d\'eines';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Mostra sempre les etiquetes de la barra de navegació';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
   String get showSeerrButton => 'Mostra botó de Seerr';
@@ -3132,7 +3127,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get purple => 'Lila';
 
   @override
-  String get teal => 'Verd blavós';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Marina';
@@ -3153,7 +3148,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get slate => 'Pissarra';
 
   @override
-  String get indigo => 'Indi';
+  String get indigo => 'Indigo';
 
   @override
   String get libraryDisplay => 'Exhibició de la biblioteca';
@@ -3190,19 +3185,18 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra l\'opció de navegació de carpetes';
 
   @override
-  String get groupItemsIntoCollections => 'Agrupa els elements en col·leccions';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Amaga els elements associats a col·leccions en navegar per les biblioteques';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Avís sobre l\'agrupació de biblioteques';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Per utilitzar aquest paràmetre, assegura\'t que les opcions de biblioteca \"Agrupa les pel·lícules en col·leccions\" i/o \"Agrupa les sèries en col·leccions\" estiguin activades a la configuració de visualització de la teva biblioteca al servidor de Jellyfin o Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilitat de la biblioteca';
@@ -3268,7 +3262,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Desactivat';
+  String get mediaBarModeOff => 'Apagat';
 
   @override
   String get enableMediaBar => 'Activa la barra multimèdia';
@@ -3316,11 +3310,10 @@ class AppLocalizationsCa extends AppLocalizations {
       'Reprodueix automàticament els tràilers a la barra multimèdia després de 3 segons';
 
   @override
-  String get trailerAudio => 'Àudio dels tràilers';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Activa l\'àudio dels tràilers a la barra multimèdia';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Vista prèvia de l\'episodi';
@@ -3602,7 +3595,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Activa i reordena les fonts de classificació que es mostren a l\'aplicació';
 
   @override
-  String get pluginLabel => 'Connector Moonbase';
+  String get pluginLabel => 'Connector';
 
   @override
   String get pluginDetected => 'S\'ha detectat connector';
@@ -3698,29 +3691,28 @@ class AppLocalizationsCa extends AppLocalizations {
   String get hideAdultContent => 'Amaga contingut per a adults als resultats';
 
   @override
-  String get seerrNotificationsSection => 'Notificacions';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notificacions de sol·licituds noves';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Avisa\'m quan algú enviï una sol·licitud';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Actualitzacions de sol·licituds';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprovades, rebutjades i afegides a la teva biblioteca';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Actualitzacions d\'incidències';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Incidències noves, respostes i resolucions';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3728,18 +3720,18 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Pàgina de descobriment de Seerr';
+  String get discoverRows => 'Descobriu les files';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Activeu les files que voleu veure a la pàgina principal de Seerr. Arrossegueu per reordenar. L\'ordre personalitzat es sincronitza amb Moonbase.';
+      'Arrossegueu per reordenar. Activa o desactiva les files. S\'han activat les sincronitzacions d\'ordre de files amb el connector Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Activeu les files que voleu veure a la pàgina principal de Seerr. Arrossegueu per reordenar. L\'ordre personalitzat es sincronitza amb Moonbase.';
+      'Arrossegueu per reordenar. Activa o desactiva les files.';
 
   @override
-  String get enabled => 'Activat';
+  String get enabled => 'Habilitat';
 
   @override
   String get hidden => 'Ocult';
@@ -3877,7 +3869,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get imageCacheCleared => 'S\'ha esborrat la memòria cau d\'imatges';
 
   @override
-  String get clear => 'Neteja';
+  String get clear => 'Clar';
 
   @override
   String get browse => 'Navega';
@@ -3893,11 +3885,11 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Descarregant · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'S\'està important';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -4041,149 +4033,148 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deletedStatus => 'S\'ha suprimit';
 
   @override
-  String get failedStatus => 'Ha fallat';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'En procés';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificat per $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Completada';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Aquest títol ja s\'ha sol·licitat';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Has arribat al límit de sol·licituds';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Aquest títol és a la llista de bloqueig';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'No queden temporades per sol·licitar';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'No tens permís per fer aquesta sol·licitud';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Sol·licituds';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Incidències';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Més recents';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Darrera modificació';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Cap incidència';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Et queden $remaining de $limit sol·licituds de pel·lícules';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Et queden $remaining de $limit sol·licituds de temporades';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Forma part de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Veure la col·lecció';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Sol·licitar la col·lecció';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total pel·lícules · $available disponibles';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Sol·licita $count pel·lícules';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'S\'està sol·licitant $current de $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'S\'han sol·licitat $count pel·lícules';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'S\'han sol·licitat $ok de $total pel·lícules';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Totes les pel·lícules ja estan disponibles o sol·licitades';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Informar d\'una incidència';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vídeo';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Àudio';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Què passa?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Tots els episodis';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episodi';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Obert';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Resolta';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Resoldre';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Reobrir';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Informat per $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comentaris';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Afegeix un comentari';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Vols suprimir aquesta incidència?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Enviar l\'informe';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Puntuació TMDB';
@@ -4276,7 +4267,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get networking => 'Treball en xarxa';
 
   @override
-  String get next => 'Següent';
+  String get next => 'A continuació';
 
   @override
   String get path => 'Camí';
@@ -4300,7 +4291,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get refresh => 'Actualitzar';
 
   @override
-  String get remote => 'Comandament';
+  String get remote => 'Remot';
 
   @override
   String get rename => 'Canvia el nom';
@@ -4336,7 +4327,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get status => 'Estat';
 
   @override
-  String get stop => 'Atura';
+  String get stop => 'Atureu-vos';
 
   @override
   String get streaming => 'Transmissió en continu';
@@ -4363,7 +4354,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get unmute => 'Activa el so';
 
   @override
-  String get mute => 'Silencia';
+  String get mute => 'Silenciar';
 
   @override
   String get branding => 'Marca';
@@ -4387,19 +4378,19 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteques';
 
   @override
-  String get adminDrawerDisplay => 'Visualització';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadades';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Configuració NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodificació';
 
   @override
-  String get adminDrawerResume => 'Reprèn';
+  String get adminDrawerResume => 'Currículum';
 
   @override
   String get adminDrawerStreaming => 'Transmissió en continu';
@@ -4580,7 +4571,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get sessionForward => 'Endavant';
 
   @override
-  String get sessionNext => 'Següent';
+  String get sessionNext => 'A continuació';
 
   @override
   String get sessionVolumeDown => 'Vol -';
@@ -4607,7 +4598,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audioCodec => 'Còdec d\'àudio';
 
   @override
-  String get hwAccel => 'Accel. HW';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Finalització';
@@ -4622,10 +4613,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminClearDates => 'Dates clares';
 
   @override
-  String get adminActivitySeverityAll => 'Totes les gravetats';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Interval de dates';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4663,23 +4654,23 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Vols eliminar el dispositiu \'$name\'? L\'usuari haurà d\'iniciar la sessió de nou en aquest dispositiu.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Suprimeix tots els dispositius';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Vols eliminar $count dispositius? Els usuaris afectats hauran d\'iniciar la sessió de nou. El teu dispositiu actual no es veurà afectat.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'S\'han eliminat els dispositius';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'S\'han eliminat alguns dispositius; $count no s\'han pogut eliminar.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4798,258 +4789,244 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminMetadataCountryHint => 'p. ex. EUA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Camins';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcions';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Descarregadors';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Desadors de metadades';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Descarregadors de subtítols';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Descarregadors de lletres';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Descarregadors de metadades: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Obtenidors d\'imatges: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Aquest servidor no ofereix cap descarregador per a aquest tipus de biblioteca.';
+      'This server exposes no downloaders for this library type.';
 
   @override
   String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadades';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Informació incrustada';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtítols';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imatges';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Sèries';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Música';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Pel·lícules';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Activa la supervisió en temps real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detecta els canvis als fitxers i processa\'ls automàticament.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tracta els arxius com a fitxers multimèdia';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Mostra les fotos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Desa les il·lustracions a les carpetes multimèdia';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Actualització automàtica de metadades';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Mai';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Predeterminat';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visualització';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Visualització de la biblioteca';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Mostra una vista de carpetes per veure les carpetes multimèdia simples';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Mostra els especials dins de les temporades en què es van emetre';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Agrupa les pel·lícules en col·leccions';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Agrupa les sèries en col·leccions';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Mostra contingut extern als suggeriments';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportament de la data d\'addició';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Utilitza la data d\'addició de';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data d\'exploració a la biblioteca';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data de creació del fitxer';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadades i imatges';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Idioma preferit de les metadades';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capítols';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Durada dels capítols simulats (segons)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Durada dels capítols generats per al contingut que no en té. Estableix-ho a 0 per desactivar-ho.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolució de les imatges dels capítols';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Configuració NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Les metadades NFO són compatibles amb Kodi i clients similars. La configuració s\'aplica a totes les biblioteques que desen metadades NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Usuari del qual es desaran les dades de visualització als fitxers NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Desa els camins de les imatges als fitxers NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Activa la substitució de camins per als camins d\'imatge dels NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
       'Copia les imatges d\'extrafanart a una carpeta extrathumbs';
 
   @override
-  String get adminLibNone => 'Cap';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dies';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Utilitza els títols incrustats';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Utilitza els títols incrustats per als extres';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Utilitza la informació d\'episodi incrustada';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Permet els subtítols incrustats';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permet-ho tot';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Només text';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Només imatge';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Cap';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Omet la descàrrega si hi ha subtítols incrustats';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Omet la descàrrega si la pista d\'àudio coincideix amb l\'idioma de descàrrega';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Exigeix una coincidència perfecta dels subtítols';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Desa els subtítols a les carpetes multimèdia';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Extreu les imatges dels capítols';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extreu les imatges dels capítols durant l\'exploració de la biblioteca';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Activa l\'extracció d\'imatges de trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extreu les imatges de trickplay durant l\'exploració de la biblioteca';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Desa les imatges de trickplay a les carpetes multimèdia';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Combina automàticament les sèries repartides en diverses carpetes';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName =>
-      'Nom que es mostra per a la temporada zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Activa l\'anàlisi LUFS per a la normalització d\'àudio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Prefereix l\'etiqueta d\'artistes no estàndard';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Afegeix automàticament les pel·lícules a les col·leccions';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired =>
@@ -5292,145 +5269,143 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminEnableAllChannels => 'Activa l\'accés a tots els canals';
 
   @override
-  String get adminParentalControl => 'Control parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Classificació parental màxima permesa';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'El contingut amb una classificació superior s\'amagarà a aquest usuari.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Cap';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloqueja els elements sense classificació o amb classificació no reconeguda';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Llibres';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canals';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV en directe';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Pel·lícules';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Música';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Tràilers';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Sèries';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Horaris d\'accés';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permet l\'accés només durant els horaris programats a continuació. Si no s\'ha definit cap horari, l\'accés es permet tot el dia.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Afegeix un horari';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dia';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Inici';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fi';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Cada dia';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Dia laborable';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Cap de setmana';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Diumenge';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Dilluns';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Dimarts';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Dimecres';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Dijous';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Divendres';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Dissabte';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etiquetes permeses';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Només es mostra el contingut amb aquestes etiquetes. Deixa-ho buit per permetre-ho tot.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etiquetes bloquejades';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'El contingut amb aquestes etiquetes s\'amaga a aquest usuari.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Afegeix una etiqueta';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispositius activats';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canals activats';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Proveïdor d\'autenticació';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Proveïdor de restabliment de contrasenya';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Màxim d\'intents d\'inici de sessió fallits abans del bloqueig';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Estableix-ho a 0 per al valor predeterminat, o a -1 per desactivar el bloqueig.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Accés a SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'Permet crear grups i unir-s\'hi';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permet unir-se a grups';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Sense accés';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Permet la supressió de contingut de';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5519,26 +5494,25 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Crea una còpia de seguretat';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Tria què vols incloure a la còpia de seguretat.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Base de dades';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Sempre inclosa';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadades';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtítols';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imatges de trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'S\'està creant una còpia de seguretat...';
@@ -5979,7 +5953,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'No s\'ha pogut carregar la configuració de Trickplay';
+      'No s\'ha pogut carregar la configuració de trucada';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6095,7 +6069,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminBaseUrl => 'URL base';
 
   @override
-  String get adminBaseUrlHint => 'p. ex. /jellyfin';
+  String get adminBaseUrlHint => 'p. ex. /gelatina';
 
   @override
   String get https => 'HTTPS';
@@ -6261,64 +6235,60 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminAddTuner => 'Afegeix un sintonitzador';
 
   @override
-  String get adminEditTuner => 'Edita el sintonitzador';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Sintonitzador M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fitxer o URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Adreça IP del sintonitzador';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nom descriptiu';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Agent d\'usuari';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Límit de connexions simultànies';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Nombre màxim de fluxos que permet el sintonitzador alhora. Estableix-ho a 0 per il·limitat.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Taxa de bits màxima de transmissió alternativa';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importa només els canals preferits';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permet la transcodificació per maquinari';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Permet el contenidor de transcodificació fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Permet compartir fluxos';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Activa la repetició de fluxos';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignora DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Llegeix l\'entrada a la velocitat de fotogrames nativa';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Edita el proveïdor';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6327,50 +6297,50 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fitxer o URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefix de pel·lícula';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categories de pel·lícules';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separa les categories amb una barra vertical.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categories infantils';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categories de notícies';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categories d\'esports';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nom d\'usuari';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Contrasenya';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'País';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selecciona un país';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Codi postal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obtén la programació';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programació';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Activa tots els sintonitzadors';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipus de sintonitzador';
@@ -6413,7 +6383,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Aquest tipus de sintonitzador no admet el restabliment.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6436,46 +6406,43 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Ruta d\'enregistrament de la sèrie';
 
   @override
-  String get adminMovieRecordingPath => 'Camí d\'enregistrament de pel·lícules';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Dies de dades de la guia';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automàtic';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dies';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Camí de l\'aplicació de postprocessament';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Arguments del postprocessador';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Desa les metadades NFO dels enregistraments';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages =>
-      'Desa les imatges dels enregistraments';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Temporització';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Camins d\'enregistrament';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Postprocessament';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Dades de la guia: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6519,15 +6486,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminGuideProviders => 'Proveïdors de guies';
 
   @override
-  String get adminRefreshGuideData => 'Actualitza les dades de la guia';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'S\'ha iniciat l\'actualització de les dades de la guia';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'La tasca d\'actualització de la guia no està disponible en aquest servidor.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Afegeix un proveïdor';
@@ -6611,7 +6577,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminLiveTvTitle => 'Administració de TV en directe';
 
   @override
-  String get adminApply => 'Aplica';
+  String get adminApply => 'Aplicar';
 
   @override
   String get adminNotSet => 'No configurat';
@@ -6663,7 +6629,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor de metadades';
 
   @override
-  String get adminMetadataIdentify => 'Identifica';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipus';
@@ -6947,7 +6913,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Elimina';
+  String get adminReposRemove => 'Eliminar';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7079,23 +7045,19 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Activa la pantalla de presentació';
 
   @override
-  String get adminBrandingSplashUpload => 'Carrega una imatge';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'S\'ha actualitzat la pantalla de presentació';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'No s\'ha pogut carregar la pantalla de presentació';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted =>
-      'S\'ha eliminat la pantalla de presentació';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash =>
-      'Cap pantalla de presentació personalitzada';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Acceleració de maquinari';
@@ -7112,128 +7074,118 @@ class AppLocalizationsCa extends AppLocalizations {
       'Activa la descodificació de maquinari per a:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispositiu QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Activa el descodificador NVDEC millorat';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Prefereix el descodificador per maquinari natiu del sistema';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profunditat de color de la descodificació per maquinari';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Descodificació HEVC de 10 bits';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Descodificació VP9 de 10 bits';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Descodificació HEVC RExt de 8/10 bits';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Descodificació HEVC RExt de 12 bits';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codificació per maquinari';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permet la codificació HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permet la codificació AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Activa el codificador H.264 de baix consum d\'Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Activa el codificador HEVC de baix consum d\'Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapatge de tons';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Activa el mapatge de tons';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Activa el mapatge de tons VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Activa el mapatge de tons de VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algorisme de mapatge de tons';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Mode de mapatge de tons';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Interval de mapatge de tons';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Dessaturació del mapatge de tons';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pic del mapatge de tons';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Paràmetre del mapatge de tons';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Brillantor del mapatge de tons VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contrast del mapatge de tons VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Predefinits i qualitat';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Predefinit del codificador';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF de codificació H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF de codificació H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Mètode de desentrellaçat';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Duplica la velocitat de fotogrames en desentrellaçar';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Àudio';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Activa la codificació d\'àudio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Amplificació del downmix d\'àudio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algorisme de downmix a estèreo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Mida màxima de la cua de multiplexació';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7357,10 +7309,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminTaskNeverRun => 'No córrer mai';
 
   @override
-  String get adminTaskStop => 'Atura';
+  String get adminTaskStop => 'Atureu-vos';
 
   @override
-  String get adminRunningTasks => 'Tasques en execució';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Corre';
@@ -7430,8 +7382,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hores',
-      one: '1 hora',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7477,22 +7429,22 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7506,50 +7458,49 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'URL base';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'p. ex. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'p. ex. /gelatina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Port HTTP públic';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Exigeix HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Redirigeix totes les sol·licituds remotes a HTTPS. No té cap efecte si el servidor no té un certificat vàlid.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Contrasenya del certificat';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Configuració d\'IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Activa IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Activa IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Activa l\'assignació automàtica de ports';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Xarxes LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Llista d\'adreces IP o subxarxes CIDR, separades per comes o salts de línia, que es consideren de la xarxa local.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI publicats del servidor';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Assigna una subxarxa o adreça a una URL publicada, p. ex. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Ruta del certificat';
@@ -7580,11 +7531,11 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Amortiment de l\'accelerador';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Retard de limitació (segons)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permet l\'extracció de subtítols sobre la marxa';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Percentatge mínim de currículum';
@@ -7642,23 +7593,22 @@ class AppLocalizationsCa extends AppLocalizations {
       'Llindar de resposta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Activa els avisos de resposta lenta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Activa Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Servidor';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadades';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Camins';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Rendiment';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Camí de la memòria cau';
@@ -7670,7 +7620,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminGeneralServerName => 'Nom del servidor';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Idioma de visualització preferit';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7871,8 +7821,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# files descobertes',
-      one: '# fila descoberta',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7913,21 +7863,20 @@ class AppLocalizationsCa extends AppLocalizations {
   String get offlineSavedMedia => 'Mitjans desats';
 
   @override
-  String get offlineBannerTitle => 'No tens connexió';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Es mostren les teves descàrregues';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Descàrregues';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'No es pot connectar amb el teu servidor';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Es reprodueix des de les descàrregues fins que torni';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7948,7 +7897,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String castKindControls(String kind) {
-    return 'Controls de $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -8001,42 +7950,42 @@ class AppLocalizationsCa extends AppLocalizations {
   String get pinForgot => 'Heu oblidat el PIN?';
 
   @override
-  String get pinClear => 'Neteja';
+  String get pinClear => 'Clar';
 
   @override
   String get pinBackspace => 'Retrocés';
 
   @override
   String get quickConnectAuthorized =>
-      'S\'ha autoritzat la sol·licitud de Quick Connect.';
+      'S\'ha autoritzat la sol·licitud de connexió ràpida.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'El codi de Quick Connect no és vàlid o ha caducat.';
+      'El codi de connexió ràpida no és vàlid o ha caducat.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect no és compatible amb aquest servidor.';
+      'La connexió ràpida no és compatible amb aquest servidor.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'No s\'ha pogut autoritzar el codi de Quick Connect.';
+      'No s\'ha pogut autoritzar el codi de connexió ràpida.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect està desactivat en aquest servidor.';
+      'La connexió ràpida està desactivada en aquest servidor.';
 
   @override
   String get quickConnectForbidden =>
-      'El vostre compte no pot autoritzar aquesta sol·licitud de Quick Connect.';
+      'El vostre compte no pot autoritzar aquesta sol·licitud de connexió ràpida.';
 
   @override
   String get quickConnectNotFound =>
-      'No s\'ha trobat el codi de Quick Connect. Proveu amb un codi nou.';
+      'No s\'ha trobat el codi de connexió ràpida. Prova amb un codi nou.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ha fallat: $message';
+    return 'La connexió ràpida ha fallat: $message';
   }
 
   @override
@@ -8211,7 +8160,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'La reproducció s\'ha posat en pausa. Encara estàs mirant?';
 
   @override
-  String get stillWatchingStop => 'Atura';
+  String get stillWatchingStop => 'Atureu-vos';
 
   @override
   String get stillWatchingContinue => 'Continua';
@@ -8296,13 +8245,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get contextMenuGoToSeries => 'Vés a Sèrie';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Amaga de Continuar mirant';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Amaga d\'A continuació';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Afegeix a una col·lecció';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8357,15 +8307,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabètic';
 
   @override
-  String get settingsConnectionSection => 'CONNEXIÓ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permet els certificats autosignats';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confia en els servidors que utilitzen certificats TLS autosignats o d\'una CA privada. Activa-ho només per als servidors que controlis. Això desactiva la validació de certificats per a totes les connexions.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACITAT I SEGURETAT';
@@ -8381,11 +8330,11 @@ class AppLocalizationsCa extends AppLocalizations {
       'Accents temàtics, fons, indicadors de visualització i música de tema';
 
   @override
-  String get settingsDetailsScreen => 'Pantalla de detalls';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Estil, desenfocament del fons i comportament de les pestanyes';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Pàgina d\'inici';
@@ -8427,7 +8376,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Mostra sempre les etiquetes de text a la barra de navegació superior';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8530,8 +8479,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# avisos de llicència',
-      one: '# avís de llicència',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8866,7 +8815,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Reprodueix els fluxos de Dolby Vision perfil 7 com a HEVC compatible amb HDR10 en dispositius sense DV.';
+      'Reprodueix 7 reproduccions del perfil HDR10 com a HEVC compatible amb HDR10 en dispositius que no siguin DV.';
 
   @override
   String get subtitlesUseEmbeddedStyles =>
@@ -8893,8 +8842,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra els detalls de l\'item seleccionat a dalt la pàgina de Biblioteca.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Amagar les imatges de fons mentre navegues?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Utilitzeu subtítols detallats';
@@ -8929,7 +8877,7 @@ class AppLocalizationsCa extends AppLocalizations {
       'No s\'ha pogut carregar la botiga de temes. Verifica la teva conexió i intenta-ho de nou.';
 
   @override
-  String get themeStoreSave => 'Desa';
+  String get themeStoreSave => 'Guardar';
 
   @override
   String get themeStoreSaveAndApply => 'Guardar i aplicar';
@@ -9011,11 +8959,11 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Activa o desactiva les categories de files d\'inici basades en biblioteques';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Activa els interruptors següents per mostrar les files a les seccions d\'inici.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Tipus de files';
@@ -9074,58 +9022,55 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra pel·lícules, sèries o totes dues a les files Gèneres.';
 
   @override
-  String get displayPlaylistsRows =>
-      'Mostra les files de llistes de reproducció';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Mostra les files de llistes de reproducció a les seccions d\'inici.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting =>
-      'Ordenació de les files de llistes de reproducció';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordena les files de llistes de reproducció per data d\'addició, data d\'estrena, alfabèticament i més.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Mostra les files d\'àudio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Mostra les files d\'àudio a les seccions d\'inici.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ordenació de les files d\'àudio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordena les files d\'àudio per data d\'addició, data d\'estrena, alfabèticament i més.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Llistes de reproducció d\'àudio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Aparença';
 
   @override
-  String get layout => 'Disposició';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Teclat';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Botons';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderització';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configuració d\'MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Mida de la targeta';
@@ -9135,7 +9080,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Defineix un reproductor extern per activar l\'opció de reproduir amb una pulsació llarga';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9407,7 +9352,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appearancesSeerr => 'Aparicions (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Contribucions de l\'equip (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Veure amb grup';
@@ -9493,8 +9438,8 @@ class AppLocalizationsCa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count biblioteques',
-      one: '1 biblioteca',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9654,13 +9599,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get loadingShuffle => 'S\'està carregant la reproducció aleatòria...';
 
   @override
-  String get libraryShuffleLabel => 'BARREJA DE LA BIBLIOTECA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'BARREJA ALEATÒRIA';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'BARREJA DE GÈNERES';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Canvi automàtic HDR';
@@ -9673,79 +9618,79 @@ class AppLocalizationsCa extends AppLocalizations {
   String get whenFullscreen => 'Quan a pantalla completa';
 
   @override
-  String get changeArtwork => 'Canvia la il·lustració';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Falta';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Límits de transcodificació';
 
   @override
-  String get clearAllArtworkButton => 'Esborrar totes les il·lustracions?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Segur que vols esborrar totes les il·lustracions descarregades?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirma l\'esborrat';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Segur que vols esborrar aquesta imatge ($itemType)?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Carregar?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolució: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Mostra només les il·lustracions en l\'idioma de la interfície';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirma l\'esborrat de tot';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'La imatge s\'ha carregat correctament!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'No s\'ha pogut carregar la imatge: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'No s\'ha pogut establir la imatge: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'No s\'ha pogut suprimir la imatge: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'No s\'han pogut esborrar totes les il·lustracions: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Sí';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Pòster';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fons';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Bàner';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotip';
+  String get logoCategory => 'Logo';
 
   @override
   String get thumbnailCategory => 'Miniatura';
@@ -9754,31 +9699,31 @@ class AppLocalizationsCa extends AppLocalizations {
   String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Art del disc';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Captura de pantalla';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Portada de la caixa';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Contraportada de la caixa';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Art del menú';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'pòster';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fons';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'bàner';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotip';
+  String get confirmItemLogo => 'logo';
 
   @override
   String get confirmItemThumbnail => 'miniatura';
@@ -9787,108 +9732,108 @@ class AppLocalizationsCa extends AppLocalizations {
   String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'art del disc';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'captura de pantalla';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'portada de la caixa';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'contraportada de la caixa';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'art del menú';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Totes';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Mitjana (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Baixa (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fonts';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capítols';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marcadors';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
   String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Cua';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Cronologia';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'La cronologia és buida';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Tot el llibre';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Cronologia enfocada';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exporta els marcadors';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exporta les notes';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exporta-ho tot';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'S\'ha exportat a $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'L\'exportació ha fallat: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Lletres';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Afegeix un marcador';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Afegeix una nota';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Edita la nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Escriu una nota per a aquest moment';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Temporitzador de son';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Desactivat';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Final del capítol';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalitzat';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Queden $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9903,51 +9848,51 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Velocitat de reproducció';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Restant';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Transcorregut';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Enrere ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Endavant ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capítol anterior';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Capítol següent';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capítol $current de $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Cap capítol';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Encara no hi ha cap marcador';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Encara no hi ha cap nota';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Marcador afegit a $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Restableix a 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9955,26 +9900,26 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Desa';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Cancel·la';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Suprimeix';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferències dels subtítols';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Canvia els modes de subtítols, els idiomes predeterminats, l\'aparença i les opcions de renderització.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderització dels subtítols';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opcions de visualització';
+  String get displayOptions => 'Display Options';
 
   @override
   String get releaseDateAscending => 'Data d\'estrena (Ascendent)';
@@ -9983,227 +9928,221 @@ class AppLocalizationsCa extends AppLocalizations {
   String get releaseDateDescending => 'Data d\'estrena (Descendent)';
 
   @override
-  String get groupContributions => 'Agrupa les contribucions';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Agrupa múltiples rols';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Avís d\'accés d\'escriptura a la biblioteca';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Com solucionar-ho:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Concedeix permisos d\'escriptura a l\'usuari del servei Jellyfin (p. ex., jellyfin o el PUID/PGID de Docker) per a les carpetes de la teva biblioteca multimèdia al servidor.\n\n2. O bé ves al tauler de control de Jellyfin -> Biblioteques, edita aquesta biblioteca i desactiva \'Desa les il·lustracions a les carpetes multimèdia\' per emmagatzemar-les a la base de dades interna de Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Descarta';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'La teva biblioteca \'$libraryName\' està configurada per desar les il·lustracions directament a les carpetes multimèdia (\'Desa les il·lustracions a les carpetes multimèdia\' està activat). Tanmateix, Jellyfin ha comprovat l\'accés d\'escriptura i no té permís per escriure fitxers en aquest directori:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Sembla que Jellyfin no ha pogut actualitzar la il·lustració. La teva biblioteca està configurada per desar les il·lustracions directament a les carpetes multimèdia (\'Desa les il·lustracions a les carpetes multimèdia\' està activat). Aquest error normalment es produeix quan el procés del servidor Jellyfin no té permís per escriure fitxers als teus directoris multimèdia.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Llistes externes';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Torna a reproduir';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informació del fitxer';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Mida: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Mostra totes les pistes d\'àudio ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Mostra totes les pistes de subtítols ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'S\'està comprovant la capacitat de reproducció nativa...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Capacitat de reproducció nativa: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
   String get forced => 'Forçat';
 
   @override
   String get transcodeContainerNotSupported =>
-      'El reproductor no admet el format del contenidor.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'El còdec de vídeo no és compatible.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'El còdec d\'àudio no és compatible.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'El format dels subtítols no és compatible (cal incrustar-los al vídeo).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'El perfil d\'àudio no és compatible.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'El perfil de vídeo no és compatible.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'El nivell de vídeo no és compatible.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Aquest dispositiu no admet la resolució del vídeo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'La profunditat de bits del vídeo no és compatible.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'La velocitat de fotogrames del vídeo no és compatible.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'La taxa de bits del fitxer supera el límit de transmissió del reproductor.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'La taxa de bits del vídeo supera el límit de transmissió.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'La taxa de bits de l\'àudio supera el límit de transmissió.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'El nombre de canals d\'àudio no és compatible.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabètic';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ordre d\'estrena (ascendent)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
   String get sortReleaseDescending => 'Ordre d\'estrena (Descendent)';
 
   @override
-  String get sortCustomDragDrop => 'Personalitzat (arrossega i deixa anar)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Opcions d\'ordenació de la llista de reproducció';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Restableix l\'ordenació';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Torna a veure T$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Torna a veure la llista de reproducció';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'No s\'han trobat subtítols.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Controls d\'administració';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motor de renderització (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller és el renderitzador de GPU modern de Flutter, per a animacions més fluides i menys interrupcions. En alguns descodificadors de TV i GPU antigues pot provocar defectes visuals o vídeo en negre; desactiva\'l si en detectes. Automàtic tria el millor valor predeterminat per al teu dispositiu. Reinicia Moonfin per aplicar-ho.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automàtic';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Activat';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Desactivat';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Cal reiniciar';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin s\'ha de reiniciar per canviar el motor de renderització. Tanca l\'aplicació ara i torna a obrir-la per aplicar-ho.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Tanca l\'aplicació ara';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Actualitza la biblioteca';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Actualitza totes les biblioteques';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Data d\'addició (més antigues primer)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Data d\'addició (més recents primer)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabètic (A a Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabètic (Z a A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'S\'està carregant l\'analítica del servidor... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual que l\'origen';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'Top 250 pel·lícules d\'IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'Top 250 sèries de TV d\'IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Pel·lícules més populars d\'IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Sèries de TV més populars d\'IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Pel·lícules pitjor valorades d\'IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Millors pel·lícules en anglès d\'IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -9,22 +9,22 @@ class AppLocalizationsCs extends AppLocalizations {
   AppLocalizationsCs([String locale = 'cs']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Měsíční ploutev';
 
   @override
-  String get accountPreferences => 'PŘEDVOLBY ÚČTU';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Jazyk rozhraní';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Výchozí nastavení systému';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Přihlaste se';
 
   @override
-  String get empty => 'Prázdné';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Rychlé připojení';
 
   @override
   String get password => 'Heslo';
@@ -51,7 +51,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get waitingForAuthorization => 'Čekání na autorizaci...';
 
   @override
-  String get back => 'Zpět';
+  String get back => 'Zadní';
 
   @override
   String get serverUnavailable => 'Server je nedostupný';
@@ -113,7 +113,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get cancel => 'Zrušit';
 
   @override
-  String get remove => 'Odebrat';
+  String get remove => 'Odstranit';
 
   @override
   String get connectToServer => 'Připojte se k serveru';
@@ -142,62 +142,62 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsAppearanceTheme => 'Téma aplikace';
 
   @override
-  String get detailScreenStyle => 'Styl obrazovky s detaily';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasický je původní vystředěné rozvržení Moonfinu. Moderní je responzivní filmové rozvržení.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasický';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderní';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Rozbalené karty';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automaticky zobrazovat obsah karty při procházení. Vypněte, pokud chcete každou kartu otevírat a zavírat ručně.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Zobrazit technické údaje?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Zobrazit v souhrnu banneru kodek, rozlišení a informace o streamu';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Systém doporučení';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Použijte algoritmus Moonfin doporučuje pro místní knihovnu, nebo online metriky podobnosti z TMDb. Poznámka: Online doporučení vyžadují integraci Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin doporučuje';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Podobnost podle TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Použít limit rodičovského hodnocení?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Omezit návrhy Moonfin doporučuje podle rodičovského hodnocení cílového média';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Styl rozhraní';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatický se přizpůsobí vašemu zařízení. Zvolte Apple nebo Material pro vynucení vzhledu.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatický';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,31 +206,31 @@ class AppLocalizationsCs extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kvalita skla';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automaticky vybere nejlepší efekt skla pro toto zařízení. Plná vynutí skutečné rozostření; Snížená používá odlehčené sklo, které šetří výkon GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automaticky';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Plná';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Snížená';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Přepínejte mezi Moonfin a Neon Pulse bez restartování aplikace';
 
   @override
-  String get customThemeTitle => 'Vlastní motiv';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Vlastní motivy mění vzhled napříč celým Moonfinem. Vyberte si možnost, která vyhovuje vašemu stylu.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Preferujte systémovou klávesnici';
@@ -240,7 +240,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Pro zadávání textu použijte ve výchozím nastavení metodu zadávání vašeho zařízení';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Měsíční ploutev';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -258,14 +258,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Styl tekutého skla s plynoucím přechodem na pozadí, matnými plochami a modrým akcentem ve stylu Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixel-art styl s hrubou paletou, hranatými okraji, ostrými stíny a pixelovým písmem';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -328,36 +328,35 @@ class AppLocalizationsCs extends AppLocalizations {
   String get exit => 'Výstup';
 
   @override
-  String get gameMenu => 'Nabídka';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pozastaveno';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Uložit stav';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Hry';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Načíst stav';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Zrychlit';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Nastavení emulátoru';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Toto jádro nemá žádné nastavitelné možnosti.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Podržením otevřete nabídku';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spouštění her zatím není na tomto zařízení podporováno.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nepodařilo se načíst žádné domácí řádky';
@@ -379,13 +378,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get schedule => 'Naplánovat';
 
   @override
-  String get series => 'Seriály';
+  String get series => 'Série';
 
   @override
   String get noItemsFound => 'Nebyly nalezeny žádné položky';
 
   @override
-  String get home => 'Domů';
+  String get home => 'Domov';
 
   @override
   String get browseAll => 'Procházet vše';
@@ -508,7 +507,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get albumArtists => 'Umělci alb';
 
   @override
-  String get artists => 'Interpreti';
+  String get artists => 'Umělci';
 
   @override
   String get bookmarks => 'Záložky';
@@ -604,7 +603,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get listen => 'Poslouchat';
 
   @override
-  String get resume => 'Pokračovat';
+  String get resume => 'Resumé';
 
   @override
   String get failedToLoadLibrary => 'Načtení knihovny se nezdařilo';
@@ -748,13 +747,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get readStatus => 'Číst';
 
   @override
-  String get watched => 'Zhlédnuto';
+  String get watched => 'Sledováno';
 
   @override
   String get unread => 'Nepřečtený';
 
   @override
-  String get unwatched => 'Nezhlédnuto';
+  String get unwatched => 'Nesledováno';
 
   @override
   String get seriesStatus => 'Stav série';
@@ -766,45 +765,43 @@ class AppLocalizationsCs extends AppLocalizations {
   String get books => 'knihy';
 
   @override
-  String get latestBooks => 'Nejnovější knihy';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Nejnovější audioknihy';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knih',
-      many: '$count knihy',
-      few: '$count knihy',
-      one: '1 kniha',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Kniha';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiokniha';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Přečteno $percent %';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Zbývá $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Číst';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Poslouchat';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -881,10 +878,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audioknih',
-      many: '$count audioknihy',
-      few: '$count audioknihy',
-      one: '1 audiokniha',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -899,7 +894,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get failedToLoad => 'Načtení se nezdařilo';
 
   @override
-  String get delete => 'Smazat';
+  String get delete => 'Vymazat';
 
   @override
   String get save => 'Uložit';
@@ -920,7 +915,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get nextUp => 'Další Nahoru';
 
   @override
-  String get seasons => 'Sezóny';
+  String get seasons => 'Roční období';
 
   @override
   String get chapters => 'Kapitoly';
@@ -947,7 +942,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tableOfContents => 'Obsah';
 
   @override
-  String get tracklist => 'Seznam skladeb';
+  String get tracklist => 'Tracklist';
 
   @override
   String discNumber(int number) {
@@ -988,10 +983,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezón',
-      many: '$count sezóny',
-      few: '$count sezóny',
-      one: '1 sezóna',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1002,40 +995,40 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get items => 'Položky';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Bonusy';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Ze zákulisí';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Vystřižené scény';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Rozhovory';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scény';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Krátké filmy';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Upoutávky';
+  String get trailers => 'Přívěsy';
 
   @override
   String timeRemaining(String time) {
-    return 'Zbývá $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Končí za $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1053,7 +1046,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get play => 'Přehrát';
+  String get play => 'Hrát';
 
   @override
   String get startOver => 'Začít znovu';
@@ -1077,10 +1070,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get version => 'Verze';
 
   @override
-  String get cast => 'Odeslat';
+  String get cast => 'Obsazení';
 
   @override
-  String get trailer => 'Upoutávka';
+  String get trailer => 'Přívěs';
 
   @override
   String get finished => 'Hotovo';
@@ -1193,7 +1186,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get subtitleTrack => 'Titulková stopa';
 
   @override
-  String get none => 'Žádné';
+  String get none => 'Žádný';
 
   @override
   String get downloadSubtitlesLabel => 'Stáhnout titulky...';
@@ -1271,13 +1264,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get director => 'ŘEDITEL';
 
   @override
-  String get directors => 'REŽIE';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCÉNÁŘ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENÁRISTÉ';
+  String get writers => 'SPISOVATELÉ';
 
   @override
   String get studio => 'STUDIO';
@@ -1312,10 +1305,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count stop',
-      many: '$count stopy',
-      few: '$count stopy',
-      one: '1 stopa',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1325,10 +1316,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapitol',
-      many: '$count kapitoly',
-      few: '$count kapitoly',
-      one: '1 kapitola',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1355,16 +1344,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get readMore => 'Přečtěte si více';
 
   @override
-  String get shuffle => 'Náhodně';
+  String get shuffle => 'Zamíchat';
 
   @override
-  String get shuffleAllMusic => 'Zamíchat veškerou hudbu';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Přihlaste se do Moonfinu na telefonu';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Nelze se připojit k serveru';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1376,7 +1365,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '${count}k';
+    return '${count}ch';
   }
 
   @override
@@ -1462,7 +1451,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get unavailable => 'Není k dispozici';
 
   @override
-  String get pause => 'Pozastavit';
+  String get pause => 'Pauza';
 
   @override
   String get syncPosition => 'Synchronizovat pozici';
@@ -1509,11 +1498,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automaticky';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
-    return '$mbps Mb/s';
+    return '$mbps Mbps';
   }
 
   @override
@@ -1524,12 +1513,12 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1563,7 +1552,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get transcodeReasons => 'Důvody překódování';
 
   @override
-  String get player => 'Přehrávač';
+  String get player => 'Hráč';
 
   @override
   String get container => 'Kontejner';
@@ -1587,7 +1576,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get videoBitrate => 'Přenosová rychlost videa';
 
   @override
-  String get track => 'Stopa';
+  String get track => 'Dráha';
 
   @override
   String get channels => 'Kanály';
@@ -1802,22 +1791,22 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Následuje: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Zbývá $minutes min';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Zbývá $hours h';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Zbývá $hours h $minutes min';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1840,7 +1829,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get favoriteChannel => 'Oblíbený kanál';
 
   @override
-  String get record => 'Nahrát';
+  String get record => 'Záznam';
 
   @override
   String get cancelRecordingAction => 'Zrušit nahrávání';
@@ -1855,10 +1844,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get unableToCreateRecording => 'Nelze vytvořit záznam';
 
   @override
-  String get watch => 'Sledovat';
+  String get watch => 'Hodinky';
 
   @override
-  String get close => 'Zavřít';
+  String get close => 'Blízko';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1892,7 +1881,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get no => 'Ne';
+  String get no => 'Žádný';
 
   @override
   String get yesCancel => 'Ano, zrušit';
@@ -2067,10 +2056,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizod',
-      many: '$count epizody',
-      few: '$count epizody',
-      one: '1 epizoda',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2296,11 +2283,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Stránky s detaily, domovské řádky a hlasitost';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
-    return '$value %';
+    return '$value%';
   }
 
   @override
@@ -2311,18 +2298,18 @@ class AppLocalizationsCs extends AppLocalizations {
       'Přehrát při procházení domovské obrazovky';
 
   @override
-  String get loopThemeMusic => 'Opakovat úvodní hudbu';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Přehrávat skladbu dokola místo jednoho přehrání';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Podrobnosti Rozostření pozadí';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2338,23 +2325,23 @@ class AppLocalizationsCs extends AppLocalizations {
   String get playerZoomMode => 'Režim zvětšení přehrávače';
 
   @override
-  String get settingsScrollWheelAction => 'Kolečko myši';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Zvolte, co má během přehrávání dělat rolování kolečkem myši nad videem.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Vypnuto';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Převíjení (vpřed / zpět)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Hlasitost';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Hlasitost';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2369,7 +2356,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get refreshRateSwitching => 'Přepínání obnovovací frekvence';
 
   @override
-  String get disabled => 'Vypnuto';
+  String get disabled => 'Zakázáno';
 
   @override
   String get scaleOnTv => 'Měřítko v televizi';
@@ -2408,37 +2395,37 @@ class AppLocalizationsCs extends AppLocalizations {
   String get defaultAudioLanguage => 'Výchozí jazyk zvuku';
 
   @override
-  String get fallbackAudioLanguage => 'Záložní jazyk zvuku';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Upřednostnit výchozí zvukovou stopu';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Upřednostnit původní zvukovou stopu před lokalizovaným dabingem.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Upřednostnit stopy s audiopopisem';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Upřednostnit stopy s audiopopisem před běžnými stopami.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Překódování (zvuk)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Přímý stream (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Překódování (datový tok nebo rozlišení)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Překódování (video a zvuk)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Překódování (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (výchozí nastavení serveru)';
@@ -2519,7 +2506,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Zvolte, jak se zvuk dekóduje. AVR Passthrough posílá surové streamy Dolby/DTS do vašeho receiveru; Automaticky nebo Downmix dekódují lokálně.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Průchod AVR';
@@ -2529,14 +2516,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Vyberte cílový formát pro překódování vícekanálového zvuku, když zdrojový stream nelze přehrát přímo ani poslat v původní podobě.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automatická detekce\n(doporučeno)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(výchozí)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2545,27 +2531,26 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(bezztrátový)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(pouze stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(úsporný)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(bezztrátový)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maximální počet zvukových kanálů';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Nastavte maximální počet kanálů vaší zvukové sestavy. Vícekanálové streamy nad tímto limitem se smíchají do menšího počtu kanálů nebo překódují.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automatická detekce\n(výchozí podle hardwaru)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2577,7 +2562,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvadrofonní';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2670,11 +2655,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Reproduktor';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Sluchátka';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '${count}k PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2759,7 +2744,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2781,7 +2766,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get resumeAndSkip => 'Obnovit a přeskočit';
 
   @override
-  String get resumeRewind => 'Převinutí při navázání';
+  String get resumeRewind => 'Resume Rewind';
 
   @override
   String get unpauseRewind => 'Zrušit pozastavení přetáčení';
@@ -2850,45 +2835,45 @@ class AppLocalizationsCs extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Přizpůsobte vzhled titulků';
 
   @override
-  String get subtitleMode => 'Režim titulků';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Označené';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Vždy';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Cizojazyčné';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Vynucené';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Přehrává stopy, které jsou v metadatech mediálního souboru interně označené jako „výchozí“ nebo „vynucené“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automaticky načte a zobrazí titulky při každém spuštění videa.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automaticky zapne titulky, pokud je výchozí zvuková stopa v cizím jazyce.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Načte pouze titulky výslovně označené příznakem „vynucené“.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Zcela vypne automatické načítání titulků.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Záložní jazyk titulků';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream titulků';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Rychlá hnědá liška přeskakuje líného psa';
@@ -2936,7 +2921,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get global => 'Globální';
 
   @override
-  String get desktop => 'Počítač';
+  String get desktop => 'Desktop';
 
   @override
   String get mobile => 'Mobilní';
@@ -3092,10 +3077,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showLibrariesInToolbar => 'Zobrazit knihovny na liště Toolbar';
 
   @override
-  String get navbarAlwaysExpanded => 'Vždy zobrazovat popisky navigační lišty';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Zobrazit tlačítko Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Neprůhlednost navigační lišty';
@@ -3113,7 +3098,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get purple => 'Fialová';
 
   @override
-  String get teal => 'Modrozelená';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'námořnictvo';
@@ -3134,7 +3119,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get slate => 'Břidlice';
 
   @override
-  String get indigo => 'Indigová';
+  String get indigo => 'Indigo';
 
   @override
   String get libraryDisplay => 'Zobrazení knihovny';
@@ -3169,19 +3154,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showFolderBrowsingOption => 'Zobrazit možnost procházení složek';
 
   @override
-  String get groupItemsIntoCollections => 'Seskupovat položky do kolekcí';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Skrýt při procházení knihoven položky patřící do kolekcí';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Upozornění k seskupování knihovny';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Chcete-li toto nastavení použít, ujistěte se, že máte v nastavení zobrazení dané knihovny na serveru Jellyfin nebo Emby zapnuté možnosti „Seskupovat filmy do kolekcí“ a/nebo „Seskupovat seriály do kolekcí“.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Viditelnost knihovny';
@@ -3214,7 +3198,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get mediaBar => 'Mediální lišta';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Mediální zdroje';
@@ -3240,7 +3224,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Vyberte si mezi různými styly mediálního panelu nebo mediální panel vypněte';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Měsíční ploutev';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3277,7 +3261,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noneExcluded => 'Žádná vyloučena';
 
   @override
-  String get autoAdvance => 'Automatický přechod';
+  String get autoAdvance => 'Auto Advance';
 
   @override
   String get autoAdvanceSlides => 'Automaticky přejít na další snímek';
@@ -3293,10 +3277,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Automatické přehrávání upoutávek na liště médií po 3 sekundách';
 
   @override
-  String get trailerAudio => 'Zvuk upoutávek';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Zapnout zvuk upoutávek v mediální liště';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Náhled epizody';
@@ -3372,11 +3356,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get combineBothRows => 'Spojte oba řádky do jedné domovské sekce';
 
   @override
-  String get fullScreenRows => 'Rozšířené domovské řádky';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Omezit domovské řádky na 1 řádek na obrazovku';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Typ obrázku na řádek';
@@ -3391,7 +3374,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get lastUser => 'Poslední uživatel';
 
   @override
-  String get currentUser => 'Aktuální uživatel';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vždy ověřit';
@@ -3496,10 +3479,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zobrazení hodin během spořiče obrazovky';
 
   @override
-  String get clockModeStatic => 'Statické';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Poskakující';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritici)';
@@ -3570,7 +3553,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Povolte a změňte pořadí zdrojů hodnocení zobrazovaných v aplikaci';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin detekován';
@@ -3595,7 +3578,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get availableServices => 'Dostupné služby';
 
   @override
-  String get serverPluginSync => 'Synchronizace serverového pluginu';
+  String get serverPluginSync => 'Server Plugin Sync';
 
   @override
   String get syncSettingsWithPlugin =>
@@ -3642,7 +3625,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get networks => 'sítě';
 
   @override
-  String get seerrDiscoveryRows => 'Objevovací řádky Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Resetovat řádky na výchozí hodnoty';
@@ -3665,27 +3648,28 @@ class AppLocalizationsCs extends AppLocalizations {
   String get hideAdultContent => 'Skrýt ve výsledcích obsah pouze pro dospělé';
 
   @override
-  String get seerrNotificationsSection => 'Oznámení';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Oznámení o nových žádostech';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Upozornit mě, když někdo odešle žádost';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Aktualizace žádostí';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Schváleno, zamítnuto a přidáno do vaší knihovny';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Aktualizace problémů';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nové problémy, odpovědi a řešení';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3693,18 +3677,18 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Stránka objevování Seerr';
+  String get discoverRows => 'Objevte řádky';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Povolte řádky, které chcete vidět na hlavní stránce Seerr. Přetažením změníte pořadí. Vlastní pořadí se synchronizuje s pluginem Moonbase.';
+      'Přetažením změníte pořadí. Povolit nebo zakázat řádky. Povolená synchronizace pořadí řádků s pluginem Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Povolte řádky, které chcete vidět na hlavní stránce Seerr. Přetažením změníte pořadí. Vlastní pořadí se synchronizuje s pluginem Moonbase.';
+      'Přetažením změníte pořadí. Povolit nebo zakázat řádky.';
 
   @override
-  String get enabled => 'Zapnuto';
+  String get enabled => 'Povoleno';
 
   @override
   String get hidden => 'Skrytý';
@@ -3840,7 +3824,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get imageCacheCleared => 'Mezipaměť obrázků byla vymazána';
 
   @override
-  String get clear => 'Vymazat';
+  String get clear => 'Jasný';
 
   @override
   String get browse => 'Prohlížet';
@@ -3856,11 +3840,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Stahování · $percent %';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importuje se';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3965,7 +3949,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showMore => 'Zobrazit více';
 
   @override
-  String get appearances => 'Účinkování';
+  String get appearances => 'Vystoupení';
 
   @override
   String get crewSection => 'Posádka';
@@ -4003,147 +3987,148 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deletedStatus => 'Smazáno';
 
   @override
-  String get failedStatus => 'Selhalo';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Zpracovává se';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Upravil(a) $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Dokončeno';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Tento titul už byl vyžádán';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Byl dosažen limit žádostí';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Tento titul je na seznamu blokovaných';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Nezbývají žádné sezóny k vyžádání';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Nemáte oprávnění vytvořit tuto žádost';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Žádosti';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problémy';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nejnovější';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Naposledy upravené';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Žádné problémy';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Zbývá $remaining z $limit žádostí o filmy';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Zbývá $remaining z $limit žádostí o sezóny';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Součást kolekce $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Zobrazit kolekci';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Vyžádat kolekci';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmů · $available dostupných';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Vyžádat $count filmů';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Odesílá se žádost $current z $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Vyžádáno $count filmů';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Vyžádáno $ok z $total filmů';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Všechny filmy jsou už dostupné nebo vyžádané';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Nahlásit problém';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Zvuk';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Co je špatně?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Všechny epizody';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizoda';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Otevřeno';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Vyřešený';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Vyřešit';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Znovu otevřít';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Nahlásil(a) $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentářů';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Přidat komentář';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Smazat tento problém?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Odeslat hlášení';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Skóre TMDB';
@@ -4167,7 +4152,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get originalLanguageLabel => 'Původní jazyk';
 
   @override
-  String get seasonsLabel => 'Sezóny';
+  String get seasonsLabel => 'Roční období';
 
   @override
   String get episodesLabel => 'Epizody';
@@ -4182,7 +4167,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get address => 'Adresa';
 
   @override
-  String get analytics => 'Analytika';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalog';
@@ -4215,7 +4200,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get forward => 'Vpřed';
 
   @override
-  String get general => 'Obecné';
+  String get general => 'Generál';
 
   @override
   String get go => 'Jít';
@@ -4260,7 +4245,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get refresh => 'Obnovit';
 
   @override
-  String get remote => 'Dálkové ovládání';
+  String get remote => 'Vzdálený';
 
   @override
   String get rename => 'Přejmenovat';
@@ -4278,7 +4263,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get run => 'Běh';
 
   @override
-  String get search => 'Hledat';
+  String get search => 'Vyhledávání';
 
   @override
   String get select => 'Vybrat';
@@ -4296,7 +4281,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get status => 'Postavení';
 
   @override
-  String get stop => 'Zastavit';
+  String get stop => 'Zastávka';
 
   @override
   String get streaming => 'Streamování';
@@ -4326,19 +4311,19 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mute => 'Ztlumit';
 
   @override
-  String get branding => 'Vzhled značky';
+  String get branding => 'Branding';
 
   @override
-  String get adminDrawerDashboard => 'Nástěnka';
+  String get adminDrawerDashboard => 'Dashboard';
 
   @override
-  String get adminDrawerAnalytics => 'Analytika';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Nastavení';
 
   @override
-  String get adminDrawerBranding => 'Vzhled značky';
+  String get adminDrawerBranding => 'Branding';
 
   @override
   String get adminDrawerUsers => 'Uživatelé';
@@ -4347,19 +4332,19 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminDrawerLibraries => 'Knihovny';
 
   @override
-  String get adminDrawerDisplay => 'Zobrazení';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Nastavení NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Překódování';
 
   @override
-  String get adminDrawerResume => 'Pokračovat';
+  String get adminDrawerResume => 'Resumé';
 
   @override
   String get adminDrawerStreaming => 'Streamování';
@@ -4541,10 +4526,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get sessionNext => 'Další';
 
   @override
-  String get sessionVolumeDown => 'Hlas. –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Hlas. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4553,7 +4538,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get nowPlaying => 'Právě se přehrává';
 
   @override
-  String get volume => 'Hlasitost';
+  String get volume => 'Objem';
 
   @override
   String get actions => 'Akce';
@@ -4565,7 +4550,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audioCodec => 'Audio kodek';
 
   @override
-  String get hwAccel => 'HW akcelerace';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Dokončení';
@@ -4580,10 +4565,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminClearDates => 'Vymazat data';
 
   @override
-  String get adminActivitySeverityAll => 'Všechny závažnosti';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Časové období';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4620,23 +4605,23 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Odebrat zařízení „$name“? Uživatel se na něm bude muset znovu přihlásit.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Smazat všechna zařízení';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Odebrat $count zařízení? Dotčení uživatelé se budou muset znovu přihlásit. Vaše aktuální zařízení to neovlivní.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Zařízení byla odebrána';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Některá zařízení byla odebrána; $count se odebrat nepodařilo.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4751,251 +4736,244 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminMetadataCountryHint => 'např. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Cesty';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Možnosti';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Stahovače';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Ukládání metadat';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Stahovače titulků';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Stahovače textů písní';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Stahovače metadat: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Zdroje obrázků: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Tento server nenabízí pro tento typ knihovny žádné stahovače.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Obecné';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Vložené informace';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Titulky';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Obrázky';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Seriály';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Hudba';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmy';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Zapnout sledování v reálném čase';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Rozpoznávat změny souborů a automaticky je zpracovávat.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Považovat archivy za mediální soubory';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Zobrazovat fotky';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Ukládat grafiku do složek s médii';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatická obnova metadat';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nikdy';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Výchozí';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Zobrazení';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Zobrazení knihovny';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Zobrazovat složkové zobrazení s prostými složkami médií';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Zobrazovat speciály v sezónách, ve kterých se vysílaly';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Seskupovat filmy do kolekcí';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Seskupovat seriály do kolekcí';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Zobrazovat v návrzích externí obsah';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Chování data přidání';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Použít datum přidání z';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Datum načtení do knihovny';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum vytvoření souboru';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata a obrázky';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Preferovaný jazyk metadat';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitoly';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Délka náhradních kapitol (sekundy)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Délka kapitol generovaných pro média, která žádné nemají. Nastavením na 0 funkci vypnete.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Rozlišení obrázků kapitol';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Nastavení NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadata NFO jsou kompatibilní s Kodi a podobnými klienty. Nastavení platí pro všechny knihovny, které ukládají metadata NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Uživatel, jehož data o sledování se ukládají do souborů NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Ukládat cesty k obrázkům do souborů NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Zapnout nahrazování cest u obrázků v NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopírovat obrázky extrafanart do složky extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Žádné';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dní';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Používat vložené názvy';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => 'Používat vložené názvy u bonusů';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Používat vložené informace o epizodách';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Povolit vložené titulky';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Povolit vše';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Pouze textové';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Pouze obrazové';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Žádné';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Přeskočit stahování, pokud jsou k dispozici vložené titulky';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Přeskočit stahování, pokud zvuková stopa odpovídá jazyku stahování';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Vyžadovat přesnou shodu titulků';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Ukládat titulky do složek s médii';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Extrahovat obrázky kapitol';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extrahovat obrázky kapitol při skenování knihovny';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Zapnout extrakci obrázků trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extrahovat obrázky trickplay při skenování knihovny';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Ukládat obrázky trickplay do složek s médii';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automaticky slučovat seriály rozdělené do více složek';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Zobrazovaný název nulté sezóny';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Zapnout skenování LUFS pro normalizaci hlasitosti';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Upřednostnit nestandardní tag interpretů';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automaticky přidávat filmy do kolekcí';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Název knihovny je povinný';
@@ -5113,7 +5091,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminDeleteUser => 'Smazat uživatele';
 
   @override
-  String get admin => 'Správce';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5233,145 +5211,143 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminEnableAllChannels => 'Povolit přístup ke všem kanálům';
 
   @override
-  String get adminParentalControl => 'Rodičovská kontrola';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Maximální povolené rodičovské hodnocení';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Obsah s vyšším hodnocením bude tomuto uživateli skrytý.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Žádné';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokovat položky bez hodnocení nebo s nerozpoznaným hodnocením';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Knihy';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanály';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Živá televize';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmy';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Hudba';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Upoutávky';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriály';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Časové plány přístupu';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Povolit přístup pouze v níže naplánovaných časech. Pokud není nastaven žádný plán, je přístup povolen po celý den.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Přidat plán';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Den';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Začátek';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Konec';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Každý den';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Všední den';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Víkend';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Neděle';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Pondělí';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Úterý';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Středa';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Čtvrtek';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Pátek';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sobota';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Povolené štítky';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Zobrazí se pouze obsah s těmito štítky. Ponechte prázdné pro povolení všeho.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokované štítky';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Obsah s těmito štítky bude tomuto uživateli skrytý.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Přidat štítek';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Povolená zařízení';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Povolené kanály';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Poskytovatel ověření';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Poskytovatel obnovy hesla';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maximální počet neúspěšných přihlášení před zablokováním';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Zadejte 0 pro výchozí hodnotu, nebo -1 pro vypnutí blokování.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Přístup k SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Povolit vytváření skupin a připojování k nim';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Povolit připojování ke skupinám';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Bez přístupu';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Povolit mazání obsahu z';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5458,25 +5434,25 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Vytvořit zálohu';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Zvolte, co se má do zálohy zahrnout.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Databáze';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Vždy zahrnuto';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Titulky';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Obrázky trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Vytváření zálohy...';
@@ -5905,7 +5881,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminThrottleBuffering => 'Vyrovnávací paměť plynu';
 
   @override
-  String get adminTrickplaySaved => 'Nastavení Trickplay uloženo';
+  String get adminTrickplaySaved => 'Nastavení trikové hry uloženo';
 
   @override
   String get adminTrickplayLoadFailed =>
@@ -6010,10 +5986,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ports => 'Porty';
 
   @override
-  String get adminHttpPort => 'Port HTTP';
+  String get adminHttpPort => 'HTTP port';
 
   @override
-  String get adminHttpsPort => 'Port HTTPS';
+  String get adminHttpsPort => 'HTTPS port';
 
   @override
   String get adminPublicHttpsPort => 'Veřejný port HTTPS';
@@ -6022,7 +5998,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminBaseUrl => 'Základní URL';
 
   @override
-  String get adminBaseUrlHint => 'např. /jellyfin';
+  String get adminBaseUrlHint => 'např. /ploutev';
 
   @override
   String get https => 'HTTPS';
@@ -6185,62 +6161,60 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminAddTuner => 'Přidat tuner';
 
   @override
-  String get adminEditTuner => 'Upravit tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Soubor nebo URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP adresa tuneru';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Popisný název';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limit souběžných připojení';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Maximální počet streamů, které tuner zvládne najednou. Zadejte 0 pro neomezený počet.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Záložní maximální datový tok streamu';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importovat pouze oblíbené kanály';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Povolit hardwarové překódování';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Povolit kontejner fMP4 pro překódování';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Povolit sdílení streamu';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Zapnout smyčkování streamu';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorovat DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Číst vstup v nativní snímkové frekvenci';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Upravit poskytovatele';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6249,50 +6223,50 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Soubor nebo URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Předpona filmů';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategorie filmů';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Více kategorií oddělte svislou čarou.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategorie pro děti';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategorie zpravodajství';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategorie sportu';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Uživatelské jméno';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Heslo';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Země';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Vyberte zemi';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'PSČ';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Načíst programy';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programy';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Zapnout všechny tunery';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Typ tuneru';
@@ -6334,7 +6308,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Tento typ tuneru nepodporuje resetování.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6357,45 +6331,43 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Cesta záznamu série';
 
   @override
-  String get adminMovieRecordingPath => 'Cesta pro nahrávání filmů';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Počet dní dat programu';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automaticky';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dní';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Cesta k aplikaci pro následné zpracování';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumenty následného zpracování';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Ukládat metadata NFO k nahrávkám';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Ukládat obrázky k nahrávkám';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Časování';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Cesty pro nahrávání';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Následné zpracování';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Data programu: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6439,14 +6411,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminGuideProviders => 'Poskytovatelé průvodců';
 
   @override
-  String get adminRefreshGuideData => 'Obnovit data programu';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Obnova dat programu byla zahájena';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Úloha obnovy programu není na tomto serveru k dispozici.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Přidat poskytovatele';
@@ -6472,11 +6444,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Doběh: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Vyhledávání tunerů';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Mapování kanálů';
@@ -6580,7 +6552,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor metadat';
 
   @override
-  String get adminMetadataIdentify => 'Identifikovat';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Typ';
@@ -6595,7 +6567,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminMetadataImages => 'Obrázky';
 
   @override
-  String get adminMetadataFieldTitle => 'Název';
+  String get adminMetadataFieldTitle => 'Titul';
 
   @override
   String get adminMetadataFieldSortTitle => 'Seřadit název';
@@ -6863,7 +6835,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Odebrat';
+  String get adminReposRemove => 'Odstranit';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6941,10 +6913,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminNetworkingPorts => 'Porty';
 
   @override
-  String get adminNetworkingHttpPort => 'Port HTTP';
+  String get adminNetworkingHttpPort => 'HTTP port';
 
   @override
-  String get adminNetworkingHttpsPort => 'Port HTTPS';
+  String get adminNetworkingHttpsPort => 'HTTPS port';
 
   @override
   String get adminNetworkingEnableHttps => 'Povolit HTTPS';
@@ -6974,7 +6946,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminNetworkingAddEntry => 'Přidat záznam';
 
   @override
-  String get adminBrandingTitle => 'Vzhled značky';
+  String get adminBrandingTitle => 'Branding';
 
   @override
   String get adminBrandingLoginDisclaimer =>
@@ -6995,21 +6967,19 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Povolit úvodní obrazovku';
 
   @override
-  String get adminBrandingSplashUpload => 'Nahrát obrázek';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'Úvodní obrazovka byla aktualizována';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Nahrání úvodní obrazovky se nezdařilo';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Úvodní obrazovka byla odebrána';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Žádná vlastní úvodní obrazovka';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardwarová akcelerace';
@@ -7025,125 +6995,121 @@ class AppLocalizationsCs extends AppLocalizations {
       'Povolit hardwarové dekódování pro:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Zařízení QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Zapnout vylepšený dekodér NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Upřednostnit nativní hardwarový dekodér systému';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Barevná hloubka hardwarového dekódování';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10bitové dekódování HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10bitové dekódování VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      '8/10bitové dekódování HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      '12bitové dekódování HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardwarové kódování';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Povolit kódování HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Povolit kódování AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Zapnout nízkopříkonový kodér Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Zapnout nízkopříkonový kodér Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapování tónů';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Zapnout mapování tónů';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Zapnout mapování tónů VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Zapnout mapování tónů VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritmus mapování tónů';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Režim mapování tónů';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Rozsah mapování tónů';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturace mapování tónů';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Špička mapování tónů';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametr mapování tónů';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'Jas mapování tónů VPP';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast mapování tónů VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Předvolby a kvalita';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Předvolba kodéru';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF kódování H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF kódování H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metoda odstranění prokládání';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Zdvojnásobit snímkovou frekvenci při odstranění prokládání';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Zvuk';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Zapnout kódování zvuku s VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Zesílení při downmixu zvuku';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmus downmixu do sterea';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maximální velikost fronty muxování';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automaticky';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kódování';
@@ -7263,10 +7229,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminTaskNeverRun => 'Nikdy neutíkej';
 
   @override
-  String get adminTaskStop => 'Zastavit';
+  String get adminTaskStop => 'Zastávka';
 
   @override
-  String get adminRunningTasks => 'Běžící úlohy';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Běh';
@@ -7336,10 +7302,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hodin',
-      many: '$count hodiny',
-      few: '$count hodiny',
-      one: '1 hodina',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7385,22 +7349,22 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day. $month.';
+    return '$month/$day';
   }
 
   @override
@@ -7414,50 +7378,49 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Základní URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'např. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'např. /ploutev';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Veřejný port HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Vyžadovat HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Přesměrovat všechny vzdálené požadavky na HTTPS. Nemá účinek, pokud server nemá platný certifikát.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Heslo certifikátu';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Nastavení IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Zapnout IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Zapnout IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Zapnout automatické mapování portů';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Sítě LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Seznam IP adres nebo podsítí CIDR oddělený čárkami nebo řádky, které se považují za místní síť.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publikované adresy serveru';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Namapujte podsíť nebo adresu na publikovanou URL, např. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Cesta k certifikátu';
@@ -7487,11 +7450,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Vyrovnávací paměť plynu';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Prodleva omezení (sekundy)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Povolit průběžnou extrakci titulků';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimální procento obnovení';
@@ -7547,11 +7510,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Práh pomalé odezvy (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Zapnout upozornění na pomalé odezvy';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Zapnout Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7560,10 +7522,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Cesty';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Výkon';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cesta keš';
@@ -7575,7 +7537,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminGeneralServerName => 'Název serveru';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Preferovaný jazyk zobrazení';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nastavení se nepodařilo načíst';
@@ -7627,10 +7589,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# účastníků',
-      many: '# účastníka',
-      few: '# účastníci',
-      one: '# účastník',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7777,10 +7737,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'nalezeno # řádků',
-      many: 'nalezeno # řádku',
-      few: 'nalezeny # řádky',
-      one: 'nalezen # řádek',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7821,20 +7779,20 @@ class AppLocalizationsCs extends AppLocalizations {
   String get offlineSavedMedia => 'Uložená média';
 
   @override
-  String get offlineBannerTitle => 'Jste offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Zobrazujeme vaše stažené položky';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Stažené';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Nelze se připojit k serveru';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Do jeho obnovení se přehrává ze stažených položek';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7907,13 +7865,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pinForgot => 'Zapomněli jste PIN?';
 
   @override
-  String get pinClear => 'Vymazat';
+  String get pinClear => 'Jasný';
 
   @override
   String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Požadavek Quick Connect byl schválen.';
+  String get quickConnectAuthorized => 'Požadavek na rychlé připojení povolen.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -7921,7 +7879,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect není na tomto serveru podporován.';
+      'Rychlé připojení není na tomto serveru podporováno.';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7929,19 +7887,19 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect je na tomto serveru zakázán.';
+      'Rychlé připojení je na tomto serveru zakázáno.';
 
   @override
   String get quickConnectForbidden =>
-      'Váš účet nemůže autorizovat tento požadavek Quick Connect.';
+      'Váš účet nemůže autorizovat tento požadavek rychlého připojení.';
 
   @override
   String get quickConnectNotFound =>
-      'Kód Quick Connect nebyl nalezen. Zkuste nový kód.';
+      'Kód rychlého připojení nebyl nalezen. Zkuste nový kód.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect se nezdařil: $message';
+    return 'Rychlé připojení se nezdařilo: $message';
   }
 
   @override
@@ -7993,7 +7951,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Nejsou k dispozici žádná zařízení pro vzdálené přehrávání.\n\nNa iOS mohou být cíle AirPlay v simulátoru nedostupné.';
 
   @override
-  String get trackActionPlayNext => 'Přehrát jako další';
+  String get trackActionPlayNext => 'Play Next';
 
   @override
   String get trackActionAddToQueue => 'Přidat do fronty';
@@ -8037,7 +7995,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trackActionDeleteFileFailed => 'Stažený soubor nelze smazat';
 
   @override
-  String get shuffleBy => 'Zamíchat podle';
+  String get shuffleBy => 'Shuffle By';
 
   @override
   String get shuffleSelectLibrary => 'Vyberte Knihovna';
@@ -8102,14 +8060,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get upNext => 'Nahoru Další';
 
   @override
-  String get playNext => 'Přehrát jako další';
+  String get playNext => 'Play Next';
 
   @override
   String get stillWatchingContent =>
       'Přehrávání bylo pozastaveno. Pořád se díváš?';
 
   @override
-  String get stillWatchingStop => 'Zastavit';
+  String get stillWatchingStop => 'Zastávka';
 
   @override
   String get stillWatchingContinue => 'Pokračovat';
@@ -8194,13 +8152,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Skrýt z Pokračovat ve sledování';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Skrýt z Další na řadě';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Přidat do kolekce';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8255,15 +8213,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsAlphabetical => 'Abecední';
 
   @override
-  String get settingsConnectionSection => 'PŘIPOJENÍ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Povolit certifikáty podepsané svým vydavatelem';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Důvěřovat serverům s certifikáty TLS podepsanými svým vydavatelem nebo privátní certifikační autoritou. Zapínejte pouze u serverů, které máte pod kontrolou. Vypne to ověřování certifikátů pro všechna připojení.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'SOUKROMÍ A BEZPEČNOST';
@@ -8279,11 +8236,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'Akcenty tématu, pozadí, indikátory sledování a hudba tématu';
 
   @override
-  String get settingsDetailsScreen => 'Obrazovka s detaily';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Styl, rozostření pozadí a chování karet';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Domovská stránka';
@@ -8321,11 +8278,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Zobrazit tlačítko Seerr v navigační liště';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vždy zobrazovat textové popisky v horní navigační liště';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8427,10 +8384,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licenčních upozornění',
-      many: '# licenčního upozornění',
-      few: '# licenční upozornění',
-      one: '# licenční upozornění',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8478,16 +8433,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Přeskočit úvody a závěry?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Odpočet mediálních segmentů';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Ukazatel průběhu';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Odpočet';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Žádné';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Vyzvat uživatele';
@@ -8511,7 +8466,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Jak by mělo být video zmenšeno, aby se vešlo na obrazovku.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv => 'Přehrávací jádro (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8718,7 +8673,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nedávno vydané – $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8750,11 +8705,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'Vynutit netunelované přehrávání. Užitečné na zařízeních s tunelováním audio/video diskontinuit.';
 
   @override
-  String get enableTunnelingTitle => 'Zapnout tunelování';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Pokročilé. Vede zvuk i video propojenou hardwarovou cestou. Ve výchozím stavu vypnuto, protože na některých zařízeních způsobuje výpadky zvuku a obrazu.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Namapujte Dolby Vision profil 7 na HEVC';
@@ -8779,14 +8734,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Použijte rady pro velikost písma vložené do stopy titulků. Zakažte použití velikosti titulků z vašich předvoleb stylu.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Zobrazit detaily média';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Zobrazovat detaily vybrané položky v horní části stránek knihovny.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Skrýt pozadí při procházení?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Použijte podrobné podnadpisy';
@@ -8804,37 +8759,37 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Obchod s motivy';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Procházejte a ukládejte komunitní motivy';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Uložte si motiv, abyste ho mohli používat jako ostatní uložené motivy.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Momentálně nejsou k dispozici žádné motivy.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Obchod s motivy se nepodařilo načíst. Zkontrolujte připojení a zkuste to znovu.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Uložit';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Uložit a použít';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Uloženo';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Tento motiv se nepodařilo načíst.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Motiv „$themeName“ byl uložen.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8893,21 +8848,21 @@ class AppLocalizationsCs extends AppLocalizations {
   String get homeRowsSection => 'Domácí řádky';
 
   @override
-  String get homeRowDisplay => 'Zobrazení domovských řádků';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sekce domovských řádků';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Přepínače domovských řádků';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Zapněte nebo vypněte kategorie domovských řádků podle knihoven';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Zapnutím následujících přepínačů zobrazíte řádky v domovských sekcích.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Typ řádků';
@@ -8966,56 +8921,55 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zobrazit filmy, seriály nebo obojí v řádcích Žánry.';
 
   @override
-  String get displayPlaylistsRows => 'Zobrazovat řádky playlistů';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Zobrazovat řádky playlistů v domovských sekcích.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Řazení řádků playlistů';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Řaďte řádky playlistů podle data přidání, data vydání, abecedy a dalších kritérií.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Zobrazovat řádky se zvukem';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Zobrazovat řádky se zvukem v domovských sekcích.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Řazení řádků se zvukem';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Řaďte řádky se zvukem podle data přidání, data vydání, abecedy a dalších kritérií.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Zvukové playlisty';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Vzhled';
 
   @override
-  String get layout => 'Rozvržení';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Motiv';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klávesnice';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Tlačítka';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Vykreslování';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfigurace MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Velikost karty';
@@ -9025,7 +8979,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Nastavte externí přehrávač pro zapnutí přehrávání dlouhým stiskem';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9039,7 +8993,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get connection => 'Spojení';
 
   @override
-  String get audioTranscodeTarget => 'Cílový formát překódování zvuku';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Průchod';
@@ -9293,7 +9247,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get appearancesSeerr => 'Vzhled (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Příspěvky štábu (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Sledujte se skupinou';
@@ -9379,10 +9333,8 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knihoven',
-      many: '$count knihovny',
-      few: '$count knihovny',
-      one: '1 knihovna',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9411,7 +9363,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminServerPathImageCache => 'Mezipaměť obrázků';
 
   @override
-  String get adminServerPathCache => 'Mezipaměť';
+  String get adminServerPathCache => 'Cache';
 
   @override
   String get adminServerPathLogs => 'Protokoly';
@@ -9542,13 +9494,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get loadingShuffle => 'Načítání náhodného přehrávání...';
 
   @override
-  String get libraryShuffleLabel => 'ZAMÍCHÁNÍ KNIHOVNY';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'NÁHODNÉ ZAMÍCHÁNÍ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ZAMÍCHÁNÍ ŽÁNRŮ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automatické přepínání HDR';
@@ -9561,73 +9513,73 @@ class AppLocalizationsCs extends AppLocalizations {
   String get whenFullscreen => 'Při zobrazení na celou obrazovku';
 
   @override
-  String get changeArtwork => 'Změnit grafiku';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Chybí';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Limity překódování';
 
   @override
-  String get clearAllArtworkButton => 'Odstranit veškerou grafiku?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Opravdu chcete odstranit veškerou staženou grafiku?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Potvrdit odstranění';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Opravdu chcete odstranit tuto položku: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Nahrát?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Rozlišení: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Zobrazovat pouze grafiku v jazyce rozhraní';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Potvrdit odstranění všeho';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Obrázek byl úspěšně nahrán!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Nahrání obrázku se nezdařilo: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Nastavení obrázku se nezdařilo: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Smazání obrázku se nezdařilo: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Odstranění veškeré grafiky se nezdařilo: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ano';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakát';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Pozadí';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9636,31 +9588,31 @@ class AppLocalizationsCs extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Náhled';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika disku';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Snímek obrazovky';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Přední obal';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Zadní obal';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika nabídky';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakát';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'pozadí';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9669,114 +9621,114 @@ class AppLocalizationsCs extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'náhled';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafika disku';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'snímek obrazovky';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'přední obal';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'zadní obal';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafika nabídky';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Vše';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Vysoké (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Střední (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Nízké (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Zdroje';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitoly';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Záložky';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Poznámky';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Fronta';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Časová osa';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Časová osa je prázdná';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Celá kniha';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Přiblížená časová osa';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportovat záložky';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportovat poznámky';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportovat vše';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportováno do $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Export se nezdařil: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Text';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Přidat záložku';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Přidat poznámku';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Upravit poznámku';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Napište si poznámku k tomuto místu';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Časovač vypnutí';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Vypnuto';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Konec kapitoly';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Vlastní';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Zbývá $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9791,306 +9743,301 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Rychlost přehrávání';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Zbývá';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Uplynulo';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Zpět o $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Vpřed o $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Předchozí kapitola';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Další kapitola';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitola $current z $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Žádné kapitoly';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Zatím žádné záložky';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Zatím žádné poznámky';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Záložka přidána na $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Obnovit na 1,0×';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
-    return '$value×';
+    return '${value}x';
   }
 
   @override
-  String get audiobookSave => 'Uložit';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Zrušit';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Smazat';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Předvolby titulků';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Změňte režimy titulků, výchozí jazyky, vzhled a možnosti vykreslování.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Vykreslování titulků';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Možnosti zobrazení';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Datum vydání (vzestupně)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Datum vydání (sestupně)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Seskupit příspěvky';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Seskupit více rolí';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Upozornění na přístup pro zápis do knihovny';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Jak to napravit:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Udělte uživateli služby Jellyfin (např. jellyfin nebo Docker PUID/PGID) oprávnění k zápisu do složek vaší mediální knihovny na serveru.\n\n2. Nebo přejděte na nástěnce Jellyfin do sekce Knihovny, upravte tuto knihovnu a vypněte možnost „Ukládat grafiku do složek s médii“, aby se grafika ukládala do interní databáze Jellyfinu.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Zavřít';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Vaše knihovna „$libraryName“ je nastavena tak, aby ukládala grafiku přímo do složek s médii (je zapnutá možnost „Ukládat grafiku do složek s médii“). Jellyfin však otestoval přístup pro zápis a nemá oprávnění zapisovat soubory do tohoto adresáře:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Vypadá to, že se Jellyfinu nepodařilo aktualizovat grafiku. Vaše knihovna je nastavena tak, aby ukládala grafiku přímo do složek s médii (je zapnutá možnost „Ukládat grafiku do složek s médii“). Tato chyba obvykle nastává, když proces serveru Jellyfin nemá oprávnění zapisovat soubory do vašich adresářů s médii.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Externí seznamy';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Přehrát znovu';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informace o souboru';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Velikost: $size  •  Formát: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Zobrazit všechny zvukové stopy ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Zobrazit všechny titulkové stopy ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Kontroluje se možnost přímého přehrávání...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Možnost přímého přehrávání: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Vynucené';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Formát kontejneru přehrávač nepodporuje.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Video kodek není podporován.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Zvukový kodek není podporován.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Formát titulků není podporován (vyžaduje vypálení do obrazu).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Zvukový profil není podporován.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Video profil není podporován.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Úroveň videa není podporována.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Rozlišení videa toto zařízení nepodporuje.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Bitová hloubka videa není podporována.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Snímková frekvence videa není podporována.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Datový tok souboru překračuje limit přehrávače pro streamování.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Datový tok videa překračuje limit pro streamování.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Datový tok zvuku překračuje limit pro streamování.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Počet zvukových kanálů není podporován.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Abecedně';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Pořadí vydání (vzestupně)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Pořadí vydání (sestupně)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Vlastní (přetažením)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Možnosti řazení playlistu';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Obnovit řazení';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Znovu přehrát S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Znovu přehrát playlist';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nebyly nalezeny žádné titulky.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Ovládání pro správce';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Vykreslovací jádro (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller je moderní GPU renderer Flutteru pro plynulejší animace a méně zadrhávání. Na některých TV boxech a starších GPU může způsobovat grafické chyby nebo černé video; v takovém případě jej vypněte. Automaticky zvolí nejlepší výchozí nastavení pro vaše zařízení. Změna se projeví po restartu Moonfinu.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automaticky';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Zapnuto';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Vypnuto';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Vyžaduje restart';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Ke změně vykreslovacího jádra je nutné Moonfin restartovat. Zavřete aplikaci a znovu ji otevřete, aby se změna projevila.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Zavřít aplikaci';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Obnovit knihovnu';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Obnovit všechny knihovny';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Datum přidání (od nejstarších)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Datum přidání (od nejnovějších)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Abecedně (A–Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Abecedně (Z–A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Načítání analytiky serveru... $percentage %';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Podle zdroje';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filmů';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 seriálů';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Nejpopulárnější filmy podle IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Nejpopulárnější seriály podle IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Nejhůře hodnocené filmy podle IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Nejlépe hodnocené anglické filmy podle IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -9,22 +9,22 @@ class AppLocalizationsCy extends AppLocalizations {
   AppLocalizationsCy([String locale = 'cy']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Lleuad';
 
   @override
-  String get accountPreferences => 'DEWISIADAU CYFRIF';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Iaith y Rhyngwyneb';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Rhagosodiad y System';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Mewngofnodwch';
 
   @override
-  String get empty => 'Gwag';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Cyswllt Cyflym';
 
   @override
   String get password => 'Cyfrinair';
@@ -51,7 +51,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get waitingForAuthorization => 'Aros am awdurdodiad...';
 
   @override
-  String get back => 'Yn ôl';
+  String get back => 'Yn ol';
 
   @override
   String get serverUnavailable => 'Nid yw\'r gweinydd ar gael';
@@ -113,7 +113,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get cancel => 'Canslo';
 
   @override
-  String get remove => 'Tynnu';
+  String get remove => 'Dileu';
 
   @override
   String get connectToServer => 'Cysylltwch â\'r Gweinydd';
@@ -141,62 +141,62 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAppearanceTheme => 'Thema Ap';
 
   @override
-  String get detailScreenStyle => 'Arddull y sgrin fanylion';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Clasurol yw cynllun canolog gwreiddiol Moonfin. Modern yw cynllun sinematig ymatebol.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Clasurol';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Tabiau Estynedig';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Dangos cynnwys tab yn awtomatig wrth bori drwy\'r tabiau. Diffoddwch hyn i agor a chau pob tab â llaw.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Dangos Manylion Technegol?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Dangos gwybodaeth am y codec, y cydraniad a\'r ffrwd yng nghrynodeb y faner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'System Argymell';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Defnyddiwch algorithm llyfrgell leol Moonfin Recommends neu Fetrigau Tebygrwydd ar-lein TMDb. Sylwer: mae angen integreiddio Seerr ar gyfer argymhellion ar-lein.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Tebygrwydd TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Cyfyngu yn ôl y dosbarthiad oedran?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Cyfyngu awgrymiadau Moonfin Recommends yn ôl dosbarthiad oedran y cyfrwng targed';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Arddull y Rhyngwyneb';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Mae Awtomatig yn cydweddu â\'ch dyfais. Dewiswch Apple neu Material i orfodi golwg benodol.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Awtomatig';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsCy extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Ansawdd y Gwydr';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Mae Awto yn dewis yr effaith wydr orau ar gyfer y ddyfais hon. Mae Llawn yn gorfodi pylu go iawn; mae Gostyngedig yn defnyddio gwydr ysgafn sy\'n arbed pŵer y GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Awto';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Llawn';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Gostyngedig';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Newid rhwng Moonfin a Neon Pulse heb ailgychwyn yr app';
 
   @override
-  String get customThemeTitle => 'Thema Bersonol';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Mae themâu personol yn newid elfennau gweledol ar draws Moonfin. Dewiswch un o\'r opsiynau hyn i weddu i\'ch arddull.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Mae\'n well gennyf bysellfwrdd system';
@@ -239,7 +239,7 @@ class AppLocalizationsCy extends AppLocalizations {
       'Defnyddiwch eich dull mewnbwn dyfais yn ddiofyn ar gyfer mewnbynnu testun';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Lleuad';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsCy extends AppLocalizations {
       'Arddull tonnau synth gyda llewyrch magenta, testun cyan, a chyferbyniad crôm cryfach';
 
   @override
-  String get themeGlass => 'Gwydr';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Arddull gwydr hylifol gyda chefndir graddliw symudol, arwynebau barugog, ac acen glas Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'Arwr 8-did';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Arddull celf picsel retro gyda phalet trwchus, borderi bloclyd, cysgodion caled, a ffont picsel';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,36 +327,35 @@ class AppLocalizationsCy extends AppLocalizations {
   String get exit => 'Ymadael';
 
   @override
-  String get gameMenu => 'Dewislen';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Wedi oedi';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Arbed cyflwr';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Gemau';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Llwytho cyflwr';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Chwarae ymlaen';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Gosodiadau\'r efelychydd';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Nid oes gan y craidd hwn unrhyw opsiynau addasadwy.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Daliwch i agor y ddewislen';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Nid yw chwarae gemau\'n cael ei gefnogi ar y ddyfais hon eto.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nid oedd modd llwytho unrhyw resi cartref';
@@ -378,13 +377,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get schedule => 'Atodlen';
 
   @override
-  String get series => 'Cyfresi';
+  String get series => 'Cyfres';
 
   @override
   String get noItemsFound => 'Ni chanfuwyd unrhyw eitemau';
 
   @override
-  String get home => 'Hafan';
+  String get home => 'Cartref';
 
   @override
   String get browseAll => 'Pori Pawb';
@@ -555,7 +554,7 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dewiswch pa ffrydiau pwnc i\'w dangos yn Darganfod.';
 
   @override
-  String get apply => 'Gweithredu';
+  String get apply => 'Ymgeisiwch';
 
   @override
   String get openLink => 'Agor Dolen';
@@ -579,7 +578,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count teitl';
+    return '$count titles';
   }
 
   @override
@@ -604,7 +603,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get listen => 'Gwrandewch';
 
   @override
-  String get resume => 'Parhau';
+  String get resume => 'Ail-ddechrau';
 
   @override
   String get failedToLoadLibrary => 'Wedi methu llwytho\'r llyfrgell';
@@ -671,7 +670,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String genresCount(int count) {
-    return '$count genre';
+    return '$count genres';
   }
 
   @override
@@ -749,7 +748,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get readStatus => 'Darllen';
 
   @override
-  String get watched => 'Gwyliwyd';
+  String get watched => 'Gwylio';
 
   @override
   String get unread => 'Heb ei ddarllen';
@@ -767,45 +766,43 @@ class AppLocalizationsCy extends AppLocalizations {
   String get books => 'Llyfrau';
 
   @override
-  String get latestBooks => 'Llyfrau Diweddaraf';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Llyfrau Sain Diweddaraf';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count llyfr',
-      two: '$count lyfr',
-      zero: '$count o lyfrau',
-      one: '1 llyfr',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Llyfr';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Llyfr sain';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% wedi\'i ddarllen';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time ar ôl';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Darllen';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Gwrando';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Awdur';
@@ -814,7 +811,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get unknownAuthor => 'Awdur Anhysbys';
 
   @override
-  String get uncategorized => 'Heb gategori';
+  String get uncategorized => 'Uncategorized';
 
   @override
   String get overview => 'Trosolwg';
@@ -882,10 +879,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count llyfr sain',
-      two: '$count lyfr sain',
-      zero: '$count o lyfrau sain',
-      one: '1 llyfr sain',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -903,7 +898,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get delete => 'Dileu';
 
   @override
-  String get save => 'Cadw';
+  String get save => 'Arbed';
 
   @override
   String get moreLikeThis => 'Mwy Fel Hyn';
@@ -1001,40 +996,40 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get items => 'Eitemau';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ychwanegion';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Y Tu Ôl i\'r Llenni';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Golygfeydd wedi\'u Dileu';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Cyfweliadau';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Golygfeydd';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Ffilmiau Byrion';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Rhaghysbysebion';
+  String get trailers => 'Trelars';
 
   @override
   String timeRemaining(String time) {
-    return '$time ar ôl';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Yn gorffen ymhen $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1076,10 +1071,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get version => 'Fersiwn';
 
   @override
-  String get cast => 'Castio';
+  String get cast => 'Cast';
 
   @override
-  String get trailer => 'Rhaghysbyseb';
+  String get trailer => 'Trelar';
 
   @override
   String get finished => 'Wedi gorffen';
@@ -1274,13 +1269,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get director => 'CYFARWYDDWR';
 
   @override
-  String get directors => 'CYFARWYDDWYR';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'AWDUR';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SGRIPTWYR';
+  String get writers => 'YSGRIFENWYR';
 
   @override
   String get studio => 'STIWDIO';
@@ -1315,12 +1310,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count trac',
-      many: '$count thrac',
-      few: '$count thrac',
-      two: '$count drac',
-      zero: '$count o draciau',
-      one: '1 trac',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1330,12 +1321,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pennod',
-      many: '$count phennod',
-      few: '$count pennod',
-      two: '$count bennod',
-      zero: '$count o benodau',
-      one: '1 bennod',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1362,16 +1349,16 @@ class AppLocalizationsCy extends AppLocalizations {
   String get readMore => 'Darllen Mwy';
 
   @override
-  String get shuffle => 'Cymysgu';
+  String get shuffle => 'Siffrwd';
 
   @override
-  String get shuffleAllMusic => 'Hapchwarae\'r holl gerddoriaeth';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Mewngofnodwch i Moonfin ar eich ffôn';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Methu cyrraedd eich gweinydd';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1470,7 +1457,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get unavailable => 'Ddim ar gael';
 
   @override
-  String get pause => 'Oedi';
+  String get pause => 'Oedwch';
 
   @override
   String get syncPosition => 'Safle Cysoni';
@@ -1517,7 +1504,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Awto';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1577,7 +1564,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get container => 'Cynhwysydd';
 
   @override
-  String get bitrate => 'Cyfradd didau';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Fideo';
@@ -1811,22 +1798,22 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Nesaf: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m ar ôl';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h ar ôl';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m ar ôl';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1849,7 +1836,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get favoriteChannel => 'Hoff Sianel';
 
   @override
-  String get record => 'Recordio';
+  String get record => 'Cofnod';
 
   @override
   String get cancelRecordingAction => 'Canslo Recordio';
@@ -1901,7 +1888,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get no => 'Na';
+  String get no => 'Nac ydw';
 
   @override
   String get yesCancel => 'Ydw, Diddymu';
@@ -2028,12 +2015,12 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes mun';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season P$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2057,7 +2044,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -2076,12 +2063,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pennod',
-      many: '$count phennod',
-      few: '$count pennod',
-      two: '$count bennod',
-      zero: '$count o benodau',
-      one: '1 bennod',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2308,7 +2291,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Tudalennau manylion, rhesi cartref, a lefel sain';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2322,11 +2305,11 @@ class AppLocalizationsCy extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Chwarae wrth bori\'r sgrin gartref';
 
   @override
-  String get loopThemeMusic => 'Dolennu\'r Gerddoriaeth Thema';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ailadrodd y trac yn hytrach na\'i chwarae unwaith';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Manylion Blur Cefndir';
@@ -2349,23 +2332,23 @@ class AppLocalizationsCy extends AppLocalizations {
   String get playerZoomMode => 'Modd Chwyddo Chwaraewr';
 
   @override
-  String get settingsScrollWheelAction => 'Olwyn sgrolio\'r llygoden';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Dewiswch beth mae sgrolio olwyn y llygoden dros y fideo yn ei wneud wrth chwarae.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'I ffwrdd';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Symud (ymlaen / yn ôl)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Lefel sain';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Lefel sain';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Ffit';
@@ -2380,7 +2363,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get refreshRateSwitching => 'Newid Cyfradd Adnewyddu';
 
   @override
-  String get disabled => 'Wedi\'i analluogi';
+  String get disabled => 'Anabl';
 
   @override
   String get scaleOnTv => 'Graddfa ar y teledu';
@@ -2419,37 +2402,37 @@ class AppLocalizationsCy extends AppLocalizations {
   String get defaultAudioLanguage => 'Iaith Sain Ragosodedig';
 
   @override
-  String get fallbackAudioLanguage => 'Iaith Sain Wrth Gefn';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Ffafrio\'r Trac Sain Rhagosodedig';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Ffafrio\'r trac sain gwreiddiol yn hytrach na throsleisio wedi\'i leoleiddio.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Ffafrio Traciau Disgrifiad Sain';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Ffafrio traciau disgrifiad sain yn hytrach na thraciau arferol.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Trawsgodio (Sain)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Ffrwd Uniongyrchol (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Trawsgodio (Cyfradd Didau neu Gydraniad)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Trawsgodio (Fideo a Sain)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Trawsgodio (Fideo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Awto (Diofyn Gweinydd)';
@@ -2530,24 +2513,23 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Dewiswch sut mae sain yn cael ei ddadgodio. Mae Trosglwyddo AVR yn anfon ffrydiau Dolby/DTS crai i\'ch derbynnydd; mae Awto neu Gymysgu i Lawr yn dadgodio\'n lleol.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Trosglwyddo AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Codec Sain Wrth Gefn';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Dewiswch y fformat targed ar gyfer trawsgodio sain aml-sianel pan na ellir chwarae\'r ffrwd ffynhonnell yn uniongyrchol na\'i throsglwyddo.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Canfod yn Awtomatig\n(Argymhellir)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Rhagosodedig)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2556,27 +2538,26 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Di-golled)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo yn Unig)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Effeithlon)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Di-golled)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Uchafswm Sianeli Sain';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Ffurfweddwch uchafswm sianeli eich gosodiad sain. Bydd ffrydiau aml-sianel sy\'n uwch na\'r terfyn hwn yn cael eu cymysgu i lawr neu eu trawsgodio.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Canfod yn Awtomatig\n(Rhagosodiad Caledwedd)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2585,28 +2566,28 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Amgylchynol';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Cwadroffonig';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Amgylchynol';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Amgylchynol';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Amgylchynol';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Amgylchynol';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Passthrough (Uwch)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Trosglwyddo Codec';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
@@ -2616,7 +2597,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAudioEac3Passthrough => 'Llwybr EAC3';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Trosglwyddo EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
   String get settingsAudioDtsCorePassthrough => 'Llwybr Craidd DTS';
@@ -2625,7 +2606,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAudioDtsHdPassthrough => 'Llwybr drwodd MA DTS-HD';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Trosglwyddo TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'Gwir HD Passthrough';
 
   @override
   String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough Atmos TrueHD';
@@ -2661,7 +2642,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAudioDecodeLabel => 'Dadgodio';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Trosglwyddo';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
   String get settingsAudioHdRoute => 'Llwybr sain HD';
@@ -2682,7 +2663,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Llefarydd';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Clustffonau';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2860,45 +2841,45 @@ class AppLocalizationsCy extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Addasu ymddangosiad is-deitl';
 
   @override
-  String get subtitleMode => 'Modd Isdeitlau';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Wedi\'u Fflagio';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Bob amser';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Tramor';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Gorfodol';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Yn chwarae traciau sydd wedi\'u fflagio\'n fewnol ym metadata\'r ffeil gyfrwng fel \"default\" neu \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Yn llwytho ac yn dangos isdeitlau\'n awtomatig bob tro y bydd fideo\'n dechrau.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Yn troi isdeitlau ymlaen yn awtomatig os yw\'r trac sain rhagosodedig mewn iaith dramor.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Yn llwytho isdeitlau sydd wedi\'u tagio\'n benodol â\'r fflag metadata \"forced\" yn unig.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Yn analluogi llwytho isdeitlau\'n awtomatig yn llwyr.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Iaith Isdeitlau Wrth Gefn';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Ffrwd Isdeitlau';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2933,7 +2914,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get green => 'Gwyrdd';
 
   @override
-  String get cyan => 'Gwyrddlas';
+  String get cyan => 'Cyan';
 
   @override
   String get red => 'Coch';
@@ -3104,10 +3085,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get showLibrariesInToolbar => 'Dangos Llyfrgelloedd yn y Bar Offer';
 
   @override
-  String get navbarAlwaysExpanded => 'Dangos Labeli\'r Bar Llywio Bob Amser';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Dangos Botwm Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Anhryloywder Navbar';
@@ -3182,19 +3163,18 @@ class AppLocalizationsCy extends AppLocalizations {
   String get showFolderBrowsingOption => 'Dangos opsiwn pori ffolder';
 
   @override
-  String get groupItemsIntoCollections => 'Grwpio Eitemau\'n Gasgliadau';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Cuddio eitemau llyfrgell sy\'n perthyn i gasgliad wrth bori drwy lyfrgelloedd';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Hysbysiad Grwpio Llyfrgell';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'I ddefnyddio\'r gosodiad hwn, gwnewch yn siŵr bod gosodiadau Llyfrgell \"Grwpio ffilmiau\'n gasgliadau\" a/neu \"Grwpio sioeau\'n gasgliadau\" wedi\'u galluogi o dan osodiadau Dangos eich llyfrgell ar eich gweinydd Jellyfin neu Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Gwelededd Llyfrgell';
@@ -3253,7 +3233,7 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dewiswch rhwng gwahanol arddulliau bar cyfryngau, neu diffoddwch y bar cyfryngau';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Lleuad';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3306,11 +3286,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Trelars chwarae\'n awtomatig yn y bar cyfryngau ar ôl 3 eiliad';
 
   @override
-  String get trailerAudio => 'Sain Rhaghysbysebion';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Galluogi sain ar gyfer rhaghysbysebion yn y bar cyfryngau';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Rhagolwg o Bennod';
@@ -3386,11 +3365,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get combineBothRows => 'Cyfunwch y ddwy res yn un adran gartref';
 
   @override
-  String get fullScreenRows => 'Rhesi Cartref Estynedig';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Cyfyngu rhesi cartref i 1 rhes fesul sgrin';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Math Delwedd Fesul Rhes';
@@ -3405,7 +3383,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get lastUser => 'Defnyddiwr Diwethaf';
 
   @override
-  String get currentUser => 'Defnyddiwr Cyfredol';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Dilysu bob amser';
@@ -3480,7 +3458,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes mun';
+    return '$minutes min';
   }
 
   @override
@@ -3511,10 +3489,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Arddangos cloc yn ystod arbedwr sgrin';
 
   @override
-  String get clockModeStatic => 'Statig';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Yn bownsio';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Tomatos pwdr (beirniaid)';
@@ -3585,7 +3563,7 @@ class AppLocalizationsCy extends AppLocalizations {
       'Galluogi ac aildrefnu\'r ffynonellau graddio a ddangosir trwy\'r ap';
 
   @override
-  String get pluginLabel => 'Ategyn Moonbase';
+  String get pluginLabel => 'Ategyn';
 
   @override
   String get pluginDetected => 'Ategyn Wedi\'i Ganfod';
@@ -3657,7 +3635,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get networks => 'Rhwydweithiau';
 
   @override
-  String get seerrDiscoveryRows => 'Rhesi Darganfod Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Ailosod rhesi i ragosodiadau';
@@ -3680,28 +3658,28 @@ class AppLocalizationsCy extends AppLocalizations {
   String get hideAdultContent => 'Cuddio cynnwys oedolion yn y canlyniadau';
 
   @override
-  String get seerrNotificationsSection => 'Hysbysiadau';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Hysbysiadau cais newydd';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Rhoi gwybod i mi pan fydd rhywun yn cyflwyno cais';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Diweddariadau ceisiadau';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Wedi\'i gymeradwyo, ei wrthod, a\'i ychwanegu at eich llyfrgell';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Diweddariadau materion';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Materion newydd, atebion a datrysiadau';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3709,18 +3687,18 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Tudalen Ddarganfod Seerr';
+  String get discoverRows => 'Darganfod Rhesi';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Galluogwch resi i\'w gweld ar brif dudalen Seerr. Llusgwch i aildrefnu. Mae\'r drefn bersonol yn cydweddu â Moonbase.';
+      'Llusgwch i aildrefnu. Galluogi neu analluogi rhesi. Wedi galluogi cysoni trefn rhesi ag ategyn Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Galluogwch resi i\'w gweld ar brif dudalen Seerr. Llusgwch i aildrefnu. Mae\'r drefn bersonol yn cydweddu â Moonbase.';
+      'Llusgwch i aildrefnu. Galluogi neu analluogi rhesi.';
 
   @override
-  String get enabled => 'Wedi\'i alluogi';
+  String get enabled => 'Galluogwyd';
 
   @override
   String get hidden => 'Cudd';
@@ -3855,7 +3833,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get imageCacheCleared => 'Storfa ddelweddau wedi\'i chlirio';
 
   @override
-  String get clear => 'Clirio';
+  String get clear => 'Clir';
 
   @override
   String get browse => 'Pori';
@@ -3871,11 +3849,11 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Wrthi\'n lawrlwytho · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Wrthi\'n mewnforio';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -4018,149 +3996,148 @@ class AppLocalizationsCy extends AppLocalizations {
   String get deletedStatus => 'Wedi\'i ddileu';
 
   @override
-  String get failedStatus => 'Wedi methu';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Wrthi\'n prosesu';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Wedi\'i addasu gan $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Wedi\'i gwblhau';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Gwnaethpwyd cais am y teitl hwn eisoes';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Wedi cyrraedd y terfyn ceisiadau';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Mae\'r teitl hwn ar y rhestr rwystro';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Does dim tymhorau ar ôl i wneud cais amdanynt';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Does gennych chi ddim caniatâd i wneud y cais hwn';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Ceisiadau';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Materion';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Diweddaraf';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Wedi\'i Addasu Ddiwethaf';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Dim materion';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining o $limit cais am ffilm ar ôl';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining o $limit cais am dymor ar ôl';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Rhan o $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Gweld y Casgliad';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Gwneud Cais am y Casgliad';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total ffilm · $available ar gael';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Gwneud cais am $count ffilm';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Wrthi\'n gwneud cais am $current o $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Wedi gwneud cais am $count ffilm';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Wedi gwneud cais am $ok o $total ffilm';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Mae pob ffilm ar gael neu wedi\'i cheisio eisoes';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Adrodd Mater';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Fideo';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Sain';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Beth sy\'n bod?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Pob Pennod';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Pennod';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Ar agor';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Wedi\'i ddatrys';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Datrys';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Ailagor';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Wedi\'i adrodd gan $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count sylw';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Ychwanegu sylw';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Dileu\'r mater hwn?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Cyflwyno\'r Adroddiad';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Sgôr TMDB';
@@ -4217,7 +4194,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get disable => 'Analluogi';
 
   @override
-  String get done => 'Gorffen';
+  String get done => 'Wedi\'i wneud';
 
   @override
   String get edit => 'Golygu';
@@ -4277,7 +4254,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get refresh => 'Adnewyddu';
 
   @override
-  String get remote => 'Rheolydd pell';
+  String get remote => 'Anghysbell';
 
   @override
   String get rename => 'Ailenwi';
@@ -4295,7 +4272,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get run => 'Rhedeg';
 
   @override
-  String get search => 'Chwilio';
+  String get search => 'Chwiliwch';
 
   @override
   String get select => 'Dewiswch';
@@ -4340,7 +4317,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get unmute => 'Dad-dewi';
 
   @override
-  String get mute => 'Distewi';
+  String get mute => 'Tewi';
 
   @override
   String get branding => 'Brandio';
@@ -4364,19 +4341,19 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminDrawerLibraries => 'Llyfrgelloedd';
 
   @override
-  String get adminDrawerDisplay => 'Dangos';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Gosodiadau NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Trawsgodio';
 
   @override
-  String get adminDrawerResume => 'Parhau';
+  String get adminDrawerResume => 'Ail-ddechrau';
 
   @override
   String get adminDrawerStreaming => 'Ffrydio';
@@ -4563,7 +4540,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get sessionVolumeDown => 'Vol -';
 
   @override
-  String get sessionVolumeUp => 'Sain +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4572,7 +4549,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get nowPlaying => 'Yn Chwarae Nawr';
 
   @override
-  String get volume => 'Lefel sain';
+  String get volume => 'Cyfrol';
 
   @override
   String get actions => 'Gweithredoedd';
@@ -4584,7 +4561,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audioCodec => 'Codec Sain';
 
   @override
-  String get hwAccel => 'Cyflymu Caledwedd';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Cwblhau';
@@ -4599,10 +4576,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminClearDates => 'Dyddiadau clir';
 
   @override
-  String get adminActivitySeverityAll => 'Pob difrifoldeb';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Ystod dyddiadau';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4639,23 +4616,23 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Tynnu\'r ddyfais \'$name\'? Bydd angen i\'r defnyddiwr fewngofnodi eto ar y ddyfais hon.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Dileu pob dyfais';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Tynnu $count dyfais? Bydd angen i\'r defnyddwyr yr effeithir arnynt fewngofnodi eto. Nid effeithir ar eich dyfais bresennol.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Dyfeisiau wedi\'u tynnu';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Tynnwyd rhai dyfeisiau; nid oedd modd tynnu $count.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4770,255 +4747,244 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminMetadataCountryHint => 'e.e. Unol Daleithiau, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Llwybrau';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opsiynau';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Lawrlwythwyr';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Cadwyr metadata';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Lawrlwythwyr isdeitlau';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Lawrlwythwyr geiriau caneuon';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Lawrlwythwyr metadata: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Estynwyr delweddau: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Nid yw\'r gweinydd hwn yn cynnig lawrlwythwyr ar gyfer y math hwn o lyfrgell.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Cyffredinol';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Gwybodaeth Fewnblanedig';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Isdeitlau';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Delweddau';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Cyfresi';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Cerddoriaeth';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Ffilmiau';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Galluogi monitro amser real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Canfod newidiadau i ffeiliau a\'u prosesu\'n awtomatig.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Trin archifau fel ffeiliau cyfryngau';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Dangos lluniau';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Cadw gwaith celf yn y ffolderi cyfryngau';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Adnewyddu metadata\'n awtomatig';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Byth';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Rhagosodedig';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Dangos';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Dangos y llyfrgell';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Dangos golwg ffolder i ddangos ffolderi cyfryngau plaen';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Dangos penodau arbennig o fewn y tymhorau y cawsant eu darlledu ynddynt';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grwpio ffilmiau\'n gasgliadau';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grwpio sioeau\'n gasgliadau';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Dangos cynnwys allanol mewn awgrymiadau';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Ymddygiad y dyddiad ychwanegu';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Defnyddio\'r dyddiad ychwanegu o';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Y dyddiad y\'i sganiwyd i\'r llyfrgell';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Y dyddiad y crëwyd y ffeil';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata a Delweddau';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Iaith fetadata ddewisol';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Penodau';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Hyd penodau ffug (eiliadau)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Hyd y penodau a gynhyrchir ar gyfer cyfryngau heb rai. Gosodwch i 0 i\'w analluogi.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Cydraniad delweddau penodau';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Gosodiadau NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Mae metadata NFO yn gydnaws â Kodi a chleientiaid tebyg. Mae\'r gosodiadau\'n berthnasol i bob llyfrgell sy\'n cadw metadata NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Y defnyddiwr y cedwir data gwylio ar ei gyfer mewn ffeiliau NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Cadw llwybrau delweddau o fewn ffeiliau NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Galluogi amnewid llwybrau ar gyfer llwybrau delweddau NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copïo delweddau extrafanart i ffolder extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Dim';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days diwrnod';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Defnyddio teitlau mewnblanedig';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Defnyddio teitlau mewnblanedig ar gyfer ychwanegion';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Defnyddio gwybodaeth fewnblanedig am benodau';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Caniatáu isdeitlau mewnblanedig';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Caniatáu pob un';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Testun yn unig';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Delwedd yn unig';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Dim';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Hepgor y lawrlwythiad os oes isdeitlau mewnblanedig yn bresennol';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Hepgor y lawrlwythiad os yw\'r trac sain yn cyfateb i iaith y lawrlwythiad';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Mynnu bod yr isdeitlau\'n cyfateb yn berffaith';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Cadw isdeitlau yn y ffolderi cyfryngau';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Echdynnu delweddau penodau';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Echdynnu delweddau penodau yn ystod sgan y llyfrgell';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Galluogi echdynnu delweddau Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Echdynnu delweddau Trickplay yn ystod sgan y llyfrgell';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Cadw delweddau Trickplay yn y ffolderi cyfryngau';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Uno cyfresi sydd wedi\'u gwasgaru ar draws sawl ffolder yn awtomatig';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Enw dangos tymor sero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Galluogi sgan LUFS ar gyfer normaleiddio sain';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Ffafrio\'r tag artistiaid ansafonol';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Ychwanegu ffilmiau at gasgliadau\'n awtomatig';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Mae angen enw\'r llyfrgell';
@@ -5254,145 +5220,143 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminEnableAllChannels => 'Galluogi mynediad i bob sianel';
 
   @override
-  String get adminParentalControl => 'Rheolaeth Rieni';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Uchafswm y dosbarthiad oedran a ganiateir';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Bydd cynnwys â dosbarthiad uwch yn cael ei guddio rhag y defnyddiwr hwn.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Dim';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Rhwystro eitemau heb wybodaeth ddosbarthu, neu â gwybodaeth annealladwy';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Llyfrau';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Sianeli';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Teledu byw';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Ffilmiau';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Cerddoriaeth';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Rhaghysbysebion';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Sioeau';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Amserlenni Mynediad';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Caniatáu mynediad yn ystod yr amserau a drefnwyd isod yn unig. Caniateir mynediad drwy\'r dydd pan na fydd amserlen wedi\'i gosod.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Ychwanegu Amserlen';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Diwrnod';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Dechrau';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Diwedd';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Bob dydd';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Diwrnod gwaith';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Penwythnos';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Dydd Sul';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Dydd Llun';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Dydd Mawrth';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Dydd Mercher';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Dydd Iau';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Dydd Gwener';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Dydd Sadwrn';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tagiau a ganiateir';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Dim ond cynnwys â\'r tagiau hyn a ddangosir. Gadewch yn wag i ganiatáu pob un.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Tagiau wedi\'u rhwystro';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Mae cynnwys â\'r tagiau hyn yn cael ei guddio rhag y defnyddiwr hwn.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Ychwanegu tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dyfeisiau wedi\'u galluogi';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Sianeli wedi\'u galluogi';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Darparwr dilysu';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Darparwr ailosod cyfrinair';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Uchafswm y ceisiadau mewngofnodi aflwyddiannus cyn cloi allan';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Gosodwch i 0 ar gyfer y rhagosodiad, neu -1 i analluogi cloi allan.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Mynediad SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Caniatáu creu grwpiau ac ymuno â nhw';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Caniatáu ymuno â grwpiau';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Dim mynediad';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Caniatáu dileu cynnwys o';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5480,26 +5444,25 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Creu Copi Wrth Gefn';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Dewiswch beth i\'w gynnwys yn y copi wrth gefn.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Cronfa ddata';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Wedi\'i gynnwys bob amser';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Isdeitlau';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Delweddau Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Wrthi\'n creu copi wrth gefn...';
@@ -6100,7 +6063,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminRefreshMetadata => 'Adnewyddu Metadata';
 
   @override
-  String get recursive => 'Atgyrchol';
+  String get recursive => 'Recursive';
 
   @override
   String get adminReplaceAllMetadata => 'Disodli\'r holl fetadata';
@@ -6211,62 +6174,60 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminAddTuner => 'Ychwanegu Tuner';
 
   @override
-  String get adminEditTuner => 'Golygu\'r Tiwniwr';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tiwniwr M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Ffeil neu URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Cyfeiriad IP y tiwniwr';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Enw cyfeillgar';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Asiant defnyddiwr';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Terfyn cysylltiadau ar yr un pryd';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Yr uchafswm o ffrydiau y mae\'r tiwniwr yn eu caniatáu ar yr un pryd. Gosodwch i 0 ar gyfer diderfyn.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Uchafswm cyfradd didau ffrydio wrth gefn';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Mewnforio sianeli ffefryn yn unig';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Caniatáu trawsgodio caledwedd';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Caniatáu\'r cynhwysydd trawsgodio fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Caniatáu rhannu ffrydiau';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Galluogi dolennu ffrydiau';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Anwybyddu DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Darllen y mewnbwn ar y gyfradd fframiau frodorol';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Golygu\'r Darparwr';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6275,50 +6236,50 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Ffeil neu URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Rhagddodiad ffilmiau';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorïau ffilmiau';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Gwahanwch sawl categori â bar fertigol.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorïau plant';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorïau newyddion';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorïau chwaraeon';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Enw defnyddiwr';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Cyfrinair';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Gwlad';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Dewiswch wlad';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Cod post';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Nôl y rhestrau';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Rhestrau';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Galluogi pob tiwniwr';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Math Tiwniwr';
@@ -6360,7 +6321,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Nid yw\'r math hwn o diwniwr yn cefnogi ailosod.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6383,43 +6344,43 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Llwybr recordio cyfres';
 
   @override
-  String get adminMovieRecordingPath => 'Llwybr recordio ffilmiau';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Diwrnodau o ddata\'r canllaw';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Awtomatig';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days diwrnod';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Llwybr y rhaglen ôl-brosesu';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Ymresymiadau\'r ôl-broseswr';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Cadw metadata NFO recordiadau';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Cadw delweddau recordiadau';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Amseru';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Llwybrau recordio';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Ôl-brosesu';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Data\'r canllaw: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6461,14 +6422,14 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminGuideProviders => 'Darparwyr Arweinwyr';
 
   @override
-  String get adminRefreshGuideData => 'Adnewyddu Data\'r Canllaw';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Dechreuwyd adnewyddu data\'r canllaw';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Nid yw\'r dasg adnewyddu\'r canllaw ar gael ar y gweinydd hwn.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Ychwanegu Darparwr';
@@ -6551,7 +6512,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminLiveTvTitle => 'Gweinyddu teledu byw';
 
   @override
-  String get adminApply => 'Gweithredu';
+  String get adminApply => 'Ymgeisiwch';
 
   @override
   String get adminNotSet => 'Heb ei osod';
@@ -6603,7 +6564,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Golygydd Metadata';
 
   @override
-  String get adminMetadataIdentify => 'Adnabod';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Math';
@@ -6645,7 +6606,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminMetadataFieldCriticRating => 'Gradd feirniadol';
 
   @override
-  String get adminMetadataFieldTagline => 'Slogan';
+  String get adminMetadataFieldTagline => 'Tagline';
 
   @override
   String get adminMetadataFieldOverview => 'Trosolwg';
@@ -6696,7 +6657,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminMetadataImageThumb => 'Bawd';
 
   @override
-  String get adminMetadataRecursive => 'Atgyrchol';
+  String get adminMetadataRecursive => 'Recursive';
 
   @override
   String get adminMetadataProvider => 'Darparwr';
@@ -6887,7 +6848,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Tynnu';
+  String get adminReposRemove => 'Dileu';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7018,20 +6979,19 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Galluogi sgrin sblash';
 
   @override
-  String get adminBrandingSplashUpload => 'Uwchlwytho delwedd';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Sgrin gychwyn wedi\'i diweddaru';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Wedi methu uwchlwytho\'r sgrin gychwyn';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Sgrin gychwyn wedi\'i thynnu';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Dim sgrin gychwyn bersonol';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Cyflymiad Caledwedd';
@@ -7047,122 +7007,121 @@ class AppLocalizationsCy extends AppLocalizations {
       'Galluogi dadgodio caledwedd ar gyfer:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dyfais QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Galluogi\'r dadgodiwr NVDEC gwell';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Ffafrio dadgodiwr caledwedd brodorol y system';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Dyfnder lliw dadgodio caledwedd';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Dadgodio HEVC 10-did';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Dadgodio VP9 10-did';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'Dadgodio HEVC RExt 8/10-did';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'Dadgodio HEVC RExt 12-did';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Amgodio caledwedd';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Caniatáu amgodio HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Caniatáu amgodio AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Galluogi amgodiwr H.264 pŵer isel Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Galluogi amgodiwr HEVC pŵer isel Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapio Tôn';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Galluogi mapio tôn';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Galluogi mapio tôn VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Galluogi mapio tôn VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algorithm mapio tôn';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modd mapio tôn';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Ystod mapio tôn';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Dadddirlawnder mapio tôn';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Brig mapio tôn';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Paramedr mapio tôn';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Disgleirdeb mapio tôn VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'Cyferbyniad mapio tôn VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Rhagosodiadau ac Ansawdd';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Rhagosodiad yr amgodiwr';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF amgodio H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF amgodio H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Dull dadgydblethu';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dyblu\'r gyfradd fframiau wrth ddadgydblethu';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Sain';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Galluogi amgodio VBR ar gyfer sain';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Hwb cymysgu sain i lawr';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algorithm cymysgu stereo i lawr';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Uchafswm maint y ciw muxio';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Awto';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Amgodio';
@@ -7285,7 +7244,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminTaskStop => 'Stopio';
 
   @override
-  String get adminRunningTasks => 'Tasgau\'n Rhedeg';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Rhedeg';
@@ -7355,9 +7314,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count awr',
-      zero: '$count o oriau',
-      one: '1 awr',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7418,7 +7376,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7438,44 +7396,43 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Porth HTTP cyhoeddus';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Mynnu HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Ailgyfeirio pob cais o bell i HTTPS. Nid yw\'n cael unrhyw effaith os nad oes gan y gweinydd dystysgrif ddilys.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Cyfrinair y dystysgrif';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Gosodiadau IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Galluogi IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Galluogi IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Galluogi mapio pyrth yn awtomatig';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Rhwydweithiau LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Rhestr o gyfeiriadau IP neu is-rwydweithiau CIDR, wedi\'u gwahanu gan gomas neu linellau, sy\'n cael eu trin fel rhai ar y rhwydwaith lleol.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URIau gweinydd cyhoeddedig';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Mapio is-rwydwaith neu gyfeiriad i URL cyhoeddedig, e.e. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Llwybr tystysgrif';
@@ -7505,11 +7462,11 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Byffro throttle';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Oedi cyn cyfyngu (eiliadau)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Caniatáu echdynnu isdeitlau ar y pryd';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Isafswm canran ailddechrau';
@@ -7566,23 +7523,22 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Trothwy ymateb araf (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Galluogi rhybuddion ymateb araf';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Galluogi Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Gweinydd';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Llwybrau';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Perfformiad';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Llwybr storfa';
@@ -7594,7 +7550,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminGeneralServerName => 'Enw gweinydd';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Iaith ddangos ddewisol';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Wedi methu llwytho gosodiadau';
@@ -7646,12 +7602,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# cyfranogwr',
-      many: '# chyfranogwr',
-      few: '# chyfranogwr',
-      two: '# gyfranogwr',
-      zero: '# o gyfranogwyr',
-      one: '# cyfranogwr',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7797,10 +7749,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rhes wedi\'u darganfod',
-      two: '# res wedi\'u darganfod',
-      zero: '# o resi wedi\'u darganfod',
-      one: '# rhes wedi\'i darganfod',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7841,20 +7791,20 @@ class AppLocalizationsCy extends AppLocalizations {
   String get offlineSavedMedia => 'Cyfryngau wedi\'u Cadw';
 
   @override
-  String get offlineBannerTitle => 'Rydych chi all-lein';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Yn dangos eich lawrlwythiadau';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Lawrlwythiadau';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Methu cyrraedd eich gweinydd';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Yn chwarae o\'ch lawrlwythiadau nes iddo ddod yn ôl';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7927,13 +7877,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get pinForgot => 'Wedi anghofio PIN?';
 
   @override
-  String get pinClear => 'Clirio';
+  String get pinClear => 'Clir';
 
   @override
   String get pinBackspace => 'Gofod cefn';
 
   @override
-  String get quickConnectAuthorized => 'Awdurdodwyd y cais Quick Connect.';
+  String get quickConnectAuthorized => 'Cais Cyswllt Cyflym wedi\'i awdurdodi.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -7953,7 +7903,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get quickConnectForbidden =>
-      'Ni all eich cyfrif awdurdodi\'r cais Quick Connect hwn.';
+      'Ni all eich cyfrif awdurdodi\'r cais Cyswllt Cyflym hwn.';
 
   @override
   String get quickConnectNotFound =>
@@ -8167,7 +8117,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get playerTooltipCastControls => 'Rheolaethau cast';
 
   @override
-  String get playerTooltipPlaybackQuality => 'Cyfradd didau';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'Rhowch sgrin lawn';
@@ -8212,13 +8162,14 @@ class AppLocalizationsCy extends AppLocalizations {
   String get contextMenuGoToSeries => 'Ewch i Gyfres';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Cuddio o Parhewch i Wylio';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Cuddio o Nesaf';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Ychwanegu at Gasgliad';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8273,15 +8224,14 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsAlphabetical => 'Yn nhrefn yr wyddor';
 
   @override
-  String get settingsConnectionSection => 'CYSYLLTIAD';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Caniatáu tystysgrifau hunanlofnodedig';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Ymddiried mewn gweinyddion sy\'n defnyddio tystysgrifau TLS hunanlofnodedig neu rai o CA preifat. Galluogwch hyn ar gyfer gweinyddion rydych chi\'n eu rheoli yn unig. Mae hyn yn analluogi dilysu tystysgrifau ar gyfer pob cysylltiad.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PREIFATRWYDD A DIOGELWCH';
@@ -8297,11 +8247,11 @@ class AppLocalizationsCy extends AppLocalizations {
       'Acenion thema, cefndir, dangosyddion gwylio, a cherddoriaeth thema';
 
   @override
-  String get settingsDetailsScreen => 'Sgrin Fanylion';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Arddull, pylu\'r cefndir, ac ymddygiad tabiau';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Tudalen Gartref';
@@ -8339,11 +8289,11 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Dangos botwm Seerr yn y bar llywio';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Dangos labeli testun yn y bar llywio uchaf bob amser';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8446,9 +8396,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# hysbysiad trwydded',
-      zero: '# o hysbysiadau trwydded',
-      one: '# hysbysiad trwydded',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8497,16 +8446,16 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hepgor Intros a Outros?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Cyfrif i Lawr Segment Cyfryngau';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Bar Cynnydd';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Amserydd';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Dim';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Defnyddiwr Prydlon';
@@ -8735,7 +8684,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName a Ryddhawyd yn Ddiweddar';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8768,11 +8717,11 @@ class AppLocalizationsCy extends AppLocalizations {
       'Gorfodi chwarae di-dwnnel. Defnyddiol ar ddyfeisiadau gyda diffyg parhad sain/fideo twnelu.';
 
   @override
-  String get enableTunnelingTitle => 'Galluogi twnelu';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Uwch. Yn llwybro sain a fideo drwy lwybr caledwedd cyplysedig. I ffwrdd yn ddiofyn am ei fod yn achosi i sain/fideo dorri ar rai dyfeisiau.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Mapiwch Dolby Vision proffil 7 i HEVC';
@@ -8798,14 +8747,14 @@ class AppLocalizationsCy extends AppLocalizations {
       'Cymhwyso awgrymiadau maint ffont sydd wedi\'u hymgorffori yn y trac is-deitl. Analluogi defnyddio maint yr is-deitl o\'ch dewisiadau arddull.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Dangos Manylion y Cyfrwng';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Dangos manylion yr eitem a ddewiswyd ar frig tudalennau\'r Llyfrgell.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Cuddio Cefndiroedd wrth Bori?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Defnyddiwch Is-benawdau Manwl';
@@ -8823,37 +8772,37 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Siop Themâu';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Pori a chadw themâu\'r gymuned';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Arbedwch thema i\'w defnyddio fel eich themâu eraill sydd wedi\'u harbed.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Does dim themâu ar gael ar hyn o bryd.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Methwyd â llwytho\'r Siop Themâu. Gwiriwch eich cysylltiad a rhowch gynnig arall arni.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Cadw';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Arbed a gosod';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Wedi\'i arbed';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Methwyd â llwytho\'r thema hon.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Wedi arbed \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8912,21 +8861,21 @@ class AppLocalizationsCy extends AppLocalizations {
   String get homeRowsSection => 'Rhesi Cartref';
 
   @override
-  String get homeRowDisplay => 'Dangos y Rhesi Cartref';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Adrannau\'r Rhesi Cartref';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Togls y Rhesi Cartref';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Galluogi neu analluogi categorïau\'r rhesi cartref sy\'n seiliedig ar lyfrgelloedd';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Galluogwch y togls canlynol i ddangos y rhesi yn yr Adrannau Cartref.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Math Rhesi';
@@ -8985,56 +8934,55 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dangos Ffilmiau, Cyfresi, neu\'r ddau yn rhesi Genres.';
 
   @override
-  String get displayPlaylistsRows => 'Dangos Rhesi Rhestrau Chwarae';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Dangos rhesi Rhestrau Chwarae yn yr Adrannau Cartref.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Trefnu Rhesi\'r Rhestrau Chwarae';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Trefnu rhesi\'r Rhestrau Chwarae yn ôl y dyddiad ychwanegu, y dyddiad rhyddhau, yn nhrefn yr wyddor, a mwy.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Dangos Rhesi Sain';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Dangos rhesi Sain yn yr Adrannau Cartref.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Trefnu\'r Rhesi Sain';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Trefnu rhesi Sain yn ôl y dyddiad ychwanegu, y dyddiad rhyddhau, yn nhrefn yr wyddor, a mwy.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Rhestrau Chwarae Sain';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Gwedd';
+  String get appearance => 'Ymddangosiad';
 
   @override
-  String get layout => 'Cynllun';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Thema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Bysellfwrdd';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Botymau';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Rendro';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Ffurfweddiad MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Maint Cerdyn';
@@ -9044,7 +8992,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Gosodwch chwaraewr allanol i alluogi\'r opsiwn chwarae gwasg-hir';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9061,7 +9009,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audioTranscodeTarget => 'Targed Trawsnewid Sain';
 
   @override
-  String get passthrough => 'Trosglwyddo';
+  String get passthrough => 'Passthrough';
 
   @override
   String get supportedOnThisDevice => 'Cefnogir ar y ddyfais hon';
@@ -9313,7 +9261,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get appearancesSeerr => 'Ymddangosiadau (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Cyfraniadau\'r Criw (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Gwyliwch gyda\'r grŵp';
@@ -9399,10 +9347,8 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Llyfrgell',
-      two: '$count Lyfrgell',
-      zero: '$count o Lyfrgelloedd',
-      one: '1 Llyfrgell',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9431,7 +9377,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminServerPathImageCache => 'Cache Delwedd';
 
   @override
-  String get adminServerPathCache => 'Storfa';
+  String get adminServerPathCache => 'Cache';
 
   @override
   String get adminServerPathLogs => 'Logiau';
@@ -9494,7 +9440,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get mixedMoviesAndShows => 'Ffilmiau a Sioeau Cymysg';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Sync Cyflym Intel';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9561,13 +9507,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get loadingShuffle => 'Wrthi\'n llwytho siffrwd...';
 
   @override
-  String get libraryShuffleLabel => 'HAPCHWARAE\'R LLYFRGELL';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'HAPCHWARAE AR HAP';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'HAPCHWARAE GENRES';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Newid HDR Auto';
@@ -9580,222 +9526,222 @@ class AppLocalizationsCy extends AppLocalizations {
   String get whenFullscreen => 'Pan fydd sgrin lawn';
 
   @override
-  String get changeArtwork => 'Newid y Gwaith Celf';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Ar goll';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Terfynau Trawsgodio';
 
   @override
-  String get clearAllArtworkButton => 'Clirio\'r holl waith celf?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Ydych chi\'n siŵr eich bod am glirio\'r holl waith celf a lawrlwythwyd?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Cadarnhau\'r Clirio';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Ydych chi\'n siŵr eich bod am glirio\'r $itemType hwn?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Uwchlwytho?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Cydraniad: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Dangos gwaith celf yn iaith y rhyngwyneb yn unig';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Cadarnhau Clirio\'r Cyfan';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Uwchlwythwyd y ddelwedd yn llwyddiannus!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Wedi methu uwchlwytho\'r ddelwedd: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Wedi methu gosod y ddelwedd: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Wedi methu dileu\'r ddelwedd: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Wedi methu clirio\'r holl waith celf: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ie';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Cefndiroedd';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Baner';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Mân-lun';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Celf';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Celf y Ddisg';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Sgrinlun';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Clawr y Blwch';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Clawr Cefn y Blwch';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Celf y Ddewislen';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'cefndir';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'baner';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'mân-lun';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'celf';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'celf disg';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'sgrinlun';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'clawr blwch';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'clawr cefn blwch';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'celf dewislen';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Pob un';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Uchel (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Canolig (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Isel (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Ffynonellau';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Penodau';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Nodau tudalen';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Nodiadau';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Ciw';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Llinell amser';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Mae\'r llinell amser yn wag';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Y Llyfr Cyfan';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Llinell Amser â Ffocws';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Allforio\'r Nodau Tudalen';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Allforio\'r Nodiadau';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Allforio\'r Cyfan';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Wedi\'i allforio i $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Methodd yr allforio: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Geiriau';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Ychwanegu nod tudalen';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Ychwanegu nodiad';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Golygu\'r nodiad';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Ysgrifennwch nodiad ar gyfer y foment hon';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Amserydd cysgu';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'I ffwrdd';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Diwedd y bennod';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personol';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining ar ôl';
+    return '$remaining left';
   }
 
   @override
@@ -9803,58 +9749,58 @@ class AppLocalizationsCy extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count mun',
-      one: '1 mun',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Cyflymder chwarae';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Ar ôl';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Wedi mynd heibio';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Yn ôl ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Ymlaen ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Y bennod flaenorol';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Y bennod nesaf';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Pennod $current o $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Dim penodau';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Dim nodau tudalen eto';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Dim nodiadau eto';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Ychwanegwyd nod tudalen ar $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Ailosod i 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9862,252 +9808,249 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Cadw';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Canslo';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Dileu';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Dewisiadau Isdeitlau';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Newid moddau isdeitlau, ieithoedd rhagosodedig, golwg, ac opsiynau rendro.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Rendro Isdeitlau';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opsiynau Dangos';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Dyddiad Rhyddhau (Esgyn)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Dyddiad Rhyddhau (Disgyn)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grwpio Cyfraniadau';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grwpio sawl rôl';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Rhybudd Mynediad Ysgrifennu i\'r Llyfrgell';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Sut i drwsio hyn:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Rhowch ganiatâd ysgrifennu i ddefnyddiwr gwasanaeth Jellyfin (e.e. jellyfin neu PUID/PGID Docker) ar gyfer ffolderi eich llyfrgell gyfryngau ar y gweinydd.\n\n2. Neu, ewch i\'ch Dangosfwrdd Jellyfin -> Llyfrgelloedd, golygwch y llyfrgell hon, ac analluogwch \'Cadw gwaith celf yn y ffolderi cyfryngau\' i storio gwaith celf yng nghronfa ddata fewnol Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Diystyru';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Mae eich llyfrgell \'$libraryName\' wedi\'i ffurfweddu i gadw gwaith celf yn uniongyrchol yn y ffolderi cyfryngau (mae \'Cadw gwaith celf yn y ffolderi cyfryngau\' wedi\'i alluogi). Fodd bynnag, mae Jellyfin wedi profi mynediad ysgrifennu ac nid oes ganddo ganiatâd i ysgrifennu ffeiliau i\'r cyfeiriadur hwn:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Mae\'n ymddangos bod Jellyfin wedi methu â diweddaru\'r gwaith celf. Mae eich llyfrgell wedi\'i ffurfweddu i gadw gwaith celf yn uniongyrchol yn y ffolderi cyfryngau (mae \'Cadw gwaith celf yn y ffolderi cyfryngau\' wedi\'i alluogi). Mae\'r gwall hwn fel arfer yn digwydd pan nad oes gan broses gweinydd Jellyfin ganiatâd i ysgrifennu ffeiliau i\'ch cyfeiriaduron cyfryngau.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Rhestrau Allanol';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Ailchwarae';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Gwybodaeth am y Ffeil';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Maint: $size  •  Fformat: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Dangos Pob Trac Sain ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Dangos Pob Trac Isdeitlau ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Yn gwirio\'r gallu Direct Play...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Gallu Direct Play: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Gorfodol';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Nid yw\'r chwaraewr yn cefnogi fformat y cynhwysydd.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Ni chefnogir y codec fideo.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Ni chefnogir y codec sain.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Ni chefnogir fformat yr isdeitlau (mae angen eu llosgi i mewn).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Ni chefnogir y proffil sain.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Ni chefnogir y proffil fideo.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Ni chefnogir lefel y fideo.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Nid yw\'r ddyfais hon yn cefnogi cydraniad y fideo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Ni chefnogir dyfnder didau\'r fideo.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Ni chefnogir cyfradd fframiau\'r fideo.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Mae cyfradd didau\'r ffeil yn uwch na therfyn ffrydio\'r chwaraewr.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Mae cyfradd didau\'r fideo yn uwch na\'r terfyn ffrydio.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Mae cyfradd didau\'r sain yn uwch na\'r terfyn ffrydio.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Ni chefnogir nifer y sianeli sain.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Yn nhrefn yr wyddor';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Trefn Rhyddhau (Esgyn)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Trefn Rhyddhau (Disgyn)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personol (Llusgo a Gollwng)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opsiynau Trefnu\'r Rhestr Chwarae';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Ailosod y Drefn';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Ailwylio T$season:P$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Ailwylio\'r Rhestr Chwarae';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Ni chanfuwyd unrhyw isdeitlau.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Rheolyddion Gweinyddu';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Injan rendro (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller yw rendrwr GPU modern Flutter, ar gyfer animeiddiadau llyfnach a llai o hercian. Ar rai bocsys teledu a GPUau hŷn gall achosi namau neu fideo du; diffoddwch ef os gwelwch chi\'r rheini. Mae Awtomatig yn dewis y rhagosodiad gorau ar gyfer eich dyfais. Ailgychwynnwch Moonfin i\'w osod.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Awtomatig';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ymlaen';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'I ffwrdd';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Mae angen ailgychwyn';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Mae angen i Moonfin ailgychwyn i newid yr injan rendro. Caewch yr ap nawr, yna ei ailagor i osod y newid.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Cau\'r ap nawr';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Adnewyddu\'r Llyfrgell';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Adnewyddu Pob Llyfrgell';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Dyddiad Ychwanegu (Hynaf yn Gyntaf)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Dyddiad Ychwanegu (Diweddaraf yn Gyntaf)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Yn nhrefn yr wyddor (A i Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Yn nhrefn yr wyddor (Z i A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Yn llwytho Dadansoddeg y Gweinydd... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Cydweddu â\'r ffynhonnell';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => '250 Ffilm Orau IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => '250 Cyfres Deledu Orau IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Ffilmiau Mwyaf Poblogaidd IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Cyfresi Teledu Mwyaf Poblogaidd IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Ffilmiau â\'r Sgôr Isaf ar IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Ffilmiau Saesneg â\'r Sgôr Uchaf ar IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -32,7 +32,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Hurtig tilslutning';
 
   @override
   String get password => 'Adgangskode';
@@ -143,62 +143,62 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsAppearanceTheme => 'App-tema';
 
   @override
-  String get detailScreenStyle => 'Detaljeskærmens stil';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassisk er det oprindelige centrerede Moonfin-layout. Moderne er et responsivt, filmisk layout.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassisk';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderne';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Udvidede faneblade';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Vis automatisk indholdet, når du bladrer gennem faneblade. Slå fra for at åbne og lukke hvert faneblad manuelt.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Vis tekniske detaljer?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Vis codec, opløsning og streamoplysninger i banneroversigten';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Anbefalingssystem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Brug Moonfin Anbefaler-algoritmen til dit lokale bibliotek eller TMDb\'s lighedsmålinger online. Bemærk: Onlineanbefalinger kræver Seerr-integration.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin Anbefaler';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-lighed';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Begræns efter aldersgrænse?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Begræns forslag fra Moonfin Anbefaler efter målmediets aldersgrænse';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Grænsefladestil';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatisk tilpasser sig din enhed. Vælg Apple eller Material for at fastlåse et udseende.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatisk';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -207,31 +207,31 @@ class AppLocalizationsDa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glaskvalitet';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto vælger den bedste glaseffekt til denne enhed. Fuld fremtvinger ægte sløring; Reduceret bruger et let glas, der sparer GPU-strøm.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Fuld';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reduceret';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Skift mellem Moonfin og Neon Pulse uden at genstarte appen';
 
   @override
-  String get customThemeTitle => 'Brugerdefineret tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Brugerdefinerede temaer ændrer visuelle elementer i hele Moonfin. Vælg en af disse muligheder, der passer til din stil.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Foretræk systemtastatur';
@@ -248,7 +248,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Det nuværende Moonfin-udseende, som alle vil komme til at elske';
 
   @override
-  String get themeNeonPulse => 'Neonpuls';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle =>
@@ -259,14 +259,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Flydende glas-design med en glidende gradientbaggrund, frostede overflader og Apple-blå accentfarve';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit-helt';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixelart-design med en fed palet, kantede rammer, hårde slagskygger og en pixelskrifttype';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Log ind med din Emby Connect-konto';
@@ -331,33 +331,32 @@ class AppLocalizationsDa extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Sat på pause';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Gem tilstand';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Spil';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Indlæs tilstand';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Spol frem';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulatorindstillinger';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Denne kerne har ingen justerbare indstillinger.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Hold nede for at åbne menuen';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spil understøttes endnu ikke på denne enhed.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Ingen Hjem-rækker kunne indlæses';
@@ -484,7 +483,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get small => 'Lille';
 
   @override
-  String get medium => 'Mellem';
+  String get medium => 'Medium';
 
   @override
   String get large => 'Stor';
@@ -501,7 +500,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get views => 'Visninger';
 
   @override
-  String get albums => 'Album';
+  String get albums => 'Albums';
 
   @override
   String get albumArtists => 'Album kunstnere';
@@ -553,7 +552,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vælg, hvilke emnefeeds der skal vises i Discover.';
 
   @override
-  String get apply => 'Anvend';
+  String get apply => 'Anvende';
 
   @override
   String get openLink => 'Åbn link';
@@ -602,7 +601,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get listen => 'Lytte';
 
   @override
-  String get resume => 'Genoptag';
+  String get resume => 'Genoptage';
 
   @override
   String get failedToLoadLibrary => 'Kunne ikke indlæse biblioteket';
@@ -729,7 +728,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get folder => 'Mappe';
+  String get folder => 'Folder';
 
   @override
   String get filters => 'Filtre';
@@ -744,13 +743,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get readStatus => 'Læse';
 
   @override
-  String get watched => 'Set';
+  String get watched => 'Så';
 
   @override
   String get unread => 'Ulæst';
 
   @override
-  String get unwatched => 'Ikke set';
+  String get unwatched => 'Uovervåget';
 
   @override
   String get seriesStatus => 'Seriestatus';
@@ -762,43 +761,43 @@ class AppLocalizationsDa extends AppLocalizations {
   String get books => 'Bøger';
 
   @override
-  String get latestBooks => 'Seneste bøger';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Seneste lydbøger';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bøger',
-      one: '1 bog',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Bog';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Lydbog';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% læst';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time tilbage';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Læs';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Lyt';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Forfatter';
@@ -875,8 +874,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count lydbøger',
-      one: '1 lydbog',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -894,13 +893,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get delete => 'Slet';
 
   @override
-  String get save => 'Gem';
+  String get save => 'Spare';
 
   @override
   String get moreLikeThis => 'Mere som denne';
 
   @override
-  String get castAndCrew => 'Medvirkende & hold';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Samling';
@@ -912,7 +911,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get nextUp => 'Næste op';
 
   @override
-  String get seasons => 'Sæsoner';
+  String get seasons => 'Årstider';
 
   @override
   String get chapters => 'kapitler';
@@ -980,8 +979,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sæsoner',
-      one: '1 sæson',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -992,16 +991,16 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get items => 'Elementer';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ekstramateriale';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Bag kulisserne';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Slettede scener';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
@@ -1010,17 +1009,17 @@ class AppLocalizationsDa extends AppLocalizations {
   String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scener';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kortfilm';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Trailere';
 
   @override
   String timeRemaining(String time) {
-    return '$time tilbage';
+    return '$time remaining';
   }
 
   @override
@@ -1043,7 +1042,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get play => 'Afspil';
+  String get play => 'Spil';
 
   @override
   String get startOver => 'Start forfra';
@@ -1268,10 +1267,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get writer => 'FORFATTER';
 
   @override
-  String get writers => 'MANUSKRIPTFORFATTERE';
+  String get writers => 'SKRIFTERE';
 
   @override
-  String get studio => 'STUDIE';
+  String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
@@ -1303,8 +1302,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count numre',
-      one: '1 nummer',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1314,8 +1313,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapitler',
-      one: '1 kapitel',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1345,13 +1344,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get shuffle => 'Bland';
 
   @override
-  String get shuffleAllMusic => 'Bland al musik';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Log ind på Moonfin på din telefon';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Kan ikke få forbindelse til din server';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1370,7 +1369,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mono => 'Mono';
 
   @override
-  String get stereo => 'Stereo';
+  String get stereo => 'Stereoanlæg';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1474,10 +1473,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get castingToGoogleCast => 'Caster til Google Cast';
 
   @override
-  String get castingViaAirPlay => 'Caster via AirPlay';
+  String get castingViaAirPlay => 'Casting via AirPlay';
 
   @override
-  String get castingViaDlna => 'Caster via DLNA';
+  String get castingViaDlna => 'Casting via DLNA';
 
   @override
   String secondsCount(int seconds) {
@@ -1488,7 +1487,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get longPressToUnlock => 'Langt tryk for at låse op';
 
   @override
-  String get off => 'Fra';
+  String get off => 'Slukket';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1550,7 +1549,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get transcodeReasons => 'Omkodningsårsager';
 
   @override
-  String get player => 'Afspiller';
+  String get player => 'Spiller';
 
   @override
   String get container => 'Beholder';
@@ -1574,7 +1573,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get videoBitrate => 'Video bitrate';
 
   @override
-  String get track => 'Spor';
+  String get track => 'Spore';
 
   @override
   String get channels => 'Kanaler';
@@ -1583,7 +1582,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audioBitrate => 'Lyd bitrate';
 
   @override
-  String get sampleRate => 'Samplingsfrekvens';
+  String get sampleRate => 'Sample Rate';
 
   @override
   String get format => 'Format';
@@ -1789,22 +1788,22 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Næste: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min tilbage';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours t tilbage';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours t $minutes min tilbage';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1827,7 +1826,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get favoriteChannel => 'Yndlingskanal';
 
   @override
-  String get record => 'Optag';
+  String get record => 'Optage';
 
   @override
   String get cancelRecordingAction => 'Annuller optagelse';
@@ -1842,7 +1841,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get unableToCreateRecording => 'Kan ikke oprette optagelse';
 
   @override
-  String get watch => 'Se';
+  String get watch => 'Ur';
 
   @override
   String get close => 'Luk';
@@ -1879,7 +1878,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get no => 'Nej';
+  String get no => 'Ingen';
 
   @override
   String get yesCancel => 'Ja, annuller';
@@ -2055,7 +2054,7 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episoder',
+      other: '$count episodes',
       one: '1 episode',
     );
     return '$_temp0';
@@ -2214,7 +2213,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get never => 'Aldrig';
 
   @override
-  String get focusExpansionAnimation => 'Animation for fokusudvidelse';
+  String get focusExpansionAnimation => 'Focus Expansion Animation';
 
   @override
   String get desktopUiScale => 'Desktop UI-skala';
@@ -2282,7 +2281,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detaljesider, rækker på startskærmen og lydstyrke';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2297,11 +2296,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Spil, når du browser på startskærmen';
 
   @override
-  String get loopThemeMusic => 'Gentag temamusik';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Gentag nummeret i stedet for at afspille det én gang';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detaljer Baggrundssløring';
@@ -2337,10 +2336,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get scrollWheelActionSeek => 'Søg (frem/tilbage)';
 
   @override
-  String get scrollWheelActionVolume => 'Lydstyrke';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Lydstyrke';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Passe';
@@ -2355,7 +2354,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get refreshRateSwitching => 'Skift af opdateringshastighed';
 
   @override
-  String get disabled => 'Deaktiveret';
+  String get disabled => 'Handicappet';
 
   @override
   String get scaleOnTv => 'Skala på TV';
@@ -2394,37 +2393,37 @@ class AppLocalizationsDa extends AppLocalizations {
   String get defaultAudioLanguage => 'Standard lydsprog';
 
   @override
-  String get fallbackAudioLanguage => 'Reservesprog for lyd';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Foretræk standardlydspor';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Foretræk det originale lydspor frem for lokaliseret eftersynkronisering.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Foretræk synstolkningsspor';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Foretræk synstolkningsspor frem for normale spor.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodning (lyd)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Direct Stream (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodning (bitrate eller opløsning)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodning (video og lyd)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodning (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (serverstandard)';
@@ -2484,10 +2483,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get polish => 'Polere';
 
   @override
-  String get ac3Passthrough => 'AC3-passthrough';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'DTS-passthrough';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'TrueHD-understøttelse';
@@ -2508,21 +2507,20 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vælg hvordan lyd afkodes. AVR Passthrough sender rå Dolby/DTS spor til din receiver; Auto og Nedjuster afkoder lokalt.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR-passthrough';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Reservecodec for lyd';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Vælg det format, flerkanalslyd skal transkodes til, når kildestrømmen hverken kan afspilles direkte eller sendes igennem.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Registrér automatisk\n(anbefales)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(standard)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2531,27 +2529,26 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(tabsfri)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(kun stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(effektiv)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(tabsfri)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maks. antal lydkanaler';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Angiv det maksimale antal kanaler i dit lydanlæg. Flerkanalsstrømme, der overskrider denne grænse, bliver downmixet eller transkodet.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Registrér automatisk\n(hardwarestandard)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2563,7 +2560,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvadrofonisk';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2581,29 +2578,29 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsAudioPassthroughAdvanced => 'Passthrough (avanceret)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Codec-passthrough';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
       'Aktiver kun formater, som din AVR eller HDMI-vask understøtter.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3-passthrough';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos)-passthrough';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core-passthrough';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA-passthrough';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD-passthrough';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos-passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2656,11 +2653,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Højttaler';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Hovedtelefoner';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count-kanals PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2681,21 +2678,22 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS-lydcodecs';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs => 'HLS fMP4-lydcodecs';
+  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif-passthrough';
+      'audio-spdif passthrough';
 
   @override
   String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktiv lydrute';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'HD-lydunderstøttelse for ruten';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nattilstand';
@@ -2731,7 +2729,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get nextUpAndQueuing => 'Næste op & i kø';
 
   @override
-  String get nextUpDisplay => 'Visning af Næste op';
+  String get nextUpDisplay => 'Next Up Display';
 
   @override
   String get extended => 'Udvidet';
@@ -2834,45 +2832,45 @@ class AppLocalizationsDa extends AppLocalizations {
       'Tilpas undertekstens udseende';
 
   @override
-  String get subtitleMode => 'Underteksttilstand';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Markeret';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Altid';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Fremmedsprog';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Tvungen';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Afspiller spor, der i mediefilens metadata er markeret som \"default\" eller \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Indlæser og viser automatisk undertekster, hver gang en video starter.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Slår automatisk undertekster til, hvis standardlydsporet er på et fremmedsprog.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Indlæser kun undertekster, der udtrykkeligt er mærket med det tvungne metadataflag.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Deaktiverer automatisk indlæsning af undertekster fuldstændigt.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Reservesprog for undertekster';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Undertekststrøm';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2921,7 +2919,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get global => 'Global';
 
   @override
-  String get desktop => 'Computer';
+  String get desktop => 'Desktop';
 
   @override
   String get mobile => 'Mobil';
@@ -3077,10 +3075,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showLibrariesInToolbar => 'Vis biblioteker i værktøjslinjen';
 
   @override
-  String get navbarAlwaysExpanded => 'Udvid altid navigationslinjens etiketter';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Vis Seerr-knap';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar Opacitet';
@@ -3155,19 +3153,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showFolderBrowsingOption => 'Vis mulighed for browsing af mapper';
 
   @override
-  String get groupItemsIntoCollections => 'Gruppér elementer i samlinger';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Skjul biblioteksemner, der hører til en samling, når du gennemser biblioteker';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Bemærkning om biblioteksgruppering';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'For at bruge denne indstilling skal du sikre dig, at biblioteksindstillingerne \"Gruppér film i samlinger\" og/eller \"Gruppér serier i samlinger\" er slået til under dit biblioteks visningsindstillinger på din Jellyfin- eller Emby-server.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliotekets synlighed';
@@ -3226,13 +3223,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vælg mellem forskellige medielinjestilarter, eller slå medielinjen fra';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Månefinne';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Fra';
+  String get mediaBarModeOff => 'Slukket';
 
   @override
   String get enableMediaBar => 'Aktiver Media Bar';
@@ -3279,10 +3276,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Afspil trailere automatisk i mediebjælken efter 3 sekunder';
 
   @override
-  String get trailerAudio => 'Trailerlyd';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Aktivér lyd for trailere i mediebaren';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Forhåndsvisning af episode';
@@ -3360,11 +3357,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Kombiner begge rækker til en enkelt hjemmesektion';
 
   @override
-  String get fullScreenRows => 'Udvidede rækker på startskærmen';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Begræns startskærmen til én række pr. skærm';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Billedtype pr. række';
@@ -3379,7 +3375,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get lastUser => 'Sidste bruger';
 
   @override
-  String get currentUser => 'Nuværende bruger';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentificer altid';
@@ -3439,7 +3435,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get enableBuiltInScreensaver => 'Aktiver den indbyggede pauseskærm';
 
   @override
-  String get mode => 'Tilstand';
+  String get mode => 'Mode';
 
   @override
   String get libraryArt => 'Bibliotekskunst';
@@ -3451,7 +3447,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get clock => 'Ur';
 
   @override
-  String get timeout => 'Tidsgrænse';
+  String get timeout => 'Timeout';
 
   @override
   String minutesShort(int minutes) {
@@ -3485,10 +3481,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get displayClockDuringScreensaver => 'Vis ur under pauseskærm';
 
   @override
-  String get clockModeStatic => 'Fast';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Hoppende';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rådne tomater (kritikere)';
@@ -3558,7 +3554,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Aktiver og omarranger de vurderingskilder, der vises i hele appen';
 
   @override
-  String get pluginLabel => 'Moonbase-plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin fundet';
@@ -3583,7 +3579,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get availableServices => 'Tilgængelige tjenester';
 
   @override
-  String get serverPluginSync => 'Synkronisering af serverplugin';
+  String get serverPluginSync => 'Server Plugin Sync';
 
   @override
   String get syncSettingsWithPlugin =>
@@ -3603,7 +3599,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recentlyAdded => 'Nyligt tilføjet';
 
   @override
-  String get trending => 'Populært lige nu';
+  String get trending => 'Trending';
 
   @override
   String get popularMovies => 'Populære film';
@@ -3630,7 +3626,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get networks => 'Netværk';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-opdagelsesrækker';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Nulstil rækker til standardindstillinger';
@@ -3653,27 +3649,28 @@ class AppLocalizationsDa extends AppLocalizations {
   String get hideAdultContent => 'Skjul voksenindhold i resultater';
 
   @override
-  String get seerrNotificationsSection => 'Notifikationer';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Notifikationer om nye anmodninger';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Giv mig besked, når nogen sender en anmodning';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Opdateringer om anmodninger';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Godkendt, afvist og tilføjet til dit bibliotek';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Opdateringer om problemer';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nye problemer, svar og løsninger';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3681,15 +3678,15 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr-opdagelsesside';
+  String get discoverRows => 'Opdag Rows';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktiver de rækker, du vil se på Seerr-hovedsiden. Træk for at omarrangere. Den tilpassede rækkefølge synkroniseres med Moonbase.';
+      'Træk for at omarrangere. Aktiver eller deaktiver rækker. Aktiveret rækkefølge synkroniseres med Moonfin-pluginnet.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktiver de rækker, du vil se på Seerr-hovedsiden. Træk for at omarrangere. Den tilpassede rækkefølge synkroniseres med Moonbase.';
+      'Træk for at omarrangere. Aktiver eller deaktiver rækker.';
 
   @override
   String get enabled => 'Aktiveret';
@@ -3827,7 +3824,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get imageCacheCleared => 'Billedcachen er ryddet';
 
   @override
-  String get clear => 'Ryd';
+  String get clear => 'Klar';
 
   @override
   String get browse => 'Gennemse';
@@ -3843,11 +3840,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Downloader · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importerer';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3908,7 +3905,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Budget: $amount \$';
+    return 'Budget: \$$amount';
   }
 
   @override
@@ -3989,148 +3986,148 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deletedStatus => 'Slettet';
 
   @override
-  String get failedStatus => 'Mislykkedes';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Behandles';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Ændret af $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Fuldført';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Der er allerede anmodet om denne titel';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Grænsen for anmodninger er nået';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Denne titel er blokeret';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Der er ikke flere sæsoner at anmode om';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Du har ikke tilladelse til at foretage denne anmodning';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Anmodninger';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemer';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nyeste';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Senest ændret';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Ingen problemer';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining af $limit filmanmodninger tilbage';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining af $limit sæsonanmodninger tilbage';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Del af $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vis samling';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Anmod om samling';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total film · $available tilgængelige';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Anmod om $count film';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Anmoder om $current af $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Der er anmodet om $count film';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Der er anmodet om $ok af $total film';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alle film er allerede tilgængelige eller anmodet om';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Rapportér problem';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Lyd';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Hvad er der galt?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alle episoder';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Åben';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Løst';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Markér som løst';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Genåbn';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Rapporteret af $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommentarer';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Tilføj en kommentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Slet dette problem?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Send rapport';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-score';
@@ -4145,7 +4142,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get revenueLabel => 'Indtægter';
 
   @override
-  String get runtimeLabel => 'Spilletid';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'Budget';
@@ -4154,7 +4151,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get originalLanguageLabel => 'Originalsprog';
 
   @override
-  String get seasonsLabel => 'Sæsoner';
+  String get seasonsLabel => 'Årstider';
 
   @override
   String get episodesLabel => 'Episoder';
@@ -4163,13 +4160,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get access => 'Adgang';
 
   @override
-  String get add => 'Tilføj';
+  String get add => 'Tilføje';
 
   @override
   String get address => 'Adresse';
 
   @override
-  String get analytics => 'Analyse';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalog';
@@ -4190,7 +4187,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get done => 'Færdig';
 
   @override
-  String get edit => 'Rediger';
+  String get edit => 'Redigere';
 
   @override
   String get encoding => 'Kodning';
@@ -4199,10 +4196,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get error => 'Fejl';
 
   @override
-  String get forward => 'Frem';
+  String get forward => 'Forward';
 
   @override
-  String get general => 'Generelt';
+  String get general => 'Generel';
 
   @override
   String get go => 'Gå';
@@ -4247,7 +4244,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get refresh => 'Opfriske';
 
   @override
-  String get remote => 'Fjernbetjening';
+  String get remote => 'Fjern';
 
   @override
   String get rename => 'Omdøb';
@@ -4265,7 +4262,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get run => 'Løbe';
 
   @override
-  String get search => 'Søg';
+  String get search => 'Søge';
 
   @override
   String get select => 'Vælge';
@@ -4292,7 +4289,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get time => 'Tid';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trickspil';
 
   @override
   String get uninstall => 'Afinstaller';
@@ -4310,16 +4307,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get unmute => 'Slå lyden til';
 
   @override
-  String get mute => 'Slå lyd fra';
+  String get mute => 'Stum';
 
   @override
   String get branding => 'Branding';
 
   @override
-  String get adminDrawerDashboard => 'Kontrolpanel';
+  String get adminDrawerDashboard => 'Dashboard';
 
   @override
-  String get adminDrawerAnalytics => 'Analyse';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Indstillinger';
@@ -4334,25 +4331,25 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteker';
 
   @override
-  String get adminDrawerDisplay => 'Visning';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-indstillinger';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Omkodning';
 
   @override
-  String get adminDrawerResume => 'Genoptag';
+  String get adminDrawerResume => 'Genoptage';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trickspil';
 
   @override
   String get adminDrawerDevices => 'Enheder';
@@ -4370,7 +4367,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminDrawerBackups => 'Sikkerhedskopier';
 
   @override
-  String get adminDrawerLogs => 'Logfiler';
+  String get adminDrawerLogs => 'Logs';
 
   @override
   String get adminDrawerScheduledTasks => 'Planlagte opgaver';
@@ -4443,7 +4440,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get analyticsContentRatings => 'Indholdsvurderinger';
 
   @override
-  String get analyticsRuntimeBuckets => 'Spilletidsintervaller';
+  String get analyticsRuntimeBuckets => 'Runtime Buckets';
 
   @override
   String get analyticsFileFormats => 'Filformater';
@@ -4523,7 +4520,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get sessionRewind => 'Spole tilbage';
 
   @override
-  String get sessionForward => 'Spol frem';
+  String get sessionForward => 'Forward';
 
   @override
   String get sessionNext => 'Næste';
@@ -4532,7 +4529,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get sessionVolumeDown => 'bind –';
 
   @override
-  String get sessionVolumeUp => 'Lyd +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4541,19 +4538,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get nowPlaying => 'Spiller nu';
 
   @override
-  String get volume => 'Lydstyrke';
+  String get volume => 'Bind';
 
   @override
   String get actions => 'Handlinger';
 
   @override
-  String get videoCodec => 'Videocodec';
+  String get videoCodec => 'Video Codec';
 
   @override
-  String get audioCodec => 'Lydcodec';
+  String get audioCodec => 'Audio Codec';
 
   @override
-  String get hwAccel => 'HW-accel';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Fuldførelse';
@@ -4568,10 +4565,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminClearDates => 'Klare datoer';
 
   @override
-  String get adminActivitySeverityAll => 'Alle alvorsgrader';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datointerval';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4608,23 +4605,23 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Fjern enheden \'$name\'? Brugeren skal logge ind igen på denne enhed.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Slet alle enheder';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Fjern $count enheder? Berørte brugere skal logge ind igen. Din nuværende enhed påvirkes ikke.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Enhederne er fjernet';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Nogle enheder blev fjernet; $count kunne ikke fjernes.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4739,247 +4736,244 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminMetadataCountryHint => 'f.eks. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Stier';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Indstillinger';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Downloadere';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadatagemmere';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Undertekstdownloadere';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Sangtekstdownloadere';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadatadownloadere: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Billedhentere: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Denne server har ingen downloadere til denne bibliotekstype.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Generelt';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Indlejrede oplysninger';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Undertekster';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Billeder';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serier';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musik';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Film';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktivér overvågning i realtid';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Registrér filændringer, og behandl dem automatisk.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Behandl arkiver som mediefiler';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Vis fotos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Gem grafik i mediemapperne';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatisk opdatering af metadata';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Aldrig';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Standard';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visning';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Biblioteksvisning';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Vis en mappevisning med almindelige mediemapper';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Vis specialafsnit i de sæsoner, de blev sendt i';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Gruppér film i samlinger';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Gruppér serier i samlinger';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Vis eksternt indhold i forslag';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Adfærd for tilføjelsesdato';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Brug tilføjelsesdato fra';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Datoen for scanning ind i biblioteket';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datoen filen blev oprettet';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata og billeder';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Foretrukket metadatasprog';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitler';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Varighed af dummy-kapitler (sekunder)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Længden på kapitler, der genereres til medier uden kapitler. Sæt til 0 for at deaktivere.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Opløsning for kapitelbilleder';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-indstillinger';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metadata er kompatible med Kodi og lignende klienter. Indstillingerne gælder for alle biblioteker, der gemmer NFO-metadata.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'Bruger, hvis visningsdata gemmes i NFO-filer';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Gem billedstier i NFO-filer';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktivér stierstatning for billedstier i NFO-filer';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopiér extrafanart-billeder til en extrathumbs-mappe';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ingen';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dage';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Brug indlejrede titler';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Brug indlejrede titler til ekstramateriale';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Brug indlejrede episodeoplysninger';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Tillad indlejrede undertekster';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Tillad alle';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Kun tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Kun billede';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ingen';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Spring download over, hvis der findes indlejrede undertekster';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Spring download over, hvis lydsporet matcher downloadsproget';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Kræv et perfekt undertekstmatch';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Gem undertekster i mediemapperne';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Udtræk kapitelbilleder';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Udtræk kapitelbilleder under biblioteksscanningen';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktivér udtrækning af trickplay-billeder';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Udtræk trickplay-billeder under biblioteksscanningen';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Gem trickplay-billeder i mediemapperne';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Flet automatisk serier, der er fordelt over flere mapper';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Visningsnavn for sæson nul';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Aktivér LUFS-scanning til lydnormalisering';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Foretræk ikke-standardiseret artists-tag';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Tilføj automatisk film til samlinger';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Bibliotekets navn er påkrævet';
@@ -5214,145 +5208,143 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktiver adgang til alle kanaler';
 
   @override
-  String get adminParentalControl => 'Forældrekontrol';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Højest tilladte aldersgrænse';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Indhold med en højere aldersgrænse skjules for denne bruger.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ingen';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokér emner uden eller med ukendte aldersoplysninger';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Bøger';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanaler';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
   String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Film';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musik';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailere';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serier';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Adgangsplaner';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Tillad kun adgang i de planlagte tidsrum nedenfor. Der er adgang hele døgnet, når der ikke er angivet en plan.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Tilføj plan';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dag';
+  String get adminScheduleDay => 'Day';
 
   @override
   String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Slut';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Hver dag';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Hverdag';
+  String get adminDayWeekday => 'Weekday';
 
   @override
   String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Søndag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Mandag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Tirsdag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Onsdag';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Torsdag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Fredag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Lørdag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tilladte tags';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Kun indhold med disse tags vises. Lad feltet stå tomt for at tillade alt.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokerede tags';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Indhold med disse tags skjules for denne bruger.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Tilføj tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Aktiverede enheder';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Aktiverede kanaler';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Godkendelsesudbyder';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Udbyder til nulstilling af adgangskode';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksimalt antal mislykkede loginforsøg før låsning';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Sæt til 0 for standardværdien, eller -1 for at deaktivere låsning.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-adgang';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Tillad oprettelse af og deltagelse i grupper';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Tillad deltagelse i grupper';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Ingen adgang';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Tillad sletning af indhold fra';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5439,26 +5431,25 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Opret sikkerhedskopi';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Vælg, hvad sikkerhedskopien skal indeholde.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
   String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Altid inkluderet';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Undertekster';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-billeder';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Opretter backup...';
@@ -5746,7 +5737,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminRepositoryNameHint => 'f.eks. Jellyfin Stald';
 
   @override
-  String get adminRepositoryUrl => 'Depot-URL';
+  String get adminRepositoryUrl => 'Repository URL';
 
   @override
   String get adminAddEntry => 'Tilføj post';
@@ -5993,7 +5984,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminHttpPort => 'HTTP-port';
 
   @override
-  String get adminHttpsPort => 'HTTPS-port';
+  String get adminHttpsPort => 'HTTPS port';
 
   @override
   String get adminPublicHttpsPort => 'Offentlig HTTPS-port';
@@ -6164,61 +6155,60 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminAddTuner => 'Tilføj Tuner';
 
   @override
-  String get adminEditTuner => 'Redigér tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fil eller URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Tunerens IP-adresse';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Visningsnavn';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Grænse for samtidige forbindelser';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Det maksimale antal streams, tuneren tillader samtidigt. Sæt til 0 for ubegrænset.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Maksimal streamingbitrate som reserve';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importér kun favoritkanaler';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Tillad hardwaretranskodning';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Tillad fMP4 som transkodningscontainer';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Tillad deling af streams';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Aktivér looping af streams';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorér DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Læs input med den oprindelige billedhastighed';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Redigér udbyder';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6227,50 +6217,50 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fil eller URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmpræfiks';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmkategorier';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Adskil flere kategorier med en lodret streg.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Børnekategorier';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nyhedskategorier';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportskategorier';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Brugernavn';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Adgangskode';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Vælg et land';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postnummer';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Hent programoversigter';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programoversigter';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktivér alle tunere';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuner type';
@@ -6312,7 +6302,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Denne tunertype understøtter ikke nulstilling.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6335,44 +6325,43 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serieoptagelsessti';
 
   @override
-  String get adminMovieRecordingPath => 'Sti til filmoptagelser';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Antal dage med programdata';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatisk';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dage';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Sti til efterbehandlingsprogram';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumenter til efterbehandling';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Gem NFO-metadata for optagelser';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Gem billeder for optagelser';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tidsindstilling';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Stier til optagelser';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Efterbehandling';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Programdata: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6415,14 +6404,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminGuideProviders => 'Guide udbydere';
 
   @override
-  String get adminRefreshGuideData => 'Opdatér programdata';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Opdatering af programdata er startet';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Opgaven til opdatering af programoversigten er ikke tilgængelig på denne server.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Tilføj udbyder';
@@ -6451,7 +6440,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get adminTunerDiscovery => 'Registrering af tunere';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Kanalkortlægninger';
@@ -6503,7 +6492,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminLiveTvTitle => 'Direkte tv-administration';
 
   @override
-  String get adminApply => 'Anvend';
+  String get adminApply => 'Anvende';
 
   @override
   String get adminNotSet => 'Ikke indstillet';
@@ -6552,10 +6541,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminLogViewerNoMatches => 'Ingen matchende linjer';
 
   @override
-  String get adminMetadataEditorTitle => 'Metadataeditor';
+  String get adminMetadataEditorTitle => 'Metadata Editor';
 
   @override
-  String get adminMetadataIdentify => 'Identificér';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Type';
@@ -6837,7 +6826,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Fjern';
+  String get adminReposRemove => 'Fjerne';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6861,7 +6850,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminReposAddTitle => 'Tilføj lager';
 
   @override
-  String get adminReposUrl => 'Depot-URL';
+  String get adminReposUrl => 'Repository URL';
 
   @override
   String get adminReposNameHint => 'f.eks. Jellyfin Stald';
@@ -6918,7 +6907,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminNetworkingHttpPort => 'HTTP-port';
 
   @override
-  String get adminNetworkingHttpsPort => 'HTTPS-port';
+  String get adminNetworkingHttpsPort => 'HTTPS port';
 
   @override
   String get adminNetworkingEnableHttps => 'Aktiver HTTPS';
@@ -6968,20 +6957,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktiver splash screen';
 
   @override
-  String get adminBrandingSplashUpload => 'Upload billede';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Velkomstskærmen er opdateret';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Velkomstskærmen kunne ikke uploades';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Velkomstskærmen er fjernet';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Ingen tilpasset velkomstskærm';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardwareacceleration';
@@ -6996,120 +6984,118 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Aktiver hardwareafkodning for:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-enhed';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Aktivér forbedret NVDEC-dekoder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Foretræk systemets oprindelige hardwaredekoder';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Farvedybde ved hardwaredekodning';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC-dekodning';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9-dekodning';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bit-dekodning';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit-dekodning';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardwarekodning';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Tillad HEVC-kodning';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Tillad AV1-kodning';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktivér Intels strømbesparende H.264-encoder';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktivér Intels strømbesparende HEVC-encoder';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktivér tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Aktivér VPP-tone mapping';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktivér VideoToolbox-tone mapping';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritme til tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Tilstand for tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Område for tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Afmætning ved tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Spidsværdi for tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter for tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Lysstyrke for VPP-tone mapping';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast for VPP-tone mapping';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Forudindstillinger og kvalitet';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Forudindstilling for encoder';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF for H.264-kodning';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF for H.265-kodning (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Deinterlacing-metode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Fordobl billedhastigheden ved deinterlacing';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Lyd';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktivér VBR-kodning af lyd';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Forstærkning ved downmix af lyd';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritme til stereo-downmix';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Maksimal størrelse på muxing-kø';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7235,7 +7221,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Kørende opgaver';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Løbe';
@@ -7305,8 +7291,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count timer',
-      one: '1 time',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7357,7 +7343,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '${hours}t';
+    return '${hours}h';
   }
 
   @override
@@ -7367,7 +7353,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7387,43 +7373,43 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Offentlig HTTP-port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Kræv HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Omdiriger alle fjernforespørgsler til HTTPS. Har ingen effekt, hvis serveren ikke har et gyldigt certifikat.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Adgangskode til certifikat';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-indstillinger';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktivér IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktivér IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'Aktivér automatisk portmapping';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-netværk';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Liste over IP-adresser eller CIDR-undernet, adskilt med komma eller linjeskift, som behandles som en del af det lokale netværk.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publicerede server-URI\'er';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Tilknyt et undernet eller en adresse til en publiceret URL, f.eks. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Certifikatsti';
@@ -7453,12 +7439,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Gasspjældbuffring';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Forsinkelse for throttling (sekunder)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Tillad udtrækning af undertekster undervejs';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimum cv-procent';
@@ -7516,11 +7501,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Tærskel for langsom respons (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktivér advarsler om langsomme svar';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktivér Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7529,10 +7513,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Stier';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Ydeevne';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cache-sti';
@@ -7544,7 +7528,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminGeneralServerName => 'Servernavn';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Foretrukket visningssprog';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Indstillingerne kunne ikke indlæses';
@@ -7596,8 +7580,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# deltagere',
-      one: '# deltager',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7744,8 +7728,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rækker fundet',
-      one: '# række fundet',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7786,21 +7770,20 @@ class AppLocalizationsDa extends AppLocalizations {
   String get offlineSavedMedia => 'Gemte medier';
 
   @override
-  String get offlineBannerTitle => 'Du er offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Viser dine downloads';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
   String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Kan ikke få forbindelse til din server';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Afspiller fra downloads, indtil den er tilbage';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7873,10 +7856,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get pinForgot => 'Har du glemt PIN-koden?';
 
   @override
-  String get pinClear => 'Ryd';
+  String get pinClear => 'Klar';
 
   @override
-  String get pinBackspace => 'Tilbagetast';
+  String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized => 'Quick Connect-anmodning godkendt.';
@@ -7907,7 +7890,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect mislykkedes: $message';
+    return 'Hurtig forbindelse mislykkedes: $message';
   }
 
   @override
@@ -8134,7 +8117,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Tillad rotation';
 
   @override
-  String get playerTooltipPrevious => 'Forrige';
+  String get playerTooltipPrevious => 'Tidligere';
 
   @override
   String get playerTooltipSeekBack => 'Søg tilbage';
@@ -8159,13 +8142,13 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Skjul fra Fortsæt med at se';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Skjul fra Næste op';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Tilføj til samling';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8220,15 +8203,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetisk';
 
   @override
-  String get settingsConnectionSection => 'FORBINDELSE';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Tillad selvsignerede certifikater';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Stol på servere, der bruger selvsignerede TLS-certifikater eller certifikater fra en privat CA. Aktivér kun for servere, du selv kontrollerer. Dette deaktiverer certifikatvalidering for alle forbindelser.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'FORTROLIGHED OG SIKKERHED';
@@ -8244,11 +8226,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Temaaccenter, baggrunde, sete indikatorer og temamusik';
 
   @override
-  String get settingsDetailsScreen => 'Detaljeskærm';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, baggrundssløring og faneadfærd';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Hjemmeside';
@@ -8286,11 +8268,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Vis Seerr-knappen i navigationslinjen';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vis altid tekstetiketter i den øverste navigationslinje';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8336,7 +8318,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Maksimalt antal elementer at downloade på én gang.';
 
   @override
-  String get settingsAppInfo => 'APPOPLYSNINGER';
+  String get settingsAppInfo => 'APP INFO';
 
   @override
   String get settingsReportAnIssue => 'Rapporter et problem';
@@ -8361,7 +8343,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Doner en kop kaffe til udvikleren';
 
   @override
-  String get settingsLegal => 'JURIDISK';
+  String get settingsLegal => 'LEGAL';
 
   @override
   String get settingsLicenses => 'Licenser';
@@ -8392,8 +8374,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licensmeddelelser',
-      one: '# licensmeddelelse',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8442,16 +8424,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Springe introer og outros over?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Nedtælling for mediesegment';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Statuslinje';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ingen';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Spørg bruger';
@@ -8475,7 +8457,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Hvordan video skal skaleres, så den passer til skærmen.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv => 'Afspilningsmotor (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8485,7 +8467,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (anbefales)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (ældre)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (forældet)';
@@ -8494,7 +8476,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsPlaybackEngineMpvRecommended => 'mpv (anbefales)';
 
   @override
-  String get settingsDolbyVisionFallback => 'Dolby Vision-reserve';
+  String get settingsDolbyVisionFallback => 'Dolby Vision Fallback';
 
   @override
   String get settingsDolbyVisionFallbackDescription =>
@@ -8680,7 +8662,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nyligt udgivet i $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8712,11 +8694,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Tving ikke-tunneleret afspilning. Nyttig på enheder med tunnellyd/video-afbrydelser.';
 
   @override
-  String get enableTunnelingTitle => 'Aktivér tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avanceret. Sender lyd og video gennem en koblet hardwaresti. Slået fra som standard, fordi det giver udfald i lyd og video på nogle enheder.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Kort Dolby Vision profil 7 til HEVC';
@@ -8741,15 +8723,14 @@ class AppLocalizationsDa extends AppLocalizations {
       'Anvend tip til skriftstørrelse, der er indlejret i undertekstsporet. Deaktiver for at bruge undertekststørrelsen fra dine stilpræferencer.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Vis mediedetaljer';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Vis detaljer om det valgte emne øverst på bibliotekssider.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Skjul baggrundsbilleder, mens du browser?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Brug detaljerede underoverskrifter';
@@ -8767,37 +8748,37 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Temabutik';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Gennemse og gem temaer fra fællesskabet';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Gem et tema for at bruge det ligesom dine andre gemte temaer.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Der er ingen temaer tilgængelige lige nu.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Temabutikken kunne ikke indlæses. Tjek din forbindelse, og prøv igen.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Gem';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Gem og anvend';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Gemt';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Dette tema kunne ikke indlæses.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" er gemt.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8855,21 +8836,21 @@ class AppLocalizationsDa extends AppLocalizations {
   String get homeRowsSection => 'Hjemmerækker';
 
   @override
-  String get homeRowDisplay => 'Visning af rækker på startskærmen';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sektioner på startskærmen';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Til/fra for rækker på startskærmen';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Aktivér eller deaktivér biblioteksbaserede rækkekategorier på startskærmen';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktivér følgende kontakter for at vise rækkerne i startskærmens sektioner.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rækketype';
@@ -8927,35 +8908,34 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vis film, serier eller begge i genrerækker.';
 
   @override
-  String get displayPlaylistsRows => 'Vis afspilningslisterækker';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Vis afspilningslisterækker i startskærmens sektioner.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortering af afspilningslisterækker';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sortér afspilningslisterækker efter tilføjelsesdato, udgivelsesdato, alfabetisk og mere.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Vis lydrækker';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Vis lydrækker i startskærmens sektioner.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortering af lydrækker';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sortér lydrækker efter tilføjelsesdato, udgivelsesdato, alfabetisk og mere.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Lydafspilningslister';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Udseende';
@@ -8964,19 +8944,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastatur';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Knapper';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Gengivelse';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-konfiguration';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kortstørrelse';
@@ -8986,7 +8966,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Vælg en ekstern afspiller for at aktivere afspilning ved langt tryk';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9011,7 +8991,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get notSupportedOnThisDevice => 'Ikke understøttet på denne enhed';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD)-passthrough';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
@@ -9123,7 +9103,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get webDiagnosticsDefaultServerUrl => 'Standard server-URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL til discovery-proxy';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
   String get notConfigured => 'ikke konfigureret';
@@ -9167,7 +9147,7 @@ class AppLocalizationsDa extends AppLocalizations {
       'Eksempel på overskriftsstykke (nginx-stil)';
 
   @override
-  String get note => 'Bemærk';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
@@ -9248,10 +9228,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get guestAppearances => 'Gæsteoptræden';
 
   @override
-  String get appearancesSeerr => 'Optrædener (Seerr)';
+  String get appearancesSeerr => 'Optrædener (seer)';
 
   @override
-  String get crewContributionsSeerr => 'Crewets bidrag (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Se med gruppen';
@@ -9336,8 +9316,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count biblioteker',
-      one: '1 bibliotek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9369,7 +9349,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Logfiler';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
@@ -9496,13 +9476,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get loadingShuffle => 'Indlæser shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'BLAND BIBLIOTEK';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'BLAND TILFÆLDIGT';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'BLAND GENRER';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automatisk HDR-skift';
@@ -9515,73 +9495,73 @@ class AppLocalizationsDa extends AppLocalizations {
   String get whenFullscreen => 'Når fuldskærm';
 
   @override
-  String get changeArtwork => 'Skift grafik';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Mangler';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Omkodningsgrænser';
 
   @override
-  String get clearAllArtworkButton => 'Ryd al grafik?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Er du sikker på, at du vil rydde al downloadet grafik?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Bekræft rydning';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Er du sikker på, at du vil rydde dette billede ($itemType)?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
   String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Opløsning: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Vis kun grafik på grænsefladens sprog';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Bekræft rydning af alt';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Billedet blev uploadet!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Billedet kunne ikke uploades: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Billedet kunne ikke anvendes: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Billedet kunne ikke slettes: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Al grafik kunne ikke ryddes: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Baggrundsbilleder';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9590,31 +9570,31 @@ class AppLocalizationsDa extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniature';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafik';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Diskgrafik';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Skærmbillede';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Coverforside';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Coverbagside';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menugrafik';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'baggrundsbillede';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9623,114 +9603,114 @@ class AppLocalizationsDa extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniature';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafik';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'diskgrafik';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'skærmbillede';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'coverforside';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'coverbagside';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menugrafik';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alle';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Høj (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Mellem (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Lav (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Kilder';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitler';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Bogmærker';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Noter';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Kø';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Tidslinje';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Tidslinjen er tom';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Hele bogen';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokuseret tidslinje';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksportér bogmærker';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksportér noter';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksportér alt';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksporteret til $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksport mislykkedes: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Sangtekster';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Tilføj bogmærke';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Tilføj note';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Redigér note';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Skriv en note til dette tidspunkt';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Sleep-timer';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Fra';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Slut på kapitlet';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Tilpasset';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining tilbage';
+    return '$remaining left';
   }
 
   @override
@@ -9745,51 +9725,51 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Afspilningshastighed';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Tilbage';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Forløbet';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Tilbage ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Frem ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Forrige kapitel';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Næste kapitel';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitel $current af $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Ingen kapitler';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Ingen bogmærker endnu';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Ingen noter endnu';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Bogmærke tilføjet ved $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Nulstil til 1,0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9797,253 +9777,249 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Gem';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Annullér';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Slet';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Undertekstindstillinger';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Skift underteksttilstande, standardsprog, udseende og gengivelsesindstillinger.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Gengivelse af undertekster';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Visningsindstillinger';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Udgivelsesdato (stigende)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Udgivelsesdato (faldende)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Gruppér bidrag';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Gruppér flere roller';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Advarsel om skriveadgang til bibliotek';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Sådan løser du det:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Giv Jellyfin-tjenestens bruger (f.eks. jellyfin eller Docker PUID/PGID) skriverettigheder til dine mediebiblioteksmapper på serveren.\n\n2. Eller gå til dit Jellyfin-kontrolpanel -> Biblioteker, redigér dette bibliotek, og slå \'Gem grafik i mediemapperne\' fra for at gemme grafikken i Jellyfins interne database.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Afvis';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Dit bibliotek \'$libraryName\' er indstillet til at gemme grafik direkte i mediemapperne (\'Gem grafik i mediemapperne\' er slået til). Jellyfin har dog testet skriveadgangen og har ikke tilladelse til at skrive filer til denne mappe:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Det ser ud til, at Jellyfin ikke kunne opdatere grafikken. Dit bibliotek er indstillet til at gemme grafik direkte i mediemapperne (\'Gem grafik i mediemapperne\' er slået til). Denne fejl opstår typisk, når Jellyfin-serverprocessen ikke har tilladelse til at skrive filer til dine mediemapper.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Eksterne lister';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Afspil igen';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Filoplysninger';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Størrelse: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Vis alle ($count) lydspor';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Vis alle ($count) undertekstspor';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Kontrollerer Direct Play-understøttelse...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play-understøttelse: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Tvungen';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Containerformatet understøttes ikke af afspilleren.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Videocodec understøttes ikke.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Lydcodec understøttes ikke.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Undertekstformatet understøttes ikke (kræver indbrænding).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Lydprofilen understøttes ikke.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Videoprofilen understøttes ikke.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Videoniveauet understøttes ikke.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Videoopløsningen understøttes ikke af denne enhed.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Videoens bitdybde understøttes ikke.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Videoens billedhastighed understøttes ikke.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Filens bitrate overskrider afspillerens streaminggrænse.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Videoens bitrate overskrider streaminggrænsen.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Lydens bitrate overskrider streaminggrænsen.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Antallet af lydkanaler understøttes ikke.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetisk';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Udgivelsesrækkefølge (stigende)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Udgivelsesrækkefølge (faldende)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Tilpasset (træk og slip)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Sorteringsindstillinger for afspilningsliste';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Nulstil sortering';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Se S$season:E$episode igen';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Se afspilningslisten igen';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Der blev ikke fundet nogen undertekster.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administratorkontroller';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Gengivelsesmotor (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller er Flutters moderne GPU-renderer, der giver jævnere animationer og mindre hakken. På nogle TV-bokse og ældre GPU\'er kan den give grafikfejl eller sort video; slå den fra, hvis du oplever det. Automatisk vælger den bedste standardindstilling til din enhed. Genstart Moonfin for at anvende ændringen.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatisk';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Til';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Fra';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Genstart påkrævet';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin skal genstartes for at skifte gengivelsesmotor. Luk appen nu, og åbn den igen for at anvende ændringen.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Luk appen nu';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Opdatér bibliotek';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Opdatér alle biblioteker';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Tilføjelsesdato (ældste først)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Tilføjelsesdato (nyeste først)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetisk (A til Å)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetisk (Å til A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Indlæser serveranalyse... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Match kilden';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250-film';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250-serier';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Mest populære film på IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Mest populære serier på IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Lavest bedømte film på IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Bedst bedømte engelsksprogede film på IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -141,14 +141,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsAppearanceTheme => 'App-Theme';
 
   @override
-  String get detailScreenStyle => 'Stil der Detailseite';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '„Klassisch“ ist das ursprüngliche zentrierte Moonfin-Layout. „Modern“ ist ein responsives, filmisches Layout.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassisch';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
@@ -165,17 +165,17 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Codec-, Auflösungs- und Stream-Informationen in der Banner-Zusammenfassung anzeigen';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Empfehlungssystem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Den lokalen Bibliotheksalgorithmus „Moonfin empfiehlt“ oder die Online-Ähnlichkeitsmetriken von TMDb verwenden. Hinweis: Online-Empfehlungen erfordern die Seerr-Integration.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin empfiehlt';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
   String get recommendationSystemTmdb => 'TMDb-Ähnlichkeit';
@@ -186,7 +186,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Vorschläge von „Moonfin empfiehlt“ nach Altersfreigabe der Zielmedien begrenzen';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
   String get interfaceStyle => 'Oberflächen-Stil';
@@ -205,20 +205,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glass-Qualität';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '„Automatisch“ wählt den besten Glass-Effekt für dieses Gerät. „Voll“ erzwingt echte Unschärfe, „Reduziert“ nutzt ein leichtgewichtiges Glass, das GPU-Leistung spart.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automatisch';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Voll';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reduziert';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
@@ -229,7 +229,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get customThemeSubtitle =>
-      'Benutzerdefinierte Themes verändern visuelle Elemente in ganz Moonfin. Wählen Sie eine dieser Optionen passend zu Ihrem Stil.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Bevorzugen der Systemtastatur';
@@ -263,7 +263,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro-Pixelart-Stil mit kräftiger Palette, klobigen Rändern, harten Schlagschatten und Pixelschrift';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,36 +327,35 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exit => 'Beenden';
 
   @override
-  String get gameMenu => 'Menü';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pausiert';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Spielstand speichern';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Spiele';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Spielstand laden';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Schnellvorlauf';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulator-Einstellungen';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Dieser Core bietet keine einstellbaren Optionen.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Zum Öffnen des Menüs gedrückt halten';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spiele werden auf diesem Gerät noch nicht unterstützt.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -373,7 +372,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get guide => 'TV-Programminfo';
 
   @override
-  String get recordings => 'Aufnahmen';
+  String get recordings => 'TV-Aufnahmen';
 
   @override
   String get schedule => 'TV-Zeitplan';
@@ -795,13 +794,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get readStatus => 'Gelesen';
 
   @override
-  String get watched => 'Gesehen';
+  String get watched => 'Angesehen';
 
   @override
   String get unread => 'Ungelesen';
 
   @override
-  String get unwatched => 'Ungesehen';
+  String get unwatched => 'Nicht angesehen';
 
   @override
   String get seriesStatus => 'Serienstatus';
@@ -813,43 +812,43 @@ class AppLocalizationsDe extends AppLocalizations {
   String get books => 'Bücher';
 
   @override
-  String get latestBooks => 'Neueste Bücher';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Neueste Hörbücher';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bücher',
-      one: '1 Buch',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Buch';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Hörbuch';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% gelesen';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Noch $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lesen';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Anhören';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -1062,16 +1061,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get items => 'Inhalte';
+  String get items => 'Items';
 
   @override
   String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Hinter den Kulissen';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Gelöschte Szenen';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
@@ -1080,17 +1079,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Szenen';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kurzfilme';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailer';
+  String get trailers => 'Anhänger';
 
   @override
   String timeRemaining(String time) {
-    return 'Noch $time';
+    return '$time remaining';
   }
 
   @override
@@ -1137,7 +1136,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get version => 'Version';
 
   @override
-  String get cast => 'Übertragen';
+  String get cast => 'Abspielen auf';
 
   @override
   String get trailer => 'Trailer';
@@ -1415,17 +1414,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get readMore => 'Mehr anzeigen';
 
   @override
-  String get shuffle => 'Zufallswiedergabe';
+  String get shuffle => 'Durchmischte Wiedergabe';
 
   @override
-  String get shuffleAllMusic => 'Alle Musik zufällig abspielen';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt =>
-      'Melden Sie sich auf Ihrem Telefon bei Moonfin an';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Server nicht erreichbar';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1872,22 +1870,22 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Danach: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Noch $minutes Min.';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Noch $hours Std.';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Noch $hours Std. $minutes Min.';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -2091,7 +2089,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes Min.';
+    return '$minutes min';
   }
 
   @override
@@ -2139,8 +2137,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Episoden',
-      one: '1 Episode',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2367,7 +2365,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detailseiten, Startseiten-Zeilen und Lautstärke';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2382,11 +2380,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Beim Durchstöbern der Startseite abspielen';
 
   @override
-  String get loopThemeMusic => 'Titelmusik wiederholen';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Den Titel wiederholen, statt ihn nur einmal abzuspielen';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detail-Hintergrundunschärfe';
@@ -2409,23 +2407,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get playerZoomMode => 'Player-Zoommodus';
 
   @override
-  String get settingsScrollWheelAction => 'Mausrad';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Legen Sie fest, was das Scrollen mit dem Mausrad über dem Video während der Wiedergabe bewirkt.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Aus';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Spulen (vor / zurück)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Lautstärke';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Lautstärke';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Einpassen';
@@ -2479,37 +2477,37 @@ class AppLocalizationsDe extends AppLocalizations {
   String get defaultAudioLanguage => 'Standard-Audiosprache';
 
   @override
-  String get fallbackAudioLanguage => 'Fallback-Audiosprache';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Standard-Audiospur bevorzugen';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Die Original-Audiospur der synchronisierten Fassung vorziehen.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Audiodeskriptions-Spuren bevorzugen';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Audiodeskriptions-Spuren gegenüber normalen Spuren bevorzugen.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodierung (Audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
   String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodierung (Bitrate oder Auflösung)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodierung (Video & Audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodierung (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatisch (Serverstandard)';
@@ -2590,7 +2588,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Legen Sie fest, wie Audio dekodiert wird. AVR-Passthrough sendet rohe Dolby-/DTS-Streams an Ihren Receiver; „Automatisch“ oder „Downmix“ dekodiert lokal.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR-Passthrough';
@@ -2600,14 +2598,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Wählen Sie das Zielformat für die Transkodierung von Mehrkanal-Audio, wenn der Quellstream nicht direkt abgespielt oder durchgeleitet werden kann.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automatisch erkennen\n(Empfohlen)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Standard)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2616,27 +2613,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Verlustfrei)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Nur Stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Effizient)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Verlustfrei)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maximale Audiokanäle';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Konfigurieren Sie die maximale Kanalzahl Ihres Audio-Setups. Mehrkanal-Streams über diesem Limit werden heruntergemischt oder transkodiert.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automatisch erkennen\n(Hardware-Standard)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2648,7 +2644,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrofonie';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2741,7 +2737,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Lautsprecher';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kopfhörer';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2921,45 +2917,45 @@ class AppLocalizationsDe extends AppLocalizations {
       'Passen Sie das Erscheinungsbild der Untertitel an';
 
   @override
-  String get subtitleMode => 'Untertitelmodus';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Markiert';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Immer';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Fremdsprachig';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Erzwungen';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Spielt Spuren ab, die in den Metadaten der Mediendatei intern als „default“ oder „forced“ markiert sind.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Lädt und zeigt bei jedem Videostart automatisch Untertitel an.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Schaltet Untertitel automatisch ein, wenn die Standard-Audiospur fremdsprachig ist.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Lädt nur Untertitel, die ausdrücklich mit dem Flag „forced“ gekennzeichnet sind.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Deaktiviert das automatische Laden von Untertiteln vollständig.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Fallback-Untertitelsprache';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Untertitelspur';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3165,11 +3161,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bibliotheken in der Symbolleiste anzeigen';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Beschriftungen der Navigationsleiste immer anzeigen';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr-Schaltfläche anzeigen';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navigationsleisten-Transparenz';
@@ -3244,19 +3239,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showFolderBrowsingOption => 'Ordner-Durchsuchen-Option anzeigen';
 
   @override
-  String get groupItemsIntoCollections => 'Inhalte in Sammlungen gruppieren';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Zu Sammlungen gehörende Bibliothekselemente beim Durchsuchen von Bibliotheken ausblenden';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Hinweis zur Bibliotheksgruppierung';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Um diese Einstellung zu nutzen, stellen Sie sicher, dass die Bibliothekseinstellungen „Filme in Sammlungen gruppieren“ und/oder „Serien in Sammlungen gruppieren“ in den Anzeigeeinstellungen Ihrer Bibliothek auf Ihrem Jellyfin- oder Emby-Server aktiviert sind.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliothekssichtbarkeit';
@@ -3315,7 +3309,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wählen Sie zwischen verschiedenen Stilen für die Medienleiste oder schalten Sie die Medienleiste aus';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Mondflosse';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3370,11 +3364,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Trailer in der Medienleiste nach 3 Sekunden automatisch abspielen';
 
   @override
-  String get trailerAudio => 'Trailer-Audio';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Ton für Trailer in der Medienleiste aktivieren';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Episodenvorschau';
@@ -3452,11 +3445,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Beide Reihen in einen Startseitenbereich zusammenführen';
 
   @override
-  String get fullScreenRows => 'Erweiterte Startseiten-Zeilen';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Startseite auf eine Zeile pro Bildschirm begrenzen';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Bildtyp pro Reihe';
@@ -3471,7 +3463,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lastUser => 'Letzter Benutzer';
 
   @override
-  String get currentUser => 'Aktueller Benutzer';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Immer authentifizieren';
@@ -3549,7 +3541,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes Min.';
+    return '$minutes min';
   }
 
   @override
@@ -3580,10 +3572,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Uhr während des Bildschirmschoners anzeigen';
 
   @override
-  String get clockModeStatic => 'Statisch';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Springend';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritiker)';
@@ -3657,7 +3649,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bewertungsquellen aktivieren und neu anordnen, die in der App angezeigt werden';
 
   @override
-  String get pluginLabel => 'Moonbase-Plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin erkannt';
@@ -3729,7 +3721,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get networks => 'Netzwerke';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-Entdeckungszeilen';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Reihen auf Standard zurücksetzen';
@@ -3753,29 +3745,28 @@ class AppLocalizationsDe extends AppLocalizations {
       'Inhalte für Erwachsene in Ergebnissen ausblenden';
 
   @override
-  String get seerrNotificationsSection => 'Benachrichtigungen';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Benachrichtigungen zu neuen Anfragen';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Benachrichtigen, wenn jemand eine Anfrage stellt';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Anfrage-Updates';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Genehmigt, abgelehnt und zur Bibliothek hinzugefügt';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Problem-Updates';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Neue Probleme, Antworten und Lösungen';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3783,15 +3774,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr-Entdecken-Seite';
+  String get discoverRows => 'Entdecken-Reihen';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktiviere die Reihen, die auf der Seerr-Hauptseite erscheinen sollen. Zum Neuordnen ziehen. Die eigene Reihenfolge wird mit Moonbase synchronisiert.';
+      'Zum Neuordnen ziehen. Reihen aktivieren oder deaktivieren. Die Reihenfolge wird mit dem Moonfin-Plugin synchronisiert.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktiviere die Reihen, die auf der Seerr-Hauptseite erscheinen sollen. Zum Neuordnen ziehen. Die eigene Reihenfolge wird mit Moonbase synchronisiert.';
+      'Zum Neuordnen ziehen. Reihen aktivieren oder deaktivieren.';
 
   @override
   String get enabled => 'Aktiviert';
@@ -3948,11 +3939,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Wird heruntergeladen · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Wird importiert';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -4094,102 +4085,102 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deletedStatus => 'Gelöscht';
 
   @override
-  String get failedStatus => 'Fehlgeschlagen';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'In Bearbeitung';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Geändert von $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Abgeschlossen';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Dieser Titel wurde bereits angefragt';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Anfragelimit erreicht';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Dieser Titel steht auf der Sperrliste';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Keine Staffeln mehr zum Anfragen übrig';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Sie haben keine Berechtigung für diese Anfrage';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Anfragen';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Probleme';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Neueste';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Zuletzt geändert';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Keine Probleme';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Noch $remaining von $limit Filmanfragen übrig';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Noch $remaining von $limit Staffelanfragen übrig';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Teil von $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Sammlung anzeigen';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Sammlung anfragen';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total Filme · $available verfügbar';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count Filme anfragen';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Anfrage $current von $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count Filme angefragt';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok von $total Filmen angefragt';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alle Filme sind bereits verfügbar oder angefragt';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Problem melden';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4198,44 +4189,44 @@ class AppLocalizationsDe extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Was ist das Problem?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alle Episoden';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Offen';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Gelöst';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Lösen';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Wieder öffnen';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Gemeldet von $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count Kommentare';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Kommentar hinzufügen';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Dieses Problem löschen?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Meldung absenden';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-Score';
@@ -4259,7 +4250,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get originalLanguageLabel => 'Originalsprache';
 
   @override
-  String get seasonsLabel => 'Staffeln';
+  String get seasonsLabel => 'Jahreszeiten';
 
   @override
   String get episodesLabel => 'Episoden';
@@ -4370,7 +4361,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get run => 'Ausführen';
 
   @override
-  String get search => 'Suchen';
+  String get search => 'Suche';
 
   @override
   String get select => 'Auswählen';
@@ -4397,7 +4388,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get time => 'Zeit';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trickspiel';
 
   @override
   String get uninstall => 'Deinstallieren';
@@ -4439,13 +4430,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotheken';
 
   @override
-  String get adminDrawerDisplay => 'Anzeige';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadaten';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-Einstellungen';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodierung';
@@ -4457,7 +4448,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminDrawerStreaming => 'Studios';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trickspiel';
 
   @override
   String get adminDrawerDevices => 'Geräte';
@@ -4675,10 +4666,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminClearDates => 'Daten löschen';
 
   @override
-  String get adminActivitySeverityAll => 'Alle Schweregrade';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Zeitraum';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4715,23 +4706,23 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Gerät „$name“ entfernen? Der Benutzer muss sich auf diesem Gerät erneut anmelden.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Alle Geräte löschen';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count Geräte entfernen? Betroffene Benutzer müssen sich erneut anmelden. Ihr aktuelles Gerät ist nicht betroffen.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Geräte entfernt';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Einige Geräte wurden entfernt; $count konnten nicht entfernt werden.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4847,252 +4838,244 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminMetadataCountryHint => 'z. B. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Pfade';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Optionen';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Downloader';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadaten-Speicherer';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Untertitel-Downloader';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Liedtext-Downloader';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadaten-Downloader: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Bildquellen: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Dieser Server bietet keine Downloader für diesen Bibliothekstyp.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Allgemein';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadaten';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Eingebettete Informationen';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Untertitel';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Bilder';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serien';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musik';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filme';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Echtzeitüberwachung aktivieren';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Dateiänderungen erkennen und automatisch verarbeiten.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Archive als Mediendateien behandeln';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Fotos anzeigen';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Bildmaterial in Medienordnern speichern';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatische Metadatenaktualisierung';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nie';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Standard';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Anzeige';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotheksanzeige';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Ordneransicht anzeigen, um einfache Medienordner darzustellen';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Specials in den Staffeln anzeigen, in denen sie ausgestrahlt wurden';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Filme in Sammlungen gruppieren';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Serien in Sammlungen gruppieren';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Externe Inhalte in Vorschlägen anzeigen';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Verhalten für Hinzufügedatum';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Hinzufügedatum verwenden von';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Datum des Scans in die Bibliothek';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Erstellungsdatum der Datei';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadaten und Bilder';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Bevorzugte Metadatensprache';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitel';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Dauer von Platzhalter-Kapiteln (Sekunden)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Länge der Kapitel, die für Medien ohne Kapitel erzeugt werden. 0 deaktiviert die Funktion.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Auflösung der Kapitelbilder';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-Einstellungen';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-Metadaten sind mit Kodi und ähnlichen Clients kompatibel. Die Einstellungen gelten für alle Bibliotheken, die NFO-Metadaten speichern.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Benutzer, dessen Wiedergabedaten in NFO-Dateien gespeichert werden';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Bildpfade in NFO-Dateien speichern';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Pfadersetzung für NFO-Bildpfade aktivieren';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Extrafanart-Bilder in einen Extrathumbs-Ordner kopieren';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Keine';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days Tage';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Eingebettete Titel verwenden';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Eingebettete Titel für Extras verwenden';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Eingebettete Episodeninformationen verwenden';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Eingebettete Untertitel zulassen';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Alle zulassen';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Nur Text';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Nur Bild';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Keine';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Download überspringen, wenn eingebettete Untertitel vorhanden sind';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Download überspringen, wenn die Audiospur der Download-Sprache entspricht';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Exakte Untertitel-Übereinstimmung verlangen';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Untertitel in Medienordnern speichern';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Kapitelbilder extrahieren';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Kapitelbilder während des Bibliotheksscans extrahieren';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay-Bildextraktion aktivieren';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Trickplay-Bilder während des Bibliotheksscans extrahieren';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay-Bilder in Medienordnern speichern';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Serien automatisch zusammenführen, die über mehrere Ordner verteilt sind';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Anzeigename für Staffel 0';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'LUFS-Scan für Audionormalisierung aktivieren';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Nicht-standardmäßigen Interpreten-Tag bevorzugen';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Filme automatisch zu Sammlungen hinzufügen';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Bibliotheksname ist erforderlich';
@@ -5331,145 +5314,143 @@ class AppLocalizationsDe extends AppLocalizations {
       'Ermöglichen Sie den Zugriff auf alle Kanäle';
 
   @override
-  String get adminParentalControl => 'Jugendschutz';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Maximal erlaubte Altersfreigabe';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Inhalte mit einer höheren Freigabe werden für diesen Benutzer ausgeblendet.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Keine';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Inhalte ohne oder mit unbekannter Altersfreigabe blockieren';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Bücher';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanäle';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Live-TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filme';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musik';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailer';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serien';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Zugriffszeiten';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Zugriff nur während der unten festgelegten Zeiten erlauben. Ohne Zeitplan ist der Zugriff ganztägig erlaubt.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Zeitplan hinzufügen';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Tag';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Beginn';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Ende';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Täglich';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Wochentag';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Wochenende';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Sonntag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Montag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Dienstag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Mittwoch';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Donnerstag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Freitag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Samstag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Erlaubte Tags';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Nur Inhalte mit diesen Tags werden angezeigt. Leer lassen, um alle zuzulassen.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blockierte Tags';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Inhalte mit diesen Tags werden für diesen Benutzer ausgeblendet.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Tag hinzufügen';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Aktivierte Geräte';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Aktivierte Kanäle';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Authentifizierungsanbieter';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Anbieter zum Zurücksetzen des Passworts';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maximale Fehlversuche bis zur Sperrung';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      '0 für den Standardwert, -1 deaktiviert die Sperrung.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-Zugriff';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Erstellen von und Beitreten zu Gruppen erlauben';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Beitreten zu Gruppen erlauben';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Kein Zugriff';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Löschen von Inhalten erlauben aus';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5558,26 +5539,25 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Backup erstellen';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Wählen Sie aus, was in das Backup aufgenommen werden soll.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Datenbank';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Immer enthalten';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadaten';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Untertitel';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-Bilder';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Backup wird erstellt...';
@@ -6291,61 +6271,60 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminAddTuner => 'Tuner hinzufügen';
 
   @override
-  String get adminEditTuner => 'Tuner bearbeiten';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-Tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Datei oder URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-Adresse des Tuners';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Anzeigename';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'User-Agent';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limit gleichzeitiger Verbindungen';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Die maximale Anzahl an Streams, die der Tuner gleichzeitig zulässt. 0 bedeutet unbegrenzt.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Maximale Fallback-Streaming-Bitrate';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Nur Favoriten-Kanäle importieren';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Hardware-Transkodierung erlauben';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4-Transkodierungscontainer erlauben';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Stream-Sharing erlauben';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Stream-Schleife aktivieren';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS ignorieren';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Eingabe mit nativer Bildrate lesen';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Anbieter bearbeiten';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6354,50 +6333,50 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Datei oder URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Film-Präfix';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Film-Kategorien';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Mehrere Kategorien mit einem senkrechten Strich trennen.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kinder-Kategorien';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nachrichten-Kategorien';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sport-Kategorien';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Benutzername';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Passwort';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Land auswählen';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postleitzahl';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Programmlisten abrufen';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programmlisten';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Alle Tuner aktivieren';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuner-Typ';
@@ -6439,7 +6418,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Dieser Tuner-Typ unterstützt kein Zurücksetzen.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6462,45 +6441,43 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serienaufnahmepfad';
 
   @override
-  String get adminMovieRecordingPath => 'Aufnahmepfad für Filme';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Tage mit Programmdaten';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatisch';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days Tage';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Pfad zur Nachbearbeitungsanwendung';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumente für die Nachbearbeitung';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'NFO-Metadaten für Aufnahmen speichern';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Bilder für Aufnahmen speichern';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Zeitsteuerung';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Aufnahmepfade';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Nachbearbeitung';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Programmdaten: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6543,15 +6520,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminGuideProviders => 'Programmführer-Anbieter';
 
   @override
-  String get adminRefreshGuideData => 'Programmdaten aktualisieren';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Aktualisierung der Programmdaten gestartet';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Die Aufgabe zum Aktualisieren der Programmdaten ist auf diesem Server nicht verfügbar.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Anbieter hinzufügen';
@@ -6685,7 +6661,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadaten-Editor';
 
   @override
-  String get adminMetadataIdentify => 'Identifizieren';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Typ';
@@ -7099,21 +7075,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Startbildschirm aktivieren';
 
   @override
-  String get adminBrandingSplashUpload => 'Bild hochladen';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Startbildschirm aktualisiert';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Startbildschirm konnte nicht hochgeladen werden';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Startbildschirm entfernt';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash =>
-      'Kein benutzerdefinierter Startbildschirm';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardwarebeschleunigung';
@@ -7129,125 +7103,121 @@ class AppLocalizationsDe extends AppLocalizations {
       'Hardwaredekodierung aktivieren für:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-Gerät';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Erweiterten NVDEC-Decoder aktivieren';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Systemeigenen Hardware-Decoder bevorzugen';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Farbtiefe der Hardware-Dekodierung';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-Bit-HEVC-Dekodierung';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-Bit-VP9-Dekodierung';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC-RExt-8/10-Bit-Dekodierung';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC-RExt-12-Bit-Dekodierung';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardware-Kodierung';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC-Kodierung erlauben';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1-Kodierung erlauben';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel-Low-Power-H.264-Encoder aktivieren';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel-Low-Power-HEVC-Encoder aktivieren';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone-Mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Tone-Mapping aktivieren';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP-Tone-Mapping aktivieren';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox-Tone-Mapping aktivieren';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Tone-Mapping-Algorithmus';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Tone-Mapping-Modus';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Tone-Mapping-Bereich';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Tone-Mapping-Entsättigung';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Tone-Mapping-Spitzenwert';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Tone-Mapping-Parameter';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP-Tone-Mapping-Helligkeit';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP-Tone-Mapping-Kontrast';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Presets & Qualität';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Encoder-Preset';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF für H.264-Kodierung';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF für H.265-(HEVC-)Kodierung';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Deinterlacing-Methode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Bildrate beim Deinterlacing verdoppeln';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'VBR-Audiokodierung aktivieren';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Audio-Downmix-Verstärkung';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Stereo-Downmix-Algorithmus';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maximale Muxing-Warteschlangengröße';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automatisch';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodierung';
@@ -7370,7 +7340,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminTaskStop => 'Stoppen';
 
   @override
-  String get adminRunningTasks => 'Laufende Aufgaben';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Ausführen';
@@ -7440,8 +7410,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Stunden',
-      one: '1 Stunde',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7502,7 +7472,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month.';
+    return '$month/$day';
   }
 
   @override
@@ -7522,44 +7492,43 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Öffentlicher HTTP-Port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS erforderlich';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Alle Remote-Anfragen auf HTTPS umleiten. Ohne gültiges Serverzertifikat wirkungslos.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Zertifikatspasswort';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-Einstellungen';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 aktivieren';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 aktivieren';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Automatisches Port-Mapping aktivieren';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-Netzwerke';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Durch Komma oder Zeilenumbruch getrennte Liste von IP-Adressen oder CIDR-Subnetzen, die als lokales Netzwerk gelten.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Veröffentlichte Server-URIs';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Ein Subnetz oder eine Adresse einer veröffentlichten URL zuordnen, z. B. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Zertifikatspfad';
@@ -7589,11 +7558,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Pufferung drosseln';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Drosselungsverzögerung (Sekunden)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Untertitel-Extraktion in Echtzeit erlauben';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Mindest-Fortsetzungsprozentsatz';
@@ -7650,23 +7619,22 @@ class AppLocalizationsDe extends AppLocalizations {
       'Schwellenwert für langsame Antwort (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Warnungen bei langsamen Antworten aktivieren';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect aktivieren';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadaten';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Pfade';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Leistung';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cache-Pfad';
@@ -7678,7 +7646,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminGeneralServerName => 'Servername';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Bevorzugte Anzeigesprache';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7731,8 +7699,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# Teilnehmer',
-      one: '# Teilnehmer',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7880,8 +7848,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# Zeilen gefunden',
-      one: '# Zeile gefunden',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7922,20 +7890,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get offlineSavedMedia => 'Gespeicherte Medien';
 
   @override
-  String get offlineBannerTitle => 'Du bist offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Deine Downloads werden angezeigt';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
   String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Server nicht erreichbar';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Wiedergabe aus Downloads, bis er wieder da ist';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8014,35 +7982,36 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pinBackspace => 'Rücktaste';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect-Anfrage autorisiert.';
+  String get quickConnectAuthorized =>
+      'Schnellverbindungs-Anfrage autorisiert.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect-Code ist ungültig oder abgelaufen.';
+      'Schnellverbindungs-Code ist ungültig oder abgelaufen.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect wird auf diesem Server nicht unterstützt.';
+      'Schnellverbindung wird auf diesem Server nicht unterstützt.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect-Code konnte nicht autorisiert werden.';
+      'Schnellverbindungs-Code konnte nicht autorisiert werden.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect ist auf diesem Server deaktiviert.';
+      'Schnellverbindung ist auf diesem Server deaktiviert.';
 
   @override
   String get quickConnectForbidden =>
-      'Dein Konto kann diese Quick Connect-Anfrage nicht autorisieren.';
+      'Dein Konto kann diese Schnellverbindungs-Anfrage nicht autorisieren.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect-Code wurde nicht gefunden. Versuche einen neuen Code.';
+      'Schnellverbindungs-Code wurde nicht gefunden. Versuche einen neuen Code.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect fehlgeschlagen: $message';
+    return 'Schnellverbindung fehlgeschlagen: $message';
   }
 
   @override
@@ -8275,7 +8244,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Drehung zulassen';
 
   @override
-  String get playerTooltipPrevious => 'Vorheriges';
+  String get playerTooltipPrevious => 'Vorherige';
 
   @override
   String get playerTooltipSeekBack => 'Zurückspulen';
@@ -8300,13 +8269,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Aus „Weiterschauen“ ausblenden';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Aus „Nächste Folge“ ausblenden';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Zu Sammlung hinzufügen';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8361,15 +8330,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsAlphabetical => 'Alphabetisch';
 
   @override
-  String get settingsConnectionSection => 'VERBINDUNG';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Selbstsignierte Zertifikate zulassen';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Servern mit selbstsignierten oder privaten CA-TLS-Zertifikaten vertrauen. Nur für Server aktivieren, die Sie selbst kontrollieren. Dies deaktiviert die Zertifikatsprüfung für alle Verbindungen.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'Privatsphäre und Sicherheit';
@@ -8385,11 +8353,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Themenakzente, Hintergründe, beobachtete Indikatoren und Themenmusik';
 
   @override
-  String get settingsDetailsScreen => 'Detailseite';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, Hintergrundunschärfe und Tab-Verhalten';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Startseite';
@@ -8427,11 +8395,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Seerr-Schaltfläche in der Navigationsleiste anzeigen';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Textbeschriftungen in der oberen Navigationsleiste immer anzeigen';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8535,8 +8503,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# Lizenzhinweise',
-      one: '# Lizenzhinweis',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8584,16 +8552,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros und Outros überspringen?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Countdown für Mediensegmente';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Fortschrittsbalken';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Keine';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Prompt-Benutzer';
@@ -8826,7 +8794,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Kürzlich erschienen: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8858,11 +8826,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Nicht getunnelte Wiedergabe erzwingen. Nützlich bei Geräten mit Tunnel-Audio-/Video-Diskontinuitäten.';
 
   @override
-  String get enableTunnelingTitle => 'Tunneling aktivieren';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Erweitert. Leitet Audio und Video über einen gekoppelten Hardware-Pfad. Standardmäßig aus, da es auf manchen Geräten zu Audio-/Videoaussetzern führt.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8889,15 +8857,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wenden Sie Hinweise zur Schriftgröße an, die in die Untertitelspur eingebettet sind. Deaktivieren Sie die Verwendung der Untertitelgröße aus Ihren Stileinstellungen.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mediendetails anzeigen';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Details des ausgewählten Elements oben auf Bibliotheksseiten anzeigen.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Hintergrundbilder beim Durchsuchen ausblenden?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings =>
@@ -8916,39 +8883,37 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme-Store';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Community-Themes durchstöbern und speichern';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Speichern Sie ein Theme, um es wie Ihre anderen gespeicherten Themes zu verwenden.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Derzeit sind keine Themes verfügbar.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Der Theme-Store konnte nicht geladen werden. Prüfen Sie Ihre Verbindung und versuchen Sie es erneut.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Speichern';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Speichern & anwenden';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Gespeichert';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage =>
-      'Dieses Theme konnte nicht geladen werden.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '„$themeName“ gespeichert.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -9007,21 +8972,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get homeRowsSection => 'Home-Reihen';
 
   @override
-  String get homeRowDisplay => 'Anzeige der Home-Zeilen';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Home-Zeilen-Abschnitte';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Home-Zeilen-Schalter';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Bibliotheksbasierte Kategorien der Home-Zeilen aktivieren oder deaktivieren';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktivieren Sie die folgenden Schalter, um die Zeilen in den Home-Abschnitten anzuzeigen.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Zeilentyp';
@@ -9080,38 +9045,37 @@ class AppLocalizationsDe extends AppLocalizations {
       'Zeigen Sie Filme, Serien oder beides in den Genrezeilen an.';
 
   @override
-  String get displayPlaylistsRows => 'Wiedergabelisten-Zeilen anzeigen';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Wiedergabelisten-Zeilen in Home-Abschnitten anzeigen.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortierung der Wiedergabelisten-Zeilen';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Wiedergabelisten-Zeilen nach Hinzufügungsdatum, Veröffentlichungsdatum, alphabetisch und mehr sortieren.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Audio-Zeilen anzeigen';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Audio-Zeilen in Home-Abschnitten anzeigen.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortierung der Audio-Zeilen';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Audio-Zeilen nach Hinzufügungsdatum, Veröffentlichungsdatum, alphabetisch und mehr sortieren.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Audio-Wiedergabelisten';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Erscheinungsbild';
+  String get appearance => 'Aussehen';
 
   @override
   String get layout => 'Layout';
@@ -9120,16 +9084,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastatur';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Schaltflächen';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-Konfiguration';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kartengröße';
@@ -9139,7 +9103,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Externen Player festlegen, um die Wiedergabe per langem Drücken zu aktivieren';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9407,7 +9371,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appearancesSeerr => 'Auftritte (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Crew-Beiträge (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Mit der Gruppe ansehen';
@@ -9493,8 +9457,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotheken',
-      one: '1 Bibliothek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9654,13 +9618,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loadingShuffle => 'Zufallswiedergabe wird geladen...';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTHEK MISCHEN';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ZUFÄLLIG MISCHEN';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'GENRES MISCHEN';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automatische HDR-Umschaltung';
@@ -9673,73 +9637,73 @@ class AppLocalizationsDe extends AppLocalizations {
   String get whenFullscreen => 'Im Vollbildmodus';
 
   @override
-  String get changeArtwork => 'Bildmaterial ändern';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Fehlt';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Transkodierungsgrenzen';
 
   @override
-  String get clearAllArtworkButton => 'Gesamtes Bildmaterial löschen?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Möchten Sie wirklich das gesamte heruntergeladene Bildmaterial löschen?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Löschen bestätigen';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Möchten Sie Folgendes wirklich löschen: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Hochladen?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Auflösung: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Nur Bildmaterial in der Oberflächensprache anzeigen';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Alles löschen bestätigen';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Bild erfolgreich hochgeladen!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Bild konnte nicht hochgeladen werden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Bild konnte nicht festgelegt werden: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Bild konnte nicht gelöscht werden: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Bildmaterial konnte nicht vollständig gelöscht werden: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Hintergrundbilder';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9748,147 +9712,147 @@ class AppLocalizationsDe extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Vorschaubild';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Artwork';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Disc-Artwork';
+  String get discArtCategory => 'Disc Art';
 
   @override
   String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Box-Cover';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Box-Rückseite';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menü-Artwork';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'Poster';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'Hintergrundbild';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'Banner';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'Logo';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'Vorschaubild';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'Artwork';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'Disc-Artwork';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'Screenshot';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'Box-Cover';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'Box-Rückseite';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'Menü-Artwork';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alle';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Hoch (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Mittel (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Niedrig (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Quellen';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitel';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Lesezeichen';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notizen';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Warteschlange';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Zeitleiste';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Zeitleiste ist leer';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Ganzes Buch';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokussierte Zeitleiste';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Lesezeichen exportieren';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Notizen exportieren';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Alle exportieren';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportiert nach $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Export fehlgeschlagen: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Liedtext';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Lesezeichen hinzufügen';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Notiz hinzufügen';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Notiz bearbeiten';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Notiz zu dieser Stelle schreiben';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Sleeptimer';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Aus';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Kapitelende';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Benutzerdefiniert';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Noch $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9896,58 +9860,58 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Min.',
-      one: '1 Min.',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Wiedergabegeschwindigkeit';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Verbleibend';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Vergangen';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds s zurück';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds s vor';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Vorheriges Kapitel';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Nächstes Kapitel';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitel $current von $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Keine Kapitel';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Noch keine Lesezeichen';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Noch keine Notizen';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Lesezeichen bei $position hinzugefügt';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Auf 1.0x zurücksetzen';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9955,253 +9919,249 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Speichern';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Abbrechen';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Löschen';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Untertitel-Einstellungen';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Untertitelmodi, Standardsprachen, Erscheinungsbild und Rendering-Optionen ändern.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Untertitel-Rendering';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Anzeigeoptionen';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Veröffentlichungsdatum (aufsteigend)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Veröffentlichungsdatum (absteigend)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Beiträge gruppieren';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Mehrere Rollen gruppieren';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Warnung: Schreibzugriff auf Bibliothek';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'So beheben Sie das Problem:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Erteilen Sie dem Jellyfin-Dienstbenutzer (z. B. jellyfin oder Docker PUID/PGID) Schreibrechte für die Ordner Ihrer Medienbibliothek auf dem Server.\n\n2. Oder öffnen Sie Ihr Jellyfin-Dashboard -> Bibliotheken, bearbeiten Sie diese Bibliothek und deaktivieren Sie „Bildmaterial in Medienordnern speichern“, um Bildmaterial in der internen Datenbank von Jellyfin abzulegen.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Verwerfen';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Ihre Bibliothek „$libraryName“ ist so konfiguriert, dass Bildmaterial direkt in den Medienordnern gespeichert wird („Bildmaterial in Medienordnern speichern“ ist aktiviert). Jellyfin hat den Schreibzugriff getestet und hat keine Berechtigung, Dateien in dieses Verzeichnis zu schreiben:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin konnte das Bildmaterial offenbar nicht aktualisieren. Ihre Bibliothek ist so konfiguriert, dass Bildmaterial direkt in den Medienordnern gespeichert wird („Bildmaterial in Medienordnern speichern“ ist aktiviert). Dieser Fehler tritt typischerweise auf, wenn der Jellyfin-Serverprozess keine Berechtigung hat, Dateien in Ihre Medienverzeichnisse zu schreiben.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Externe Listen';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Erneut abspielen';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Dateiinformationen';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Größe: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Alle ($count) Audiospuren anzeigen';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Alle ($count) Untertitelspuren anzeigen';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Direct Play-Fähigkeit wird geprüft...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play-Fähigkeit: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Erzwungen';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Das Containerformat wird vom Player nicht unterstützt.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Der Video-Codec wird nicht unterstützt.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Der Audio-Codec wird nicht unterstützt.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Das Untertitelformat wird nicht unterstützt (muss eingebrannt werden).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Das Audioprofil wird nicht unterstützt.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Das Videoprofil wird nicht unterstützt.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Das Video-Level wird nicht unterstützt.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Die Videoauflösung wird von diesem Gerät nicht unterstützt.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Die Video-Bittiefe wird nicht unterstützt.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Die Video-Bildrate wird nicht unterstützt.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Die Dateibitrate überschreitet das Streaming-Limit des Players.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Die Videobitrate überschreitet das Streaming-Limit.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Die Audiobitrate überschreitet das Streaming-Limit.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Die Anzahl der Audiokanäle wird nicht unterstützt.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alphabetisch';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Erscheinungsreihenfolge (aufsteigend)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Erscheinungsreihenfolge (absteigend)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Benutzerdefiniert (Drag-and-Drop)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Sortieroptionen für Wiedergabelisten';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Sortierung zurücksetzen';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode erneut ansehen';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Wiedergabeliste erneut ansehen';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Keine Untertitel gefunden.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Admin-Steuerung';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Rendering-Engine (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller ist Flutters moderner GPU-Renderer für flüssigere Animationen und weniger Ruckeln. Auf manchen TV-Boxen und älteren GPUs kann er Grafikfehler oder ein schwarzes Bild verursachen; schalten Sie ihn dann aus. „Automatisch“ wählt die beste Standardeinstellung für Ihr Gerät. Starten Sie Moonfin neu, um die Änderung anzuwenden.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatisch';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ein';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Aus';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Neustart erforderlich';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin muss neu gestartet werden, um die Rendering-Engine zu ändern. Schließen Sie die App jetzt und öffnen Sie sie erneut, um die Änderung anzuwenden.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'App jetzt schließen';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Bibliothek aktualisieren';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Alle Bibliotheken aktualisieren';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Hinzugefügt am (älteste zuerst)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Hinzugefügt am (neueste zuerst)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alphabetisch (A bis Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alphabetisch (Z bis A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Server-Analysen werden geladen... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Wie Quelle';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 Filme';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 Serien';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Beliebteste Filme';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Beliebteste Serien';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Am schlechtesten bewertete Filme';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb Bestbewertete englische Filme';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -12,19 +12,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'ΠΡΟΤΙΜΗΣΕΙΣ ΛΟΓΑΡΙΑΣΜΟΥ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Γλώσσα περιβάλλοντος';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Προεπιλογή συστήματος';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Είσοδος';
 
   @override
-  String get empty => 'Κενό';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Γρήγορη σύνδεση';
 
   @override
   String get password => 'Σύνθημα';
@@ -114,7 +114,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cancel => 'Ματαίωση';
 
   @override
-  String get remove => 'Αφαίρεση';
+  String get remove => 'Αφαιρώ';
 
   @override
   String get connectToServer => 'Σύνδεση στον διακομιστή';
@@ -143,62 +143,62 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Θέμα εφαρμογής';
 
   @override
-  String get detailScreenStyle => 'Στυλ οθόνης λεπτομερειών';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Το Κλασικό είναι η αρχική, κεντραρισμένη διάταξη του Moonfin. Το Μοντέρνο είναι μια προσαρμοστική, κινηματογραφική διάταξη.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Κλασικό';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Μοντέρνο';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Αναπτυγμένες καρτέλες';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Αυτόματη εμφάνιση του περιεχομένου των καρτελών κατά την περιήγηση. Απενεργοποιήστε το για να ανοίγετε και να κλείνετε κάθε καρτέλα χειροκίνητα.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Εμφάνιση τεχνικών λεπτομερειών;';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Εμφάνιση κωδικοποιητή, ανάλυσης και πληροφοριών ροής στη σύνοψη του banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Σύστημα προτάσεων';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Χρησιμοποιήστε τον αλγόριθμο τοπικής βιβλιοθήκης «Προτάσεις Moonfin» ή τις διαδικτυακές μετρήσεις ομοιότητας του TMDb. Σημείωση: οι διαδικτυακές προτάσεις απαιτούν ενσωμάτωση με το Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Προτάσεις Moonfin';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Ομοιότητα TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Εφαρμογή ορίου γονικής διαβάθμισης;';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Περιορισμός των προτάσεων του Moonfin με βάση τη γονική διαβάθμιση του επιλεγμένου περιεχομένου';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Στυλ περιβάλλοντος';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Το Αυτόματο προσαρμόζεται στη συσκευή σας. Επιλέξτε Apple ή Material για να επιβάλετε μια εμφάνιση.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Αυτόματο';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -207,31 +207,31 @@ class AppLocalizationsEl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Ποιότητα γυαλιού';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Το Αυτόματο επιλέγει το καλύτερο εφέ γυαλιού για αυτήν τη συσκευή. Το Πλήρες επιβάλλει πραγματικό θόλωμα· το Μειωμένο χρησιμοποιεί ένα ελαφρύ γυαλί που εξοικονομεί ενέργεια GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Αυτόματο';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Πλήρες';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Μειωμένο';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Εναλλαγή μεταξύ Moonfin και Neon Pulse χωρίς επανεκκίνηση της εφαρμογής';
 
   @override
-  String get customThemeTitle => 'Προσαρμοσμένο θέμα';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Τα προσαρμοσμένα θέματα αλλάζουν τα οπτικά στοιχεία σε όλο το Moonfin. Επιλέξτε μία από αυτές τις επιλογές που ταιριάζει στο στυλ σας.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Προτιμήστε το πληκτρολόγιο συστήματος';
@@ -255,18 +255,18 @@ class AppLocalizationsEl extends AppLocalizations {
       'Στυλ Synthwave με ματζέντα λάμψη, κυανό κείμενο και ισχυρότερη αντίθεση χρωμίου';
 
   @override
-  String get themeGlass => 'Γυαλί';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Στυλ υγρού γυαλιού με φόντο μεταβαλλόμενης διαβάθμισης, παγωμένες επιφάνειες και μπλε χρώμα τονισμού της Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'Ήρωας 8-bit';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ρετρό στυλ pixel-art με χοντροκομμένη παλέτα, τετράγωνα περιγράμματα, έντονες σκιές και γραμματοσειρά pixel';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -329,36 +329,35 @@ class AppLocalizationsEl extends AppLocalizations {
   String get exit => 'Εξοδος';
 
   @override
-  String get gameMenu => 'Μενού';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Σε παύση';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Αποθήκευση κατάστασης';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Παιχνίδια';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Φόρτωση κατάστασης';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Γρήγορη προώθηση';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Ρυθμίσεις εξομοιωτή';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Αυτός ο πυρήνας δεν διαθέτει ρυθμιζόμενες επιλογές.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Κρατήστε πατημένο για άνοιγμα του μενού';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Η αναπαραγωγή παιχνιδιών δεν υποστηρίζεται ακόμη σε αυτήν τη συσκευή.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Δεν ήταν δυνατή η φόρτωση των αρχικών σειρών';
@@ -374,19 +373,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get guide => 'Οδηγός';
 
   @override
-  String get recordings => 'Εγγραφές';
+  String get recordings => 'Ηχογραφήσεις';
 
   @override
   String get schedule => 'Πρόγραμμα';
 
   @override
-  String get series => 'Σειρές';
+  String get series => 'Σειρά';
 
   @override
   String get noItemsFound => 'Δεν βρέθηκαν στοιχεία';
 
   @override
-  String get home => 'Αρχική';
+  String get home => 'Σπίτι';
 
   @override
   String get browseAll => 'Περιήγηση σε όλα';
@@ -558,7 +557,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Επιλέξτε ποιο θέμα θα εμφανίζεται στο Discover.';
 
   @override
-  String get apply => 'Εφαρμογή';
+  String get apply => 'Εφαρμόζω';
 
   @override
   String get openLink => 'Ανοίξτε τον σύνδεσμο';
@@ -608,7 +607,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get listen => 'Ακούω';
 
   @override
-  String get resume => 'Συνέχεια';
+  String get resume => 'Περίληψη';
 
   @override
   String get failedToLoadLibrary => 'Η φόρτωση της βιβλιοθήκης απέτυχε';
@@ -753,13 +752,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get readStatus => 'Ανάγνωση';
 
   @override
-  String get watched => 'Παρακολουθημένα';
+  String get watched => 'Παρακολούθησαν';
 
   @override
   String get unread => 'Αδιάβαστος';
 
   @override
-  String get unwatched => 'Μη παρακολουθημένα';
+  String get unwatched => 'Απαρατήρητο';
 
   @override
   String get seriesStatus => 'Κατάσταση σειράς';
@@ -771,43 +770,43 @@ class AppLocalizationsEl extends AppLocalizations {
   String get books => 'Βιβλία';
 
   @override
-  String get latestBooks => 'Πρόσφατα βιβλία';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Πρόσφατα ηχητικά βιβλία';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count βιβλία',
-      one: '1 βιβλίο',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Βιβλίο';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Ηχητικό βιβλίο';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% αναγνωσμένο';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Απομένουν $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Ανάγνωση';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Ακρόαση';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Συγγραφέας';
@@ -885,8 +884,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ηχητικά βιβλία',
-      one: '1 ηχητικό βιβλίο',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -901,16 +900,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get failedToLoad => 'Αποτυχία φόρτωσης';
 
   @override
-  String get delete => 'Διαγραφή';
+  String get delete => 'Διαγράφω';
 
   @override
-  String get save => 'Αποθήκευση';
+  String get save => 'Εκτός';
 
   @override
   String get moreLikeThis => 'Περισσότερα σαν αυτό';
 
   @override
-  String get castAndCrew => 'Ηθοποιοί και συντελεστές';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Συλλογή';
@@ -922,7 +921,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get nextUp => 'Επόμενο επάνω';
 
   @override
-  String get seasons => 'Κύκλοι';
+  String get seasons => 'εποχές';
 
   @override
   String get chapters => 'Κεφάλαια';
@@ -949,7 +948,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tableOfContents => 'Πίνακας περιεχομένων';
 
   @override
-  String get tracklist => 'Λίστα κομματιών';
+  String get tracklist => 'Tracklist';
 
   @override
   String discNumber(int number) {
@@ -990,8 +989,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count σεζόν',
-      one: '1 σεζόν',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1002,40 +1001,40 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get items => 'Στοιχεία';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Πρόσθετα';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Παρασκήνια';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Διαγραμμένες σκηνές';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Αφιερώματα';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Συνεντεύξεις';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Σκηνές';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Ταινίες μικρού μήκους';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Τρέιλερ';
+  String get trailers => 'Ρυμουλκούμενα';
 
   @override
   String timeRemaining(String time) {
-    return 'Απομένουν $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Τελειώνει σε $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1053,7 +1052,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get play => 'Αναπαραγωγή';
+  String get play => 'Παιχνίδι';
 
   @override
   String get startOver => 'Ξεκινήστε από την αρχή';
@@ -1077,10 +1076,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get version => 'Εκδοχή';
 
   @override
-  String get cast => 'Μετάδοση';
+  String get cast => 'Εκμαγείο';
 
   @override
-  String get trailer => 'Τρέιλερ';
+  String get trailer => 'Τροχόσπιτο';
 
   @override
   String get finished => 'Πεπερασμένος';
@@ -1197,7 +1196,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get subtitleTrack => 'Κομμάτι υπότιτλων';
 
   @override
-  String get none => 'Κανένα';
+  String get none => 'Κανένας';
 
   @override
   String get downloadSubtitlesLabel => 'Κατεβάστε υπότιτλους...';
@@ -1278,13 +1277,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get director => 'ΔΙΕΥΘΥΝΤΗΣ';
 
   @override
-  String get directors => 'ΣΚΗΝΟΘΕΣΙΑ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ΣΕΝΑΡΙΟ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'ΣΕΝΑΡΙΟΓΡΑΦΟΙ';
+  String get writers => 'ΣΥΓΓΡΑΦΕΙΣ';
 
   @override
   String get studio => 'ΣΤΟΥΝΤΙΟ';
@@ -1319,8 +1318,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count κομμάτια',
-      one: '1 κομμάτι',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1330,8 +1329,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count κεφάλαια',
-      one: '1 κεφάλαιο',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1358,17 +1357,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get readMore => 'Διαβάστε περισσότερα';
 
   @override
-  String get shuffle => 'Τυχαία αναπαραγωγή';
+  String get shuffle => 'Ανάμιξη';
 
   @override
-  String get shuffleAllMusic => 'Τυχαία αναπαραγωγή όλης της μουσικής';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Συνδεθείτε στο Moonfin από το τηλέφωνό σας';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable =>
-      'Δεν είναι δυνατή η σύνδεση με τον διακομιστή σας';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1380,14 +1378,14 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count καν.';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Μονοφωνικό';
+  String get mono => 'Μονο';
 
   @override
-  String get stereo => 'Στερεοφωνικό';
+  String get stereo => 'Στέρεο';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1507,7 +1505,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get longPressToUnlock => 'Πατήστε παρατεταμένα για ξεκλείδωμα';
 
   @override
-  String get off => 'Ανενεργό';
+  String get off => 'Μακριά από';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1569,7 +1567,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get transcodeReasons => 'Λόγοι διακωδικοποίησης';
 
   @override
-  String get player => 'Πρόγραμμα αναπαραγωγής';
+  String get player => 'Παίχτης';
 
   @override
   String get container => 'Δοχείο';
@@ -1593,7 +1591,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get videoBitrate => 'Ρυθμός bit βίντεο';
 
   @override
-  String get track => 'Κομμάτι';
+  String get track => 'Τροχιά';
 
   @override
   String get channels => 'Κανάλια';
@@ -1812,22 +1810,22 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Επόμενο: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Απομένουν $minutesλ';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Απομένουν $hoursω';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Απομένουν $hoursω $minutesλ';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1851,7 +1849,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get favoriteChannel => 'Αγαπημένο κανάλι';
 
   @override
-  String get record => 'Εγγραφή';
+  String get record => 'Ρεκόρ';
 
   @override
   String get cancelRecordingAction => 'Ακύρωση εγγραφής';
@@ -1867,10 +1865,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Δεν είναι δυνατή η δημιουργία εγγραφής';
 
   @override
-  String get watch => 'Παρακολούθηση';
+  String get watch => 'Ρολόι';
 
   @override
-  String get close => 'Κλείσιμο';
+  String get close => 'Κοντά';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1904,7 +1902,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get no => 'Όχι';
+  String get no => 'Οχι';
 
   @override
   String get yesCancel => 'Ναι, Ακύρωση';
@@ -1954,7 +1952,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Τύπος λογαριασμού Seerr';
+  String get seerrAccountType => 'Τύπος λογαριασμού Seer';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2013,7 +2011,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get season => 'Κύκλος';
+  String get season => 'Εποχή';
 
   @override
   String get errorLoadingEpisodes => 'Σφάλμα κατά τη φόρτωση επεισοδίων';
@@ -2036,7 +2034,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'Σ$season Ε$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2060,7 +2058,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'Σ$number';
+    return 'S$number';
   }
 
   @override
@@ -2079,8 +2077,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count επεισόδια',
-      one: '1 επεισόδιο',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2310,7 +2308,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Σελίδες λεπτομερειών, σειρές αρχικής και ένταση';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2325,11 +2323,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Παίξτε κατά την περιήγηση στην αρχική οθόνη';
 
   @override
-  String get loopThemeMusic => 'Επανάληψη μουσικής θέματος';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Επανάληψη του κομματιού αντί για μία μόνο αναπαραγωγή';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Λεπτομέρειες Θάμπωμα φόντου';
@@ -2352,23 +2350,23 @@ class AppLocalizationsEl extends AppLocalizations {
   String get playerZoomMode => 'Λειτουργία ζουμ παίκτη';
 
   @override
-  String get settingsScrollWheelAction => 'Ροδέλα ποντικιού';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Επιλέξτε τι κάνει η κύλιση της ροδέλας του ποντικιού πάνω από το βίντεο κατά την αναπαραγωγή.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Ανενεργό';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Μετακίνηση (εμπρός / πίσω)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Ένταση';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Ένταση';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Κατάλληλος';
@@ -2383,7 +2381,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get refreshRateSwitching => 'Εναλλαγή ρυθμού ανανέωσης';
 
   @override
-  String get disabled => 'Απενεργοποιημένο';
+  String get disabled => 'Ανάπηρος';
 
   @override
   String get scaleOnTv => 'Κλίμακα στην τηλεόραση';
@@ -2422,39 +2420,37 @@ class AppLocalizationsEl extends AppLocalizations {
   String get defaultAudioLanguage => 'Προεπιλεγμένη γλώσσα ήχου';
 
   @override
-  String get fallbackAudioLanguage => 'Εφεδρική γλώσσα ήχου';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Προτίμηση προεπιλεγμένου κομματιού ήχου';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Προτίμηση του πρωτότυπου κομματιού ήχου έναντι της μεταγλώττισης.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'Προτίμηση κομματιών ακουστικής περιγραφής';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Προτίμηση των κομματιών ακουστικής περιγραφής έναντι των κανονικών κομματιών.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Διακωδικοποίηση (ήχος)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Απευθείας ροή (επανασυσκευασία)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Διακωδικοποίηση (ρυθμός bit ή ανάλυση)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Διακωδικοποίηση (βίντεο και ήχος)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Διακωδικοποίηση (βίντεο)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Αυτόματο (Προεπιλογή διακομιστή)';
@@ -2514,10 +2510,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get polish => 'Στίλβωση';
 
   @override
-  String get ac3Passthrough => 'Διέλευση AC3';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'Διέλευση DTS';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'Υποστήριξη TrueHD';
@@ -2535,24 +2531,23 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Επιλέξτε τον τρόπο αποκωδικοποίησης του ήχου. Η Διέλευση AVR στέλνει ακατέργαστες ροές Dolby/DTS στον δέκτη σας· η Αυτόματη ή η Μείξη αποκωδικοποιεί τοπικά.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Διέλευση AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Εναλλακτικός κωδικοποιητής ήχου';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Επιλέξτε τη μορφή προορισμού για τη διακωδικοποίηση πολυκάναλου ήχου όταν η ροή προέλευσης δεν μπορεί να αναπαραχθεί απευθείας ή να περάσει με διέλευση.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Αυτόματος εντοπισμός\n(Συνιστάται)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Προεπιλογή)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2561,80 +2556,79 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Χωρίς απώλειες)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Μόνο στερεοφωνικό)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Αποδοτικό)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Χωρίς απώλειες)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Μέγιστα κανάλια ήχου';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Ρυθμίστε τον μέγιστο αριθμό καναλιών της ηχητικής σας εγκατάστασης. Οι πολυκάναλες ροές που υπερβαίνουν αυτό το όριο θα υποστούν μείξη ή διακωδικοποίηση.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Αυτόματος εντοπισμός\n(Προεπιλογή υλικού)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Μονοφωνικό';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Στερεοφωνικό';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Περιβάλλων ήχος';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Τετραφωνικό';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Περιβάλλων ήχος';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Περιβάλλων ήχος';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Περιβάλλων ήχος';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Περιβάλλων ήχος';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced =>
       'Passthrough (Για προχωρημένους)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Διέλευση κωδικοποιητή';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
       'Ενεργοποίηση μόνο μορφών που υποστηρίζει ο νεροχύτης AVR ή HDMI.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Διέλευση EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Διέλευση EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Διέλευση DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Διέλευση DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Διέλευση TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Διέλευση TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2667,7 +2661,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsAudioDecodeLabel => 'Αποκρυπτογραφώ';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Διέλευση';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
   String get settingsAudioHdRoute => 'Διαδρομή ήχου HD';
@@ -2688,11 +2682,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Ομιλητής';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Ακουστικά';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count καν. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2721,7 +2715,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'διέλευση audio-spdif';
+      'audio-spdif passthrough';
 
   @override
   String get settingsAudioDiagnosticsActiveAudioRoute => 'Ενεργή διαδρομή ήχου';
@@ -2777,7 +2771,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueδ';
+    return '${value}s';
   }
 
   @override
@@ -2798,7 +2792,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resumeAndSkip => 'Βιογραφικό & Παράλειψη';
 
   @override
-  String get resumeRewind => 'Επαναφορά κατά τη συνέχιση';
+  String get resumeRewind => 'Resume Rewind';
 
   @override
   String get unpauseRewind => 'Κατάργηση παύσης επαναφοράς';
@@ -2832,7 +2826,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get selectMpvConf => 'Επιλέξτε mpv.conf';
 
   @override
-  String get pathToMpvConf => '/διαδρομή/προς/mpv.conf';
+  String get pathToMpvConf => '/path/to/mpv.conf';
 
   @override
   String get subtitleStyleDescription =>
@@ -2868,45 +2862,45 @@ class AppLocalizationsEl extends AppLocalizations {
       'Προσαρμόστε την εμφάνιση των υπότιτλων';
 
   @override
-  String get subtitleMode => 'Λειτουργία υπότιτλων';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Με σήμανση';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Πάντα';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Ξενόγλωσσα';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Εξαναγκασμένα';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Αναπαράγει τα κομμάτια που έχουν σήμανση «default» ή «forced» στα μεταδεδομένα του αρχείου πολυμέσων.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Φορτώνει και εμφανίζει αυτόματα τους υπότιτλους κάθε φορά που ξεκινά ένα βίντεο.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Ενεργοποιεί αυτόματα τους υπότιτλους αν το προεπιλεγμένο κομμάτι ήχου είναι σε ξένη γλώσσα.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Φορτώνει μόνο τους υπότιτλους που φέρουν ρητή σήμανση με την ένδειξη μεταδεδομένων «forced».';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Απενεργοποιεί εντελώς την αυτόματη φόρτωση υπότιτλων.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Εφεδρική γλώσσα υπότιτλων';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Ροή υπότιτλων';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2916,7 +2910,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get verticalOffset => 'Κάθετη μετατόπιση';
 
   @override
-  String get pgsDirectPlay => 'Απευθείας αναπαραγωγή PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Άμεση αναπαραγωγή υπότιτλων PGS';
@@ -3094,7 +3088,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get navigationStyle => 'Στυλ πλοήγησης';
 
   @override
-  String get topBar => 'Επάνω γραμμή';
+  String get topBar => 'Top Bar';
 
   @override
   String get leftSidebar => 'Αριστερή πλευρική γραμμή';
@@ -3112,10 +3106,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Εμφάνιση βιβλιοθηκών στο Toolbar';
 
   @override
-  String get navbarAlwaysExpanded => 'Πάντα αναπτυγμένες ετικέτες πλοήγησης';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Εμφάνιση κουμπιού Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Αδιαφάνεια γραμμής πλοήγησης';
@@ -3190,19 +3184,18 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Εμφάνιση επιλογής περιήγησης φακέλου';
 
   @override
-  String get groupItemsIntoCollections => 'Ομαδοποίηση στοιχείων σε συλλογές';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Απόκρυψη των στοιχείων βιβλιοθήκης που ανήκουν σε συλλογή κατά την περιήγηση στις βιβλιοθήκες';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Ειδοποίηση ομαδοποίησης βιβλιοθήκης';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Για να χρησιμοποιήσετε αυτήν τη ρύθμιση, βεβαιωθείτε ότι οι ρυθμίσεις βιβλιοθήκης «Ομαδοποίηση ταινιών σε συλλογές» ή/και «Ομαδοποίηση σειρών σε συλλογές» είναι ενεργοποιημένες στις ρυθμίσεις Εμφάνισης της βιβλιοθήκης σας, στον διακομιστή Jellyfin ή Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Βιβλιοθήκη Ορατότητα';
@@ -3235,7 +3228,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get mediaBar => 'Γραμμή πολυμέσων';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Πηγές ΜΜΕ';
@@ -3267,7 +3260,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Ανενεργό';
+  String get mediaBarModeOff => 'Μακριά από';
 
   @override
   String get enableMediaBar => 'Ενεργοποιήστε τη γραμμή πολυμέσων';
@@ -3314,11 +3307,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αυτόματη αναπαραγωγή τρέιλερ στη γραμμή πολυμέσων μετά από 3 δευτερόλεπτα';
 
   @override
-  String get trailerAudio => 'Ήχος τρέιλερ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Ενεργοποίηση ήχου για τα τρέιλερ στη γραμμή πολυμέσων';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Προεπισκόπηση επεισοδίου';
@@ -3396,11 +3388,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Συνδυάστε και τις δύο σειρές σε ένα ενιαίο αρχικό τμήμα';
 
   @override
-  String get fullScreenRows => 'Αναπτυγμένες σειρές αρχικής';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Περιορισμός των σειρών της αρχικής σε 1 σειρά ανά οθόνη';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Τύπος εικόνας ανά σειρά';
@@ -3415,7 +3406,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get lastUser => 'Τελευταίος χρήστης';
 
   @override
-  String get currentUser => 'Τρέχων χρήστης';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Πάντα έλεγχος ταυτότητας';
@@ -3477,7 +3468,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ενεργοποιήστε την ενσωματωμένη προφύλαξη οθόνης';
 
   @override
-  String get mode => 'Λειτουργία';
+  String get mode => 'Τρόπος';
 
   @override
   String get libraryArt => 'Τέχνη βιβλιοθήκης';
@@ -3489,7 +3480,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clock => 'Ρολόι';
 
   @override
-  String get timeout => 'Χρονικό όριο';
+  String get timeout => 'Timeout';
 
   @override
   String minutesShort(int minutes) {
@@ -3525,10 +3516,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση ρολογιού κατά την προφύλαξη οθόνης';
 
   @override
-  String get clockModeStatic => 'Στατικό';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Αναπηδώμενο';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Κριτικοί)';
@@ -3571,7 +3562,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get showMdbListAndTmdbRatings =>
-      'Εμφάνιση αξιολογήσεων MDBList και TMDB';
+      'Εμφάνιση αξιολογήσεων MDBLlist και TMDB';
 
   @override
   String get ratingLabels => 'Ετικέτες αξιολόγησης';
@@ -3602,7 +3593,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ενεργοποιήστε και αναδιατάξτε τις πηγές αξιολόγησης που εμφανίζονται σε όλη την εφαρμογή';
 
   @override
-  String get pluginLabel => 'Πρόσθετο Moonbase';
+  String get pluginLabel => 'Πρόσθετο';
 
   @override
   String get pluginDetected => 'Εντοπίστηκε πρόσθετο';
@@ -3674,7 +3665,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get networks => 'Δίκτυα';
 
   @override
-  String get seerrDiscoveryRows => 'Σειρές ανακάλυψης Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Επαναφέρετε τις σειρές στις προεπιλογές';
@@ -3698,28 +3689,28 @@ class AppLocalizationsEl extends AppLocalizations {
       'Απόκρυψη περιεχομένου για ενηλίκους στα αποτελέσματα';
 
   @override
-  String get seerrNotificationsSection => 'Ειδοποιήσεις';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Ειδοποιήσεις νέων αιτημάτων';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Να ειδοποιούμαι όταν κάποιος υποβάλλει αίτημα';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Ενημερώσεις αιτημάτων';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Εγκρίθηκε, απορρίφθηκε και προστέθηκε στη βιβλιοθήκη σας';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ενημερώσεις ζητημάτων';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Νέα ζητήματα, απαντήσεις και επιλύσεις';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3727,15 +3718,15 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Σελίδα ανακάλυψης Seerr';
+  String get discoverRows => 'Ανακαλύψτε σειρές';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Ενεργοποιήστε τις σειρές που θέλετε να βλέπετε στην κύρια σελίδα του Seerr. Σύρετε για αναδιάταξη. Η προσαρμοσμένη σειρά συγχρονίζεται με το Moonbase.';
+      'Σύρετε για αναδιάταξη. Ενεργοποίηση ή απενεργοποίηση σειρών. Η ενεργοποιημένη σειρά σειρών συγχρονίζεται με την προσθήκη Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Ενεργοποιήστε τις σειρές που θέλετε να βλέπετε στην κύρια σελίδα του Seerr. Σύρετε για αναδιάταξη. Η προσαρμοσμένη σειρά συγχρονίζεται με το Moonbase.';
+      'Σύρετε για αναδιάταξη. Ενεργοποίηση ή απενεργοποίηση σειρών.';
 
   @override
   String get enabled => 'Ενεργοποιημένο';
@@ -3851,7 +3842,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Μέγεθος αφίσας, τύπος εικόνας, προβολή φακέλου';
 
   @override
-  String get mdbListTmdbRatingSources => 'MDBList, TMDB και πηγές αξιολόγησης';
+  String get mdbListTmdbRatingSources => 'MDBLlist, TMDB και πηγές αξιολόγησης';
 
   @override
   String gbValue(String value) {
@@ -3873,7 +3864,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get imageCacheCleared => 'Η προσωρινή μνήμη εικόνων εκκαθαρίστηκε';
 
   @override
-  String get clear => 'Εκκαθάριση';
+  String get clear => 'Σαφής';
 
   @override
   String get browse => 'Ξεφυλλίζω';
@@ -3889,11 +3880,11 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Λήψη · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Εισαγωγή';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3901,7 +3892,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Ρυθμίσεις Seerr';
+  String get seerrSettings => 'Ρυθμίσεις Seer';
 
   @override
   String get requestMore => 'Ζητήστε περισσότερα';
@@ -4036,149 +4027,148 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deletedStatus => 'Διαγράφηκε';
 
   @override
-  String get failedStatus => 'Απέτυχε';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Σε επεξεργασία';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Τροποποιήθηκε από $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Ολοκληρώθηκε';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Αυτός ο τίτλος έχει ήδη ζητηθεί';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Συμπληρώθηκε το όριο αιτημάτων';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Αυτός ο τίτλος είναι σε λίστα αποκλεισμού';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Δεν απομένουν σεζόν για αίτημα';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Δεν έχετε δικαίωμα να υποβάλετε αυτό το αίτημα';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Αιτήματα';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Ζητήματα';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Νεότερα';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Τελευταία τροποποίηση';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Κανένα ζήτημα';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Απομένουν $remaining από $limit αιτήματα ταινιών';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Απομένουν $remaining από $limit αιτήματα σεζόν';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Μέρος του $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Προβολή συλλογής';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Αίτημα συλλογής';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total ταινίες · $available διαθέσιμες';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Αίτημα για $count ταινίες';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Υποβολή αιτήματος $current από $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Ζητήθηκαν $count ταινίες';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Ζητήθηκαν $ok από $total ταινίες';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Όλες οι ταινίες είναι ήδη διαθέσιμες ή έχουν ζητηθεί';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Αναφορά ζητήματος';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Βίντεο';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Ήχος';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Τι πρόβλημα υπάρχει;';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Όλα τα επεισόδια';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Επεισόδιο';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Ανοιχτό';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Επιλύθηκε';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Επίλυση';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Επανάνοιγμα';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Αναφέρθηκε από $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count σχόλια';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Προσθήκη σχολίου';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Διαγραφή αυτού του ζητήματος;';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Υποβολή αναφοράς';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Βαθμολογία TMDB';
@@ -4202,7 +4192,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get originalLanguageLabel => 'Γλώσσα Πρωτότυπου';
 
   @override
-  String get seasonsLabel => 'Κύκλοι';
+  String get seasonsLabel => 'εποχές';
 
   @override
   String get episodesLabel => 'Επεισόδια';
@@ -4211,13 +4201,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get access => 'Πρόσβαση';
 
   @override
-  String get add => 'Προσθήκη';
+  String get add => 'Προσθέτω';
 
   @override
   String get address => 'Διεύθυνση';
 
   @override
-  String get analytics => 'Αναλυτικά στοιχεία';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Κατάλογος';
@@ -4235,10 +4225,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get disable => 'Καθιστώ ανίκανο';
 
   @override
-  String get done => 'Τέλος';
+  String get done => 'Γινώμενος';
 
   @override
-  String get edit => 'Επεξεργασία';
+  String get edit => 'Εκδίδω';
 
   @override
   String get encoding => 'Κωδικοποίηση';
@@ -4247,10 +4237,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get error => 'Σφάλμα';
 
   @override
-  String get forward => 'Εμπρός';
+  String get forward => 'Προς τα εμπρός';
 
   @override
-  String get general => 'Γενικά';
+  String get general => 'Γενικός';
 
   @override
   String get go => 'Πάω';
@@ -4271,7 +4261,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get networking => 'Δικτύωση';
 
   @override
-  String get next => 'Επόμενο';
+  String get next => 'Επόμενος';
 
   @override
   String get path => 'Μονοπάτι';
@@ -4295,7 +4285,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get refresh => 'Φρεσκάρω';
 
   @override
-  String get remote => 'Τηλεχειριστήριο';
+  String get remote => 'Μακρινός';
 
   @override
   String get rename => 'Μετονομάζω';
@@ -4313,7 +4303,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get run => 'Τρέξιμο';
 
   @override
-  String get search => 'Αναζήτηση';
+  String get search => 'Ερευνα';
 
   @override
   String get select => 'Επιλέγω';
@@ -4331,7 +4321,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get status => 'Κατάσταση';
 
   @override
-  String get stop => 'Διακοπή';
+  String get stop => 'Στάση';
 
   @override
   String get streaming => 'Ροή';
@@ -4340,7 +4330,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get time => 'Φορά';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Κόλπος';
 
   @override
   String get uninstall => 'Απεγκατάσταση';
@@ -4358,7 +4348,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get unmute => 'Κατάργηση σίγασης';
 
   @override
-  String get mute => 'Σίγαση';
+  String get mute => 'Βουβός';
 
   @override
   String get branding => 'Επωνυμία';
@@ -4367,7 +4357,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminDrawerDashboard => 'Ταμπλό';
 
   @override
-  String get adminDrawerAnalytics => 'Αναλυτικά στοιχεία';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Ρυθμίσεις';
@@ -4382,25 +4372,25 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminDrawerLibraries => 'Βιβλιοθήκες';
 
   @override
-  String get adminDrawerDisplay => 'Εμφάνιση';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Μεταδεδομένα';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Ρυθμίσεις NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Διακωδικοποίηση';
 
   @override
-  String get adminDrawerResume => 'Συνέχεια';
+  String get adminDrawerResume => 'Περίληψη';
 
   @override
   String get adminDrawerStreaming => 'Ροή';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Κόλπος';
 
   @override
   String get adminDrawerDevices => 'Συσκευές';
@@ -4572,10 +4562,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get sessionRewind => 'Πίσω';
 
   @override
-  String get sessionForward => 'Εμπρός';
+  String get sessionForward => 'Προς τα εμπρός';
 
   @override
-  String get sessionNext => 'Επόμενο';
+  String get sessionNext => 'Επόμενος';
 
   @override
   String get sessionVolumeDown => 'τόμος -';
@@ -4590,7 +4580,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get nowPlaying => 'Παίζει τώρα';
 
   @override
-  String get volume => 'Ένταση';
+  String get volume => 'Τόμος';
 
   @override
   String get actions => 'Δράσεις';
@@ -4602,7 +4592,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audioCodec => 'Κωδικοποιητής ήχου';
 
   @override
-  String get hwAccel => 'Επιτάχυνση υλικού';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Ολοκλήρωση';
@@ -4617,10 +4607,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminClearDates => 'Καθαρές ημερομηνίες';
 
   @override
-  String get adminActivitySeverityAll => 'Όλα τα επίπεδα σοβαρότητας';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Εύρος ημερομηνιών';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4658,23 +4648,23 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Κατάργηση της συσκευής «$name»; Ο χρήστης θα χρειαστεί να συνδεθεί ξανά σε αυτήν τη συσκευή.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Διαγραφή όλων των συσκευών';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Κατάργηση $count συσκευών; Οι χρήστες που επηρεάζονται θα χρειαστεί να συνδεθούν ξανά. Η τρέχουσα συσκευή σας δεν επηρεάζεται.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Οι συσκευές καταργήθηκαν';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Ορισμένες συσκευές καταργήθηκαν· $count δεν ήταν δυνατό να καταργηθούν.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4792,256 +4782,244 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminMetadataCountryHint => 'π.χ. ΗΠΑ, ΓΕ, Γαλλία';
 
   @override
-  String get adminLibraryTabPaths => 'Διαδρομές';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Επιλογές';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Προγράμματα λήψης';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Προγράμματα αποθήκευσης μεταδεδομένων';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Προγράμματα λήψης υπότιτλων';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Προγράμματα λήψης στίχων';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Προγράμματα λήψης μεταδεδομένων: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Προγράμματα ανάκτησης εικόνων: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Αυτός ο διακομιστής δεν παρέχει προγράμματα λήψης για αυτόν τον τύπο βιβλιοθήκης.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Γενικά';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Μεταδεδομένα';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Ενσωματωμένες πληροφορίες';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Υπότιτλοι';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Εικόνες';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Σειρές';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Μουσική';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Ταινίες';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'Ενεργοποίηση παρακολούθησης σε πραγματικό χρόνο';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Εντοπισμός αλλαγών στα αρχεία και αυτόματη επεξεργασία τους.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Αντιμετώπιση των αρχειοθηκών ως αρχείων πολυμέσων';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Εμφάνιση φωτογραφιών';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Αποθήκευση εξωφύλλων στους φακέλους πολυμέσων';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Αυτόματη ανανέωση μεταδεδομένων';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Ποτέ';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Προεπιλογή';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Εμφάνιση';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Εμφάνιση βιβλιοθήκης';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Εμφάνιση προβολής φακέλων για την εμφάνιση απλών φακέλων πολυμέσων';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Εμφάνιση των ειδικών επεισοδίων μέσα στις σεζόν όπου προβλήθηκαν';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Ομαδοποίηση ταινιών σε συλλογές';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Ομαδοποίηση σειρών σε συλλογές';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Εμφάνιση εξωτερικού περιεχομένου στις προτάσεις';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Συμπεριφορά ημερομηνίας προσθήκης';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Χρήση ημερομηνίας προσθήκης από';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Ημερομηνία σάρωσης στη βιβλιοθήκη';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Ημερομηνία δημιουργίας του αρχείου';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Μεταδεδομένα και εικόνες';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Προτιμώμενη γλώσσα μεταδεδομένων';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Κεφάλαια';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Διάρκεια εικονικών κεφαλαίων (δευτερόλεπτα)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Διάρκεια των κεφαλαίων που δημιουργούνται για πολυμέσα χωρίς κεφάλαια. Ορίστε 0 για απενεργοποίηση.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Ανάλυση εικόνας κεφαλαίου';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Ρυθμίσεις NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Τα μεταδεδομένα NFO είναι συμβατά με το Kodi και παρόμοιες εφαρμογές. Οι ρυθμίσεις ισχύουν για όλες τις βιβλιοθήκες που αποθηκεύουν μεταδεδομένα NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Χρήστης για τον οποίο αποθηκεύονται τα δεδομένα παρακολούθησης στα αρχεία NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Αποθήκευση των διαδρομών εικόνων μέσα στα αρχεία NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Ενεργοποίηση αντικατάστασης διαδρομών για τις διαδρομές εικόνων NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Αντιγραφή των εικόνων extrafanart σε φάκελο extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Κανένα';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ημέρες';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Χρήση ενσωματωμένων τίτλων';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Χρήση ενσωματωμένων τίτλων για τα πρόσθετα';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Χρήση ενσωματωμένων πληροφοριών επεισοδίου';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Να επιτρέπονται οι ενσωματωμένοι υπότιτλοι';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Όλοι';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Μόνο κειμένου';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Μόνο εικόνας';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Κανένα';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Παράλειψη της λήψης αν υπάρχουν ενσωματωμένοι υπότιτλοι';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Παράλειψη της λήψης αν το κομμάτι ήχου ταιριάζει με τη γλώσσα λήψης';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Απαίτηση απόλυτης αντιστοίχισης υπότιτλων';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Αποθήκευση των υπότιτλων στους φακέλους πολυμέσων';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Εξαγωγή εικόνων κεφαλαίων';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Εξαγωγή εικόνων κεφαλαίων κατά τη σάρωση της βιβλιοθήκης';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Ενεργοποίηση εξαγωγής εικόνων trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Εξαγωγή εικόνων trickplay κατά τη σάρωση της βιβλιοθήκης';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Αποθήκευση των εικόνων trickplay στους φακέλους πολυμέσων';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Αυτόματη συγχώνευση των σειρών που είναι μοιρασμένες σε πολλούς φακέλους';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Εμφανιζόμενο όνομα της σεζόν μηδέν';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Ενεργοποίηση σάρωσης LUFS για κανονικοποίηση ήχου';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Προτίμηση της μη τυπικής ετικέτας καλλιτεχνών';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Αυτόματη προσθήκη ταινιών σε συλλογές';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Απαιτείται το όνομα της βιβλιοθήκης';
@@ -5292,146 +5270,143 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ενεργοποιήστε την πρόσβαση σε όλα τα κανάλια';
 
   @override
-  String get adminParentalControl => 'Γονικός έλεγχος';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Μέγιστη επιτρεπόμενη γονική διαβάθμιση';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Το περιεχόμενο με υψηλότερη διαβάθμιση θα αποκρύπτεται από αυτόν τον χρήστη.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Καμία';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Αποκλεισμός των στοιχείων χωρίς διαβάθμιση ή με μη αναγνωρισμένες πληροφορίες διαβάθμισης';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Βιβλία';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Κανάλια';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Ζωντανή τηλεόραση';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Ταινίες';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Μουσική';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Τρέιλερ';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Σειρές';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Προγράμματα πρόσβασης';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Να επιτρέπεται η πρόσβαση μόνο κατά τις προγραμματισμένες ώρες παρακάτω. Όταν δεν έχει οριστεί πρόγραμμα, η πρόσβαση επιτρέπεται όλη την ημέρα.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Προσθήκη προγράμματος';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Ημέρα';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Έναρξη';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Λήξη';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Κάθε μέρα';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Καθημερινή';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Σαββατοκύριακο';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Κυριακή';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Δευτέρα';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Τρίτη';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Τετάρτη';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Πέμπτη';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Παρασκευή';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Σάββατο';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Επιτρεπόμενες ετικέτες';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Εμφανίζεται μόνο το περιεχόμενο με αυτές τις ετικέτες. Αφήστε το κενό για να επιτρέπονται όλα.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Αποκλεισμένες ετικέτες';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Το περιεχόμενο με αυτές τις ετικέτες αποκρύπτεται από αυτόν τον χρήστη.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Προσθήκη ετικέτας';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Ενεργοποιημένες συσκευές';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Ενεργοποιημένα κανάλια';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Πάροχος ταυτοποίησης';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Πάροχος επαναφοράς κωδικού πρόσβασης';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Μέγιστος αριθμός αποτυχημένων προσπαθειών σύνδεσης πριν από το κλείδωμα';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Ορίστε 0 για την προεπιλογή ή -1 για απενεργοποίηση του κλειδώματος.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Πρόσβαση SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Να επιτρέπεται η δημιουργία ομάδων και η συμμετοχή σε αυτές';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Να επιτρέπεται η συμμετοχή σε ομάδες';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Χωρίς πρόσβαση';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Να επιτρέπεται η διαγραφή περιεχομένου από';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5519,26 +5494,25 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Δημιουργία αντιγράφου ασφαλείας';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Επιλέξτε τι θα περιλαμβάνεται στο αντίγραφο ασφαλείας.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Βάση δεδομένων';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Περιλαμβάνεται πάντα';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Μεταδεδομένα';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Υπότιτλοι';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Εικόνες trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Δημιουργία αντιγράφου ασφαλείας...';
@@ -5976,7 +5950,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Αποτυχία φόρτωσης ρυθμίσεων Trickplay';
+      'Αποτυχία φόρτωσης ρυθμίσεων παιχνιδιού';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6257,64 +6231,60 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminAddTuner => 'Προσθήκη δέκτη';
 
   @override
-  String get adminEditTuner => 'Επεξεργασία δέκτη';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Δέκτης M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Αρχείο ή URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Διεύθυνση IP του δέκτη';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Εμφανιζόμενο όνομα';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Πράκτορας χρήστη';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Όριο ταυτόχρονων συνδέσεων';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Ο μέγιστος αριθμός ροών που επιτρέπει ταυτόχρονα ο δέκτης. Ορίστε 0 για απεριόριστες.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Εφεδρικός μέγιστος ρυθμός bit ροής';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Εισαγωγή μόνο των αγαπημένων καναλιών';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Να επιτρέπεται η διακωδικοποίηση με υλικό';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Να επιτρέπεται το κοντέινερ διακωδικοποίησης fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Να επιτρέπεται η κοινή χρήση ροής';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Ενεργοποίηση επανάληψης ροής';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Παράβλεψη DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Ανάγνωση της εισόδου στον εγγενή ρυθμό καρέ';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Επεξεργασία παρόχου';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6323,50 +6293,50 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Αρχείο ή URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Πρόθεμα ταινιών';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Κατηγορίες ταινιών';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Διαχωρίστε τις κατηγορίες με κάθετη γραμμή.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Κατηγορίες παιδικών';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Κατηγορίες ειδήσεων';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Κατηγορίες αθλητικών';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Όνομα χρήστη';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Κωδικός πρόσβασης';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Χώρα';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Επιλέξτε χώρα';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Ταχυδρομικός κώδικας';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Λήψη προγράμματος';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Πρόγραμμα';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Ενεργοποίηση όλων των δεκτών';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Τύπος δέκτη';
@@ -6408,7 +6378,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Αυτός ο τύπος δέκτη δεν υποστηρίζει επαναφορά.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6431,45 +6401,43 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Διαδρομή εγγραφής σειράς';
 
   @override
-  String get adminMovieRecordingPath => 'Διαδρομή εγγραφής ταινιών';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Ημέρες δεδομένων οδηγού';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Αυτόματο';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ημέρες';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Διαδρομή εφαρμογής μετεπεξεργασίας';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Ορίσματα μετεπεξεργαστή';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Αποθήκευση μεταδεδομένων NFO της εγγραφής';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Αποθήκευση εικόνων της εγγραφής';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Χρονισμός';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Διαδρομές εγγραφών';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Μετεπεξεργασία';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Δεδομένα οδηγού: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6515,15 +6483,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminGuideProviders => 'Πάροχοι οδηγών';
 
   @override
-  String get adminRefreshGuideData => 'Ανανέωση δεδομένων οδηγού';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Η ανανέωση των δεδομένων οδηγού ξεκίνησε';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Η εργασία ανανέωσης του οδηγού δεν είναι διαθέσιμη σε αυτόν τον διακομιστή.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Προσθήκη παρόχου';
@@ -6606,7 +6573,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminLiveTvTitle => 'Διαχείριση ζωντανής τηλεόρασης';
 
   @override
-  String get adminApply => 'Εφαρμογή';
+  String get adminApply => 'Εφαρμόζω';
 
   @override
   String get adminNotSet => 'Δεν έχει οριστεί';
@@ -6658,7 +6625,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Επεξεργαστής Μεταδεδομένων';
 
   @override
-  String get adminMetadataIdentify => 'Αναγνώριση';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Τύπος';
@@ -6944,7 +6911,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Αφαίρεση';
+  String get adminReposRemove => 'Αφαιρώ';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7076,20 +7043,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Ενεργοποίηση εκκίνησης οθόνης';
 
   @override
-  String get adminBrandingSplashUpload => 'Μεταφόρτωση εικόνας';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Η οθόνη έναρξης ενημερώθηκε';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Η μεταφόρτωση της οθόνης έναρξης απέτυχε';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Η οθόνη έναρξης καταργήθηκε';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Καμία προσαρμοσμένη οθόνη έναρξης';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Επιτάχυνση υλικού';
@@ -7106,132 +7072,121 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ενεργοποίηση αποκωδικοποίησης υλικού για:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Συσκευή QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ενεργοποίηση του βελτιωμένου αποκωδικοποιητή NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Προτίμηση του εγγενούς αποκωδικοποιητή υλικού του συστήματος';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Βάθος χρώματος αποκωδικοποίησης υλικού';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Αποκωδικοποίηση HEVC 10-bit';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Αποκωδικοποίηση VP9 10-bit';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Αποκωδικοποίηση HEVC RExt 8/10-bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Αποκωδικοποίηση HEVC RExt 12-bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Κωδικοποίηση με υλικό';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding =>
-      'Να επιτρέπεται η κωδικοποίηση HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding =>
-      'Να επιτρέπεται η κωδικοποίηση AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Ενεργοποίηση του κωδικοποιητή Intel H.264 χαμηλής κατανάλωσης';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Ενεργοποίηση του κωδικοποιητή Intel HEVC χαμηλής κατανάλωσης';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Χαρτογράφηση τόνων';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'Ενεργοποίηση χαρτογράφησης τόνων';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Ενεργοποίηση χαρτογράφησης τόνων VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Ενεργοποίηση χαρτογράφησης τόνων VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Αλγόριθμος χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Λειτουργία χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Εύρος χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Αποκορεσμός χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Κορυφή χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Παράμετρος χαρτογράφησης τόνων';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Φωτεινότητα χαρτογράφησης τόνων VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Αντίθεση χαρτογράφησης τόνων VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Προρυθμίσεις και ποιότητα';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Προρύθμιση κωδικοποιητή';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF κωδικοποίησης H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF κωδικοποίησης H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Μέθοδος αποδιαπλοκής';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Διπλασιασμός του ρυθμού καρέ κατά την αποδιαπλοκή';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Ήχος';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Ενεργοποίηση κωδικοποίησης ήχου VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Ενίσχυση μείξης ήχου';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Αλγόριθμος στερεοφωνικής μείξης';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Μέγιστο μέγεθος ουράς πολυπλεξίας';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Αυτόματο';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Κωδικοποίηση';
@@ -7353,10 +7308,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminTaskNeverRun => 'Μην τρέχετε ποτέ';
 
   @override
-  String get adminTaskStop => 'Διακοπή';
+  String get adminTaskStop => 'Στάση';
 
   @override
-  String get adminRunningTasks => 'Εργασίες σε εξέλιξη';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Τρέξιμο';
@@ -7426,8 +7381,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ώρες',
-      one: '1 ώρα',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7473,22 +7428,22 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesλ';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursω';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysη';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7508,44 +7463,43 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Δημόσια θύρα HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Απαίτηση HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Ανακατεύθυνση όλων των απομακρυσμένων αιτημάτων σε HTTPS. Δεν έχει καμία επίδραση αν ο διακομιστής δεν διαθέτει έγκυρο πιστοποιητικό.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Κωδικός πρόσβασης πιστοποιητικού';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Ρυθμίσεις IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Ενεργοποίηση IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Ενεργοποίηση IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Ενεργοποίηση αυτόματης αντιστοίχισης θυρών';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Δίκτυα LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Λίστα διευθύνσεων IP ή υποδικτύων CIDR, χωρισμένων με κόμμα ή ανά γραμμή, που θεωρούνται μέρος του τοπικού δικτύου.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Δημοσιευμένα URI διακομιστή';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Αντιστοιχίστε ένα υποδίκτυο ή μια διεύθυνση σε δημοσιευμένο URL, π.χ. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Διαδρομή πιστοποιητικού';
@@ -7577,12 +7531,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Ρυθμιστικό γκάζι';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Καθυστέρηση περιορισμού (δευτερόλεπτα)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Να επιτρέπεται η εξαγωγή υπότιτλων κατά την αναπαραγωγή';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Ελάχιστο ποσοστό βιογραφικού';
@@ -7641,23 +7594,22 @@ class AppLocalizationsEl extends AppLocalizations {
       'Κατώφλι αργής απόκρισης (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ενεργοποίηση προειδοποιήσεων αργής απόκρισης';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Ενεργοποίηση του Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Διακομιστής';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Μεταδεδομένα';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Διαδρομές';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Επιδόσεις';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Διαδρομή προσωρινής μνήμης';
@@ -7669,7 +7621,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminGeneralServerName => 'Όνομα διακομιστή';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Προτιμώμενη γλώσσα εμφάνισης';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Αποτυχία φόρτωσης ρυθμίσεων';
@@ -7722,8 +7674,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# συμμετέχοντες',
-      one: '# συμμετέχων',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7871,8 +7823,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Βρέθηκαν # σειρές',
-      one: 'Βρέθηκε # σειρά',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7913,21 +7865,20 @@ class AppLocalizationsEl extends AppLocalizations {
   String get offlineSavedMedia => 'Αποθηκευμένα μέσα';
 
   @override
-  String get offlineBannerTitle => 'Είστε εκτός σύνδεσης';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Εμφανίζονται οι λήψεις σας';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Λήψεις';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Δεν είναι δυνατή η σύνδεση με τον διακομιστή σας';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Αναπαραγωγή από τις λήψεις μέχρι να επανέλθει';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8001,10 +7952,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get pinForgot => 'Ξεχάσατε το PIN;';
 
   @override
-  String get pinClear => 'Εκκαθάριση';
+  String get pinClear => 'Σαφής';
 
   @override
-  String get pinBackspace => 'Διαγραφή';
+  String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized => 'Εγκρίθηκε το αίτημα Quick Connect.';
@@ -8015,27 +7966,27 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get quickConnectNotSupported =>
-      'Το Quick Connect δεν υποστηρίζεται σε αυτόν τον διακομιστή.';
+      'Η γρήγορη σύνδεση δεν υποστηρίζεται σε αυτόν τον διακομιστή.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Απέτυχε η εξουσιοδότηση του κωδικού Quick Connect.';
+      'Απέτυχε η εξουσιοδότηση του κώδικα γρήγορης σύνδεσης.';
 
   @override
   String get quickConnectDisabled =>
-      'Το Quick Connect είναι απενεργοποιημένο σε αυτόν τον διακομιστή.';
+      'Η γρήγορη σύνδεση είναι απενεργοποιημένη σε αυτόν τον διακομιστή.';
 
   @override
   String get quickConnectForbidden =>
-      'Ο λογαριασμός σας δεν μπορεί να εξουσιοδοτήσει αυτό το αίτημα Quick Connect.';
+      'Ο λογαριασμός σας δεν μπορεί να εξουσιοδοτήσει αυτό το αίτημα Γρήγορης σύνδεσης.';
 
   @override
   String get quickConnectNotFound =>
-      'Ο κωδικός Quick Connect δεν βρέθηκε. Δοκιμάστε έναν νέο κωδικό.';
+      'Ο κωδικός γρήγορης σύνδεσης δεν βρέθηκε. Δοκιμάστε έναν νέο κωδικό.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Το Quick Connect απέτυχε: $message';
+    return 'Η γρήγορη σύνδεση απέτυχε: $message';
   }
 
   @override
@@ -8205,7 +8156,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Η αναπαραγωγή έχει διακοπεί. Παρακολουθείς ακόμα;';
 
   @override
-  String get stillWatchingStop => 'Διακοπή';
+  String get stillWatchingStop => 'Στάση';
 
   @override
   String get stillWatchingContinue => 'Συνεχίζω';
@@ -8267,7 +8218,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Επιτρέψτε την περιστροφή';
 
   @override
-  String get playerTooltipPrevious => 'Προηγούμενο';
+  String get playerTooltipPrevious => 'Προηγούμενος';
 
   @override
   String get playerTooltipSeekBack => 'Αναζητήστε πίσω';
@@ -8292,13 +8243,13 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Απόκρυψη από τη Συνέχιση παρακολούθησης';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Απόκρυψη από τα Επόμενα';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Προσθήκη σε συλλογή';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8353,15 +8304,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsAlphabetical => 'Αλφαβητικός';
 
   @override
-  String get settingsConnectionSection => 'ΣΥΝΔΕΣΗ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Να επιτρέπονται τα αυτο-υπογεγραμμένα πιστοποιητικά';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Εμπιστοσύνη σε διακομιστές που χρησιμοποιούν αυτο-υπογεγραμμένα πιστοποιητικά TLS ή πιστοποιητικά ιδιωτικής CA. Ενεργοποιήστε το μόνο για διακομιστές που ελέγχετε εσείς. Απενεργοποιεί την επαλήθευση πιστοποιητικών για όλες τις συνδέσεις.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ΑΠΟΡΡΗΤΟ ΚΑΙ ΑΣΦΑΛΕΙΑ';
@@ -8377,11 +8327,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Προφορές θεμάτων, σκηνικά, δείκτες παρακολούθησης και μουσική θεμάτων';
 
   @override
-  String get settingsDetailsScreen => 'Οθόνη λεπτομερειών';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Στυλ, θόλωμα φόντου και συμπεριφορά καρτελών';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Αρχική Σελίδα';
@@ -8419,11 +8369,11 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Εμφάνιση του κουμπιού Seerr στη γραμμή πλοήγησης';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Πάντα εμφάνιση των ετικετών κειμένου στην επάνω γραμμή πλοήγησης';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8527,8 +8477,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ειδοποιήσεις άδειας',
-      one: '# ειδοποίηση άδειας',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8578,17 +8528,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Παράλειψη εισαγωγών και εξόδων;';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Αντίστροφη μέτρηση τμήματος πολυμέσων';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Γραμμή προόδου';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Χρονόμετρο';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Κανένα';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Προτροπή χρήστη';
@@ -8799,7 +8748,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ελάχιστη καθυστέρηση παράλειψης';
 
   @override
-  String get settingsSyncplayExtraOffset => 'Πρόσθετη αντιστάθμιση SyncPlay';
+  String get settingsSyncplayExtraOffset => 'SyncPlay Extra Offset';
 
   @override
   String get onNow => 'Στο Τώρα';
@@ -8822,7 +8771,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Πρόσφατες κυκλοφορίες: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8856,11 +8805,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αναγκαστική αναπαραγωγή χωρίς σήραγγα. Χρήσιμο σε συσκευές με ασυνέχειες ήχου/εικόνας με σήραγγα.';
 
   @override
-  String get enableTunnelingTitle => 'Ενεργοποίηση διοχέτευσης';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Για προχωρημένους. Δρομολογεί τον ήχο και το βίντεο μέσω μιας συζευγμένης διαδρομής υλικού. Είναι απενεργοποιημένο από προεπιλογή επειδή προκαλεί διακοπές ήχου/βίντεο σε ορισμένες συσκευές.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8887,15 +8836,14 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εφαρμόστε υποδείξεις μεγέθους γραμματοσειράς που είναι ενσωματωμένες στο κομμάτι υπότιτλων. Απενεργοποιήστε τη χρήση του μεγέθους υποτίτλων από τις προτιμήσεις στυλ σας.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Εμφάνιση λεπτομερειών πολυμέσων';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Εμφάνιση των λεπτομερειών του επιλεγμένου στοιχείου στο επάνω μέρος των σελίδων της Βιβλιοθήκης.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Απόκρυψη των εικόνων φόντου κατά την περιήγηση;';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings =>
@@ -8914,40 +8862,37 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Κατάστημα θεμάτων';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Περιηγηθείτε και αποθηκεύστε θέματα της κοινότητας';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Αποθηκεύστε ένα θέμα για να το χρησιμοποιείτε όπως τα υπόλοιπα αποθηκευμένα θέματά σας.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty =>
-      'Δεν υπάρχουν διαθέσιμα θέματα αυτήν τη στιγμή.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Δεν ήταν δυνατή η φόρτωση του Καταστήματος θεμάτων. Ελέγξτε τη σύνδεσή σας και δοκιμάστε ξανά.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Αποθήκευση';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Αποθήκευση και εφαρμογή';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Αποθηκεύτηκε';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage =>
-      'Δεν ήταν δυνατή η φόρτωση αυτού του θέματος.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Αποθηκεύτηκε το «$themeName».';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -9006,21 +8951,21 @@ class AppLocalizationsEl extends AppLocalizations {
   String get homeRowsSection => 'Αρχικές Σειρές';
 
   @override
-  String get homeRowDisplay => 'Εμφάνιση σειρών αρχικής';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Ενότητες σειρών αρχικής';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Διακόπτες σειρών αρχικής';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Ενεργοποίηση ή απενεργοποίηση των κατηγοριών σειρών αρχικής που βασίζονται σε βιβλιοθήκες';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Ενεργοποιήστε τους παρακάτω διακόπτες για να εμφανίζονται οι σειρές στις Ενότητες αρχικής.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Τύπος σειρών';
@@ -9079,56 +9024,55 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση Ταινιών, Σειρών ή και των δύο στις σειρές Ειδών.';
 
   @override
-  String get displayPlaylistsRows => 'Εμφάνιση σειρών λιστών αναπαραγωγής';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Εμφάνιση των σειρών λιστών αναπαραγωγής στις Ενότητες αρχικής.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Ταξινόμηση σειρών λιστών αναπαραγωγής';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ταξινομήστε τις σειρές λιστών αναπαραγωγής κατά ημερομηνία προσθήκης, ημερομηνία κυκλοφορίας, αλφαβητικά και άλλα.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Εμφάνιση σειρών ήχου';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Εμφάνιση των σειρών ήχου στις Ενότητες αρχικής.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ταξινόμηση σειρών ήχου';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ταξινομήστε τις σειρές ήχου κατά ημερομηνία προσθήκης, ημερομηνία κυκλοφορίας, αλφαβητικά και άλλα.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Λίστες αναπαραγωγής ήχου';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Εμφάνιση';
 
   @override
-  String get layout => 'Διάταξη';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Θέμα';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Πληκτρολόγιο';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Κουμπιά';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Απόδοση';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Διαμόρφωση MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Μέγεθος κάρτας';
@@ -9138,7 +9082,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Ορίστε εξωτερικό πρόγραμμα αναπαραγωγής για να ενεργοποιηθεί η επιλογή αναπαραγωγής με παρατεταμένο πάτημα';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9154,7 +9098,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audioTranscodeTarget => 'Στόχος διακωδικοποίησης ήχου';
 
   @override
-  String get passthrough => 'Διέλευση';
+  String get passthrough => 'Passthrough';
 
   @override
   String get supportedOnThisDevice => 'Υποστηρίζεται σε αυτήν τη συσκευή';
@@ -9164,7 +9108,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Δεν υποστηρίζεται σε αυτήν τη συσκευή';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Διέλευση DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
@@ -9172,7 +9116,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Διέλευση TrueHD με Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
   String get mediaPlayerBehavior => 'Συμπεριφορά Media Player';
@@ -9413,7 +9357,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appearancesSeerr => 'Εμφανίσεις (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Συμμετοχές συντελεστών (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Παρακολουθήστε με ομάδα';
@@ -9499,8 +9443,8 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count βιβλιοθήκες',
-      one: '1 βιβλιοθήκη',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9659,13 +9603,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get loadingShuffle => 'Φόρτωση τυχαίας αναπαραγωγής...';
 
   @override
-  String get libraryShuffleLabel => 'ΤΥΧΑΙΑ ΑΠΟ ΒΙΒΛΙΟΘΗΚΗ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ΤΥΧΑΙΑ ΕΠΙΛΟΓΗ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ΤΥΧΑΙΑ ΑΠΟ ΕΙΔΗ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Αυτόματη εναλλαγή HDR';
@@ -9678,222 +9622,222 @@ class AppLocalizationsEl extends AppLocalizations {
   String get whenFullscreen => 'Σε πλήρη οθόνη';
 
   @override
-  String get changeArtwork => 'Αλλαγή γραφικών';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Λείπει';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Όρια διακωδικοποίησης';
 
   @override
-  String get clearAllArtworkButton => 'Εκκαθάριση όλων των γραφικών;';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Είστε βέβαιοι ότι θέλετε να διαγράψετε όλα τα ληφθέντα γραφικά;';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Επιβεβαίωση εκκαθάρισης';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Είστε βέβαιοι ότι θέλετε να διαγράψετε το εξής: $itemType;';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Μεταφόρτωση;';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Ανάλυση: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Εμφάνιση μόνο των γραφικών στη γλώσσα του περιβάλλοντος';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Επιβεβαίωση εκκαθάρισης όλων';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Η εικόνα μεταφορτώθηκε με επιτυχία!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Η μεταφόρτωση της εικόνας απέτυχε: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Ο ορισμός της εικόνας απέτυχε: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Η διαγραφή της εικόνας απέτυχε: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Η εκκαθάριση όλων των γραφικών απέτυχε: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ναι';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Αφίσα';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Εικόνες φόντου';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Λογότυπο';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Μικρογραφία';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Εικαστικό';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Εικαστικό δίσκου';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Στιγμιότυπο';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Εξώφυλλο κουτιού';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Οπισθόφυλλο κουτιού';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Εικαστικό μενού';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'αφίσα';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'εικόνα φόντου';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'λογότυπο';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'μικρογραφία';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'εικαστικό';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'εικαστικό δίσκου';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'στιγμιότυπο';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'εξώφυλλο κουτιού';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'οπισθόφυλλο κουτιού';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'εικαστικό μενού';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Όλες';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Υψηλή (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Μεσαία (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Χαμηλή (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Πηγές';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Κεφάλαια';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Σελιδοδείκτες';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Σημειώσεις';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Ουρά';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Χρονολόγιο';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Το χρονολόγιο είναι κενό';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Όλο το βιβλίο';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Εστιασμένο χρονολόγιο';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Εξαγωγή σελιδοδεικτών';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Εξαγωγή σημειώσεων';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Εξαγωγή όλων';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Έγινε εξαγωγή στο $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Η εξαγωγή απέτυχε: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Στίχοι';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Προσθήκη σελιδοδείκτη';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Προσθήκη σημείωσης';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Επεξεργασία σημείωσης';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Γράψτε μια σημείωση για αυτό το σημείο';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Χρονοδιακόπτης ύπνου';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Ανενεργό';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Τέλος κεφαλαίου';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Προσαρμοσμένος';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Απομένουν $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9901,58 +9845,58 @@ class AppLocalizationsEl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count λεπτά',
-      one: '1 λεπτό',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Ταχύτητα αναπαραγωγής';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Απομένει';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Πέρασε';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Πίσω $secondsδ';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Μπροστά $secondsδ';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Προηγούμενο κεφάλαιο';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Επόμενο κεφάλαιο';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Κεφάλαιο $current από $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Χωρίς κεφάλαια';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Δεν υπάρχουν ακόμα σελιδοδείκτες';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Δεν υπάρχουν ακόμα σημειώσεις';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Προστέθηκε σελιδοδείκτης στο $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Επαναφορά σε 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9960,257 +9904,249 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Αποθήκευση';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Ακύρωση';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Διαγραφή';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Προτιμήσεις υπότιτλων';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Αλλάξτε τις λειτουργίες υπότιτλων, τις προεπιλεγμένες γλώσσες, την εμφάνιση και τις επιλογές απόδοσης.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Απόδοση υπότιτλων';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Επιλογές εμφάνισης';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Ημερομηνία κυκλοφορίας (αύξουσα)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Ημερομηνία κυκλοφορίας (φθίνουσα)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Ομαδοποίηση συμμετοχών';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Ομαδοποίηση πολλαπλών ρόλων';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Προειδοποίηση δικαιωμάτων εγγραφής βιβλιοθήκης';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Πώς να το διορθώσετε:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Παραχωρήστε δικαιώματα εγγραφής στον χρήστη της υπηρεσίας Jellyfin (π.χ. jellyfin ή Docker PUID/PGID) για τους φακέλους της βιβλιοθήκης πολυμέσων σας στον διακομιστή.\n\n2. Εναλλακτικά, μεταβείτε στον Πίνακα ελέγχου του Jellyfin -> Βιβλιοθήκες, επεξεργαστείτε αυτήν τη βιβλιοθήκη και απενεργοποιήστε την επιλογή «Αποθήκευση εξωφύλλων στους φακέλους πολυμέσων», ώστε τα εξώφυλλα να αποθηκεύονται στην εσωτερική βάση δεδομένων του Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Απόρριψη';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Η βιβλιοθήκη σας «$libraryName» έχει ρυθμιστεί να αποθηκεύει τα εξώφυλλα απευθείας στους φακέλους πολυμέσων (η επιλογή «Αποθήκευση εξωφύλλων στους φακέλους πολυμέσων» είναι ενεργοποιημένη). Ωστόσο, το Jellyfin έλεγξε τα δικαιώματα εγγραφής και δεν έχει άδεια να γράψει αρχεία σε αυτόν τον κατάλογο:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Φαίνεται ότι το Jellyfin δεν κατάφερε να ενημερώσει τα εξώφυλλα. Η βιβλιοθήκη σας έχει ρυθμιστεί να αποθηκεύει τα εξώφυλλα απευθείας στους φακέλους πολυμέσων (η επιλογή «Αποθήκευση εξωφύλλων στους φακέλους πολυμέσων» είναι ενεργοποιημένη). Αυτό το σφάλμα συνήθως προκύπτει όταν η διεργασία του διακομιστή Jellyfin δεν έχει άδεια να γράψει αρχεία στους καταλόγους πολυμέσων σας.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Εξωτερικές λίστες';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Επανάληψη';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Πληροφορίες αρχείου';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Μέγεθος: $size  •  Μορφή: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Εμφάνιση όλων των κομματιών ήχου ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Εμφάνιση όλων των κομματιών υπότιτλων ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Έλεγχος δυνατότητας απευθείας αναπαραγωγής...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Δυνατότητα απευθείας αναπαραγωγής: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Εξαναγκασμένο';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Η μορφή κοντέινερ δεν υποστηρίζεται από το πρόγραμμα αναπαραγωγής.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Ο κωδικοποιητής βίντεο δεν υποστηρίζεται.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Ο κωδικοποιητής ήχου δεν υποστηρίζεται.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Η μορφή υπότιτλων δεν υποστηρίζεται (απαιτείται εγγραφή στην εικόνα).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Το προφίλ ήχου δεν υποστηρίζεται.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Το προφίλ βίντεο δεν υποστηρίζεται.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Το επίπεδο βίντεο δεν υποστηρίζεται.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Η ανάλυση του βίντεο δεν υποστηρίζεται από αυτήν τη συσκευή.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Το βάθος bit του βίντεο δεν υποστηρίζεται.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Ο ρυθμός καρέ του βίντεο δεν υποστηρίζεται.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Ο ρυθμός bit του αρχείου υπερβαίνει το όριο ροής του προγράμματος αναπαραγωγής.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Ο ρυθμός bit του βίντεο υπερβαίνει το όριο ροής.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Ο ρυθμός bit του ήχου υπερβαίνει το όριο ροής.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Ο αριθμός των καναλιών ήχου δεν υποστηρίζεται.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Αλφαβητικά';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Σειρά κυκλοφορίας (αύξουσα)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Σειρά κυκλοφορίας (φθίνουσα)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Προσαρμοσμένη (μεταφορά και απόθεση)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Επιλογές ταξινόμησης λίστας αναπαραγωγής';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Επαναφορά ταξινόμησης';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Νέα παρακολούθηση Σ$season:Ε$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Νέα παρακολούθηση λίστας αναπαραγωγής';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Δεν βρέθηκαν υπότιτλοι.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Στοιχεία ελέγχου διαχειριστή';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Μηχανή απόδοσης (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Το Impeller είναι ο σύγχρονος επεξεργαστής απόδοσης GPU του Flutter, για πιο ομαλά κινούμενα γραφικά και λιγότερα κολλήματα. Σε ορισμένα TV box και παλαιότερες GPU μπορεί να προκαλέσει προβλήματα εμφάνισης ή μαύρο βίντεο· απενεργοποιήστε το αν παρατηρήσετε κάτι τέτοιο. Το Αυτόματο επιλέγει την καλύτερη προεπιλογή για τη συσκευή σας. Επανεκκινήστε το Moonfin για να εφαρμοστεί.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Αυτόματο';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ενεργό';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Ανενεργό';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Απαιτείται επανεκκίνηση';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Το Moonfin πρέπει να επανεκκινήσει για να αλλάξει η μηχανή απόδοσης. Κλείστε την εφαρμογή τώρα και ανοίξτε την ξανά για να εφαρμοστεί.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Κλείσιμο εφαρμογής τώρα';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Ανανέωση βιβλιοθήκης';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Ανανέωση όλων των βιβλιοθηκών';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Ημερομηνία προσθήκης (παλαιότερα πρώτα)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Ημερομηνία προσθήκης (νεότερα πρώτα)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Αλφαβητικά (Α έως Ω)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Αλφαβητικά (Ω έως Α)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Φόρτωση αναλυτικών στοιχείων διακομιστή... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Ίδια με την πηγή';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb: Κορυφαίες 250 ταινίες';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb: Κορυφαίες 250 τηλεοπτικές σειρές';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb: Δημοφιλέστερες ταινίες';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows =>
-      'IMDb: Δημοφιλέστερες τηλεοπτικές σειρές';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'IMDb: Ταινίες με τη χαμηλότερη βαθμολογία';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb: Κορυφαίες αγγλόφωνες ταινίες';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -13264,6 +13264,17 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   }
 
   @override
+  String get discoverRows => 'Discover Rows';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      'Drag to reorder. Enable or disable rows. Enabled row order syncs with the Moonfin plugin.';
+
+  @override
+  String get discoverRowsDescription =>
+      'Drag to reorder. Enable or disable rows.';
+
+  @override
   String get enabled => 'Enabled';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -12,19 +12,19 @@ class AppLocalizationsEo extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'KONTAJ PREFEROJ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Interfaca lingvo';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Sistema defaŭlto';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Ensalutu';
 
   @override
-  String get empty => 'Malplena';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Rapida Konekto';
 
   @override
   String get password => 'Pasvorto';
@@ -141,62 +141,62 @@ class AppLocalizationsEo extends AppLocalizations {
   String get settingsAppearanceTheme => 'Aplika Temo';
 
   @override
-  String get detailScreenStyle => 'Stilo de detala ekrano';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasika estas la origina centrigita aranĝo de Moonfin. Moderna estas respondema kinema aranĝo.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasika';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderna';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Etenditaj langetoj';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Aŭtomate montri la enhavon de la langetoj dum vi trarigardas ilin. Malŝaltu por malfermi kaj fermi ĉiun langeton permane.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Ĉu montri teknikajn detalojn?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Montri informojn pri kodeko, distingivo kaj fluo en la resumo de la banero';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Rekomenda sistemo';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Uzi la lok-bibliotekan algoritmon de Moonfin Recommends aŭ la retajn similecajn metrikojn de TMDb. Noto: retaj rekomendoj bezonas Seerr-integriĝon.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-simileco';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Ĉu apliki limon de aĝoklasifiko?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limigi la sugestojn de Moonfin Recommends laŭ la aĝoklasifiko de la celata aŭdvidaĵo';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Interfaca stilo';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Aŭtomata adaptiĝas al via aparato. Elektu Apple aŭ Material por devigi aspekton.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Aŭtomata';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsEo extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kvalito de vitro';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Aŭtomata elektas la plej bonan vitran efekton por ĉi tiu aparato. Plena devigas veran malfokusigon; Reduktita uzas malpezan vitron, kiu ŝparas GPU-energion.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Aŭtomata';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Plena';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reduktita';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Ŝanĝu inter Moonfin kaj Neon Pulse sen rekomenci la apon';
 
   @override
-  String get customThemeTitle => 'Propra temo';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Propraj temoj ŝanĝas vidajn elementojn tra Moonfin. Elektu unu el ĉi tiuj ebloj laŭ via stilo.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Preferas sisteman klavaron';
@@ -253,18 +253,18 @@ class AppLocalizationsEo extends AppLocalizations {
       'Synthwave-stilado kun magenta brilo, cejana teksto kaj pli forta kroma kontrasto';
 
   @override
-  String get themeGlass => 'Vitro';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Likva-vitra stilo kun drivanta gradienta fono, prujnaj surfacoj kaj Apple-blua akcento';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bita Heroo';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro piksel-arta stilo kun dika paletro, blokecaj borderoj, akraj falombroj kaj piksela tiparo';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Ensalutu per via Emby Connect-konto';
@@ -326,36 +326,35 @@ class AppLocalizationsEo extends AppLocalizations {
   String get exit => 'Eliro';
 
   @override
-  String get gameMenu => 'Menuo';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Paŭzita';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Konservi staton';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Ludoj';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Ŝargi staton';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Rapide antaŭen';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Agordoj de emulilo';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Ĉi tiu kerno havas neniujn agordeblajn opciojn.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Tenu por malfermi la menuon';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Ludado ankoraŭ ne estas subtenata sur ĉi tiu aparato.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Neniuj hejmaj vicoj povus esti ŝarĝitaj';
@@ -371,13 +370,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get guide => 'Gvidilo';
 
   @override
-  String get recordings => 'Registraĵoj';
+  String get recordings => 'Registradoj';
 
   @override
   String get schedule => 'Horaro';
 
   @override
-  String get series => 'Serioj';
+  String get series => 'Serio';
 
   @override
   String get noItemsFound => 'Neniuj eroj trovitaj';
@@ -601,7 +600,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get listen => 'Aŭskultu';
 
   @override
-  String get resume => 'Daŭrigi';
+  String get resume => 'Rekomenci';
 
   @override
   String get failedToLoadLibrary => 'Malsukcesis ŝargi bibliotekon';
@@ -745,13 +744,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get readStatus => 'Legu';
 
   @override
-  String get watched => 'Spektitaj';
+  String get watched => 'Rigardis';
 
   @override
   String get unread => 'Nelegita';
 
   @override
-  String get unwatched => 'Nespektitaj';
+  String get unwatched => 'Nerigardita';
 
   @override
   String get seriesStatus => 'Serio Statuso';
@@ -763,43 +762,43 @@ class AppLocalizationsEo extends AppLocalizations {
   String get books => 'Libroj';
 
   @override
-  String get latestBooks => 'Plej novaj libroj';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Plej novaj aŭdlibroj';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count libroj',
-      one: '1 libro',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Libro';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Aŭdlibro';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% legita';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time restas';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Legi';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Aŭskulti';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Aŭtoro';
@@ -876,8 +875,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count aŭdlibroj',
-      one: '1 aŭdlibro',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -895,7 +894,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get delete => 'Forigi';
 
   @override
-  String get save => 'Konservi';
+  String get save => 'Konservu';
 
   @override
   String get moreLikeThis => 'Pli Kiel Ĉi tio';
@@ -981,8 +980,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Sezonoj',
-      one: '1 Sezono',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -993,40 +992,40 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get items => 'Eroj';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ekstraĵoj';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Malantaŭ la scenejo';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Forigitaj scenoj';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Dokumentetoj';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjuoj';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scenoj';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Mallongaj filmoj';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Antaŭfilmoj';
 
   @override
   String timeRemaining(String time) {
-    return '$time restas';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Finiĝas post $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1044,7 +1043,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get play => 'Ludi';
+  String get play => 'Ludu';
 
   @override
   String get startOver => 'Rekomencu';
@@ -1068,7 +1067,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get version => 'Versio';
 
   @override
-  String get cast => 'Elsendi';
+  String get cast => 'Rolantaro';
 
   @override
   String get trailer => 'Antaŭfilmo';
@@ -1263,13 +1262,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get director => 'DIRECTORO';
 
   @override
-  String get directors => 'REĜISOROJ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'VERKISTO';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARISTOJ';
+  String get writers => 'SKRIBOJ';
 
   @override
   String get studio => 'STUDIO';
@@ -1304,8 +1303,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count trakoj',
-      one: '1 trako',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1315,8 +1314,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ĉapitroj',
-      one: '1 ĉapitro',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1346,13 +1345,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get shuffle => 'Miksi';
 
   @override
-  String get shuffleAllMusic => 'Miksi la tutan muzikon';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Ensalutu al Moonfin per via telefono';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Ne eblas atingi vian servilon';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1364,14 +1363,14 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kanaloj';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Monofonia';
+  String get mono => 'Mono';
 
   @override
-  String get stereo => 'Stereofonia';
+  String get stereo => 'Stereo';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1505,7 +1504,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get bitrateOverride => 'Anstataŭigita bitrapido';
+  String get bitrateOverride => 'Bitrate Override';
 
   @override
   String get audioDelay => 'Audio Prokrasto';
@@ -1551,13 +1550,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get transcodeReasons => 'Transkodi Kialoj';
 
   @override
-  String get player => 'Medialudilo';
+  String get player => 'Ludanto';
 
   @override
   String get container => 'Ujo';
 
   @override
-  String get bitrate => 'Bitrapido';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Video';
@@ -1572,7 +1571,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get codec => 'Kodeko';
 
   @override
-  String get videoBitrate => 'Videa bitrapido';
+  String get videoBitrate => 'Video Bitrate';
 
   @override
   String get track => 'Trako';
@@ -1581,7 +1580,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get channels => 'Kanaloj';
 
   @override
-  String get audioBitrate => 'Aŭdia bitrapido';
+  String get audioBitrate => 'Audio Bitrate';
 
   @override
   String get sampleRate => 'Ekzempla indico';
@@ -1790,22 +1789,22 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Sekva: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}min restas';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h restas';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}min restas';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1828,7 +1827,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get favoriteChannel => 'Ŝatata Kanalo';
 
   @override
-  String get record => 'Registri';
+  String get record => 'Rekordo';
 
   @override
   String get cancelRecordingAction => 'Nuligi Registradon';
@@ -1843,10 +1842,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get unableToCreateRecording => 'Ne eblas krei registradon';
 
   @override
-  String get watch => 'Spekti';
+  String get watch => 'Rigardu';
 
   @override
-  String get close => 'Fermi';
+  String get close => 'Fermu';
 
   @override
   String failedToPlayChannel(String name) {
@@ -2055,8 +2054,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizodoj',
-      one: '1 epizodo',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2281,7 +2280,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detalaj paĝoj, hejmaj vicoj kaj laŭteco';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2295,11 +2294,11 @@ class AppLocalizationsEo extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Ludu dum foliumas hejman ekranon';
 
   @override
-  String get loopThemeMusic => 'Ripetigi teman muzikon';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ripeti la trakon anstataŭ ludi ĝin unufoje';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detaloj Fona Blur';
@@ -2322,23 +2321,23 @@ class AppLocalizationsEo extends AppLocalizations {
   String get playerZoomMode => 'Ludanta Zoom-Reĝimo';
 
   @override
-  String get settingsScrollWheelAction => 'Musa rulumrado';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Elektu kion faras rulumado de la musrado super la video dum ludado.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Malŝaltita';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Serĉi (antaŭen / malantaŭen)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Laŭteco';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Laŭteco';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2392,37 +2391,37 @@ class AppLocalizationsEo extends AppLocalizations {
   String get defaultAudioLanguage => 'Defaŭlta Audio Lingvo';
 
   @override
-  String get fallbackAudioLanguage => 'Rezerva aŭdia lingvo';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Preferi defaŭltan aŭdian trakon';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferi la originalan aŭdian trakon anstataŭ lokalizitan sinkronigadon.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferi aŭdpriskribajn trakojn';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferi aŭdpriskribajn trakojn anstataŭ normalajn trakojn.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodado (Aŭdio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Rekta fluo (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodado (Bitrapido aŭ Distingivo)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodado (Video kaj Aŭdio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodado (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Aŭtomata (Servilo defaŭlta)';
@@ -2503,24 +2502,23 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Elektu kiel la aŭdio estas dekodita. AVR Trapaso sendas krudajn Dolby/DTS-fluojn al via ricevilo; Aŭtomata aŭ Downmix dekodas loke.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Trapaso';
 
   @override
-  String get settingsAudioFallbackCodec => 'Rezerva aŭdia kodeko';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Elektu la celan formaton por transkodi plurkanalan aŭdion kiam la fontfluo ne povas esti rekte ludata aŭ trapasata.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Aŭtomata detekto\n(Rekomendita)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Defaŭlta)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2529,57 +2527,56 @@ class AppLocalizationsEo extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Senperda)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Nur stereofonia)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efika)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Senperda)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maksimumaj aŭdiaj kanaloj';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Agordu la maksimumajn kanalojn de via aŭdia aranĝo. Plurkanalaj fluoj superantaj ĉi tiun limon estos downmiksitaj aŭ transkoditaj.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Aŭtomata detekto\n(Aparatara defaŭlto)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Monofonia';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Stereofonia';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Ĉirkaŭsono';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvarfonia';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Ĉirkaŭsono';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Ĉirkaŭsono';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Ĉirkaŭsono';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Ĉirkaŭsono';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Trapaso (Altnivela)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Kodeka trapaso';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
@@ -2592,16 +2589,16 @@ class AppLocalizationsEo extends AppLocalizations {
   String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Trapaso';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core trapaso';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA trapaso';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD trapaso';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos trapaso';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2654,11 +2651,11 @@ class AppLocalizationsEo extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Parolanto';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kapaŭskultiloj';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kanaloj PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2687,7 +2684,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif trapaso';
+      'audio-spdif passthrough';
 
   @override
   String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktiva Aŭdio-Itinero';
@@ -2747,7 +2744,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get mediaQueuing => 'Vicigo de aŭdvidaĵoj';
+  String get mediaQueuing => 'Media Queuing';
 
   @override
   String get autoQueueNextEpisodes => 'Aŭtovigu sekvajn epizodojn';
@@ -2832,45 +2829,45 @@ class AppLocalizationsEo extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Agordu subtitolan aspekton';
 
   @override
-  String get subtitleMode => 'Subteksta reĝimo';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Markita';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Ĉiam';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Fremda';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Devigita';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Ludas trakojn interne markitajn en la metadatumoj de la dosiero kiel \"default\" aŭ \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Aŭtomate ŝargas kaj montras subtekstojn ĉiufoje kiam video komenciĝas.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Aŭtomate ŝaltas subtekstojn se la defaŭlta aŭdia trako estas en fremda lingvo.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Ŝargas nur subtekstojn eksplicite markitajn per la marko \"forced\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Tute malŝaltas aŭtomatan ŝargon de subtekstoj.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Rezerva subteksta lingvo';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Subteksta fluo';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3075,10 +3072,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showLibrariesInToolbar => 'Montru Bibliotekojn en Ilobreto';
 
   @override
-  String get navbarAlwaysExpanded => 'Ĉiam etendi etikedojn de la navigbreto';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Montri butonon de Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar Opakeco';
@@ -3153,19 +3150,18 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showFolderBrowsingOption => 'Montru dosierujan foliumadan opcion';
 
   @override
-  String get groupItemsIntoCollections => 'Grupigi erojn en kolektojn';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Kaŝi bibliotekajn erojn asociitajn kun kolektoj dum foliumado de bibliotekoj';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Avizo pri bibliotekgrupigo';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Por uzi ĉi tiun agordon, bonvolu certigi ke la bibliotekaj agordoj \"Grupigi filmojn en kolektojn\" kaj/aŭ \"Grupigi seriojn en kolektojn\" estas ebligitaj sub la Montroagordoj de via biblioteko en via Jellyfin- aŭ Emby-servilo.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Biblioteko Videbleco';
@@ -3277,11 +3273,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Aŭtomate ludu antaŭfilmojn en la amaskomunikila trinkejo post 3 sekundoj';
 
   @override
-  String get trailerAudio => 'Aŭdio de antaŭfilmoj';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Ebligi aŭdion por antaŭfilmoj en la aŭdvida breto';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Epizoda Antaŭrigardo';
@@ -3359,11 +3354,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Kombinu ambaŭ vicojn en ununuran hejman sekcion';
 
   @override
-  String get fullScreenRows => 'Etenditaj hejmaj vicoj';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limigi hejmajn vicojn al 1 vico po ekrano';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Per Vico Bilda Tipo';
@@ -3378,7 +3372,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get lastUser => 'Lasta Uzanto';
 
   @override
-  String get currentUser => 'Nuna uzanto';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Ĉiam Aŭtentikigi';
@@ -3443,13 +3437,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get libraryArt => 'Biblioteko Arto';
 
   @override
-  String get logo => 'Emblemo';
+  String get logo => 'Logo';
 
   @override
   String get clock => 'Horloĝo';
 
   @override
-  String get timeout => 'Tempolimo';
+  String get timeout => 'Timeout';
 
   @override
   String minutesShort(int minutes) {
@@ -3483,10 +3477,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get displayClockDuringScreensaver => 'Montru horloĝon dum ekranŝparo';
 
   @override
-  String get clockModeStatic => 'Statika';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Resaltanta';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Putraj Tomatoj (kritikistoj)';
@@ -3557,7 +3551,7 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ebligu kaj reordigu la taksofontojn montritajn tra la aplikaĵo';
 
   @override
-  String get pluginLabel => 'Moonbase-kromaĵo';
+  String get pluginLabel => 'Kromaĵo';
 
   @override
   String get pluginDetected => 'Kromaĵo Detektita';
@@ -3629,7 +3623,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get networks => 'Retoj';
 
   @override
-  String get seerrDiscoveryRows => 'Malkovraj vicoj de Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Restarigu vicojn al defaŭltoj';
@@ -3652,28 +3646,28 @@ class AppLocalizationsEo extends AppLocalizations {
   String get hideAdultContent => 'Kaŝi plenkreskan enhavon en rezultoj';
 
   @override
-  String get seerrNotificationsSection => 'Sciigoj';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Sciigoj pri novaj petoj';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Averti min kiam iu sendas peton';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Ĝisdatigoj pri petoj';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprobita, malaprobita kaj aldonita al via biblioteko';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ĝisdatigoj pri problemoj';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Novaj problemoj, respondoj kaj solvoj';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3681,15 +3675,15 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Malkovra paĝo de Seerr';
+  String get discoverRows => 'Malkovru Vicojn';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Ebligu vicojn por vidi sur la ĉefpaĝo de Seerr. Trenu por reordigi. Propra ordo sinkroniĝas kun Moonbase.';
+      'Trenu por reordigi. Ebligu aŭ malŝalti vicojn. Ebligitaj vic-ordo sinkronigas kun la kromaĵo Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Ebligu vicojn por vidi sur la ĉefpaĝo de Seerr. Trenu por reordigi. Propra ordo sinkroniĝas kun Moonbase.';
+      'Trenu por reordigi. Ebligu aŭ malŝalti vicojn.';
 
   @override
   String get enabled => 'Ebligita';
@@ -3826,7 +3820,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get imageCacheCleared => 'Bildkaŝmemoro vakigita';
 
   @override
-  String get clear => 'Vakigi';
+  String get clear => 'Klara';
 
   @override
   String get browse => 'Foliumi';
@@ -3842,11 +3836,11 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Elŝutante · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importante';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3988,148 +3982,148 @@ class AppLocalizationsEo extends AppLocalizations {
   String get deletedStatus => 'Forigita';
 
   @override
-  String get failedStatus => 'Malsukcesis';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Traktante';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modifita de $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Finita';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ĉi tiu titolo jam estis petita';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Limo de petoj atingita';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Ĉi tiu titolo estas en la bloklisto';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Neniuj sezonoj restas por peti';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Vi ne havas permeson fari ĉi tiun peton';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Petoj';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemoj';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Plej novaj';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Laste modifita';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Neniuj problemoj';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining el $limit filmpetoj restas';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining el $limit sezonpetoj restas';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Parto de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vidi kolekton';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Peti kolekton';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmoj · $available disponeblaj';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Peti $count filmojn';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Petante $current el $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Petis $count filmojn';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Petis $ok el $total filmoj';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Ĉiuj filmoj jam estas disponeblaj aŭ petitaj';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Raporti problemon';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Aŭdio';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Kio malas?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Ĉiuj epizodoj';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizodo';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Malfermita';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Solvita';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Solvi';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Remalfermi';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Raportita de $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentoj';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Aldoni komenton';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Ĉu forigi ĉi tiun problemon?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Sendi raporton';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-Poentaro';
@@ -4144,7 +4138,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get revenueLabel => 'Enspezo';
 
   @override
-  String get runtimeLabel => 'Daŭro';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'Buĝeto';
@@ -4201,7 +4195,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get forward => 'Antaŭen';
 
   @override
-  String get general => 'Ĝenerala';
+  String get general => 'Generalo';
 
   @override
   String get go => 'Iru';
@@ -4222,7 +4216,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get networking => 'Retoj';
 
   @override
-  String get next => 'Sekva';
+  String get next => 'Poste';
 
   @override
   String get path => 'Vojo';
@@ -4246,7 +4240,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get refresh => 'Refreŝigi';
 
   @override
-  String get remote => 'Teleregilo';
+  String get remote => 'Malproksima';
 
   @override
   String get rename => 'Alinomi';
@@ -4264,7 +4258,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get run => 'Kuru';
 
   @override
-  String get search => 'Serĉi';
+  String get search => 'Serĉu';
 
   @override
   String get select => 'Elektu';
@@ -4282,16 +4276,16 @@ class AppLocalizationsEo extends AppLocalizations {
   String get status => 'Statuso';
 
   @override
-  String get stop => 'Haltigi';
+  String get stop => 'Haltu';
 
   @override
-  String get streaming => 'Elsendfluado';
+  String get streaming => 'Streaming';
 
   @override
   String get time => 'Tempo';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Ruzludo';
 
   @override
   String get uninstall => 'Malinstali';
@@ -4309,7 +4303,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get unmute => 'Malŝaltu';
 
   @override
-  String get mute => 'Silentigi';
+  String get mute => 'Mute';
 
   @override
   String get branding => 'Markado';
@@ -4333,25 +4327,25 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotekoj';
 
   @override
-  String get adminDrawerDisplay => 'Montro';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadatumoj';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-agordoj';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodigo';
 
   @override
-  String get adminDrawerResume => 'Daŭrigi';
+  String get adminDrawerResume => 'Rekomenci';
 
   @override
-  String get adminDrawerStreaming => 'Elsendfluado';
+  String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Ruzludo';
 
   @override
   String get adminDrawerDevices => 'Aparatoj';
@@ -4525,13 +4519,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get sessionForward => 'Antaŭen';
 
   @override
-  String get sessionNext => 'Sekva';
+  String get sessionNext => 'Poste';
 
   @override
   String get sessionVolumeDown => 'Vol -';
 
   @override
-  String get sessionVolumeUp => 'Laŭt. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4540,19 +4534,19 @@ class AppLocalizationsEo extends AppLocalizations {
   String get nowPlaying => 'Nun Ludante';
 
   @override
-  String get volume => 'Laŭteco';
+  String get volume => 'Volumo';
 
   @override
   String get actions => 'Agoj';
 
   @override
-  String get videoCodec => 'Videa kodeko';
+  String get videoCodec => 'Video Codec';
 
   @override
   String get audioCodec => 'Aŭdiokodeko';
 
   @override
-  String get hwAccel => 'Aparatara akcelo';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Kompletigo';
@@ -4567,10 +4561,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminClearDates => 'Klaraj datoj';
 
   @override
-  String get adminActivitySeverityAll => 'Ĉiuj gravecoj';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datintervalo';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4607,23 +4601,23 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Ĉu forigi aparaton \'$name\'? La uzanto devos denove ensaluti sur ĉi tiu aparato.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Forigi ĉiujn aparatojn';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Ĉu forigi $count aparatojn? La koncernaj uzantoj devos denove ensaluti. Via nuna aparato ne estas tuŝita.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Aparatoj forigitaj';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Forigis kelkajn aparatojn; $count ne povis esti forigitaj.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4738,252 +4732,244 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminMetadataCountryHint => 'ekz. Usono, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Vojoj';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcioj';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Elŝutiloj';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Konservantoj de metadatumoj';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Elŝutiloj de subtekstoj';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Elŝutiloj de kantotekstoj';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Elŝutiloj de metadatumoj: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Alportiloj de bildoj: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ĉi tiu servilo prezentas neniujn elŝutilojn por ĉi tiu bibliotektipo.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Ĝenerala';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadatumoj';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Enigita informo';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtekstoj';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Bildoj';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serioj';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muziko';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmoj';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Ebligi realtempan monitoradon';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detekti dosierŝanĝojn kaj trakti ilin aŭtomate.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Trakti arkivojn kiel aŭdvidajn dosierojn';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Montri fotojn';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Konservi bildojn en aŭdvidajn dosierujojn';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Aŭtomata refreŝigo de metadatumoj';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Neniam';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Defaŭlta';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Montro';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotekmontro';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Montri dosierujan vidon por prezenti simplajn aŭdvidajn dosierujojn';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Montri specialaĵojn ene de la sezonoj en kiuj ili elsendiĝis';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupigi filmojn en kolektojn';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupigi seriojn en kolektojn';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Montri eksteran enhavon en sugestoj';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Konduto de aldondato';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Uzi aldondaton el';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Dato skanita en la bibliotekon';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Dato kiam la dosiero estis kreita';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadatumoj kaj bildoj';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Preferata lingvo de metadatumoj';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Ĉapitroj';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Daŭro de fikcia ĉapitro (sekundoj)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Longeco de ĉapitroj generitaj por aŭdvidaĵoj kiuj havas neniujn. Agordu al 0 por malŝalti.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Distingivo de ĉapitraj bildoj';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-agordoj';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metadatumoj kongruas kun Kodi kaj similaj klientoj. La agordoj validas por ĉiuj bibliotekoj kiuj konservas NFO-metadatumojn.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Uzanto por kiu konservi spektadan datumon en NFO-dosieroj';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Konservi bildvojojn ene de NFO-dosieroj';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Ebligi vojanstataŭigon por NFO-bildvojoj';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopii extrafanart-bildojn en extrathumbs-dosierujon';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Neniu';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days tagoj';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Uzi enigitajn titolojn';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Uzi enigitajn titolojn por ekstraĵoj';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'Uzi enigitajn epizodinformojn';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Permesi enigitajn subtekstojn';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permesi ĉiujn';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Nur teksto';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Nur bildo';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Neniu';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Preterlasi elŝuton se enigitaj subtekstoj ĉeestas';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Preterlasi elŝuton se la aŭdia trako kongruas kun la elŝutlingvo';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Postuli perfektan subtekstan kongruon';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Konservi subtekstojn en aŭdvidajn dosierujojn';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Ekstrakti ĉapitrajn bildojn';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Ekstrakti ĉapitrajn bildojn dum la bibliotekskano';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Ebligi ekstraktadon de Trickplay-bildoj';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Ekstrakti Trickplay-bildojn dum la bibliotekskano';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Konservi Trickplay-bildojn en aŭdvidajn dosierujojn';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Aŭtomate kunfandi seriojn disigitajn tra pluraj dosierujoj';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Montronomo de sezono nul';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Ebligi LUFS-skanon por aŭdia normaligo';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferi nenorman artistetikedon';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Aŭtomate aldoni filmojn al kolektoj';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Biblioteko nomo estas postulata';
@@ -5101,7 +5087,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminDeleteUser => 'Forigi Uzanton';
 
   @override
-  String get admin => 'Administranto';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5220,143 +5206,143 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminEnableAllChannels => 'Ebligu aliron al ĉiuj kanaloj';
 
   @override
-  String get adminParentalControl => 'Gepatra kontrolo';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Maksimuma permesita aĝoklasifiko';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Enhavo kun pli alta klasifiko estos kaŝita de ĉi tiu uzanto.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Neniu';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloki erojn kun neniu aŭ nerekonata klasifika informo';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Libroj';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanaloj';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Viva televido';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmoj';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muziko';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Antaŭfilmoj';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serioj';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Alirhoraroj';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permesi aliron nur dum la suba horaro. Aliro estas permesita la tutan tagon kiam neniu horaro estas agordita.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Aldoni horaron';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Tago';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Komenco';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fino';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Ĉiutage';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Labortago';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Semajnfino';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Dimanĉo';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Lundo';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Mardo';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Merkredo';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Ĵaŭdo';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Vendredo';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sabato';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Permesitaj etikedoj';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Nur enhavo kun ĉi tiuj etikedoj estas montrata. Lasu malplena por permesi ĉiujn.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokitaj etikedoj';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Enhavo kun ĉi tiuj etikedoj estas kaŝita de ĉi tiu uzanto.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Aldoni etikedon';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Ebligitaj aparatoj';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Ebligitaj kanaloj';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Aŭtentiga provizanto';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Provizanto de pasvortrestarigo';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksimumaj malsukcesaj ensalutprovoj antaŭ ŝloso';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Agordu al 0 por la defaŭlto, aŭ al -1 por malŝalti ŝloson.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-aliro';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'Permesi krei kaj aliĝi al grupoj';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permesi aliĝi al grupoj';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Neniu aliro';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Permesi forigon de enhavo el';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5443,25 +5429,25 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Krei sekurkopion';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Elektu kion inkluzivi en la sekurkopio.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Datumbazo';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Ĉiam inkluzivita';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadatumoj';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtekstoj';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-bildoj';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Kreante sekurkopion...';
@@ -5889,7 +5875,8 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminTrickplaySaved => 'Trickplay-agordoj konservitaj';
 
   @override
-  String get adminTrickplayLoadFailed => 'Malsukcesis ŝargi Trickplay-agordojn';
+  String get adminTrickplayLoadFailed =>
+      'Malsukcesis ŝargi trukludajn agordojn';
 
   @override
   String get adminEnableHardwareAcceleration => 'Ebligu aparatan akcelon';
@@ -6000,7 +5987,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminBaseUrl => 'Baza URL';
 
   @override
-  String get adminBaseUrlHint => 'ekz. /jellyfin';
+  String get adminBaseUrlHint => 'ekz. /mezulo';
 
   @override
   String get https => 'HW Accel';
@@ -6162,60 +6149,60 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminAddTuner => 'Aldonu Agordilon';
 
   @override
-  String get adminEditTuner => 'Redakti agordilon';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-agordilo';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Dosiero aŭ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-adreso de la agordilo';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Amika nomo';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limo de samtempaj konektoj';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'La maksimuma nombro da fluoj kiujn la agordilo permesas samtempe. Agordu al 0 por senlima.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Rezerva maksimuma elsenda bitrapido';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importi nur ŝatatajn kanalojn';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Permesi aparataran transkodadon';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Permesi fMP4-transkodan ujon';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Permesi fludividon';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Ebligi fluripetadon';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignori DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Legi enigon je la denaska kadrofrekvenco';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Redakti provizanton';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6224,50 +6211,50 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Dosiero aŭ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmoprefikso';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmkategorioj';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Apartigu plurajn kategoriojn per vertikala streko.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Infankategorioj';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Novaĵkategorioj';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportkategorioj';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Uzantnomo';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Pasvorto';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Lando';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Elektu landon';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Poŝtkodo';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Akiri listojn';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Listoj';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Ebligi ĉiujn agordilojn';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuner Tipo';
@@ -6309,7 +6296,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ĉi tiu agordiltipo ne subtenas restarigon.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6332,43 +6319,43 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Seria registra vojo';
 
   @override
-  String get adminMovieRecordingPath => 'Vojo de filmregistrado';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Tagoj da programdatumoj';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Aŭtomata';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days tagoj';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Vojo de posttrakta aplikaĵo';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumentoj de posttraktilo';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Konservi NFO-metadatumojn de registrado';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Konservi bildojn de registrado';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tempigo';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Registradvojoj';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Posttraktado';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Programdatumoj: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6410,15 +6397,14 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminGuideProviders => 'Gvidprovizantoj';
 
   @override
-  String get adminRefreshGuideData => 'Refreŝigi programdatumojn';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Refreŝigo de programdatumoj komenciĝis';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Tasko de programrefreŝigo ne estas disponebla sur ĉi tiu servilo.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Aldoni Provizanto';
@@ -6447,7 +6433,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get adminTunerDiscovery => 'Malkovro de agordiloj';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Kanalaj Mapoj';
@@ -6551,7 +6537,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Redaktilo de metadatumoj';
 
   @override
-  String get adminMetadataIdentify => 'Identigi';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tajpu';
@@ -6635,7 +6621,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminMetadataImageBackdrop => 'Fono';
 
   @override
-  String get adminMetadataImageLogo => 'Emblemo';
+  String get adminMetadataImageLogo => 'Logo';
 
   @override
   String get adminMetadataImageBanner => 'Standardo';
@@ -6964,20 +6950,19 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Ebligu plaŭdan ekranon';
 
   @override
-  String get adminBrandingSplashUpload => 'Alŝuti bildon';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Ekranŝprucaĵo ĝisdatigita';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Malsukcesis alŝuti ekranŝprucaĵon';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Ekranŝprucaĵo forigita';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Neniu propra ekranŝprucaĵo';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aparataro Akcelo';
@@ -6992,124 +6977,121 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Ebligu aparatan malkodigon por:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-aparato';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ebligi plibonigitan NVDEC-dekodilon';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferi la denaskan aparataran dekodilon de la sistemo';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Kolorprofundo de aparatara dekodado';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bita HEVC-dekodado';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bita VP9-dekodado';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bita dekodado';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bita dekodado';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Aparatara kodado';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permesi HEVC-kodadon';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permesi AV1-kodadon';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Ebligi Intel malaltenergian H.264-kodilon';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Ebligi Intel malaltenergian HEVC-kodilon';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tonmapado';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Ebligi tonmapadon';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Ebligi VPP-tonmapadon';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Ebligi VideoToolbox-tonmapadon';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritmo de tonmapado';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Reĝimo de tonmapado';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Amplekso de tonmapado';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Malsaturigo de tonmapado';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pinto de tonmapado';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametro de tonmapado';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'Heleco de VPP-tonmapado';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrasto de VPP-tonmapado';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Antaŭagordoj kaj kvalito';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Antaŭagordo de kodilo';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264-koda CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC)-koda CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metodo de malenteksado';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Duobligi la kadrofrekvencon dum malenteksado';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Aŭdio';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Ebligi aŭdian VBR-kodadon';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Plifortigo de aŭdia downmix';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm =>
-      'Algoritmo de stereofonia downmix';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Maksimuma grandeco de miksvico';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Aŭtomata';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodigado';
@@ -7124,7 +7106,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminPlaybackFallbackFontPath => 'Retipara vojo';
 
   @override
-  String get adminPlaybackStreaming => 'Elsendfluado';
+  String get adminPlaybackStreaming => 'Streaming';
 
   @override
   String get adminResumeVideo => 'Video';
@@ -7228,10 +7210,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminTaskNeverRun => 'Neniam kuru';
 
   @override
-  String get adminTaskStop => 'Haltigi';
+  String get adminTaskStop => 'Haltu';
 
   @override
-  String get adminRunningTasks => 'Aktivaj taskoj';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Kuru';
@@ -7301,8 +7283,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count horoj',
-      one: '1 horo',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7358,7 +7340,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String adminActivityDaysShort(int days) {
-    return '${days}t';
+    return '${days}d';
   }
 
   @override
@@ -7377,49 +7359,49 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Baza URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ekz. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ekz. /mezulo';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Publika HTTP-pordo';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Postuli HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Alidirekti ĉiujn forajn petojn al HTTPS. Havas neniun efikon se la servilo ne havas validan atestilon.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Pasvorto de atestilo';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-agordoj';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Ebligi IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Ebligi IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'Ebligi aŭtomatan pordomapadon';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-retoj';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Listo de IP-adresoj aŭ CIDR-subretoj, apartigitaj per komo aŭ linio, traktataj kiel estantaj en la loka reto.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publikigitaj servilaj URI-oj';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Mapi subreton aŭ adreson al publikigita URL, ekz. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Vojo de atestilo';
@@ -7449,11 +7431,11 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Akcelila bufro';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Bremsa prokrasto (sekundoj)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permesi ekstraktadon de subtekstoj dum ludado';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimuma resumprocento';
@@ -7510,23 +7492,22 @@ class AppLocalizationsEo extends AppLocalizations {
       'Malrapida responda sojlo (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ebligi avertojn pri malrapida respondo';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Ebligi Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Servilo';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadatumoj';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Vojoj';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Rendimento';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cache vojo';
@@ -7538,7 +7519,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminGeneralServerName => 'Servilonomo';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Preferata montrolingvo';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Malsukcesis ŝargi agordojn';
@@ -7590,8 +7571,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# partoprenantoj',
-      one: '# partoprenanto',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7737,8 +7718,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# vicoj malkovritaj',
-      one: '# vico malkovrita',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7779,20 +7760,20 @@ class AppLocalizationsEo extends AppLocalizations {
   String get offlineSavedMedia => 'Savita Amaskomunikilaro';
 
   @override
-  String get offlineBannerTitle => 'Vi estas eksterrete';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Montrante viajn elŝutojn';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Elŝutoj';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Ne eblas atingi vian servilon';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Ludante el elŝutoj ĝis ĝi revenos';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7865,21 +7846,21 @@ class AppLocalizationsEo extends AppLocalizations {
   String get pinForgot => 'Ĉu vi forgesis PIN?';
 
   @override
-  String get pinClear => 'Vakigi';
+  String get pinClear => 'Klara';
 
   @override
-  String get pinBackspace => 'Retropaŝo';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Peto de Quick Connect rajtigita.';
+  String get quickConnectAuthorized => 'Peto de Rapida Konekto rajtigita.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Kodo de Quick Connect estas nevalida aŭ eksvalidiĝinta.';
+      'Rapida Konekto-kodo estas nevalida aŭ eksvalidiĝis.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect ne estas subtenata sur ĉi tiu servilo.';
+      'Rapida Konekto ne estas subtenata sur ĉi tiu servilo.';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7887,19 +7868,19 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect estas malŝaltita sur ĉi tiu servilo.';
+      'Rapida Konekto estas malŝaltita en ĉi tiu servilo.';
 
   @override
   String get quickConnectForbidden =>
-      'Via konto ne povas rajtigi ĉi tiun peton de Quick Connect.';
+      'Via konto ne povas rajtigi ĉi tiun peton de Rapida Konekto.';
 
   @override
   String get quickConnectNotFound =>
-      'Kodo de Quick Connect ne estis trovita. Provu novan kodon.';
+      'Rapida Konekto-kodo ne estis trovita. Provu novan kodon.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect malsukcesis: $message';
+    return 'Rapida Konekto malsukcesis: $message';
   }
 
   @override
@@ -8056,7 +8037,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get lyricsNotAvailable => 'Neniu kantoteksto haveblaj';
 
   @override
-  String get upNext => 'Sekva';
+  String get upNext => 'Up Next';
 
   @override
   String get playNext => 'Ludu Poste';
@@ -8066,7 +8047,7 @@ class AppLocalizationsEo extends AppLocalizations {
       'La reprodukto estas paŭzita. Ĉu vi ankoraŭ rigardas?';
 
   @override
-  String get stillWatchingStop => 'Haltigi';
+  String get stillWatchingStop => 'Haltu';
 
   @override
   String get stillWatchingContinue => 'Daŭrigu';
@@ -8105,7 +8086,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get playerTooltipCastControls => 'Rolitaj kontroloj';
 
   @override
-  String get playerTooltipPlaybackQuality => 'Bitrapido';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'Enigu plenan ekranon';
@@ -8150,13 +8131,14 @@ class AppLocalizationsEo extends AppLocalizations {
   String get contextMenuGoToSeries => 'Iru al Serio';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Kaŝi el Daŭre Rigardi';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Kaŝi el Sekva';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Aldoni al kolekto';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8210,15 +8192,14 @@ class AppLocalizationsEo extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabeta';
 
   @override
-  String get settingsConnectionSection => 'KONEKTO';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permesi memsubskribitajn atestilojn';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Fidi servilojn uzantajn memsubskribitajn aŭ privat-CA TLS-atestilojn. Ebligu nur por serviloj kiujn vi regas. Ĉi tio malŝaltas atestilvalidigon por ĉiuj konektoj.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVATECO & SEKURECO';
@@ -8234,11 +8215,11 @@ class AppLocalizationsEo extends AppLocalizations {
       'Temaj akĉentoj, fonoj, spektitaj indikiloj kaj temomuziko';
 
   @override
-  String get settingsDetailsScreen => 'Detala ekrano';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stilo, fona malfokusigo kaj langeta konduto';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Hejmpaĝo';
@@ -8276,11 +8257,11 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Montri la butonon de Seerr en la navigbreto';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Ĉiam montri tekstajn etikedojn en la supra navigbreto';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8383,8 +8364,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licencavizoj',
-      one: '# licencavizo',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8434,17 +8415,16 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ĉu preterpasi enkondukojn kaj aliajn?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Antaŭnombrado de aŭdvida segmento';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Progresbreto';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Tempigilo';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Neniu';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Prompta Uzanto';
@@ -8672,7 +8652,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Lastatempe eldonita $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8704,11 +8684,11 @@ class AppLocalizationsEo extends AppLocalizations {
       'Devigi ne-tunelitan reproduktadon. Utila sur aparatoj kun tunelaj audio/video malkontinuecoj.';
 
   @override
-  String get enableTunnelingTitle => 'Ebligi tunuladon';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Altnivela. Direktas aŭdion kaj videon tra kunligita aparatara vojo. Malŝaltita defaŭlte ĉar ĝi kaŭzas aŭdiajn/videajn interrompojn sur kelkaj aparatoj.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Mapu Dolby Vision profilon 7 al HEVC';
@@ -8733,14 +8713,14 @@ class AppLocalizationsEo extends AppLocalizations {
       'Apliku tipargrandajn sugestojn enkonstruitajn en la subtitola trako. Malebligu uzi la subtitolon de viaj stilaj preferoj.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Montri aŭdvidajn detalojn';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Montri detalojn de la elektita ero ĉe la supro de bibliotekaj paĝoj.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Ĉu kaŝi fonbildojn dum foliumado?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Uzu Detalaj Sub-Titoloj';
@@ -8758,37 +8738,37 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Temvendejo';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Foliumi kaj konservi komunumajn temojn';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Konservu temon por uzi ĝin kiel viajn aliajn konservitajn temojn.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Neniuj temoj estas disponeblaj nun.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Ne eblis ŝargi la Temvendejon. Kontrolu vian konekton kaj reprovu.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Konservi';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Konservi kaj apliki';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Konservita';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Ĉi tiu temo ne povis esti ŝargita.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Konservis \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8847,21 +8827,21 @@ class AppLocalizationsEo extends AppLocalizations {
   String get homeRowsSection => 'Hejmaj Vicoj';
 
   @override
-  String get homeRowDisplay => 'Montro de hejmaj vicoj';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sekcioj de hejmaj vicoj';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Ŝaltiloj de hejmaj vicoj';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Ebligi aŭ malŝalti bibliotek-bazitajn kategoriojn de hejmaj vicoj';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Ebligu la sekvajn ŝaltilojn por montri la vicojn en Hejmaj Sekcioj.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Vicoj Tipo';
@@ -8920,56 +8900,55 @@ class AppLocalizationsEo extends AppLocalizations {
       'Montru Filmojn, Seriojn aŭ ambaŭ en Ĝenraj vicoj.';
 
   @override
-  String get displayPlaylistsRows => 'Montri vicojn de ludlistoj';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Montri vicojn de ludlistoj en Hejmaj Sekcioj.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Ordigo de vicoj de ludlistoj';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordigi vicojn de ludlistoj laŭ aldondato, eldondato, alfabete kaj pli.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Montri aŭdiajn vicojn';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Montri aŭdiajn vicojn en Hejmaj Sekcioj.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ordigo de aŭdiaj vicoj';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordigi aŭdiajn vicojn laŭ aldondato, eldondato, alfabete kaj pli.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Aŭdiaj ludlistoj';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Aspekto';
 
   @override
-  String get layout => 'Aranĝo';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Temo';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klavaro';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Butonoj';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Bildigado';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-agordo';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Karto Grandeco';
@@ -8979,7 +8958,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Agordu eksteran ludilon por ebligi la eblon ludi per longa premo';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9246,7 +9225,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get appearancesSeerr => 'Aperoj (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Kontribuoj de teamo (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Rigardu kun grupo';
@@ -9331,8 +9310,8 @@ class AppLocalizationsEo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotekoj',
-      one: '1 Biblioteko',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9424,7 +9403,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mixedMoviesAndShows => 'Miksitaj Filmoj kaj Spektakloj';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Intel Rapida Sinkronigo';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9491,13 +9470,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get loadingShuffle => 'Ŝargante miksadon...';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTEKA MIKSADO';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'HAZARDA MIKSADO';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ĜENRA MIKSADO';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Aŭtomata HDR Ŝanĝo';
@@ -9510,222 +9489,222 @@ class AppLocalizationsEo extends AppLocalizations {
   String get whenFullscreen => 'Kiam plenekrana';
 
   @override
-  String get changeArtwork => 'Ŝanĝi bildaĵon';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Mankanta';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Transkodigaj Limoj';
 
   @override
-  String get clearAllArtworkButton => 'Ĉu vakigi ĉiujn bildaĵojn?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Ĉu vi certas ke vi volas vakigi ĉiujn elŝutitajn bildaĵojn?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Konfirmi vakigon';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Ĉu vi certas ke vi volas vakigi ĉi tiun $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Ĉu alŝuti?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Distingivo: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Montri bildaĵojn nur en la interfaca lingvo';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Konfirmi vakigon de ĉiuj';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Bildo alŝutita sukcese!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Malsukcesis alŝuti bildon: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Malsukcesis agordi bildon: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Malsukcesis forigi bildon: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Malsukcesis vakigi ĉiujn bildaĵojn: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Jes';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Afiŝo';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fonbildoj';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Standardo';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Emblemo';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Bildeto';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Arto';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Diskarto';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ekrankopio';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Skatolkovrilo';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Malantaŭa skatolkovrilo';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menuarto';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'afiŝon';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fonbildon';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'standardon';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'emblemon';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'bildeton';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'arton';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'diskarton';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ekrankopion';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'skatolkovrilon';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'malantaŭan skatolkovrilon';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menuarton';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Ĉiuj';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Meza (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Malalta (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fontoj';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Ĉapitroj';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Legosignoj';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notoj';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Vico';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Templinio';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Templinio estas malplena';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Tuta libro';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokusita templinio';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksporti legosignojn';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksporti notojn';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksporti ĉion';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksportita al $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksporto malsukcesis: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Kantoteksto';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Aldoni legosignon';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Aldoni noton';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Redakti noton';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Skribu noton por ĉi tiu momento';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Dormtempigilo';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Malŝaltita';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fino de ĉapitro';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Propra';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining restas';
+    return '$remaining left';
   }
 
   @override
@@ -9740,51 +9719,51 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Ludrapido';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Restanta';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Pasinta';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Reen ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Antaŭen ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Antaŭa ĉapitro';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Sekva ĉapitro';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Ĉapitro $current el $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Neniuj ĉapitroj';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Ankoraŭ neniuj legosignoj';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Ankoraŭ neniuj notoj';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Legosigno aldonita ĉe $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Restarigi al 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9792,253 +9771,249 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Konservi';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Nuligi';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Forigi';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferoj de subtekstoj';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Ŝanĝi subtekstajn reĝimojn, defaŭltajn lingvojn, aspekton kaj bildigajn opciojn.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Bildigado de subtekstoj';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Montroopcioj';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Eldondato (kreskanta)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Eldondato (malkreskanta)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupigi kontribuojn';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupigi plurajn rolojn';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Averto pri skribaliro al biblioteko';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kiel ripari ĉi tion:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Donu skribpermesojn al la Jellyfin-serva uzanto (ekz. jellyfin aŭ Docker PUID/PGID) por viaj aŭdvidaj bibliotekaj dosierujoj sur la servilo.\n\n2. Aŭ, iru al via Jellyfin-panelo -> Bibliotekoj, redaktu ĉi tiun bibliotekon, kaj malŝaltu \'Konservi bildojn en aŭdvidajn dosierujojn\' por konservi bildaĵojn en la interna datumbazo de Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Forĵeti';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Via biblioteko \'$libraryName\' estas agordita por konservi bildaĵojn rekte en la aŭdvidajn dosierujojn (\'Konservi bildojn en aŭdvidajn dosierujojn\' estas ebligita). Tamen Jellyfin testis skribaliron kaj ne havas permeson skribi dosierojn en ĉi tiun dosierujon:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Ŝajnas ke Jellyfin malsukcesis ĝisdatigi la bildaĵon. Via biblioteko estas agordita por konservi bildaĵojn rekte en la aŭdvidajn dosierujojn (\'Konservi bildojn en aŭdvidajn dosierujojn\' estas ebligita). Ĉi tiu eraro tipe okazas kiam la Jellyfin-servila procezo ne havas permeson skribi dosierojn en viajn aŭdvidajn dosierujojn.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Eksteraj listoj';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Reludi';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Dosierinformo';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Grandeco: $size  •  Formato: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Montri ĉiujn ($count) aŭdiajn trakojn';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Montri ĉiujn ($count) subtekstajn trakojn';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Kontrolante la kapablon de Rekta Ludado...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Kapablo de Rekta Ludado: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Devigita';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'La ujformato ne estas subtenata de la ludilo.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'La videa kodeko ne estas subtenata.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'La aŭdia kodeko ne estas subtenata.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'La subteksta formato ne estas subtenata (postulas enbruligon).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'La aŭdia profilo ne estas subtenata.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'La videa profilo ne estas subtenata.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'La videa nivelo ne estas subtenata.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'La videa distingivo ne estas subtenata de ĉi tiu aparato.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'La videa bitprofundo ne estas subtenata.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'La videa kadrofrekvenco ne estas subtenata.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'La dosiera bitrapido superas la elsendan limon de la ludilo.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'La videa bitrapido superas la elsendan limon.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'La aŭdia bitrapido superas la elsendan limon.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'La nombro da aŭdiaj kanaloj ne estas subtenata.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabete';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Eldonordo (kreskanta)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Eldonordo (malkreskanta)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Propra (treni kaj demeti)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Ordigopcioj de ludlisto';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Restarigi ordigon';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Rerigardi S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Rerigardi ludliston';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Neniuj subtekstoj trovitaj.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administraj regiloj';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Bildiga maŝino (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller estas la moderna GPU-bildigilo de Flutter por pli glataj animacioj kaj malpli da ŝutriĝo. Sur kelkaj TV-skatoloj kaj pli malnovaj GPU-oj ĝi povas kaŭzi difektojn aŭ nigran videon; malŝaltu ĝin se vi vidas tiajn. Aŭtomata elektas la plej bonan defaŭlton por via aparato. Restartigu Moonfin por apliki.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Aŭtomata';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ŝaltita';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Malŝaltita';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Restarto necesa';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin devas restarti por ŝanĝi la bildigan maŝinon. Fermu la aplikaĵon nun, poste remalfermu ĝin por apliki.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Fermi la aplikaĵon nun';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Refreŝigi bibliotekon';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Refreŝigi ĉiujn bibliotekojn';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Aldondato (plej malnovaj unue)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Aldondato (plej novaj unue)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabete (A al Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabete (Z al A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Ŝargante servilan analitikon... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Kongrui kun fonto';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Plej Bonaj 250 Filmoj';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Plej Bonaj 250 TV-Serioj';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Plej Popularaj Filmoj';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Plej Popularaj TV-Serioj';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Plej Malalte Taksitaj Filmoj';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb Plej Bone Taksitaj Anglaj Filmoj';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12,19 +12,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERENCIAS DE LA CUENTA';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Idioma de la interfaz';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Predeterminado del sistema';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Iniciar sesión';
 
   @override
-  String get empty => 'Vacío';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contraseña';
@@ -61,7 +61,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect no disponible: $detail';
+    return 'Conexión rápida no disponible: $detail';
   }
 
   @override
@@ -113,7 +113,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancel => 'Cancelar';
 
   @override
-  String get remove => 'Quitar';
+  String get remove => 'Eliminar';
 
   @override
   String get connectToServer => 'Conectar al servidor';
@@ -141,62 +141,62 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema de la aplicación';
 
   @override
-  String get detailScreenStyle => 'Estilo de la pantalla de detalles';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Clásico es el diseño centrado original de moonfin. Moderno es un diseño cinematográfico adaptable.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Clásico';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderno';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Pestañas expandidas';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Muestra automáticamente el contenido de las pestañas al navegar por ellas. Desactívalo para abrir y cerrar cada pestaña manualmente.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => '¿Mostrar detalles técnicos?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Muestra el códec, la resolución y la información del stream en el resumen del banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistema de recomendaciones';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Usa el algoritmo local de la biblioteca Moonfin Recommends o las métricas de similitud en línea de TMDb. Nota: las recomendaciones en línea requieren la integración con Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Similitud de TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      '¿Aplicar límite de clasificación parental?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limita las sugerencias de Moonfin Recommends según la clasificación parental del contenido de referencia';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Estilo de la interfaz';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automático se adapta a tu dispositivo. Elige Apple o Material para forzar un aspecto.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automático';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Calidad del cristal';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automático elige el mejor efecto de cristal para este dispositivo. Completo fuerza el desenfoque real; Reducido usa un cristal ligero que ahorra GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automático';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Completo';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reducido';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Cambia entre Moonfin y Neon Pulse sin reiniciar la aplicación';
 
   @override
-  String get customThemeTitle => 'Tema personalizado';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Los temas personalizados modifican los elementos visuales de todo Moonfin. Elige una de estas opciones según tu estilo.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Prefiere el teclado del sistema';
@@ -253,18 +253,18 @@ class AppLocalizationsEs extends AppLocalizations {
       'Estilo Synthwave con brillo magenta, texto cian y contraste cromado más fuerte';
 
   @override
-  String get themeGlass => 'Cristal';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Estilo de cristal líquido con un fondo degradado en movimiento, superficies esmeriladas y acento azul de Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'Héroe de 8 bits';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Estilo retro de pixel art con una paleta contundente, bordes cuadriculados, sombras marcadas y una fuente de píxeles';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,35 +327,35 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exit => 'Salir';
 
   @override
-  String get gameMenu => 'Menú';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'En pausa';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Guardar estado';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Juegos';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Cargar estado';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Avance rápido';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Ajustes del emulador';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Este núcleo no tiene opciones ajustables.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Mantén pulsado para abrir el menú';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Este dispositivo aún no admite la reproducción de juegos.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'No se pudieron cargar las filas del inicio';
@@ -377,7 +377,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get schedule => 'Programación';
 
   @override
-  String get series => 'Series';
+  String get series => 'Serie';
 
   @override
   String get noItemsFound => 'No se encontraron elementos';
@@ -767,43 +767,43 @@ class AppLocalizationsEs extends AppLocalizations {
   String get books => 'Libros';
 
   @override
-  String get latestBooks => 'Últimos libros';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Últimos audiolibros';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count libros',
-      one: '1 libro',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Libro';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiolibro';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% leído';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time restante';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Leer';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Escuchar';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -998,40 +998,40 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get items => 'Elementos';
+  String get items => 'Items';
 
   @override
   String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Tras las cámaras';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Escenas eliminadas';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Reportajes';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Entrevistas';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Escenas';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Cortometrajes';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Tráileres';
+  String get trailers => 'Remolques';
 
   @override
   String timeRemaining(String time) {
-    return '$time restante';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Termina en $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1073,7 +1073,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Retransmitir';
 
   @override
   String get trailer => 'Tráiler';
@@ -1272,10 +1272,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
-  String get directors => 'DIRECTORES';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'GUIONISTA';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'GUIONISTAS';
@@ -1355,13 +1355,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shuffle => 'Aleatorio';
 
   @override
-  String get shuffleAllMusic => 'Reproducir toda la música en aleatorio';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Inicia sesión en Moonfin desde tu teléfono';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'No se puede conectar con tu servidor';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1377,7 +1377,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get mono => 'Mono';
+  String get mono => 'Mononucleosis infecciosa';
 
   @override
   String get stereo => 'Estéreo';
@@ -1802,22 +1802,22 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Siguiente: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min restantes';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours h restantes';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours h $minutes min restantes';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1840,7 +1840,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get favoriteChannel => 'Canal favorito';
 
   @override
-  String get record => 'Grabar';
+  String get record => 'Registro';
 
   @override
   String get cancelRecordingAction => 'Cancelar grabación';
@@ -1942,7 +1942,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Tipo de cuenta de Seerr';
+  String get seerrAccountType => 'Tipo de cuenta vidente';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2298,7 +2298,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Páginas de detalles, filas del inicio y volumen';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2313,11 +2313,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Reproducir al navegar por la pantalla de inicio';
 
   @override
-  String get loopThemeMusic => 'Repetir música de tema';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repetir la pista en lugar de reproducirla una vez';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Desenfoque de fondo en detalles';
@@ -2340,23 +2340,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get playerZoomMode => 'Modo de zoom del reproductor';
 
   @override
-  String get settingsScrollWheelAction => 'Rueda del ratón';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Elige qué hace la rueda del ratón al desplazarse sobre el vídeo durante la reproducción.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Desactivado';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Buscar (adelante / atrás)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Volumen';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Volumen';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Ajustar';
@@ -2409,38 +2409,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get defaultAudioLanguage => 'Idioma de audio predeterminado';
 
   @override
-  String get fallbackAudioLanguage => 'Idioma de audio alternativo';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Preferir pista de audio predeterminada';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferir la pista de audio original en lugar del doblaje localizado.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferir pistas de audiodescripción';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferir las pistas de audiodescripción en lugar de las normales.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcodificación (audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Stream directo (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodificación (tasa de bits o resolución)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodificación (vídeo y audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodificación (vídeo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automático (predeterminado del servidor)';
@@ -2520,7 +2519,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Elige cómo se decodifica el audio. Paso AVR envía los flujos Dolby/DTS sin procesar a tu receptor; Automático o Mezcla los decodifican localmente.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Paso AVR';
@@ -2530,14 +2529,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Selecciona el formato de destino para transcodificar el audio multicanal cuando el flujo de origen no admite reproducción directa ni paso directo.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detección automática\n(Recomendado)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Predeterminado)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2546,51 +2544,50 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sin pérdida)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Solo estéreo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficiente)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sin pérdida)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Canales de audio máximos';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configura el número máximo de canales de tu equipo de audio. Los flujos multicanal que superen este límite se mezclarán o se transcodificarán.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detección automática\n(Predeterminado del hardware)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estéreo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Envolvente';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Cuadrafónico';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Envolvente';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Envolvente';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Envolvente';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Envolvente';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Paso a través (avanzado)';
@@ -2672,7 +2669,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Vocero';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Auriculares';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2852,45 +2849,45 @@ class AppLocalizationsEs extends AppLocalizations {
       'Personalizar la apariencia de los subtítulos';
 
   @override
-  String get subtitleMode => 'Modo de subtítulos';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Marcados';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Siempre';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Idioma extranjero';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Forzados';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Reproduce las pistas marcadas internamente como \"predeterminadas\" o \"forzadas\" en los metadatos del archivo.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Carga y muestra los subtítulos automáticamente cada vez que empieza un vídeo.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Activa los subtítulos automáticamente si la pista de audio predeterminada está en un idioma extranjero.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Solo carga los subtítulos etiquetados explícitamente con la marca de metadatos \"forzado\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Desactiva por completo la carga automática de subtítulos.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Idioma de subtítulos alternativo';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Flujo de subtítulos';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3097,11 +3094,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar bibliotecas en la barra de herramientas';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Expandir siempre las etiquetas de la barra de navegación';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Mostrar botón de Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacidad de la barra de navegación';
@@ -3176,19 +3172,18 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar opción de exploración por carpetas';
 
   @override
-  String get groupItemsIntoCollections => 'Agrupar elementos en colecciones';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ocultar los elementos de la biblioteca asociados a una colección al explorar las bibliotecas';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Aviso sobre la agrupación de bibliotecas';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Para usar este ajuste, asegúrate de que los ajustes de biblioteca \"Agrupar películas en colecciones\" o \"Agrupar series en colecciones\" estén activados en los ajustes de Visualización de tu biblioteca en el servidor de Jellyfin o Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilidad de la biblioteca';
@@ -3247,7 +3242,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Elige entre varios estilos de barra multimedia o desactiva la barra multimedia';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'aleta lunar';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3301,11 +3296,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Reproducir tráilers automáticamente en la barra de medios después de 3 segundos';
 
   @override
-  String get trailerAudio => 'Audio del tráiler';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Activar el audio de los tráileres en la barra de medios';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Vista previa de episodio';
@@ -3383,11 +3377,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Combinar ambas filas en una sola sección del inicio';
 
   @override
-  String get fullScreenRows => 'Filas del inicio expandidas';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limitar las filas del inicio a 1 por pantalla';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Tipo de imagen por fila';
@@ -3402,7 +3395,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lastUser => 'Último usuario';
 
   @override
-  String get currentUser => 'Usuario actual';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Siempre autenticar';
@@ -3510,10 +3503,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar reloj durante el salvapantallas';
 
   @override
-  String get clockModeStatic => 'Estático';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Rebotando';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Críticos)';
@@ -3534,7 +3527,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get metacriticUser => 'Metacritic (Usuario)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Tracto';
 
   @override
   String get letterboxd => 'Buzón';
@@ -3587,7 +3580,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Habilitar y reordenar las fuentes de valoración mostradas en la app';
 
   @override
-  String get pluginLabel => 'Complemento Moonbase';
+  String get pluginLabel => 'Complemento';
 
   @override
   String get pluginDetected => 'Plugin detectado';
@@ -3659,7 +3652,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get networks => 'Redes';
 
   @override
-  String get seerrDiscoveryRows => 'Filas de descubrimiento de Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3683,29 +3676,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get hideAdultContent => 'Ocultar contenido adulto en los resultados';
 
   @override
-  String get seerrNotificationsSection => 'Notificaciones';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notificaciones de nuevas solicitudes';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Avisarme cuando alguien envíe una solicitud';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Actualizaciones de solicitudes';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprobadas, rechazadas y añadidas a tu biblioteca';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Actualizaciones de problemas';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nuevos problemas, respuestas y resoluciones';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3713,18 +3705,18 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Página de descubrimiento de Seerr';
+  String get discoverRows => 'Filas de Descubrir';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Activa las filas que quieres ver en la página principal de Seerr. Arrastra para reordenar. El orden personalizado se sincroniza con Moonbase.';
+      'Arrastra para reordenar. Habilita o deshabilita filas. El orden de filas habilitadas se sincroniza con el plugin de Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Activa las filas que quieres ver en la página principal de Seerr. Arrastra para reordenar. El orden personalizado se sincroniza con Moonbase.';
+      'Arrastra para reordenar. Habilita o deshabilita filas.';
 
   @override
-  String get enabled => 'Activado';
+  String get enabled => 'Habilitado';
 
   @override
   String get hidden => 'Oculto';
@@ -3877,11 +3869,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Descargando · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importando';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3915,7 +3907,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get declineAction => 'Rechazar';
 
   @override
-  String get similar => 'Similares';
+  String get similar => 'Similar';
 
   @override
   String get recommendations => 'Recomendaciones';
@@ -4024,149 +4016,148 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deletedStatus => 'Eliminado';
 
   @override
-  String get failedStatus => 'Fallida';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'En proceso';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificado por $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Completada';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Este título ya se ha solicitado';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Has alcanzado el límite de solicitudes';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Este título está en la lista de bloqueo';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'No quedan temporadas por solicitar';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'No tienes permiso para hacer esta solicitud';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Solicitudes';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemas';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Más recientes';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Última modificación';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'No hay problemas';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Te quedan $remaining de $limit solicitudes de películas';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Te quedan $remaining de $limit solicitudes de temporadas';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Parte de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Ver colección';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Solicitar colección';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total películas · $available disponibles';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Solicitar $count películas';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Solicitando $current de $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Se han solicitado $count películas';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Se han solicitado $ok de $total películas';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Todas las películas ya están disponibles o solicitadas';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Informar de un problema';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vídeo';
+  String get issueTypeVideo => 'Video';
 
   @override
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => '¿Qué ocurre?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Todos los episodios';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episodio';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Abierto';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Resuelto';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Resolver';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Reabrir';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Informado por $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comentarios';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Añadir un comentario';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => '¿Eliminar este problema?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Enviar informe';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Puntuación TMDB';
@@ -4190,7 +4181,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -4235,7 +4226,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get error => 'Error';
 
   @override
-  String get forward => 'Avanzar';
+  String get forward => 'Adelante';
 
   @override
   String get general => 'General';
@@ -4283,7 +4274,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get refresh => 'Actualizar';
 
   @override
-  String get remote => 'Mando a distancia';
+  String get remote => 'Remoto';
 
   @override
   String get rename => 'Renombrar';
@@ -4328,7 +4319,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get time => 'Hora';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'truco';
 
   @override
   String get uninstall => 'Desinstalar';
@@ -4370,25 +4361,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotecas';
 
   @override
-  String get adminDrawerDisplay => 'Visualización';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadatos';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Ajustes de NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodificación';
 
   @override
-  String get adminDrawerResume => 'Reanudar';
+  String get adminDrawerResume => 'Reanudación';
 
   @override
   String get adminDrawerStreaming => 'Transmisión';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'truco';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -4559,7 +4550,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sessionRewind => 'Retroceder';
 
   @override
-  String get sessionForward => 'Avanzar';
+  String get sessionForward => 'Adelantar';
 
   @override
   String get sessionNext => 'Siguiente';
@@ -4604,10 +4595,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminClearDates => 'Borrar fechas';
 
   @override
-  String get adminActivitySeverityAll => 'Todas las gravedades';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Intervalo de fechas';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4644,23 +4635,23 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '¿Eliminar el dispositivo \'$name\'? El usuario tendrá que volver a iniciar sesión en este dispositivo.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Eliminar todos los dispositivos';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '¿Eliminar $count dispositivos? Los usuarios afectados tendrán que volver a iniciar sesión. Tu dispositivo actual no se verá afectado.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Dispositivos eliminados';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Se han eliminado algunos dispositivos; $count no se han podido eliminar.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4776,259 +4767,244 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminMetadataCountryHint => 'p. ej. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Rutas';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opciones';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Descargadores';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Guardadores de metadatos';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Descargadores de subtítulos';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Descargadores de letras';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Descargadores de metadatos: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Buscadores de imágenes: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Este servidor no ofrece descargadores para este tipo de biblioteca.';
+      'This server exposes no downloaders for this library type.';
 
   @override
   String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadatos';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Información incrustada';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtítulos';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imágenes';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
   String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Música';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Películas';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'Habilitar la monitorización en tiempo real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detectar los cambios en los archivos y procesarlos automáticamente.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratar los archivos comprimidos como archivos multimedia';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Mostrar fotos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Guardar las carátulas en las carpetas multimedia';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Actualización automática de metadatos';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nunca';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Predeterminado';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visualización';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Visualización de la biblioteca';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Mostrar una vista de carpetas para ver las carpetas multimedia sin procesar';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Mostrar los especiales dentro de las temporadas en las que se emitieron';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Agrupar películas en colecciones';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Agrupar series en colecciones';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Mostrar contenido externo en las sugerencias';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection =>
-      'Comportamiento de la fecha de adición';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Usar la fecha de adición de';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Fecha de escaneo en la biblioteca';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Fecha de creación del archivo';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadatos e imágenes';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Idioma de metadatos preferido';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capítulos';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Duración de los capítulos ficticios (segundos)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Duración de los capítulos generados para el contenido que no tiene ninguno. Establece 0 para desactivarlo.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolución de las imágenes de capítulo';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Ajustes de NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Los metadatos NFO son compatibles con Kodi y clientes similares. Los ajustes se aplican a todas las bibliotecas que guardan metadatos NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Usuario cuyos datos de visualización se guardarán en los archivos NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Guardar las rutas de las imágenes en los archivos NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Habilitar la sustitución de rutas para las rutas de imagen de los NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copiar las imágenes de extrafanart en una carpeta extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ninguno';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days días';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Usar los títulos incrustados';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usar los títulos incrustados para los extras';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usar la información de episodio incrustada';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Permitir subtítulos incrustados';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permitir todos';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Solo texto';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Solo imagen';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ninguno';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Omitir la descarga si hay subtítulos incrustados';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Omitir la descarga si la pista de audio coincide con el idioma de descarga';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Exigir una coincidencia exacta de los subtítulos';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Guardar los subtítulos en las carpetas multimedia';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Extraer las imágenes de capítulo';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extraer las imágenes de capítulo durante el escaneo de la biblioteca';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Habilitar la extracción de imágenes de trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extraer las imágenes de trickplay durante el escaneo de la biblioteca';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Guardar las imágenes de trickplay en las carpetas multimedia';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Fusionar automáticamente las series repartidas en varias carpetas';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nombre de la temporada cero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Habilitar el análisis LUFS para la normalización del audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferir la etiqueta de artistas no estándar';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Añadir películas a las colecciones automáticamente';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired =>
@@ -5273,146 +5249,143 @@ class AppLocalizationsEs extends AppLocalizations {
       'Habilitar el acceso a todos los canales.';
 
   @override
-  String get adminParentalControl => 'Control parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Clasificación parental máxima permitida';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'El contenido con una clasificación superior se ocultará a este usuario.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ninguna';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloquear los elementos sin clasificación o con una clasificación no reconocida';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Libros';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canales';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV en vivo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Películas';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Música';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Tráileres';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Series';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Horarios de acceso';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permitir el acceso solo durante los horarios indicados abajo. Si no se define ningún horario, el acceso está permitido todo el día.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Añadir horario';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Día';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Inicio';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fin';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Todos los días';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Días laborables';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Fin de semana';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Domingo';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Lunes';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Martes';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Miércoles';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Jueves';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Viernes';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sábado';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etiquetas permitidas';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Solo se muestra el contenido con estas etiquetas. Déjalo vacío para permitir todo.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etiquetas bloqueadas';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'El contenido con estas etiquetas se oculta a este usuario.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Añadir etiqueta';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispositivos habilitados';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canales habilitados';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Proveedor de autenticación';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Proveedor de restablecimiento de contraseña';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Número máximo de intentos de inicio de sesión fallidos antes del bloqueo';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Establece 0 para el valor predeterminado o -1 para desactivar el bloqueo.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Acceso a SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Permitir crear grupos y unirse a ellos';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permitir unirse a grupos';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Sin acceso';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Permitir eliminar contenido de';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5500,26 +5473,25 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Crear copia de seguridad';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Elige qué incluir en la copia de seguridad.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Base de datos';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Siempre incluida';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadatos';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtítulos';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imágenes de trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Creando copia de seguridad...';
@@ -6235,65 +6207,60 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminAddTuner => 'Añadir sintonizador';
 
   @override
-  String get adminEditTuner => 'Editar sintonizador';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Sintonizador M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Archivo o URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Dirección IP del sintonizador';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nombre descriptivo';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Agente de usuario';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Límite de conexiones simultáneas';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Número máximo de flujos que el sintonizador permite a la vez. Establece 0 para ilimitado.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Tasa de bits máxima alternativa de transmisión';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importar solo los canales favoritos';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permitir la transcodificación por hardware';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Permitir el contenedor de transcodificación fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Permitir compartir flujos';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Habilitar la repetición del flujo';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorar DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Leer la entrada a la velocidad de fotogramas nativa';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Editar proveedor';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6302,50 +6269,50 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Archivo o URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefijo de película';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorías de películas';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separa varias categorías con una barra vertical.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorías infantiles';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorías de noticias';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorías de deportes';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nombre de usuario';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Contraseña';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'País';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selecciona un país';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Código postal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obtener listados';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Listados';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Habilitar todos los sintonizadores';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipo de sintonizador';
@@ -6387,7 +6354,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Este tipo de sintonizador no admite el reinicio.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6410,46 +6377,43 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Ruta de grabación de series';
 
   @override
-  String get adminMovieRecordingPath => 'Ruta de grabación de películas';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Días de datos de la guía';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automático';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days días';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Ruta de la aplicación de posprocesamiento';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumentos del posprocesador';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Guardar los metadatos NFO de las grabaciones';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages =>
-      'Guardar las imágenes de las grabaciones';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Temporización';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Rutas de grabación';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Posprocesamiento';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Datos de la guía: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6491,15 +6455,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminGuideProviders => 'Proveedores de guía';
 
   @override
-  String get adminRefreshGuideData => 'Actualizar los datos de la guía';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Actualización de los datos de la guía iniciada';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'La tarea de actualización de la guía no está disponible en este servidor.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Añadir proveedor';
@@ -6635,7 +6598,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor de metadatos';
 
   @override
-  String get adminMetadataIdentify => 'Identificar';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -6919,7 +6882,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Quitar';
+  String get adminReposRemove => 'Eliminar';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7050,22 +7013,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Habilitar pantalla de bienvenida';
 
   @override
-  String get adminBrandingSplashUpload => 'Subir imagen';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'Pantalla de bienvenida actualizada';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Error al subir la pantalla de bienvenida';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Pantalla de bienvenida eliminada';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash =>
-      'Sin pantalla de bienvenida personalizada';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aceleración por hardware';
@@ -7082,129 +7042,121 @@ class AppLocalizationsEs extends AppLocalizations {
       'Habilitar decodificación por hardware para:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Habilitar el decodificador NVDEC mejorado';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferir el decodificador de hardware nativo del sistema';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profundidad de color de la decodificación por hardware';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodificación HEVC de 10 bits';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodificación VP9 de 10 bits';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodificación HEVC RExt de 8/10 bits';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodificación HEVC RExt de 12 bits';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codificación por hardware';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permitir la codificación HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permitir la codificación AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Habilitar el codificador H.264 de bajo consumo de Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Habilitar el codificador HEVC de bajo consumo de Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapeo de tonos';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Habilitar el mapeo de tonos';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Habilitar el mapeo de tonos VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Habilitar el mapeo de tonos de VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritmo de mapeo de tonos';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modo de mapeo de tonos';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Rango de mapeo de tonos';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturación del mapeo de tonos';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pico del mapeo de tonos';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parámetro del mapeo de tonos';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Brillo del mapeo de tonos VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste del mapeo de tonos VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Preajustes y calidad';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Preajuste del codificador';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF de codificación H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF de codificación H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Método de desentrelazado';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Duplicar la velocidad de fotogramas al desentrelazar';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Habilitar la codificación de audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Ganancia de la mezcla de audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo de mezcla a estéreo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Tamaño máximo de la cola de multiplexación';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automático';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Codificación';
@@ -7328,7 +7280,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminTaskStop => 'Detener';
 
   @override
-  String get adminRunningTasks => 'Tareas en ejecución';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Ejecutar';
@@ -7480,44 +7432,43 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Puerto HTTP público';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Exigir HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Redirigir todas las peticiones remotas a HTTPS. No tiene efecto si el servidor no tiene un certificado válido.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Contraseña del certificado';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Ajustes de IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Habilitar IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Habilitar IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Habilitar la asignación automática de puertos';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Redes LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Lista de direcciones IP o subredes CIDR, separadas por comas o saltos de línea, que se consideran parte de la red local.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI publicadas del servidor';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Asigna una subred o dirección a una URL publicada, p. ej. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Ruta del certificado';
@@ -7549,11 +7500,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Limitar el búfer';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Retardo de limitación (segundos)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permitir la extracción de subtítulos sobre la marcha';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Porcentaje mínimo de reanudación';
@@ -7611,23 +7562,22 @@ class AppLocalizationsEs extends AppLocalizations {
       'Umbral de respuesta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Habilitar los avisos de respuesta lenta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Habilitar Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Servidor';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadatos';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Rutas';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Rendimiento';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Ruta de caché';
@@ -7639,7 +7589,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminGeneralServerName => 'Nombre del servidor';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Idioma de la interfaz preferido';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Error al cargar los ajustes';
@@ -7882,21 +7832,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get offlineSavedMedia => 'Contenido guardado';
 
   @override
-  String get offlineBannerTitle => 'Estás sin conexión';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Mostrando tus descargas';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Descargas';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'No se puede conectar con tu servidor';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Reproduciendo desde las descargas hasta que vuelva';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7975,35 +7924,36 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pinBackspace => 'Retroceso';
 
   @override
-  String get quickConnectAuthorized => 'Solicitud de Quick Connect autorizada.';
+  String get quickConnectAuthorized =>
+      'Solicitud de conexión rápida autorizada.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'El código de Quick Connect no es válido o ha expirado.';
+      'El código de conexión rápida no es válido o ha expirado.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect no es compatible con este servidor.';
+      'La conexión rápida no es compatible con este servidor.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Error al autorizar el código de Quick Connect.';
+      'Error al autorizar el código de conexión rápida.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect está deshabilitado en este servidor.';
+      'La conexión rápida está deshabilitada en este servidor.';
 
   @override
   String get quickConnectForbidden =>
-      'Tu cuenta no puede autorizar esta solicitud de Quick Connect.';
+      'Tu cuenta no puede autorizar esta solicitud de conexión rápida.';
 
   @override
   String get quickConnectNotFound =>
-      'No se encontró el código de Quick Connect. Prueba con un nuevo código.';
+      'No se encontró el código de conexión rápida. Prueba con un nuevo código.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Error de Quick Connect: $message';
+    return 'Error de conexión rápida: $message';
   }
 
   @override
@@ -8261,13 +8211,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Ocultar de Continuar viendo';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ocultar de A continuación';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Añadir a la colección';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8322,15 +8272,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabético';
 
   @override
-  String get settingsConnectionSection => 'CONEXIÓN';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permitir certificados autofirmados';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confiar en servidores que usan certificados TLS autofirmados o de una CA privada. Actívalo solo para servidores que controles. Esto desactiva la validación de certificados en todas las conexiones.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIDAD Y SEGURIDAD';
@@ -8346,11 +8295,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Acentos temáticos, fondos, indicadores observados y tema musical.';
 
   @override
-  String get settingsDetailsScreen => 'Pantalla de detalles';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Estilo, desenfoque del fondo y comportamiento de las pestañas';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Página de inicio';
@@ -8388,11 +8337,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Mostrar el botón de Seerr en la barra de navegación';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Mostrar siempre las etiquetas de texto en la barra de navegación superior';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8545,17 +8494,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '¿Saltar introducciones y finales?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Cuenta atrás de los segmentos multimedia';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Barra de progreso';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Temporizador';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ninguno';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Preguntar al usuario';
@@ -8786,7 +8734,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Lanzamientos recientes de $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8820,11 +8768,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Forzar la reproducción sin túnel. Útil en dispositivos con discontinuidades de audio/vídeo de túnel.';
 
   @override
-  String get enableTunnelingTitle => 'Habilitar la tunelización';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avanzado. Enruta el audio y el vídeo por una ruta de hardware acoplada. Desactivado por defecto porque provoca cortes de audio/vídeo en algunos dispositivos.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Asigne Dolby Vision perfil 7 a HEVC';
@@ -8850,15 +8798,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Aplique sugerencias de tamaño de fuente incrustadas en la pista de subtítulos. Desactive el uso del tamaño de los subtítulos en sus preferencias de estilo.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostrar detalles del contenido';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostrar los detalles del elemento seleccionado en la parte superior de las páginas de biblioteca.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      '¿Ocultar las imágenes de fondo al explorar?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';
@@ -8876,37 +8823,37 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Tienda de temas';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Explora y guarda temas de la comunidad';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Guarda un tema para usarlo como el resto de tus temas guardados.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'No hay temas disponibles en este momento.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'No se pudo cargar la Tienda de temas. Comprueba tu conexión e inténtalo de nuevo.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Guardar';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Guardar y aplicar';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Guardado';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'No se pudo cargar este tema.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Se ha guardado \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8965,21 +8912,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeRowsSection => 'Filas de inicio';
 
   @override
-  String get homeRowDisplay => 'Visualización de las filas del inicio';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Secciones de filas del inicio';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Interruptores de las filas del inicio';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Activa o desactiva las categorías de filas del inicio basadas en bibliotecas';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Activa los siguientes interruptores para mostrar las filas en las Secciones del inicio.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Tipo de filas';
@@ -9038,57 +8985,55 @@ class AppLocalizationsEs extends AppLocalizations {
       'Muestra películas, series o ambas en las filas de Géneros.';
 
   @override
-  String get displayPlaylistsRows => 'Mostrar filas de listas de reproducción';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Mostrar las filas de listas de reproducción en las Secciones del inicio.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting =>
-      'Orden de las filas de listas de reproducción';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordena las filas de listas de reproducción por fecha de adición, fecha de estreno, alfabéticamente y más.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Mostrar filas de audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Mostrar las filas de audio en las Secciones del inicio.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Orden de las filas de audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordena las filas de audio por fecha de adición, fecha de estreno, alfabéticamente y más.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Listas de reproducción de audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Apariencia';
 
   @override
-  String get layout => 'Diseño';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Teclado';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Botones';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderizado';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configuración de MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Tamaño de tarjeta';
@@ -9098,7 +9043,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Configura un reproductor externo para habilitar la opción de reproducir con pulsación larga';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9366,10 +9311,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get guestAppearances => 'Apariciones de invitados';
 
   @override
-  String get appearancesSeerr => 'Apariciones (Seerr)';
+  String get appearancesSeerr => 'Apariciones (Vidente)';
 
   @override
-  String get crewContributionsSeerr => 'Contribuciones del equipo (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Ver con grupo';
@@ -9455,8 +9400,8 @@ class AppLocalizationsEs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotecas',
-      one: '1 Biblioteca',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9484,7 +9429,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminServerPathImageCache => 'Caché de imágenes';
 
   @override
-  String get adminServerPathCache => 'Caché';
+  String get adminServerPathCache => 'Cache';
 
   @override
   String get adminServerPathLogs => 'Registros';
@@ -9547,7 +9492,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mixedMoviesAndShows => 'Películas y programas mixtos';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Sincronización rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP de chip de roca';
@@ -9614,13 +9559,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loadingShuffle => 'Cargando reproducción aleatoria...';
 
   @override
-  String get libraryShuffleLabel => 'ALEATORIO POR BIBLIOTECA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ALEATORIO TOTAL';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ALEATORIO POR GÉNEROS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Cambio automático de HDR';
@@ -9633,73 +9578,73 @@ class AppLocalizationsEs extends AppLocalizations {
   String get whenFullscreen => 'Cuando pantalla completa';
 
   @override
-  String get changeArtwork => 'Cambiar la carátula';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Falta';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Límites de transcodificación';
 
   @override
-  String get clearAllArtworkButton => '¿Borrar todas las carátulas?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      '¿Seguro que quieres borrar todas las carátulas descargadas?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirmar borrado';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return '¿Seguro que quieres borrar $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => '¿Subir?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolución: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Mostrar solo las carátulas en el idioma de la interfaz';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirmar borrado de todo';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => '¡Imagen subida correctamente!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Error al subir la imagen: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Error al establecer la imagen: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Error al eliminar la imagen: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Error al borrar todas las carátulas: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Sí';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Póster';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Imágenes de fondo';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9708,147 +9653,147 @@ class AppLocalizationsEs extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Ilustración';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Ilustración del disco';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Captura de pantalla';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Carátula';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Contraportada';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Ilustración del menú';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'el póster';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'la imagen de fondo';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'el banner';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'el logo';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'la miniatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'la ilustración';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'la ilustración del disco';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'la captura de pantalla';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'la carátula';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'la contraportada';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'la ilustración del menú';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Todas';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Media (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Baja (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fuentes';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capítulos';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marcadores';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notas';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Cola';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Cronología';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'La cronología está vacía';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Todo el libro';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Cronología centrada';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportar marcadores';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportar notas';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportar todo';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportado a $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Error al exportar: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Letras';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Añadir marcador';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Añadir nota';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Editar nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Escribe una nota para este momento';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Temporizador de apagado';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Desactivado';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fin del capítulo';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalizado';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining restante';
+    return '$remaining left';
   }
 
   @override
@@ -9863,51 +9808,51 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Velocidad de reproducción';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Restante';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Transcurrido';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Atrás $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Adelante $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capítulo anterior';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Capítulo siguiente';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capítulo $current de $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Sin capítulos';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Aún no hay marcadores';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Aún no hay notas';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Marcador añadido en $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Restablecer a 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9915,266 +9860,259 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Guardar';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Cancelar';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Eliminar';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferencias de subtítulos';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Cambia los modos de subtítulos, los idiomas predeterminados, la apariencia y las opciones de renderizado.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderizado de subtítulos';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opciones de visualización';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Fecha de estreno (ascendente)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Fecha de estreno (descendente)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Agrupar contribuciones';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Agrupar varios roles';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Aviso de acceso de escritura a la biblioteca';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Cómo solucionarlo:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Concede permisos de escritura al usuario del servicio Jellyfin (p. ej., jellyfin o el PUID/PGID de Docker) en las carpetas de tu biblioteca multimedia del servidor.\n\n2. O bien, ve al Panel de control de Jellyfin -> Bibliotecas, edita esta biblioteca y desactiva \'Guardar las carátulas en las carpetas multimedia\' para almacenar las carátulas en la base de datos interna de Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Descartar';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Tu biblioteca \'$libraryName\' está configurada para guardar las carátulas directamente en las carpetas multimedia (la opción \'Guardar las carátulas en las carpetas multimedia\' está activada). Sin embargo, Jellyfin ha comprobado el acceso de escritura y no tiene permiso para escribir archivos en este directorio:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Parece que Jellyfin no ha podido actualizar la carátula. Tu biblioteca está configurada para guardar las carátulas directamente en las carpetas multimedia (la opción \'Guardar las carátulas en las carpetas multimedia\' está activada). Este error suele producirse cuando el proceso del servidor Jellyfin no tiene permiso para escribir archivos en tus directorios multimedia.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Listas externas';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Volver a reproducir';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Información del archivo';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Tamaño: $size  •  Formato: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Mostrar todas las pistas de audio ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Mostrar todas las pistas de subtítulos ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Comprobando la compatibilidad con la reproducción directa...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel =>
-      'Compatibilidad con la reproducción directa: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Forzado';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'El reproductor no admite el formato del contenedor.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'El códec de vídeo no es compatible.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'El códec de audio no es compatible.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'El formato de subtítulos no es compatible (requiere incrustarlos).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'El perfil de audio no es compatible.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'El perfil de vídeo no es compatible.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'El nivel de vídeo no es compatible.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Este dispositivo no admite la resolución del vídeo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'La profundidad de bits del vídeo no es compatible.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'La velocidad de fotogramas del vídeo no es compatible.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'La tasa de bits del archivo supera el límite de transmisión del reproductor.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'La tasa de bits del vídeo supera el límite de transmisión.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'La tasa de bits del audio supera el límite de transmisión.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'El número de canales de audio no es compatible.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabético';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Orden de estreno (ascendente)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Orden de estreno (descendente)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personalizado (arrastrar y soltar)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Opciones de orden de la lista de reproducción';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Restablecer el orden';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Volver a ver T$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Volver a ver la lista de reproducción';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'No se han encontrado subtítulos.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Controles de administración';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motor de renderizado (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller es el renderizador de GPU moderno de Flutter, que ofrece animaciones más fluidas y menos tirones. En algunos TV box y GPU antiguas puede provocar fallos gráficos o vídeo en negro; desactívalo si te ocurre. Automático elige la mejor opción para tu dispositivo. Reinicia Moonfin para aplicar los cambios.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automático';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Activado';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Desactivado';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Reinicio necesario';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin debe reiniciarse para cambiar el motor de renderizado. Cierra la aplicación ahora y vuelve a abrirla para aplicar los cambios.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Cerrar la aplicación ahora';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Actualizar biblioteca';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Actualizar todas las bibliotecas';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Fecha de adición (más antiguas primero)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Fecha de adición (más recientes primero)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabético (de la A a la Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabético (de la Z a la A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Cargando las analíticas del servidor... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual que el origen';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'Top 250 películas de IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'Top 250 series de IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Películas más populares de IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Series más populares de IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Películas peor valoradas de IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Películas en inglés mejor valoradas de IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).
 class AppLocalizationsEs419 extends AppLocalizationsEs {
   AppLocalizationsEs419() : super('es_419');
+
+  @override
+  String get appTitle => 'aleta lunar';
 
   @override
   String get accountPreferences => 'PREFERENCIAS DE CUENTA';
@@ -10195,6 +10133,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String connectingToServer(String serverName) {
     return 'Conectándose a $serverName';
   }
+
+  @override
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contraseña';
@@ -10220,6 +10161,11 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get loginFailed => 'error de inicio de sesion';
+
+  @override
+  String quickConnectUnavailable(String detail) {
+    return 'Conexión rápida no disponible: $detail';
+  }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
@@ -10307,6 +10253,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String get keyboardPreferSystemImeDescription =>
       'Utilice el método de entrada de su dispositivo de forma predeterminada para la entrada de texto';
+
+  @override
+  String get themeMoonfin => 'aleta lunar';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -10822,6 +10771,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get librivoxPage => 'Página de LibriVox';
+
+  @override
+  String get internetArchive => 'Archivo de Internet';
 
   @override
   String get rssFeed => 'Fuente RSS';
@@ -11874,6 +11826,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => 'Tipo de cuenta vidente';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -13071,6 +13026,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
       'Elige entre varios estilos de barra multimedia o desactiva la barra multimedia';
 
   @override
+  String get mediaBarModeMoonfin => 'aleta lunar';
+
+  @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
@@ -13330,13 +13288,31 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get clockModeBouncing => 'Rebotando';
 
   @override
+  String get rottenTomatoesCritics => 'Tomates podridos (críticos)';
+
+  @override
+  String get rottenTomatoesAudience => 'Tomates podridos (público)';
+
+  @override
   String get imdb => 'IMDb';
 
   @override
   String get tmdb => 'TMDB';
 
   @override
+  String get metacritic => 'metacrítico';
+
+  @override
+  String get metacriticUser => 'Metacrítico (Usuario)';
+
+  @override
+  String get trakt => 'Tracto';
+
+  @override
   String get letterboxd => 'Buzón';
+
+  @override
+  String get myAnimeList => 'Mi lista de animes';
 
   @override
   String get aniList => 'AniLista';
@@ -13459,6 +13435,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
       'Restablecer filas a los valores predeterminados';
 
   @override
+  String get enableSeerr => 'Habilitar vidente';
+
+  @override
   String get showSeerrInNavigation =>
       'Mostrar Seerr en la navegación (requiere complemento del servidor)';
 
@@ -13477,6 +13456,17 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String loggedInAs(String username) {
     return 'Iniciado sesión como: $username';
   }
+
+  @override
+  String get discoverRows => 'Descubrir filas';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      'Arrastre para reordenar. Activar o desactivar filas. Se ha habilitado la sincronización del orden de filas con el complemento Moonfin.';
+
+  @override
+  String get discoverRowsDescription =>
+      'Arrastre para reordenar. Activar o desactivar filas.';
 
   @override
   String get enabled => 'Activado';
@@ -13621,6 +13611,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String itemsCount(int count) {
     return '$count Artículos';
   }
+
+  @override
+  String get seerrSettings => 'Configuración de vidente';
 
   @override
   String get requestMore => 'Solicitar más';
@@ -13914,6 +13907,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get time => 'Tiempo';
 
   @override
+  String get trickplay => 'truco';
+
+  @override
   String get uninstall => 'Desinstalar';
 
   @override
@@ -13960,6 +13956,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get adminDrawerStreaming => 'Transmisión';
+
+  @override
+  String get adminDrawerTrickplay => 'truco';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -15085,6 +15084,13 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get adminThrottleBuffering => 'Amortiguación del acelerador';
 
   @override
+  String get adminTrickplaySaved => 'Configuración de trucos guardada';
+
+  @override
+  String get adminTrickplayLoadFailed =>
+      'No se pudo cargar la configuración de trucos';
+
+  @override
   String get adminEnableHardwareAcceleration =>
       'Habilitar la aceleración de hardware';
 
@@ -15197,6 +15203,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get adminBaseUrl => 'URL básica';
+
+  @override
+  String get adminBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get https => 'HTTPS';
@@ -16271,10 +16280,17 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
+  String get adminTrickplayDescription =>
+      'Configure la generación de imágenes de trucos para buscar miniaturas de vista previa.';
+
+  @override
   String get adminNetworkingPublicHttpsPort => 'Puerto HTTPS público';
 
   @override
   String get adminNetworkingBaseUrl => 'URL básica';
+
+  @override
+  String get adminNetworkingBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -16689,12 +16705,37 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get pinBackspace => 'Retroceso';
 
   @override
+  String get quickConnectAuthorized =>
+      'Solicitud de Conexión Rápida autorizada.';
+
+  @override
+  String get quickConnectInvalidOrExpired =>
+      'El código de Conexión Rápida no es válido o ha caducado.';
+
+  @override
   String get quickConnectNotSupported =>
       'Quick Connect no es compatible con este servidor.';
 
   @override
+  String get quickConnectAuthorizeFailed =>
+      'No se pudo autorizar el código de Conexión rápida.';
+
+  @override
   String get quickConnectDisabled =>
       'Quick Connect está deshabilitado en este servidor.';
+
+  @override
+  String get quickConnectForbidden =>
+      'Su cuenta no puede autorizar esta solicitud de Conexión rápida.';
+
+  @override
+  String get quickConnectNotFound =>
+      'No se encontró el código de conexión rápida. Pruebe un nuevo código.';
+
+  @override
+  String quickConnectFailedWithMessage(String message) {
+    return 'Error de conexión rápida: $message';
+  }
 
   @override
   String get quickConnectEnterCode => 'Introduce el código';
@@ -17881,6 +17922,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get guestAppearances => 'Apariciones de invitados';
 
   @override
+  String get appearancesSeerr => 'Apariciones (Vidente)';
+
+  @override
   String get watchWithGroup => 'Ver con grupo';
 
   @override
@@ -18054,6 +18098,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get mixedMoviesAndShows => 'Películas y programas mixtos';
+
+  @override
+  String get intelQuickSync => 'Sincronización rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP de chip de roca';
@@ -18147,12 +18194,18 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   AppLocalizationsEsAr() : super('es_AR');
 
   @override
+  String get appTitle => 'aleta lunar';
+
+  @override
   String get signIn => 'Iniciar sesión';
 
   @override
   String connectingToServer(String serverName) {
     return 'Conectándose a $serverName';
   }
+
+  @override
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contraseña';
@@ -18178,6 +18231,11 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get loginFailed => 'error de inicio de sesion';
+
+  @override
+  String quickConnectUnavailable(String detail) {
+    return 'Conexión rápida no disponible: $detail';
+  }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
@@ -18265,6 +18323,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get keyboardPreferSystemImeDescription =>
       'Utilice el método de entrada de su dispositivo de forma predeterminada para la entrada de texto';
+
+  @override
+  String get themeMoonfin => 'aleta lunar';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -18773,6 +18834,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get librivoxPage => 'Página de LibriVox';
+
+  @override
+  String get internetArchive => 'Archivo de Internet';
 
   @override
   String get rssFeed => 'Fuente RSS';
@@ -19814,6 +19878,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => 'Tipo de cuenta vidente';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -20919,6 +20986,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
       'Elige entre varios estilos de barra multimedia o desactiva la barra multimedia';
 
   @override
+  String get mediaBarModeMoonfin => 'aleta lunar';
+
+  @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
@@ -21162,13 +21232,31 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
       'Mostrar el reloj durante el salvapantallas';
 
   @override
+  String get rottenTomatoesCritics => 'Tomates podridos (críticos)';
+
+  @override
+  String get rottenTomatoesAudience => 'Tomates podridos (público)';
+
+  @override
   String get imdb => 'IMDb';
 
   @override
   String get tmdb => 'TMDB';
 
   @override
+  String get metacritic => 'metacrítico';
+
+  @override
+  String get metacriticUser => 'Metacrítico (Usuario)';
+
+  @override
+  String get trakt => 'Tracto';
+
+  @override
   String get letterboxd => 'Buzón';
+
+  @override
+  String get myAnimeList => 'Mi lista de animes';
 
   @override
   String get aniList => 'AniLista';
@@ -21213,6 +21301,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get ratingSourcesDescription =>
       'Habilite y reordene las fuentes de calificación que se muestran en toda la aplicación';
+
+  @override
+  String get pluginLabel => 'Complemento';
 
   @override
   String get pluginDetected => 'Complemento detectado';
@@ -21288,6 +21379,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
       'Restablecer filas a los valores predeterminados';
 
   @override
+  String get enableSeerr => 'Habilitar vidente';
+
+  @override
   String get showSeerrInNavigation =>
       'Mostrar Seerr en la navegación (requiere complemento del servidor)';
 
@@ -21306,6 +21400,17 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String loggedInAs(String username) {
     return 'Iniciado sesión como: $username';
   }
+
+  @override
+  String get discoverRows => 'Descubrir filas';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      'Arrastre para reordenar. Activar o desactivar filas. Se ha habilitado la sincronización del orden de filas con el complemento Moonfin.';
+
+  @override
+  String get discoverRowsDescription =>
+      'Arrastre para reordenar. Activar o desactivar filas.';
 
   @override
   String get enabled => 'Activado';
@@ -21450,6 +21555,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String itemsCount(int count) {
     return '$count Artículos';
   }
+
+  @override
+  String get seerrSettings => 'Configuración de vidente';
 
   @override
   String get requestMore => 'Solicitar más';
@@ -21743,6 +21851,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get time => 'Tiempo';
 
   @override
+  String get trickplay => 'truco';
+
+  @override
   String get uninstall => 'Desinstalar';
 
   @override
@@ -21789,6 +21900,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get adminDrawerStreaming => 'Transmisión';
+
+  @override
+  String get adminDrawerTrickplay => 'truco';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -22914,6 +23028,13 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get adminThrottleBuffering => 'Amortiguación del acelerador';
 
   @override
+  String get adminTrickplaySaved => 'Configuración de trucos guardada';
+
+  @override
+  String get adminTrickplayLoadFailed =>
+      'No se pudo cargar la configuración de trucos';
+
+  @override
   String get adminEnableHardwareAcceleration =>
       'Habilitar la aceleración de hardware';
 
@@ -23026,6 +23147,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get adminBaseUrl => 'URL básica';
+
+  @override
+  String get adminBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get https => 'HTTPS';
@@ -24100,10 +24224,17 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
+  String get adminTrickplayDescription =>
+      'Configure la generación de imágenes de trucos para buscar miniaturas de vista previa.';
+
+  @override
   String get adminNetworkingPublicHttpsPort => 'Puerto HTTPS público';
 
   @override
   String get adminNetworkingBaseUrl => 'URL básica';
+
+  @override
+  String get adminNetworkingBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -24518,12 +24649,37 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get pinBackspace => 'Retroceso';
 
   @override
+  String get quickConnectAuthorized =>
+      'Solicitud de Conexión Rápida autorizada.';
+
+  @override
+  String get quickConnectInvalidOrExpired =>
+      'El código de Conexión Rápida no es válido o ha caducado.';
+
+  @override
   String get quickConnectNotSupported =>
       'Quick Connect no es compatible con este servidor.';
 
   @override
+  String get quickConnectAuthorizeFailed =>
+      'No se pudo autorizar el código de Conexión rápida.';
+
+  @override
   String get quickConnectDisabled =>
       'Quick Connect está deshabilitado en este servidor.';
+
+  @override
+  String get quickConnectForbidden =>
+      'Su cuenta no puede autorizar esta solicitud de Conexión rápida.';
+
+  @override
+  String get quickConnectNotFound =>
+      'No se encontró el código de conexión rápida. Pruebe un nuevo código.';
+
+  @override
+  String quickConnectFailedWithMessage(String message) {
+    return 'Error de conexión rápida: $message';
+  }
 
   @override
   String get quickConnectEnterCode => 'Introduce el código';
@@ -25710,6 +25866,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get guestAppearances => 'Apariciones de invitados';
 
   @override
+  String get appearancesSeerr => 'Apariciones (Vidente)';
+
+  @override
   String get watchWithGroup => 'Ver con grupo';
 
   @override
@@ -25883,6 +26042,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get mixedMoviesAndShows => 'Películas y programas mixtos';
+
+  @override
+  String get intelQuickSync => 'Sincronización rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP de chip de roca';
@@ -25976,12 +26138,18 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   AppLocalizationsEsDo() : super('es_DO');
 
   @override
+  String get appTitle => 'aleta lunar';
+
+  @override
   String get signIn => 'Iniciar sesión';
 
   @override
   String connectingToServer(String serverName) {
     return 'Conectándose a $serverName';
   }
+
+  @override
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contraseña';
@@ -26007,6 +26175,11 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get loginFailed => 'error de inicio de sesion';
+
+  @override
+  String quickConnectUnavailable(String detail) {
+    return 'Conexión rápida no disponible: $detail';
+  }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
@@ -26094,6 +26267,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   @override
   String get keyboardPreferSystemImeDescription =>
       'Utilice el método de entrada de su dispositivo de forma predeterminada para la entrada de texto';
+
+  @override
+  String get themeMoonfin => 'aleta lunar';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -26602,6 +26778,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get librivoxPage => 'Página de LibriVox';
+
+  @override
+  String get internetArchive => 'Archivo de Internet';
 
   @override
   String get rssFeed => 'Fuente RSS';
@@ -27643,6 +27822,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => 'Tipo de cuenta vidente';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -28748,6 +28930,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Elige entre varios estilos de barra multimedia o desactiva la barra multimedia';
 
   @override
+  String get mediaBarModeMoonfin => 'aleta lunar';
+
+  @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
@@ -28991,13 +29176,31 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Mostrar el reloj durante el salvapantallas';
 
   @override
+  String get rottenTomatoesCritics => 'Tomates podridos (críticos)';
+
+  @override
+  String get rottenTomatoesAudience => 'Tomates podridos (público)';
+
+  @override
   String get imdb => 'IMDb';
 
   @override
   String get tmdb => 'TMDB';
 
   @override
+  String get metacritic => 'metacrítico';
+
+  @override
+  String get metacriticUser => 'Metacrítico (Usuario)';
+
+  @override
+  String get trakt => 'Tracto';
+
+  @override
   String get letterboxd => 'Buzón';
+
+  @override
+  String get myAnimeList => 'Mi lista de animes';
 
   @override
   String get aniList => 'AniLista';
@@ -29042,6 +29245,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   @override
   String get ratingSourcesDescription =>
       'Habilite y reordene las fuentes de calificación que se muestran en toda la aplicación';
+
+  @override
+  String get pluginLabel => 'Complemento';
 
   @override
   String get pluginDetected => 'Complemento detectado';
@@ -29117,6 +29323,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Restablecer filas a los valores predeterminados';
 
   @override
+  String get enableSeerr => 'Habilitar vidente';
+
+  @override
   String get showSeerrInNavigation =>
       'Mostrar Seerr en la navegación (requiere complemento del servidor)';
 
@@ -29135,6 +29344,17 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String loggedInAs(String username) {
     return 'Iniciado sesión como: $username';
   }
+
+  @override
+  String get discoverRows => 'Descubrir filas';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      'Arrastre para reordenar. Activar o desactivar filas. Se ha habilitado la sincronización del orden de filas con el complemento Moonfin.';
+
+  @override
+  String get discoverRowsDescription =>
+      'Arrastre para reordenar. Activar o desactivar filas.';
 
   @override
   String get enabled => 'Activado';
@@ -29279,6 +29499,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String itemsCount(int count) {
     return '$count Artículos';
   }
+
+  @override
+  String get seerrSettings => 'Configuración de vidente';
 
   @override
   String get requestMore => 'Solicitar más';
@@ -29572,6 +29795,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get time => 'Tiempo';
 
   @override
+  String get trickplay => 'truco';
+
+  @override
   String get uninstall => 'Desinstalar';
 
   @override
@@ -29618,6 +29844,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get adminDrawerStreaming => 'Transmisión';
+
+  @override
+  String get adminDrawerTrickplay => 'truco';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -30743,6 +30972,13 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get adminThrottleBuffering => 'Amortiguación del acelerador';
 
   @override
+  String get adminTrickplaySaved => 'Configuración de trucos guardada';
+
+  @override
+  String get adminTrickplayLoadFailed =>
+      'No se pudo cargar la configuración de trucos';
+
+  @override
   String get adminEnableHardwareAcceleration =>
       'Habilitar la aceleración de hardware';
 
@@ -30855,6 +31091,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get adminBaseUrl => 'URL básica';
+
+  @override
+  String get adminBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get https => 'HTTPS';
@@ -31929,10 +32168,17 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
+  String get adminTrickplayDescription =>
+      'Configure la generación de imágenes de trucos para buscar miniaturas de vista previa.';
+
+  @override
   String get adminNetworkingPublicHttpsPort => 'Puerto HTTPS público';
 
   @override
   String get adminNetworkingBaseUrl => 'URL básica';
+
+  @override
+  String get adminNetworkingBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -32347,12 +32593,37 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get pinBackspace => 'Retroceso';
 
   @override
+  String get quickConnectAuthorized =>
+      'Solicitud de Conexión Rápida autorizada.';
+
+  @override
+  String get quickConnectInvalidOrExpired =>
+      'El código de Conexión Rápida no es válido o ha caducado.';
+
+  @override
   String get quickConnectNotSupported =>
       'Quick Connect no es compatible con este servidor.';
 
   @override
+  String get quickConnectAuthorizeFailed =>
+      'No se pudo autorizar el código de Conexión rápida.';
+
+  @override
   String get quickConnectDisabled =>
       'Quick Connect está deshabilitado en este servidor.';
+
+  @override
+  String get quickConnectForbidden =>
+      'Su cuenta no puede autorizar esta solicitud de Conexión rápida.';
+
+  @override
+  String get quickConnectNotFound =>
+      'No se encontró el código de conexión rápida. Pruebe un nuevo código.';
+
+  @override
+  String quickConnectFailedWithMessage(String message) {
+    return 'Error de conexión rápida: $message';
+  }
 
   @override
   String get quickConnectEnterCode => 'Introduce el código';
@@ -33539,6 +33810,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get guestAppearances => 'Apariciones de invitados';
 
   @override
+  String get appearancesSeerr => 'Apariciones (Vidente)';
+
+  @override
   String get watchWithGroup => 'Ver con grupo';
 
   @override
@@ -33712,6 +33986,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get mixedMoviesAndShows => 'Películas y programas mixtos';
+
+  @override
+  String get intelQuickSync => 'Sincronización rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP de chip de roca';
@@ -33805,12 +34082,18 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   AppLocalizationsEsMx() : super('es_MX');
 
   @override
+  String get appTitle => 'aleta lunar';
+
+  @override
   String get signIn => 'Iniciar sesión';
 
   @override
   String connectingToServer(String serverName) {
     return 'Conectándose a $serverName';
   }
+
+  @override
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contraseña';
@@ -33836,6 +34119,11 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get loginFailed => 'error de inicio de sesion';
+
+  @override
+  String quickConnectUnavailable(String detail) {
+    return 'Conexión rápida no disponible: $detail';
+  }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
@@ -33923,6 +34211,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get keyboardPreferSystemImeDescription =>
       'Utilice el método de entrada de su dispositivo de forma predeterminada para la entrada de texto';
+
+  @override
+  String get themeMoonfin => 'aleta lunar';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -34431,6 +34722,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get librivoxPage => 'Página de LibriVox';
+
+  @override
+  String get internetArchive => 'Archivo de Internet';
 
   @override
   String get rssFeed => 'Fuente RSS';
@@ -35472,6 +35766,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => 'Tipo de cuenta vidente';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -36577,6 +36874,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
       'Elige entre varios estilos de barra multimedia o desactiva la barra multimedia';
 
   @override
+  String get mediaBarModeMoonfin => 'aleta lunar';
+
+  @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
@@ -36820,13 +37120,31 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
       'Mostrar el reloj durante el salvapantallas';
 
   @override
+  String get rottenTomatoesCritics => 'Tomates podridos (críticos)';
+
+  @override
+  String get rottenTomatoesAudience => 'Tomates podridos (público)';
+
+  @override
   String get imdb => 'IMDb';
 
   @override
   String get tmdb => 'TMDB';
 
   @override
+  String get metacritic => 'metacrítico';
+
+  @override
+  String get metacriticUser => 'Metacrítico (Usuario)';
+
+  @override
+  String get trakt => 'Tracto';
+
+  @override
   String get letterboxd => 'Buzón';
+
+  @override
+  String get myAnimeList => 'Mi lista de animes';
 
   @override
   String get aniList => 'AniLista';
@@ -36871,6 +37189,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get ratingSourcesDescription =>
       'Habilite y reordene las fuentes de calificación que se muestran en toda la aplicación';
+
+  @override
+  String get pluginLabel => 'Complemento';
 
   @override
   String get pluginDetected => 'Complemento detectado';
@@ -36946,6 +37267,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
       'Restablecer filas a los valores predeterminados';
 
   @override
+  String get enableSeerr => 'Habilitar vidente';
+
+  @override
   String get showSeerrInNavigation =>
       'Mostrar Seerr en la navegación (requiere complemento del servidor)';
 
@@ -36964,6 +37288,17 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String loggedInAs(String username) {
     return 'Iniciado sesión como: $username';
   }
+
+  @override
+  String get discoverRows => 'Descubrir filas';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      'Arrastre para reordenar. Activar o desactivar filas. Se ha habilitado la sincronización del orden de filas con el complemento Moonfin.';
+
+  @override
+  String get discoverRowsDescription =>
+      'Arrastre para reordenar. Activar o desactivar filas.';
 
   @override
   String get enabled => 'Activado';
@@ -37108,6 +37443,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String itemsCount(int count) {
     return '$count Artículos';
   }
+
+  @override
+  String get seerrSettings => 'Configuración de vidente';
 
   @override
   String get requestMore => 'Solicitar más';
@@ -37401,6 +37739,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get time => 'Tiempo';
 
   @override
+  String get trickplay => 'truco';
+
+  @override
   String get uninstall => 'Desinstalar';
 
   @override
@@ -37447,6 +37788,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get adminDrawerStreaming => 'Transmisión';
+
+  @override
+  String get adminDrawerTrickplay => 'truco';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -38572,6 +38916,13 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get adminThrottleBuffering => 'Amortiguación del acelerador';
 
   @override
+  String get adminTrickplaySaved => 'Configuración de trucos guardada';
+
+  @override
+  String get adminTrickplayLoadFailed =>
+      'No se pudo cargar la configuración de trucos';
+
+  @override
   String get adminEnableHardwareAcceleration =>
       'Habilitar la aceleración de hardware';
 
@@ -38684,6 +39035,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get adminBaseUrl => 'URL básica';
+
+  @override
+  String get adminBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get https => 'HTTPS';
@@ -39758,10 +40112,17 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
+  String get adminTrickplayDescription =>
+      'Configure la generación de imágenes de trucos para buscar miniaturas de vista previa.';
+
+  @override
   String get adminNetworkingPublicHttpsPort => 'Puerto HTTPS público';
 
   @override
   String get adminNetworkingBaseUrl => 'URL básica';
+
+  @override
+  String get adminNetworkingBaseUrlHint => 'p.ej. /gelatina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -40176,12 +40537,37 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get pinBackspace => 'Retroceso';
 
   @override
+  String get quickConnectAuthorized =>
+      'Solicitud de Conexión Rápida autorizada.';
+
+  @override
+  String get quickConnectInvalidOrExpired =>
+      'El código de Conexión Rápida no es válido o ha caducado.';
+
+  @override
   String get quickConnectNotSupported =>
       'Quick Connect no es compatible con este servidor.';
 
   @override
+  String get quickConnectAuthorizeFailed =>
+      'No se pudo autorizar el código de Conexión rápida.';
+
+  @override
   String get quickConnectDisabled =>
       'Quick Connect está deshabilitado en este servidor.';
+
+  @override
+  String get quickConnectForbidden =>
+      'Su cuenta no puede autorizar esta solicitud de Conexión rápida.';
+
+  @override
+  String get quickConnectNotFound =>
+      'No se encontró el código de conexión rápida. Pruebe un nuevo código.';
+
+  @override
+  String quickConnectFailedWithMessage(String message) {
+    return 'Error de conexión rápida: $message';
+  }
 
   @override
   String get quickConnectEnterCode => 'Introduce el código';
@@ -41368,6 +41754,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get guestAppearances => 'Apariciones de invitados';
 
   @override
+  String get appearancesSeerr => 'Apariciones (Vidente)';
+
+  @override
   String get watchWithGroup => 'Ver con grupo';
 
   @override
@@ -41541,6 +41930,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get mixedMoviesAndShows => 'Películas y programas mixtos';
+
+  @override
+  String get intelQuickSync => 'Sincronización rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP de chip de roca';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -9,22 +9,22 @@ class AppLocalizationsEt extends AppLocalizations {
   AppLocalizationsEt([String locale = 'et']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Kuufin';
 
   @override
-  String get accountPreferences => 'KONTO EELISTUSED';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Liidese keel';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Süsteemi vaikimisi';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Logi sisse';
 
   @override
-  String get empty => 'Tühi';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Kiirühendus';
 
   @override
   String get password => 'Parool';
@@ -142,62 +142,62 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsAppearanceTheme => 'Rakenduse teema';
 
   @override
-  String get detailScreenStyle => 'Detailivaate stiil';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassikaline on algne keskjoondatud Moonfini paigutus. Moodne on kohanduv kinolik paigutus.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassikaline';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moodne';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Laiendatud vahekaardid';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Näita vahekaardi sisu automaatselt vahekaartide sirvimisel. Lülita välja, et avada ja sulgeda iga vahekaart käsitsi.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Kas näidata tehnilisi andmeid?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Näita bänneri kokkuvõttes koodeki, eraldusvõime ja voo teavet';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Soovitussüsteem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Kasuta kohalikul meediakogul põhinevat algoritmi „Moonfin soovitab“ või TMDb võrgupõhiseid sarnasusmõõdikuid. Märkus: võrgusoovitused vajavad Seerri integratsiooni.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin soovitab';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb sarnasus';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Kas piirata vanusepiiranguga?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Piira „Moonfin soovitab“ ettepanekuid sihtmeedia vanusepiirangu järgi';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Liidese stiil';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automaatne kohandub sinu seadmega. Vali Apple või Material, et sundida kindlat välimust.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automaatne';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,31 +206,31 @@ class AppLocalizationsEt extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Klaasi kvaliteet';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automaatne valib selle seadme jaoks parima klaasiefekti. Täielik sunnib päris hägustuse, Vähendatud kasutab kerget klaasi, mis säästab GPU jõudlust.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automaatne';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Täielik';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Vähendatud';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Lülitage Moonfini ja Neon Pulse vahel ilma rakendust taaskäivitamata';
 
   @override
-  String get customThemeTitle => 'Kohandatud teema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Kohandatud teemad muudavad Moonfini visuaalseid elemente kõikjal. Vali oma stiiliga sobiv variant.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Eelista süsteemiklaviatuuri';
@@ -240,7 +240,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kasutage teksti sisestamiseks vaikimisi seadme sisestusmeetodit';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Kuufin';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -254,18 +254,18 @@ class AppLocalizationsEt extends AppLocalizations {
       'Synthwave stiil magenta sära, tsüaani teksti ja tugevama kroomitud kontrastiga';
 
   @override
-  String get themeGlass => 'Klaas';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Vedela klaasi stiil hõljuva üleminekuga taustal, härmatanud pinnad ja Apple’i sinine rõhuvärv';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bitine kangelane';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pikslikunsti stiil jämeda paleti, kandiliste äärte, teravate varjude ja pikslifondiga';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -328,36 +328,35 @@ class AppLocalizationsEt extends AppLocalizations {
   String get exit => 'Välju';
 
   @override
-  String get gameMenu => 'Menüü';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pausil';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Salvesta olek';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Mängud';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Laadi olek';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Kiirkerimine';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulaatori seaded';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Sellel tuumal pole reguleeritavaid valikuid.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Hoia all, et avada menüü';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'See seade ei toeta veel mängude mängimist.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Ühtegi kodurida ei saanud laadida';
@@ -379,13 +378,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get schedule => 'Ajakava';
 
   @override
-  String get series => 'Sarjad';
+  String get series => 'seeria';
 
   @override
   String get noItemsFound => 'Üksusi ei leitud';
 
   @override
-  String get home => 'Avaleht';
+  String get home => 'Kodu';
 
   @override
   String get browseAll => 'Sirvi kõiki';
@@ -416,7 +415,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noLibrariesFound => 'Ühtegi raamatukogu ei leitud';
 
   @override
-  String get library => 'Meediakogu';
+  String get library => 'Raamatukogu';
 
   @override
   String get displaySettings => 'Kuva seaded';
@@ -508,7 +507,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get albumArtists => 'Albumi kunstnikud';
 
   @override
-  String get artists => 'Esitajad';
+  String get artists => 'Kunstnikud';
 
   @override
   String get bookmarks => 'Järjehoidjad';
@@ -749,7 +748,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get readStatus => 'Lugege';
 
   @override
-  String get watched => 'Vaadatud';
+  String get watched => 'Vaadati';
 
   @override
   String get unread => 'Lugemata';
@@ -767,43 +766,43 @@ class AppLocalizationsEt extends AppLocalizations {
   String get books => 'Raamatud';
 
   @override
-  String get latestBooks => 'Uusimad raamatud';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Uusimad audioraamatud';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count raamatut',
-      one: '1 raamat',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Raamat';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audioraamat';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% loetud';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time jäänud';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Loe';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Kuula';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -880,8 +879,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audioraamatut',
-      one: '1 audioraamat',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -917,7 +916,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get nextUp => 'Järgmine Üles';
 
   @override
-  String get seasons => 'Hooajad';
+  String get seasons => 'Aastaajad';
 
   @override
   String get chapters => 'Peatükid';
@@ -984,8 +983,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hooaega',
-      one: '1 hooaeg',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -996,40 +995,40 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get items => 'Üksused';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Lisamaterjalid';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Kaadri taga';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Väljajäetud stseenid';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Lühidokumentaalid';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjuud';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Stseenid';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Lühifilmid';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Treilerid';
+  String get trailers => 'Haagised';
 
   @override
   String timeRemaining(String time) {
-    return '$time jäänud';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Lõpeb $time pärast';
+    return 'Ends in $time';
   }
 
   @override
@@ -1047,7 +1046,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get play => 'Esita';
+  String get play => 'Mängi';
 
   @override
   String get startOver => 'Alusta otsast';
@@ -1188,7 +1187,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get subtitleTrack => 'Subtiitrirada';
 
   @override
-  String get none => 'Puudub';
+  String get none => 'Mitte ühtegi';
 
   @override
   String get downloadSubtitlesLabel => 'Laadi alla subtiitrid...';
@@ -1268,13 +1267,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
-  String get directors => 'REŽISSÖÖRID';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'STSENARIST';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'STSENARISTID';
+  String get writers => 'KIRJANIKUD';
 
   @override
   String get studio => 'STUUDIO';
@@ -1309,8 +1308,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count lugu',
-      one: '1 lugu',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1320,8 +1319,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count peatükki',
-      one: '1 peatükk',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1348,16 +1347,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get readMore => 'Loe edasi';
 
   @override
-  String get shuffle => 'Juhuesitus';
+  String get shuffle => 'Segamine';
 
   @override
-  String get shuffleAllMusic => 'Esita kogu muusika juhuslikus järjekorras';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Logi telefonis Moonfini sisse';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Serveriga ei saa ühendust';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1369,7 +1368,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1517,12 +1516,12 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1556,7 +1555,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get transcodeReasons => 'Transkodeerimise põhjused';
 
   @override
-  String get player => 'Pleier';
+  String get player => 'Mängija';
 
   @override
   String get container => 'Konteiner';
@@ -1792,26 +1791,26 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noChannelsFound => 'Ühtegi kanalit ei leitud';
 
   @override
-  String get liveBadge => 'OTSE';
+  String get liveBadge => 'LIVE';
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Järgmisena: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min jäänud';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours t jäänud';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours t $minutes min jäänud';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1834,7 +1833,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get favoriteChannel => 'Lemmikkanal';
 
   @override
-  String get record => 'Salvesta';
+  String get record => 'Salvestus';
 
   @override
   String get cancelRecordingAction => 'Tühista salvestamine';
@@ -1937,7 +1936,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerri konto tüüp';
+  String get seerrAccountType => 'Nägija konto tüüp';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2019,7 +2018,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'H$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2043,7 +2042,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'H$number';
+    return 'S$number';
   }
 
   @override
@@ -2062,8 +2061,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episoodi',
-      one: '1 episood',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2290,7 +2289,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detailivaated, avaekraani read ja helitugevus';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2304,17 +2303,18 @@ class AppLocalizationsEt extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Esita avakuva sirvimisel';
 
   @override
-  String get loopThemeMusic => 'Korda tunnusmuusikat';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'Korda lugu ühekordse esitamise asemel';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Üksikasjad Tausta hägu';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2330,23 +2330,23 @@ class AppLocalizationsEt extends AppLocalizations {
   String get playerZoomMode => 'Mängija suumirežiim';
 
   @override
-  String get settingsScrollWheelAction => 'Hiire kerimisratas';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Vali, mida hiireratta kerimine video kohal esituse ajal teeb.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Väljas';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Kerimine (edasi / tagasi)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Helitugevus';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Helitugevus';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Sobivad';
@@ -2400,37 +2400,37 @@ class AppLocalizationsEt extends AppLocalizations {
   String get defaultAudioLanguage => 'Heli vaikekeel';
 
   @override
-  String get fallbackAudioLanguage => 'Varuheli keel';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Eelista vaikimisi helirada';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Eelista originaalhelirada lokaliseeritud dublaažile.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Eelista kirjeldustõlke radu';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Eelista kirjeldustõlke radu tavaliste radade asemel.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodeerimine (heli)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Otsevoog (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodeerimine (bitikiirus või eraldusvõime)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodeerimine (video ja heli)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodeerimine (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automaatne (serveri vaikeseade)';
@@ -2511,24 +2511,23 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Vali, kuidas heli dekodeeritakse. AVR-läbilase saadab Dolby ja DTS toorvood ressiiverisse, Automaatne ja Allamiksimine dekodeerivad heli seadmes.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR-läbilase';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Heli varukoodek';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Vali sihtvorming, millesse mitmekanaliline heli transkodeeritakse, kui lähtevoogu ei saa otse esitada ega läbi lasta.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automaatne tuvastus\n(soovitatav)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(vaikimisi)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2537,27 +2536,26 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(kadudeta)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ainult stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(tõhus)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(kadudeta)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Helikanalite maksimum';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Määra oma helisüsteemi kanalite maksimum. Seda piiri ületavad mitmekanalilised vood miksitakse alla või transkodeeritakse.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automaatne tuvastus\n(riistvara vaikeväärtus)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2566,28 +2564,28 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 ruumiline heli';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 kvadrofooniline';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 ruumiline heli';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 ruumiline heli';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 ruumiline heli';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 ruumiline heli';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Läbimine (täpsem)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Koodeki läbilase';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
@@ -2600,16 +2598,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) läbipääs';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core läbilase';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'DTS-HD MA läbilaskevõime';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD läbilase';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos läbilase';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2662,11 +2660,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Kõlar';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kõrvaklapid';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2748,11 +2746,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get minimal => 'Minimaalne';
 
   @override
-  String get nextUpTimeout => '„Järgmisena“ ooteaeg';
+  String get nextUpTimeout => 'Next Up Timeout';
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2843,45 +2841,45 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kohandage subtiitrite välimust';
 
   @override
-  String get subtitleMode => 'Subtiitrite režiim';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Märgistatud';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Alati';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Võõrkeelsed';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Sunnitud';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Esitab rajad, mis on meediafaili metaandmetes märgitud „vaikimisi“ või „sunnitud“ radadeks.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Laadib ja kuvab subtiitrid automaatselt iga kord, kui video algab.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Lülitab subtiitrid automaatselt sisse, kui vaikimisi helirada on võõrkeelne.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Laadib ainult need subtiitrid, mis on selgesõnaliselt märgitud sunnitud lipuga.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Keelab subtiitrite automaatse laadimise täielikult.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Varusubtiitrite keel';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Subtiitrivoog';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Kiire pruunrebane hüppab üle laisa koera';
@@ -3086,10 +3084,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Näita teeke tööriistaribal';
 
   @override
-  String get navbarAlwaysExpanded => 'Näita navigeerimisriba silte alati';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Näita Seerri nuppu';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbari läbipaistmatus';
@@ -3163,18 +3161,18 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showFolderBrowsingOption => 'Kuva kaustade sirvimise valik';
 
   @override
-  String get groupItemsIntoCollections => 'Rühmita üksused kollektsioonidesse';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Peida kollektsiooniga seotud üksused kogude sirvimisel';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'Kogu rühmitamise teade';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Selle seade kasutamiseks veendu, et Jellyfini või Emby serveris on sinu kogu kuvamisseadetes lubatud „Rühmita filmid kollektsioonidesse“ ja/või „Rühmita saated kollektsioonidesse“.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Raamatukogu nähtavus';
@@ -3233,7 +3231,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Valige erinevate meediariba stiilide vahel või lülitage meediariba välja';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Kuufin';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3286,10 +3284,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Esitage treilereid automaatselt meediaribal 3 sekundi pärast';
 
   @override
-  String get trailerAudio => 'Treileri heli';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Luba treilerite heli meediaribal';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Episoodi eelvaade';
@@ -3365,11 +3363,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get combineBothRows => 'Ühendage mõlemad read üheks koduosaks';
 
   @override
-  String get fullScreenRows => 'Laiendatud avaekraani read';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Näita korraga ainult üht avaekraani rida';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Rea pilditüübi kohta';
@@ -3384,7 +3381,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get lastUser => 'Viimane kasutaja';
 
   @override
-  String get currentUser => 'Praegune kasutaja';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentige alati';
@@ -3488,10 +3485,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get displayClockDuringScreensaver => 'Kuva kella ekraanisäästja ajal';
 
   @override
-  String get clockModeStatic => 'Paigal';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Põrkuv';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (kriitikud)';
@@ -3562,7 +3559,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Lubage ja korraldage ümber kogu rakenduses kuvatavad reitinguallikad';
 
   @override
-  String get pluginLabel => 'Moonbase\'i plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Tuvastati plugin';
@@ -3634,7 +3631,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get networks => 'Võrgud';
 
   @override
-  String get seerrDiscoveryRows => 'Seerri avastamisread';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Lähtestage read vaikeseadetele';
@@ -3644,7 +3641,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get showSeerrInNavigation =>
-      'Kuva Seerr navigeerimisribal (nõuab serveri pluginat)';
+      'Kuva Nägija navigeerimisel (vaja on serveri pistikprogrammi)';
 
   @override
   String get seerrUnavailable =>
@@ -3658,28 +3655,28 @@ class AppLocalizationsEt extends AppLocalizations {
       'Peida tulemustes täiskasvanutele mõeldud sisu';
 
   @override
-  String get seerrNotificationsSection => 'Teavitused';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Uute taotluste teavitused';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Teavita mind, kui keegi esitab taotluse';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Taotluste uuendused';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Heaks kiidetud, tagasi lükatud ja kogusse lisatud';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Probleemide uuendused';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Uued probleemid, vastused ja lahendused';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3687,15 +3684,15 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerri avastamisleht';
+  String get discoverRows => 'Avasta read';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Lubage read, mida soovite Seerri avalehel näha. Lohistage ümberjärjestamiseks. Kohandatud järjestus sünkroonitakse Moonbase\'iga.';
+      'Lohistage ümberjärjestamiseks. Lubage või keelake read. Lubatud ridade järjestus sünkroonitakse Moonfini pistikprogrammiga.';
 
   @override
   String get discoverRowsDescription =>
-      'Lubage read, mida soovite Seerri avalehel näha. Lohistage ümberjärjestamiseks. Kohandatud järjestus sünkroonitakse Moonbase\'iga.';
+      'Lohistage ümberjärjestamiseks. Lubage või keelake read.';
 
   @override
   String get enabled => 'Lubatud';
@@ -3833,7 +3830,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get imageCacheCleared => 'Pildipuhver tühjendatud';
 
   @override
-  String get clear => 'Tühjenda';
+  String get clear => 'Selge';
 
   @override
   String get browse => 'Sirvige';
@@ -3849,11 +3846,11 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Allalaadimine · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importimine';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3861,7 +3858,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Seerri seaded';
+  String get seerrSettings => 'Nägija seaded';
 
   @override
   String get requestMore => 'Küsi lisa';
@@ -3995,147 +3992,148 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deletedStatus => 'Kustutatud';
 
   @override
-  String get failedStatus => 'Ebaõnnestus';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Töötlemisel';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Muutja: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Lõpetatud';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Seda pealkirja on juba taotletud';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Taotluste limiit on täis';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'See pealkiri on blokeerimisnimekirjas';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Rohkem taotletavaid hooaegu pole';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Sul pole õigust seda taotlust esitada';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Taotlused';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Probleemid';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Uusimad';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Viimati muudetud';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Probleeme pole';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Jäänud $remaining/$limit filmitaotlust';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Jäänud $remaining/$limit hooajataotlust';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Kuulub kollektsiooni: $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vaata kollektsiooni';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Taotle kollektsiooni';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmi · $available saadaval';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Taotle $count filmi';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Taotlemine $current/$total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Taotletud $count filmi';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Taotletud $ok/$total filmi';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Kõik filmid on juba saadaval või taotletud';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Teata probleemist';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Heli';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Mis on valesti?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Kõik episoodid';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episood';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Avatud';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Lahendatud';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Märgi lahendatuks';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Ava uuesti';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Teataja: $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommentaari';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Lisa kommentaar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Kas kustutada see probleem?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Esita teade';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB skoor';
@@ -4159,7 +4157,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get originalLanguageLabel => 'Algkeel';
 
   @override
-  String get seasonsLabel => 'Hooajad';
+  String get seasonsLabel => 'Aastaajad';
 
   @override
   String get episodesLabel => 'Episoodid';
@@ -4207,7 +4205,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get forward => 'Edasi';
 
   @override
-  String get general => 'Üldine';
+  String get general => 'Kindral';
 
   @override
   String get go => 'Mine';
@@ -4228,7 +4226,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get networking => 'Võrgustiku loomine';
 
   @override
-  String get next => 'Järgmine';
+  String get next => 'Edasi';
 
   @override
   String get path => 'Tee';
@@ -4288,7 +4286,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get status => 'Olek';
 
   @override
-  String get stop => 'Peata';
+  String get stop => 'Peatus';
 
   @override
   String get streaming => 'Voogesitus';
@@ -4336,16 +4334,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminDrawerUsers => 'Kasutajad';
 
   @override
-  String get adminDrawerLibraries => 'Meediakogud';
+  String get adminDrawerLibraries => 'raamatukogud';
 
   @override
-  String get adminDrawerDisplay => 'Kuva';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metaandmed';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO seaded';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Ümberkodeerimine';
@@ -4532,13 +4530,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get sessionForward => 'Edasi';
 
   @override
-  String get sessionNext => 'Järgmine';
+  String get sessionNext => 'Edasi';
 
   @override
-  String get sessionVolumeDown => 'Heli –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Heli +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4559,7 +4557,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audioCodec => 'Heli koodek';
 
   @override
-  String get hwAccel => 'Riistvarakiirendus';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Lõpetamine';
@@ -4574,10 +4572,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminClearDates => 'Selged kuupäevad';
 
   @override
-  String get adminActivitySeverityAll => 'Kõik raskusastmed';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Ajavahemik';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4614,23 +4612,23 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Kas eemaldada seade \'$name\'? Kasutaja peab selles seadmes uuesti sisse logima.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Kustuta kõik seadmed';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Kas eemaldada $count seadet? Mõjutatud kasutajad peavad uuesti sisse logima. Sinu praegust seadet see ei puuduta.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Seadmed eemaldatud';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Osa seadmeid eemaldati, $count seadet ei õnnestunud eemaldada.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4745,247 +4743,244 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminMetadataCountryHint => 'nt. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Teed';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Valikud';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Allalaadijad';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metaandmete salvestajad';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Subtiitrite allalaadijad';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Laulusõnade allalaadijad';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metaandmete allalaadijad: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Piltide hankijad: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'See server ei paku selle kogutüübi jaoks allalaadijaid.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Üldine';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metaandmed';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Manustatud teave';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtiitrid';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Pildid';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Sarjad';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muusika';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmid';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Luba reaalajas jälgimine';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Tuvasta failimuudatused ja töötle need automaatselt.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Käsitle arhiive meediafailidena';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Näita fotosid';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Salvesta kujunduspildid meediakaustadesse';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Metaandmete automaatne värskendamine';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Mitte kunagi';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Vaikimisi';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Kuva';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Kogu kuvamine';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Näita kaustavaadet tavaliste meediakaustade jaoks';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Näita eriosi nende hooaegade sees, kus need eetris olid';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Rühmita filmid kollektsioonidesse';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Rühmita saated kollektsioonidesse';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Näita soovitustes välist sisu';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Lisamiskuupäeva käitumine';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Kasuta lisamiskuupäevana';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Kogusse skannimise kuupäev';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Faili loomise kuupäev';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metaandmed ja pildid';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Eelistatud metaandmete keel';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Peatükid';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Asenduspeatükkide kestus (sekundites)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Peatükkide pikkus meedia jaoks, millel neid pole. Keelamiseks määra 0.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Peatükipiltide eraldusvõime';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO seaded';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO metaandmed ühilduvad Kodi ja sarnaste klientidega. Seaded kehtivad kõigile kogudele, mis salvestavad NFO metaandmeid.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Kasutaja, kelle vaatamisandmed NFO failidesse salvestatakse';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Salvesta pilditeed NFO failidesse';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Luba teede asendamine NFO pilditeede jaoks';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopeeri extrafanart-pildid kausta extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Puudub';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days päeva';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Kasuta manustatud pealkirju';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Kasuta manustatud pealkirju lisamaterjalide jaoks';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'Kasuta manustatud episooditeavet';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Luba manustatud subtiitrid';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Luba kõik';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Ainult tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Ainult pilt';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Puudub';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Jäta allalaadimine vahele, kui manustatud subtiitrid on olemas';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Jäta allalaadimine vahele, kui helirada vastab allalaadimise keelele';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Nõua täpset subtiitrite vastet';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Salvesta subtiitrid meediakaustadesse';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Eralda peatükipildid';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Eralda peatükipildid kogu skannimise ajal';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Luba Trickplay piltide eraldamine';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Eralda Trickplay pildid kogu skannimise ajal';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Salvesta Trickplay pildid meediakaustadesse';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Ühenda automaatselt sarjad, mis on jaotatud mitme kausta vahel';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nullhooaja kuvatav nimi';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Luba LUFS-skannimine heli normaliseerimiseks';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Eelista mittestandardset esitajasilti';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Lisa filmid automaatselt kollektsioonidesse';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Teegi nimi on kohustuslik';
@@ -5220,144 +5215,143 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminEnableAllChannels => 'Luba juurdepääs kõikidele kanalitele';
 
   @override
-  String get adminParentalControl => 'Vanemlik järelevalve';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Suurim lubatud vanusepiirang';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Sellest kõrgema piiranguga sisu peidetakse selle kasutaja eest.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Puudub';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokeeri üksused, mille vanusepiirangu teave puudub või on tundmatu';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Raamatud';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanalid';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Otse-TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmid';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muusika';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Treilerid';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Sarjad';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Juurdepääsu ajakavad';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Luba juurdepääs ainult allpool määratud aegadel. Kui ajakava pole määratud, on juurdepääs lubatud kogu päeva.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Lisa ajakava';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Päev';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Algus';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Lõpp';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Iga päev';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Argipäev';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Nädalavahetus';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Pühapäev';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Esmaspäev';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Teisipäev';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Kolmapäev';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Neljapäev';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Reede';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Laupäev';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Lubatud sildid';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Näidatakse ainult nende siltidega sisu. Kõige lubamiseks jäta tühjaks.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokeeritud sildid';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Nende siltidega sisu peidetakse selle kasutaja eest.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Lisa silt';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Lubatud seadmed';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Lubatud kanalid';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Autentimisteenuse pakkuja';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Parooli lähtestamise pakkuja';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Ebaõnnestunud sisselogimiskatsete maksimum enne lukustamist';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Vaikeväärtuse jaoks määra 0 või lukustamise keelamiseks -1.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay juurdepääs';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Luba rühmade loomine ja nendega liitumine';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Luba rühmadega liitumine';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Juurdepääs puudub';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Luba sisu kustutamine kaustadest';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5444,25 +5438,25 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Loo varukoopia';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Vali, mida varukoopiasse kaasata.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Andmebaas';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Alati kaasatud';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metaandmed';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtiitrid';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay pildid';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Varukoopia loomine...';
@@ -6004,7 +5998,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminBaseUrl => 'Baas-URL';
 
   @override
-  String get adminBaseUrlHint => 'nt /jellyfin';
+  String get adminBaseUrlHint => 'nt. /tarretis';
 
   @override
   String get https => 'HTTPS';
@@ -6167,62 +6161,60 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminAddTuner => 'Lisage tuuner';
 
   @override
-  String get adminEditTuner => 'Muuda tuunerit';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U tuuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fail või URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Tuuneri IP-aadress';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Kuvatav nimi';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Samaaegsete ühenduste piirang';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Voogude maksimaalne arv, mida tuuner korraga lubab. Piiramatu jaoks määra 0.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Voogedastuse varubitikiiruse ülempiir';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Impordi ainult lemmikkanalid';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Luba riistvaraline transkodeerimine';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Luba fMP4 transkodeerimiskonteiner';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Luba voo jagamine';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Luba voo kordamine';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Eira DTS-i';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Loe sisendit algsel kaadrisagedusel';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Muuda pakkujat';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6231,50 +6223,50 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fail või URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmide eesliide';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmikategooriad';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Eralda mitu kategooriat püstkriipsuga.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Lastesaadete kategooriad';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Uudistekategooriad';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Spordikategooriad';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Kasutajanimi';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Parool';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Riik';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Vali riik';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postiindeks';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Hangi kavad';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Kavad';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Luba kõik tuunerid';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuneri tüüp';
@@ -6316,7 +6308,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'See tuuneritüüp ei toeta lähtestamist.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6339,43 +6331,43 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Sarja salvestustee';
 
   @override
-  String get adminMovieRecordingPath => 'Filmisalvestiste tee';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Kavaandmete päevade arv';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automaatne';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days päeva';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Järeltöötlusrakenduse tee';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Järeltöötleja argumendid';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Salvesta salvestise NFO metaandmed';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Salvesta salvestise pildid';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Ajastus';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Salvestamise teed';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Järeltöötlus';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Kavaandmed: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6418,14 +6410,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminGuideProviders => 'Juhendi pakkujad';
 
   @override
-  String get adminRefreshGuideData => 'Värskenda kavaandmeid';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Kavaandmete värskendamine alustatud';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Kava värskendamise ülesanne pole selles serveris saadaval.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Lisa teenusepakkuja';
@@ -6559,7 +6551,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metaandmete redaktor';
 
   @override
-  String get adminMetadataIdentify => 'Tuvasta';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tüüp';
@@ -6975,20 +6967,19 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Luba pritskuva';
 
   @override
-  String get adminBrandingSplashUpload => 'Laadi pilt üles';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Avakuva uuendatud';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Avakuva üleslaadimine ebaõnnestus';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Avakuva eemaldatud';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Kohandatud avakuva puudub';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Riistvaraline kiirendus';
@@ -7004,128 +6995,121 @@ class AppLocalizationsEt extends AppLocalizations {
       'Riistvara dekodeerimise lubamine:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV seade';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Luba täiustatud NVDEC dekooder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Eelista süsteemi algset riistvaralist dekooderit';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Riistvaralise dekodeerimise värvisügavus';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bitine HEVC dekodeerimine';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bitine VP9 dekodeerimine';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bitine dekodeerimine';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-bitine dekodeerimine';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Riistvaraline kodeerimine';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Luba HEVC kodeerimine';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Luba AV1 kodeerimine';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Luba Inteli väikese energiatarbega H.264 kooder';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Luba Inteli väikese energiatarbega HEVC kooder';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Toonivastendus';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Luba toonivastendus';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Luba VPP toonivastendus';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Luba VideoToolboxi toonivastendus';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Toonivastenduse algoritm';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Toonivastenduse režiim';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Toonivastenduse vahemik';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Toonivastenduse küllastuse vähendamine';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Toonivastenduse tipptase';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Toonivastenduse parameeter';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP toonivastenduse heledus';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP toonivastenduse kontrastsus';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Eelseadistused ja kvaliteet';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Koodri eelseadistus';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 kodeerimise CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) kodeerimise CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod =>
-      'Ülerealaotuse eemaldamise meetod';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Kahekordista kaadrisagedus ülerealaotuse eemaldamisel';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Heli';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Luba heli VBR-kodeerimine';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Heli allamiksimise võimendus';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Stereo allamiksimise algoritm';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Multipleksimisjärjekorra maksimaalne suurus';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automaatne';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodeerimine';
@@ -7246,10 +7230,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminTaskNeverRun => 'Ärge kunagi jookske';
 
   @override
-  String get adminTaskStop => 'Peata';
+  String get adminTaskStop => 'Peatus';
 
   @override
-  String get adminRunningTasks => 'Töötavad ülesanded';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Jookse';
@@ -7319,8 +7303,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tundi',
-      one: '1 tund',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7366,22 +7350,22 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours t';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days p';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month.';
+    return '$month/$day';
   }
 
   @override
@@ -7395,50 +7379,49 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Baas-URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'nt /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'nt. /tarretis';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Avalik HTTP port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Nõua HTTPS-i';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Suuna kõik kaugpäringud HTTPS-ile. Ei avalda mõju, kui serveril pole kehtivat sertifikaati.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Sertifikaadi parool';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-seaded';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Luba IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Luba IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Luba automaatne portide suunamine';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Kohtvõrgud';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Komade või reavahetustega eraldatud loend IP-aadressidest või CIDR-alamvõrkudest, mida käsitletakse kohtvõrguna.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Avaldatud serveri URI-d';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Seosta alamvõrk või aadress avaldatud URL-iga, nt all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Sertifikaadi tee';
@@ -7468,11 +7451,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Drosselklapi puhverdus';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Piiramise viivitus (sekundites)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Luba subtiitrite eraldamine lennult';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimaalne jätkamise protsent';
@@ -7530,22 +7513,22 @@ class AppLocalizationsEt extends AppLocalizations {
       'Aeglase reageerimise lävi (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'Luba aeglase vastuse hoiatused';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Luba Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metaandmed';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Teed';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Jõudlus';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Vahemälu tee';
@@ -7557,7 +7540,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminGeneralServerName => 'Serveri nimi';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Eelistatud kuvakeel';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Seadete laadimine ebaõnnestus';
@@ -7579,7 +7562,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get folders => 'Kaustad';
 
   @override
-  String get libraries => 'Meediakogud';
+  String get libraries => 'raamatukogud';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7609,8 +7592,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# osalejat',
-      one: '# osaleja',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7757,8 +7740,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'leitud # rida',
-      one: 'leitud # rida',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7799,20 +7782,20 @@ class AppLocalizationsEt extends AppLocalizations {
   String get offlineSavedMedia => 'Salvestatud meedia';
 
   @override
-  String get offlineBannerTitle => 'Oled võrguühenduseta';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Näitame sinu allalaadimisi';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Allalaadimised';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Serveriga ei saa ühendust';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Esitame allalaadimistest, kuni ühendus taastub';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7885,41 +7868,40 @@ class AppLocalizationsEt extends AppLocalizations {
   String get pinForgot => 'Unustasite PIN-koodi?';
 
   @override
-  String get pinClear => 'Tühjenda';
+  String get pinClear => 'Selge';
 
   @override
   String get pinBackspace => 'Tagasilükkeklahv';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connecti taotlus on lubatud.';
+  String get quickConnectAuthorized => 'Kiirühenduse taotlus on lubatud.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connecti kood on kehtetu või aegunud.';
+      'Kiirühenduse kood on kehtetu või aegunud.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connecti ei toetata selles serveris.';
+      'Kiirühendust selles serveris ei toetata.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connecti koodi autoriseerimine ebaõnnestus.';
+      'Kiirühenduse koodi autoriseerimine ebaõnnestus.';
 
   @override
-  String get quickConnectDisabled =>
-      'Quick Connect on selles serveris keelatud.';
+  String get quickConnectDisabled => 'Kiirühendus on selles serveris keelatud.';
 
   @override
   String get quickConnectForbidden =>
-      'Teie konto ei saa seda Quick Connecti taotlust autoriseerida.';
+      'Teie konto ei saa seda kiirühenduse taotlust autoriseerida.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connecti koodi ei leitud. Proovige uut koodi.';
+      'Kiirühenduse koodi ei leitud. Proovige uut koodi.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ebaõnnestus: $message';
+    return 'Kiirühendus ebaõnnestus: $message';
   }
 
   @override
@@ -8024,7 +8006,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get shuffleSelectGenre => 'Valige Žanr';
 
   @override
-  String get shuffleLibrary => 'Meediakogu';
+  String get shuffleLibrary => 'Raamatukogu';
 
   @override
   String get shuffleGenre => 'Žanr';
@@ -8086,7 +8068,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Taasesitus on peatatud. Kas sa ikka vaatad?';
 
   @override
-  String get stillWatchingStop => 'Peata';
+  String get stillWatchingStop => 'Peatus';
 
   @override
   String get stillWatchingContinue => 'Jätka';
@@ -8171,13 +8153,13 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Peida jaotisest „Jätka vaatamist“';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Peida jaotisest „Järgmisena“';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Lisa kollektsiooni';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8232,15 +8214,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsAlphabetical => 'Tähestikuline';
 
   @override
-  String get settingsConnectionSection => 'ÜHENDUS';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Luba ise allkirjastatud sertifikaadid';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Usalda servereid, mis kasutavad ise allkirjastatud või privaatse CA TLS-sertifikaate. Luba ainult enda hallatavate serverite puhul. See keelab sertifikaatide kontrolli kõigil ühendustel.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVAATSUS JA OHUTUS';
@@ -8256,11 +8237,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'Teema aktsendid, taustad, vaadatud indikaatorid ja teemamuusika';
 
   @override
-  String get settingsDetailsScreen => 'Detailivaade';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stiil, tausta hägustus ja vahekaartide käitumine';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Avaleht';
@@ -8298,11 +8279,11 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Näita Seerri nuppu navigeerimisribal';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Näita ülemisel navigeerimisribal alati tekstisilte';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8398,15 +8379,15 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kontrollige uusimat Moonfini väljaannet';
 
   @override
-  String get settingsPoweredByFlutter => 'Töötab Flutteri baasil';
+  String get settingsPoweredByFlutter => 'Powered by Flutter';
 
   @override
   String settingsLicenseNoticesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# litsentsiteadet',
-      one: '# litsentsiteade',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8454,16 +8435,16 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kas jätta sissejuhatused ja välised vahele?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Meediasegmendi loendur';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Edenemisriba';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Taimer';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Puudub';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Küsi kasutajat';
@@ -8497,7 +8478,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (soovitatav)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (pärand)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (pärand)';
@@ -8694,7 +8675,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Hiljuti ilmunud: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8726,11 +8707,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'Sunnita tunneleerimata taasesitus. Kasulik heli/video katkestustega seadmetes.';
 
   @override
-  String get enableTunnelingTitle => 'Luba tunneldamine';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Täpsem seade. Suunab heli ja video seotud riistvaratee kaudu. Vaikimisi väljas, kuna see põhjustab mõnes seadmes heli- ja pildikatkestusi.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8757,14 +8738,14 @@ class AppLocalizationsEt extends AppLocalizations {
       'Rakendage subtiitrite rajale manustatud fondisuuruse vihjeid. Keelake oma stiilieelistuste alusel subtiitrite suuruse kasutamine.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Näita meedia üksikasju';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Näita valitud üksuse üksikasju kogulehtede ülaosas.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Kas peita taustapildid sirvimisel?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Kasutage üksikasjalikke alapealkirju';
@@ -8782,37 +8763,37 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Teemapood';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Sirvi ja salvesta kogukonna teemasid';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Salvesta teema, et kasutada seda nagu teisi salvestatud teemasid.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Praegu pole ühtegi teemat saadaval.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Teemapoodi ei õnnestunud laadida. Kontrolli ühendust ja proovi uuesti.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Salvesta';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Salvesta ja rakenda';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Salvestatud';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Seda teemat ei õnnestunud laadida.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Teema „$themeName“ salvestatud.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8870,21 +8851,21 @@ class AppLocalizationsEt extends AppLocalizations {
   String get homeRowsSection => 'Kodu read';
 
   @override
-  String get homeRowDisplay => 'Avaekraani ridade kuvamine';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Avaekraani ridade jaotised';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Avaekraani ridade lülitid';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Luba või keela kogupõhised avaekraani ridade kategooriad';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Luba järgmised lülitid, et read avaekraani jaotistes kuvataks.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Ridade tüüp';
@@ -8943,55 +8924,55 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kuva filmid, seriaalid või mõlemad žanrite ridadel.';
 
   @override
-  String get displayPlaylistsRows => 'Näita esitusloendite ridu';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Näita esitusloendite ridu avaekraani jaotistes.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Esitusloendite ridade sortimine';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sordi esitusloendite ridu lisamiskuupäeva, ilmumiskuupäeva, tähestiku ja muu järgi.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Näita heliridu';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'Näita heliridu avaekraani jaotistes.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Heliridade sortimine';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sordi heliridu lisamiskuupäeva, ilmumiskuupäeva, tähestiku ja muu järgi.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Heliesitusloendid';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Välimus';
 
   @override
-  String get layout => 'Paigutus';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Teema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klaviatuur';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Nupud';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderdamine';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV seadistus';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kaardi suurus';
@@ -9001,7 +8982,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Määra väline mängija, et lubada pika vajutuse esitusvalik';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9264,10 +9245,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get guestAppearances => 'Külalisesinemised';
 
   @override
-  String get appearancesSeerr => 'Esinemised (Seerr)';
+  String get appearancesSeerr => 'Esinemised (nägija)';
 
   @override
-  String get crewContributionsSeerr => 'Meeskonna panused (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Vaadake koos rühmaga';
@@ -9353,8 +9334,8 @@ class AppLocalizationsEt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kogu',
-      one: '1 kogu',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9446,7 +9427,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mixedMoviesAndShows => 'Segafilmid ja -saated';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Inteli kiire sünkroonimine';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9514,13 +9495,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get loadingShuffle => 'Juhusliku esituse laadimine...';
 
   @override
-  String get libraryShuffleLabel => 'KOGU SEGAMINE';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'JUHUSLIK SEGAMINE';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ŽANRIDE SEGAMINE';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automaatne HDR-i vahetamine';
@@ -9533,222 +9514,222 @@ class AppLocalizationsEt extends AppLocalizations {
   String get whenFullscreen => 'Täisekraanil';
 
   @override
-  String get changeArtwork => 'Muuda kujunduspilti';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Puudub';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Ümberkodeerimise piirangud';
 
   @override
-  String get clearAllArtworkButton => 'Kas tühjendada kõik kujunduspildid?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Kas oled kindel, et soovid kõik allalaaditud kujunduspildid tühjendada?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Kinnita tühjendamine';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Kas oled kindel, et soovid tühjendada selle: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Kas laadida üles?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Eraldusvõime: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Näita ainult liidese keeles kujunduspilte';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Kinnita kõigi tühjendamine';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Pilt laaditi edukalt üles!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Pildi üleslaadimine ebaõnnestus: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Pildi määramine ebaõnnestus: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Pildi kustutamine ebaõnnestus: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kõigi kujunduspiltide tühjendamine ebaõnnestus: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Jah';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Taustapildid';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Bänner';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Pisipilt';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Kujunduspilt';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Plaadi kujundus';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ekraanipilt';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Karbi esikaas';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Karbi tagakaas';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menüü kujundus';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'taustapilt';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'bänner';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'pisipilt';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'kujunduspilt';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'plaadi kujundus';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ekraanipilt';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'karbi esikaas';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'karbi tagakaas';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menüü kujundus';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Kõik';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Kõrge (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Keskmine (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Madal (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Allikad';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Peatükid';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Järjehoidjad';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Märkmed';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Järjekord';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Ajajoon';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Ajajoon on tühi';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Kogu raamat';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Kitsendatud ajajoon';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Ekspordi järjehoidjad';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Ekspordi märkmed';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Ekspordi kõik';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksporditud asukohta $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksportimine ebaõnnestus: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Laulusõnad';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Lisa järjehoidja';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Lisa märge';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Muuda märget';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Kirjuta selle koha kohta märge';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Unetaimer';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Väljas';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Peatüki lõpp';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Kohandatud';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining jäänud';
+    return '$remaining left';
   }
 
   @override
@@ -9763,51 +9744,51 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Esituskiirus';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Jäänud';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Möödunud';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Tagasi $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Edasi $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Eelmine peatükk';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Järgmine peatükk';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Peatükk $current/$total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Peatükke pole';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Järjehoidjaid pole veel';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Märkmeid pole veel';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Järjehoidja lisatud kohta $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Lähtesta kiirusele 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9815,248 +9796,249 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Salvesta';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Tühista';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Kustuta';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Subtiitrite eelistused';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Muuda subtiitrite režiime, vaikekeeli, välimust ja renderdamisvalikuid.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Subtiitrite renderdamine';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Kuvamisvalikud';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Ilmumiskuupäev (kasvav)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Ilmumiskuupäev (kahanev)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Rühmita panused';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Rühmita mitu rolli';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'Kogu kirjutusõiguse hoiatus';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kuidas seda parandada:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Anna Jellyfini teenuse kasutajale (nt jellyfin või Dockeri PUID/PGID) kirjutusõigused serveris asuvatele meediakogu kaustadele.\n\n2. Või mine Jellyfini juhtpaneelile -> Kogud, muuda seda kogu ja keela „Salvesta kujunduspildid meediakaustadesse“, et kujunduspilte hoitaks Jellyfini sisemises andmebaasis.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Sulge';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Sinu kogu \'$libraryName\' on seadistatud salvestama kujunduspilte otse meediakaustadesse (valik „Salvesta kujunduspildid meediakaustadesse“ on lubatud). Jellyfin kontrollis aga kirjutusõigust ja tal pole luba sellesse kataloogi faile kirjutada:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Näib, et Jellyfinil ei õnnestunud kujunduspilti uuendada. Sinu kogu on seadistatud salvestama kujunduspilte otse meediakaustadesse (valik „Salvesta kujunduspildid meediakaustadesse“ on lubatud). See viga tekib tavaliselt siis, kui Jellyfini serveriprotsessil pole luba sinu meediakataloogidesse faile kirjutada.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Välised loendid';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Esita uuesti';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Faili teave';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Suurus: $size  •  Vorming: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Näita kõiki ($count) helirada';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Näita kõiki ($count) subtiitrirada';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Otseesituse toe kontrollimine...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Otseesituse tugi: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Sunnitud';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Mängija ei toeta konteinerivormingut.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Videokoodekit ei toetata.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Helikoodekit ei toetata.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Subtiitrivormingut ei toetata (nõuab pildile põletamist).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Heliprofiili ei toetata.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Videoprofiili ei toetata.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Videotaset ei toetata.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'See seade ei toeta video eraldusvõimet.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Video bitisügavust ei toetata.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Video kaadrisagedust ei toetata.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Faili bitikiirus ületab mängija voogedastuse piiri.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Video bitikiirus ületab voogedastuse piiri.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Heli bitikiirus ületab voogedastuse piiri.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Helikanalite arvu ei toetata.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Tähestikuline';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ilmumisjärjekord (kasvav)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Ilmumisjärjekord (kahanev)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Kohandatud (lohistamisega)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Esitusloendi sortimisvalikud';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Lähtesta sortimine';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Vaata uuesti H$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Vaata esitusloendit uuesti';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Subtiitreid ei leitud.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administraatori juhtnupud';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Renderdusmootor (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller on Flutteri moodne GPU-renderdaja, mis annab sujuvamad animatsioonid ja vähem tõrkeid. Mõnes TV-boksis ja vanemas GPU-s võib see põhjustada häireid või musta pilti; sel juhul lülita see välja. Automaatne valib sinu seadme jaoks parima vaikeväärtuse. Muudatuse rakendamiseks käivita Moonfin uuesti.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automaatne';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Sees';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Väljas';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Vajalik on taaskäivitus';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Renderdusmootori muutmiseks tuleb Moonfin taaskäivitada. Sulge rakendus nüüd ja ava see uuesti, et muudatus rakenduks.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Sulge rakendus nüüd';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Värskenda kogu';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Värskenda kõiki kogusid';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Lisamiskuupäev (vanimad enne)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Lisamiskuupäev (uusimad enne)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Tähestikuline (A–Ü)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Tähestikuline (Ü–A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Serveri analüütika laadimine... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Sama mis lähtefailil';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 250 parimat filmi';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 250 parimat sarja';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb populaarseimad filmid';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb populaarseimad sarjad';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb madalaima hinnanguga filmid';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb parimad ingliskeelsed filmid';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -9,22 +9,22 @@ class AppLocalizationsFa extends AppLocalizations {
   AppLocalizationsFa([String locale = 'fa']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'باله ماه';
 
   @override
-  String get accountPreferences => 'ترجیحات حساب';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'زبان رابط کاربری';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'پیش‌فرض سیستم';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'وارد شوید';
 
   @override
-  String get empty => 'خالی';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'اتصال سریع';
 
   @override
   String get password => 'رمز عبور';
@@ -51,7 +51,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get waitingForAuthorization => 'در انتظار مجوز...';
 
   @override
-  String get back => 'بازگشت';
+  String get back => 'برگشت';
 
   @override
   String get serverUnavailable => 'سرور در دسترس نیست';
@@ -113,7 +113,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get cancel => 'لغو کنید';
 
   @override
-  String get remove => 'حذف';
+  String get remove => 'حذف کنید';
 
   @override
   String get connectToServer => 'به سرور متصل شوید';
@@ -141,61 +141,62 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsAppearanceTheme => 'تم برنامه';
 
   @override
-  String get detailScreenStyle => 'سبک صفحه جزئیات';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'کلاسیک همان چیدمان وسط‌چین اصلی Moonfin است. مدرن یک چیدمان سینمایی واکنش‌گراست.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'کلاسیک';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'مدرن';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'برگه‌های گسترده';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'محتوای هر برگه هنگام مرور برگه‌ها به‌طور خودکار نمایش داده می‌شود. برای باز و بستن دستی هر برگه، این گزینه را خاموش کنید.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'نمایش جزئیات فنی؟';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'نمایش کدک، وضوح و اطلاعات جریان در خلاصه بنر';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'سیستم پیشنهاد';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'از الگوریتم کتابخانه محلی Moonfin Recommends یا سنجه‌های شباهت آنلاین TMDb استفاده کنید. توجه: پیشنهادهای آنلاین به یکپارچه‌سازی Seerr نیاز دارند.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'شباهت TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
-  String get recommendationsApplyParentalRatingCap => 'اعمال سقف رده‌بندی سنی؟';
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'محدود کردن پیشنهادهای Moonfin Recommends بر اساس رده‌بندی سنی رسانه هدف';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'سبک رابط کاربری';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'خودکار با دستگاه شما هماهنگ می‌شود. برای اعمال اجباری یک ظاهر، Apple یا Material را انتخاب کنید.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'خودکار';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -204,31 +205,31 @@ class AppLocalizationsFa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'کیفیت شیشه';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'خودکار بهترین جلوه شیشه‌ای را برای این دستگاه انتخاب می‌کند. کامل محوشدگی واقعی را اعمال می‌کند؛ کاهش‌یافته از شیشه‌ای سبک استفاده می‌کند که در مصرف GPU صرفه‌جویی می‌کند.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'خودکار';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'کامل';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'کاهش‌یافته';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'جابه‌جایی بین Moonfin و Neon Pulse بدون راه‌اندازی مجدد برنامه';
 
   @override
-  String get customThemeTitle => 'تم سفارشی';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'تم‌های سفارشی عناصر بصری را در سراسر Moonfin تغییر می‌دهند. یکی از این گزینه‌ها را متناسب با سلیقه خود انتخاب کنید.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'صفحه کلید سیستم را ترجیح دهید';
@@ -238,7 +239,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'از روش ورودی دستگاه خود به طور پیش فرض برای وارد کردن متن استفاده کنید';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'باله ماه';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -252,18 +253,18 @@ class AppLocalizationsFa extends AppLocalizations {
       'استایل سینت ویو با درخشش سرخابی، متن فیروزه‌ای و کنتراست کروم قوی‌تر';
 
   @override
-  String get themeGlass => 'شیشه';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'استایل شیشه مایع با پس‌زمینه گرادیانی متحرک، سطوح مات و رنگ تأکیدی آبی Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'قهرمان 8-بیتی';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'استایل پیکسل‌آرت رترو با پالت درشت، حاشیه‌های بلوکی، سایه‌های تیز و فونت پیکسلی';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'با اکانت Connect Emby خود وارد شوید';
@@ -324,35 +325,35 @@ class AppLocalizationsFa extends AppLocalizations {
   String get exit => 'خارج شوید';
 
   @override
-  String get gameMenu => 'منو';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'متوقف شده';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'ذخیره وضعیت';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'بازی‌ها';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'بارگذاری وضعیت';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'جلو بردن سریع';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'تنظیمات شبیه‌ساز';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'این هسته گزینه قابل تنظیمی ندارد.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'برای باز کردن منو نگه دارید';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'اجرای بازی هنوز روی این دستگاه پشتیبانی نمی‌شود.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'هیچ ردیف خانه بارگیری نشد';
@@ -368,13 +369,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get guide => 'راهنما';
 
   @override
-  String get recordings => 'ضبط‌ها';
+  String get recordings => 'ضبط ها';
 
   @override
   String get schedule => 'برنامه ریزی کنید';
 
   @override
-  String get series => 'سریال‌ها';
+  String get series => 'سری';
 
   @override
   String get noItemsFound => 'هیچ موردی یافت نشد';
@@ -550,7 +551,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'انتخاب کنید که کدام موضوع فیدها در Discover نمایش داده شود.';
 
   @override
-  String get apply => 'اعمال';
+  String get apply => 'درخواست کنید';
 
   @override
   String get openLink => 'پیوند را باز کنید';
@@ -598,7 +599,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get listen => 'گوش کن';
 
   @override
-  String get resume => 'ادامه';
+  String get resume => 'رزومه';
 
   @override
   String get failedToLoadLibrary => 'کتابخانه بارگیری نشد';
@@ -741,13 +742,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get readStatus => 'بخوانید';
 
   @override
-  String get watched => 'تماشا شده';
+  String get watched => 'تماشا کرد';
 
   @override
   String get unread => 'خوانده نشده';
 
   @override
-  String get unwatched => 'تماشا نشده';
+  String get unwatched => 'دیده نشده';
 
   @override
   String get seriesStatus => 'وضعیت سریال';
@@ -759,43 +760,43 @@ class AppLocalizationsFa extends AppLocalizations {
   String get books => 'کتاب ها';
 
   @override
-  String get latestBooks => 'جدیدترین کتاب‌ها';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'جدیدترین کتاب‌های صوتی';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count کتاب',
-      one: '1 کتاب',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'کتاب';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'کتاب صوتی';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% خوانده شده';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time باقی‌مانده';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'خواندن';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'شنیدن';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'نویسنده';
@@ -873,8 +874,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count کتاب صوتی',
-      one: '1 کتاب صوتی',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -889,10 +890,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get failedToLoad => 'بارگیری نشد';
 
   @override
-  String get delete => 'حذف';
+  String get delete => 'حذف کنید';
 
   @override
-  String get save => 'ذخیره';
+  String get save => 'ذخیره کنید';
 
   @override
   String get moreLikeThis => 'بیشتر شبیه این';
@@ -910,7 +911,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get nextUp => 'بعدی بالا';
 
   @override
-  String get seasons => 'فصل‌ها';
+  String get seasons => 'فصل ها';
 
   @override
   String get chapters => 'فصل ها';
@@ -977,8 +978,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count فصل',
-      one: '1 فصل',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -989,47 +990,47 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get items => 'موارد';
+  String get items => 'Items';
 
   @override
-  String get extras => 'موارد اضافی';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'پشت صحنه';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'صحنه‌های حذف‌شده';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ویژه‌برنامه‌ها';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'مصاحبه‌ها';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'صحنه‌ها';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'فیلم‌های کوتاه';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'تریلرها';
 
   @override
   String timeRemaining(String time) {
-    return '$time باقی‌مانده';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time تا پایان';
+    return 'Ends in $time';
   }
 
   @override
   String get view => 'مشاهده کنید';
 
   @override
-  String get resumeReading => 'ادامه خواندن';
+  String get resumeReading => 'Resume Reading';
 
   @override
   String get read => 'بخوانید';
@@ -1040,7 +1041,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get play => 'پخش';
+  String get play => 'بازی کنید';
 
   @override
   String get startOver => 'شروع دوباره';
@@ -1064,7 +1065,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get version => 'نسخه';
 
   @override
-  String get cast => 'ارسال به دستگاه';
+  String get cast => 'بازیگران';
 
   @override
   String get trailer => 'تریلر';
@@ -1180,7 +1181,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get subtitleTrack => 'آهنگ زیرنویس';
 
   @override
-  String get none => 'هیچ‌کدام';
+  String get none => 'هیچ کدام';
 
   @override
   String get downloadSubtitlesLabel => 'دانلود زیرنویس ...';
@@ -1258,10 +1259,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get director => 'کارگردان';
 
   @override
-  String get directors => 'کارگردانان';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'نویسنده';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'نویسندگان';
@@ -1299,8 +1300,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count قطعه',
-      one: '1 قطعه',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1310,8 +1311,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count فصل',
-      one: '1 فصل',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1338,16 +1339,16 @@ class AppLocalizationsFa extends AppLocalizations {
   String get readMore => 'ادامه مطلب';
 
   @override
-  String get shuffle => 'پخش تصادفی';
+  String get shuffle => 'مخلوط کردن';
 
   @override
-  String get shuffleAllMusic => 'پخش تصادفی همه موسیقی‌ها';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'در گوشی خود وارد Moonfin شوید';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'دسترسی به سرور شما ممکن نیست';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1359,11 +1360,11 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count کانال';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'مونو';
+  String get mono => 'مونونوکلئوز';
 
   @override
   String get stereo => 'استریو';
@@ -1444,7 +1445,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unavailable => 'در دسترس نیست';
 
   @override
-  String get pause => 'مکث';
+  String get pause => 'مکث کنید';
 
   @override
   String get syncPosition => 'موقعیت همگام سازی';
@@ -1518,7 +1519,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get subtitleDelay => 'تاخیر در زیرنویس';
 
   @override
-  String get reset => 'بازنشانی';
+  String get reset => 'بازنشانی کنید';
 
   @override
   String get unknown => 'ناشناس';
@@ -1545,7 +1546,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get transcodeReasons => 'دلایل Transcode';
 
   @override
-  String get player => 'پخش‌کننده';
+  String get player => 'بازیکن';
 
   @override
   String get container => 'ظرف';
@@ -1569,7 +1570,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get videoBitrate => 'میزان بیت ویدیو';
 
   @override
-  String get track => 'قطعه';
+  String get track => 'آهنگ';
 
   @override
   String get channels => 'کانال ها';
@@ -1668,7 +1669,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get markAsRead => 'علامت گذاری به عنوان خوانده شده';
 
   @override
-  String get reloadReader => 'بارگذاری مجدد کتاب‌خوان';
+  String get reloadReader => 'Reload Reader';
 
   @override
   String get noPagesFound => 'هیچ صفحه ای یافت نشد';
@@ -1783,22 +1784,22 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'بعدی: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes دقیقه باقی‌مانده';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours ساعت باقی‌مانده';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours ساعت و $minutes دقیقه باقی‌مانده';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1820,7 +1821,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get favoriteChannel => 'کانال مورد علاقه';
 
   @override
-  String get record => 'ضبط';
+  String get record => 'ضبط کنید';
 
   @override
   String get cancelRecordingAction => 'لغو ضبط';
@@ -1835,7 +1836,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unableToCreateRecording => 'امکان ایجاد ضبط وجود ندارد';
 
   @override
-  String get watch => 'تماشا';
+  String get watch => 'تماشا کنید';
 
   @override
   String get close => 'بستن';
@@ -1920,7 +1921,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'نوع حساب Seerr';
+  String get seerrAccountType => 'نوع حساب Serr';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2002,7 +2003,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'فصل $season قسمت $episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2026,7 +2027,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'فصل $number';
+    return 'S$number';
   }
 
   @override
@@ -2045,8 +2046,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count قسمت',
-      one: '1 قسمت',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2270,7 +2271,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'صفحات جزئیات، ردیف‌های صفحه اصلی و صدا';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2284,10 +2285,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'هنگام مرور صفحه اصلی بازی کنید';
 
   @override
-  String get loopThemeMusic => 'تکرار موسیقی تم';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'تکرار قطعه به‌جای پخش یک‌باره آن';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'جزئیات تاری پس زمینه';
@@ -2310,23 +2312,23 @@ class AppLocalizationsFa extends AppLocalizations {
   String get playerZoomMode => 'حالت زوم بازیکن';
 
   @override
-  String get settingsScrollWheelAction => 'چرخ اسکرول ماوس';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'انتخاب کنید چرخاندن چرخ ماوس روی ویدیو هنگام پخش چه کاری انجام دهد.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'خاموش';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'پرش (جلو / عقب)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'میزان صدا';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'میزان صدا';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'مناسب';
@@ -2341,7 +2343,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get refreshRateSwitching => 'تغییر نرخ تازه سازی';
 
   @override
-  String get disabled => 'غیرفعال';
+  String get disabled => 'از کار افتاده است';
 
   @override
   String get scaleOnTv => 'مقیاس در تلویزیون';
@@ -2380,36 +2382,37 @@ class AppLocalizationsFa extends AppLocalizations {
   String get defaultAudioLanguage => 'زبان صوتی پیش فرض';
 
   @override
-  String get fallbackAudioLanguage => 'زبان صوتی جایگزین';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'ترجیح ترک صوتی پیش‌فرض';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'ترک صوتی اصلی به دوبله بومی‌سازی‌شده ترجیح داده شود.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ترجیح ترک‌های توضیح صوتی';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'ترک‌های توضیح صوتی به ترک‌های عادی ترجیح داده شوند.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ترنسکد (صدا)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'پخش مستقیم (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
-  String get transcodingBitrateOrResolution => 'ترنسکد (نرخ بیت یا وضوح)';
+  String get transcodingBitrateOrResolution =>
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ترنسکد (ویدیو و صدا)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ترنسکد (ویدیو)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'خودکار (پیش‌فرض سرور)';
@@ -2469,10 +2472,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get polish => 'لهستانی';
 
   @override
-  String get ac3Passthrough => 'عبور مستقیم AC3';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'عبور مستقیم DTS';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'پشتیبانی TrueHD';
@@ -2490,23 +2493,23 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'انتخاب کنید صدا چگونه رمزگشایی شود. عبور مستقیم AVR جریان‌های خام Dolby/DTS را به گیرنده شما می‌فرستد؛ خودکار یا داون‌میکس به‌صورت محلی رمزگشایی می‌کند.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'عبور مستقیم AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'کدک بازگشتی صوتی';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'قالب مقصد را برای ترنسکد صدای چندکاناله انتخاب کنید؛ زمانی که جریان منبع قابل پخش مستقیم یا عبور مستقیم نیست.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'تشخیص خودکار\n(توصیه‌شده)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(پیش‌فرض)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2515,51 +2518,50 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(بدون افت کیفیت)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(فقط استریو)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(کارآمد)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(بدون افت کیفیت)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'حداکثر کانال‌های صوتی';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'حداکثر کانال‌های سیستم صوتی خود را تنظیم کنید. جریان‌های چندکاناله فراتر از این حد داون‌میکس یا ترنسکد می‌شوند.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'تشخیص خودکار\n(پیش‌فرض سخت‌افزار)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 مونو';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 استریو';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 فراگیر';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 چهارکاناله';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 فراگیر';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 فراگیر';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 فراگیر';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 فراگیر';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'عبور (پیشرفته)';
@@ -2572,22 +2574,22 @@ class AppLocalizationsFa extends AppLocalizations {
       'فقط فرمت هایی را که سینک AVR یا HDMI شما پشتیبانی می کند، فعال کنید.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'عبور مستقیم EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'عبور مستقیم EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'عبور مستقیم DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'عبور مستقیم DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'عبور مستقیم TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'عبور مستقیم TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2640,11 +2642,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'بلندگو';
 
   @override
-  String get settingsAudioRouteHeadphones => 'هدفون';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count کانال PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2678,7 +2680,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'پشتیبانی از صدای HD در مسیر خروجی';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'حالت شب';
@@ -2727,7 +2729,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value ثانیه';
+    return '${value}s';
   }
 
   @override
@@ -2817,45 +2819,45 @@ class AppLocalizationsFa extends AppLocalizations {
   String get subtitleCustomizationDescription => 'ظاهر زیرنویس را سفارشی کنید';
 
   @override
-  String get subtitleMode => 'حالت زیرنویس';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'نشان‌دار';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'همیشه';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'زبان خارجی';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'اجباری';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'ترک‌هایی را پخش می‌کند که در فراداده فایل رسانه به‌عنوان «پیش‌فرض» یا «اجباری» نشان‌گذاری شده‌اند.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'هر بار که ویدیویی شروع می‌شود، زیرنویس‌ها را به‌طور خودکار بارگذاری و نمایش می‌دهد.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'اگر ترک صوتی پیش‌فرض به زبان خارجی باشد، زیرنویس‌ها را به‌طور خودکار روشن می‌کند.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'فقط زیرنویس‌هایی را بارگذاری می‌کند که صراحتاً با نشان فراداده «اجباری» برچسب خورده‌اند.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'بارگذاری خودکار زیرنویس را کاملاً غیرفعال می‌کند.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'زبان زیرنویس جایگزین';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'جریان زیرنویس';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'روباه قهوه ای سریع از روی سگ تنبل می پرد';
@@ -2864,7 +2866,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get verticalOffset => 'افست عمودی';
 
   @override
-  String get pgsDirectPlay => 'پخش مستقیم PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'پخش مستقیم زیرنویس PGS';
@@ -3058,10 +3060,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showLibrariesInToolbar => 'نمایش کتابخانه ها در نوار ابزار';
 
   @override
-  String get navbarAlwaysExpanded => 'همیشه نمایش برچسب‌های نوار ناوبری';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'نمایش دکمه Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'کدورت نوار ناوبری';
@@ -3135,19 +3137,18 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showFolderBrowsingOption => 'نمایش گزینه مرور پوشه';
 
   @override
-  String get groupItemsIntoCollections => 'گروه‌بندی موارد در مجموعه‌ها';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'پنهان کردن موارد کتابخانه مرتبط با مجموعه هنگام مرور کتابخانه‌ها';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'اطلاعیه گروه‌بندی کتابخانه';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'برای استفاده از این تنظیم، لطفاً مطمئن شوید تنظیمات کتابخانه‌ای «گروه‌بندی فیلم‌ها در مجموعه‌ها» و/یا «گروه‌بندی سریال‌ها در مجموعه‌ها» در بخش تنظیمات نمایش کتابخانه، روی سرور Jellyfin یا Emby شما فعال باشند.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'قابلیت مشاهده کتابخانه';
@@ -3206,7 +3207,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'از بین سبک‌های مختلف نوار رسانه انتخاب کنید، یا نوار رسانه را خاموش کنید';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'باله ماه';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3258,10 +3259,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'پخش خودکار تریلرها در نوار رسانه بعد از 3 ثانیه';
 
   @override
-  String get trailerAudio => 'صدای تریلر';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'فعال کردن صدا برای تریلرها در نوار رسانه';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'پیش نمایش قسمت';
@@ -3338,11 +3339,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get combineBothRows => 'هر دو ردیف را در یک بخش خانه ترکیب کنید';
 
   @override
-  String get fullScreenRows => 'ردیف‌های گسترده صفحه اصلی';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'محدود کردن ردیف‌های صفحه اصلی به 1 ردیف در هر صفحه';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'نوع تصویر در هر ردیف';
@@ -3357,7 +3357,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get lastUser => 'آخرین کاربر';
 
   @override
-  String get currentUser => 'کاربر فعلی';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'همیشه احراز هویت';
@@ -3464,10 +3464,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'نمایش ساعت در حین محافظ صفحه نمایش';
 
   @override
-  String get clockModeStatic => 'ثابت';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'متحرک';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'گوجه فرنگی گندیده (منتقدان)';
@@ -3488,7 +3488,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get metacriticUser => 'متاکریتیک (کاربر)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'تراکت';
 
   @override
   String get letterboxd => 'جعبه نامه';
@@ -3509,7 +3509,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get additionalRatings => 'رتبه بندی های اضافی';
 
   @override
-  String get showMdbListAndTmdbRatings => 'نمایش امتیازهای MDBList و TMDB';
+  String get showMdbListAndTmdbRatings => 'نمایش رتبه بندی MDBLlist و TMDB';
 
   @override
   String get ratingLabels => 'برچسب های رتبه بندی';
@@ -3539,7 +3539,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'منابع رتبه بندی نشان داده شده در سراسر برنامه را فعال کرده و مرتب کنید';
 
   @override
-  String get pluginLabel => 'افزونه Moonbase';
+  String get pluginLabel => 'پلاگین';
 
   @override
   String get pluginDetected => 'پلاگین شناسایی شد';
@@ -3610,7 +3610,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get networks => 'شبکه ها';
 
   @override
-  String get seerrDiscoveryRows => 'ردیف‌های کشف Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'سطرها را به حالت پیش فرض بازنشانی کنید';
@@ -3633,27 +3633,28 @@ class AppLocalizationsFa extends AppLocalizations {
   String get hideAdultContent => 'محتوای بزرگسالان را در نتایج پنهان کنید';
 
   @override
-  String get seerrNotificationsSection => 'اعلان‌ها';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'اعلان درخواست‌های جدید';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'وقتی کسی درخواستی ثبت می‌کند به من اطلاع بده';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'به‌روزرسانی درخواست‌ها';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'تأییدشده، ردشده و افزوده‌شده به کتابخانه شما';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'به‌روزرسانی مشکلات';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'مشکلات جدید، پاسخ‌ها و راه‌حل‌ها';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3661,18 +3662,18 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'صفحه کشف Seerr';
+  String get discoverRows => 'ردیف ها را کشف کنید';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'ردیف‌هایی را که می‌خواهید در صفحه اصلی Seerr ببینید فعال کنید. برای تغییر ترتیب بکشید. ترتیب سفارشی با Moonbase همگام می‌شود.';
+      'برای سفارش مجدد بکشید. فعال یا غیرفعال کردن ردیف ها سفارش ردیف فعال با افزونه Moonfin همگام‌سازی می‌شود.';
 
   @override
   String get discoverRowsDescription =>
-      'ردیف‌هایی را که می‌خواهید در صفحه اصلی Seerr ببینید فعال کنید. برای تغییر ترتیب بکشید. ترتیب سفارشی با Moonbase همگام می‌شود.';
+      'برای سفارش مجدد بکشید. فعال یا غیرفعال کردن ردیف ها';
 
   @override
-  String get enabled => 'فعال';
+  String get enabled => 'فعال شد';
 
   @override
   String get hidden => 'پنهان شده است';
@@ -3790,7 +3791,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value گیگابایت';
+    return '$value GB';
   }
 
   @override
@@ -3824,11 +3825,11 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'در حال دانلود · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'در حال وارد کردن';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3836,7 +3837,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'تنظیمات Seerr';
+  String get seerrSettings => 'تنظیمات Seer';
 
   @override
   String get requestMore => 'درخواست بیشتر';
@@ -3931,7 +3932,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showMore => 'نمایش بیشتر';
 
   @override
-  String get appearances => 'نقش‌آفرینی‌ها';
+  String get appearances => 'ظواهر';
 
   @override
   String get crewSection => 'خدمه';
@@ -3969,147 +3970,148 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deletedStatus => 'حذف شد';
 
   @override
-  String get failedStatus => 'ناموفق';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'در حال پردازش';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'تغییر داده شده توسط $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'تکمیل شد';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'این عنوان قبلاً درخواست شده است';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'به سقف درخواست رسیدید';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'این عنوان در فهرست مسدود است';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'فصلی برای درخواست باقی نمانده است';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'شما اجازه ثبت این درخواست را ندارید';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'درخواست‌ها';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'مشکلات';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'جدیدترین';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'آخرین تغییر';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'هیچ مشکلی وجود ندارد';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining از $limit درخواست فیلم باقی مانده است';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining از $limit درخواست فصل باقی مانده است';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'بخشی از $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'مشاهده مجموعه';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'درخواست مجموعه';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total فیلم · $available در دسترس';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'درخواست $count فیلم';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'در حال درخواست $current از $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count فیلم درخواست شد';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok فیلم از $total فیلم درخواست شد';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'همه فیلم‌ها از قبل در دسترس یا درخواست شده‌اند';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'گزارش مشکل';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'ویدیو';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'صدا';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'مشکل چیست؟';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'همه قسمت‌ها';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'قسمت';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'باز';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'حل‌شده';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'حل کردن';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'بازگشایی';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'گزارش‌شده توسط $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count نظر';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'افزودن نظر';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'این مشکل حذف شود؟';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'ثبت گزارش';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'امتیاز TMDB';
@@ -4133,7 +4135,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get originalLanguageLabel => 'زبان اصلی';
 
   @override
-  String get seasonsLabel => 'فصل‌ها';
+  String get seasonsLabel => 'فصل ها';
 
   @override
   String get episodesLabel => 'اپیزودها';
@@ -4142,7 +4144,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get access => 'دسترسی داشته باشید';
 
   @override
-  String get add => 'افزودن';
+  String get add => 'اضافه کنید';
 
   @override
   String get address => 'آدرس';
@@ -4169,7 +4171,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get done => 'انجام شد';
 
   @override
-  String get edit => 'ویرایش';
+  String get edit => 'ویرایش کنید';
 
   @override
   String get encoding => 'رمزگذاری';
@@ -4178,10 +4180,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get error => 'خطا';
 
   @override
-  String get forward => 'جلو';
+  String get forward => 'به جلو';
 
   @override
-  String get general => 'عمومی';
+  String get general => 'ژنرال';
 
   @override
   String get go => 'برو';
@@ -4226,7 +4228,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get refresh => 'تازه کردن';
 
   @override
-  String get remote => 'کنترل از راه دور';
+  String get remote => 'از راه دور';
 
   @override
   String get rename => 'تغییر نام دهید';
@@ -4244,7 +4246,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get run => 'اجرا کنید';
 
   @override
-  String get search => 'جستجو';
+  String get search => 'جستجو کنید';
 
   @override
   String get select => 'انتخاب کنید';
@@ -4262,7 +4264,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get status => 'وضعیت';
 
   @override
-  String get stop => 'توقف';
+  String get stop => 'توقف کنید';
 
   @override
   String get streaming => 'پخش جریانی';
@@ -4271,7 +4273,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get time => 'زمان';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ترفند بازی';
 
   @override
   String get uninstall => 'حذف نصب کنید';
@@ -4289,7 +4291,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unmute => 'باصدا کردن';
 
   @override
-  String get mute => 'بی‌صدا';
+  String get mute => 'بی صدا';
 
   @override
   String get branding => 'برندسازی';
@@ -4310,28 +4312,28 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminDrawerUsers => 'کاربران';
 
   @override
-  String get adminDrawerLibraries => 'کتابخانه‌ها';
+  String get adminDrawerLibraries => 'کتابخانه ها';
 
   @override
-  String get adminDrawerDisplay => 'نمایش';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'فراداده';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'تنظیمات NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'رمزگذاری';
 
   @override
-  String get adminDrawerResume => 'ادامه';
+  String get adminDrawerResume => 'رزومه';
 
   @override
   String get adminDrawerStreaming => 'پخش جریانی';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ترفند بازی';
 
   @override
   String get adminDrawerDevices => 'دستگاه ها';
@@ -4502,7 +4504,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get sessionRewind => 'عقب';
 
   @override
-  String get sessionForward => 'جلو';
+  String get sessionForward => 'به جلو';
 
   @override
   String get sessionNext => 'بعدی';
@@ -4520,7 +4522,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get nowPlaying => 'در حال پخش';
 
   @override
-  String get volume => 'میزان صدا';
+  String get volume => 'حجم';
 
   @override
   String get actions => 'اقدامات';
@@ -4532,7 +4534,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audioCodec => 'کدک صوتی';
 
   @override
-  String get hwAccel => 'شتاب سخت‌افزاری';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'تکمیل';
@@ -4547,10 +4549,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminClearDates => 'تاریخ ها را پاک کنید';
 
   @override
-  String get adminActivitySeverityAll => 'همه سطوح اهمیت';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'بازه زمانی';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4587,23 +4589,23 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'دستگاه «$name» حذف شود؟ کاربر باید دوباره در این دستگاه وارد شود.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'حذف همه دستگاه‌ها';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count دستگاه حذف شود؟ کاربران متأثر باید دوباره وارد شوند. دستگاه فعلی شما تحت تأثیر قرار نمی‌گیرد.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'دستگاه‌ها حذف شدند';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'برخی دستگاه‌ها حذف شدند؛ $count دستگاه حذف نشد.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4718,247 +4720,244 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminMetadataCountryHint => 'به عنوان مثال ایالات متحده، DE، FR';
 
   @override
-  String get adminLibraryTabPaths => 'مسیرها';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'گزینه‌ها';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'دانلودکننده‌ها';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'ذخیره‌کننده‌های فراداده';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'دانلودکننده‌های زیرنویس';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'دانلودکننده‌های متن ترانه';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'دانلودکننده‌های فراداده: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'دریافت‌کننده‌های تصویر: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'این سرور هیچ دانلودکننده‌ای برای این نوع کتابخانه ارائه نمی‌دهد.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'عمومی';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'فراداده';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'اطلاعات توکار';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'زیرنویس‌ها';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'تصاویر';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'سریال‌ها';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'موسیقی';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'فیلم‌ها';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'فعال کردن پایش بی‌درنگ';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'تغییرات فایل‌ها شناسایی و به‌طور خودکار پردازش می‌شوند.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'در نظر گرفتن آرشیوها به‌عنوان فایل رسانه';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'نمایش عکس‌ها';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'ذخیره آثار هنری در پوشه‌های رسانه';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'به‌روزرسانی خودکار فراداده';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'هرگز';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'پیش‌فرض';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'نمایش';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'نمایش کتابخانه';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'نمایش نمای پوشه برای نشان دادن پوشه‌های رسانه ساده';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'نمایش قسمت‌های ویژه در فصلی که پخش شده‌اند';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'گروه‌بندی فیلم‌ها در مجموعه‌ها';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'گروه‌بندی سریال‌ها در مجموعه‌ها';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'نمایش محتوای خارجی در پیشنهادها';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'رفتار تاریخ افزودن';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'استفاده از تاریخ افزودن بر اساس';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'تاریخ پویش در کتابخانه';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'تاریخ ایجاد فایل';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'فراداده و تصاویر';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'زبان ترجیحی فراداده';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'فصل‌ها';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'مدت فصل ساختگی (ثانیه)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'طول فصل‌هایی که برای رسانه‌های بدون فصل ساخته می‌شوند. برای غیرفعال کردن روی 0 تنظیم کنید.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'وضوح تصویر فصل';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'تنظیمات NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'فراداده NFO با Kodi و کلاینت‌های مشابه سازگار است. این تنظیمات برای همه کتابخانه‌هایی که فراداده NFO ذخیره می‌کنند اعمال می‌شود.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'کاربری که داده‌های تماشای او در فایل‌های NFO ذخیره می‌شود';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'ذخیره مسیر تصاویر در فایل‌های NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'فعال کردن جایگزینی مسیر برای مسیرهای تصویر NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'کپی تصاویر extrafanart در پوشه extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'هیچ‌کدام';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days روز';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'استفاده از عنوان‌های توکار';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'استفاده از عنوان‌های توکار برای موارد اضافی';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'استفاده از اطلاعات توکار قسمت';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'اجازه زیرنویس‌های توکار';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'اجازه همه';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'فقط متنی';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'فقط تصویری';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'هیچ‌کدام';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'رد کردن دانلود در صورت وجود زیرنویس توکار';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'رد کردن دانلود اگر ترک صوتی با زبان دانلود مطابقت داشته باشد';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'الزام تطابق کامل زیرنویس';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'ذخیره زیرنویس‌ها در پوشه‌های رسانه';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'استخراج تصاویر فصل';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'استخراج تصاویر فصل هنگام پویش کتابخانه';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'فعال کردن استخراج تصاویر Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'استخراج تصاویر Trickplay هنگام پویش کتابخانه';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'ذخیره تصاویر Trickplay در پوشه‌های رسانه';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'ادغام خودکار سریال‌هایی که در چند پوشه پراکنده‌اند';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'نام نمایشی فصل صفر';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'فعال کردن پویش LUFS برای یکسان‌سازی صدا';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'ترجیح برچسب هنرمندان غیراستاندارد';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'افزودن خودکار فیلم‌ها به مجموعه‌ها';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'نام کتابخانه الزامی است';
@@ -5194,143 +5193,143 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminEnableAllChannels => 'دسترسی به همه کانال ها را فعال کنید';
 
   @override
-  String get adminParentalControl => 'کنترل والدین';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'حداکثر رده‌بندی سنی مجاز';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'محتوای با رده‌بندی بالاتر از این کاربر پنهان می‌شود.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'هیچ‌کدام';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'مسدود کردن مواردی که اطلاعات رده‌بندی ندارند یا رده‌بندی‌شان ناشناخته است';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'کتاب‌ها';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'کانال‌ها';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'تلویزیون زنده';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'فیلم‌ها';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'موسیقی';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'تریلرها';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'سریال‌ها';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'زمان‌بندی‌های دسترسی';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'دسترسی فقط در زمان‌های زمان‌بندی‌شده زیر مجاز است. وقتی زمان‌بندی‌ای تنظیم نشده باشد، دسترسی در تمام طول روز مجاز است.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'افزودن زمان‌بندی';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'روز';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'شروع';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'پایان';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'هر روز';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'روزهای هفته';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'آخر هفته';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'یکشنبه';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'دوشنبه';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'سه‌شنبه';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'چهارشنبه';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'پنجشنبه';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'جمعه';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'شنبه';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'برچسب‌های مجاز';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'فقط محتوای دارای این برچسب‌ها نمایش داده می‌شود. برای اجازه به همه، خالی بگذارید.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'برچسب‌های مسدود';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'محتوای دارای این برچسب‌ها از این کاربر پنهان می‌شود.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'افزودن برچسب';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'دستگاه‌های فعال';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'کانال‌های فعال';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ارائه‌دهنده احراز هویت';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'ارائه‌دهنده بازنشانی رمز عبور';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'حداکثر تلاش‌های ناموفق ورود پیش از قفل شدن';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'برای مقدار پیش‌فرض روی 0 و برای غیرفعال کردن قفل شدن روی -1 تنظیم کنید.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'دسترسی SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'اجازه ساخت و پیوستن به گروه‌ها';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'اجازه پیوستن به گروه‌ها';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'بدون دسترسی';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'اجازه حذف محتوا از';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5417,26 +5416,25 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'ایجاد پشتیبان';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'انتخاب کنید چه چیزی در پشتیبان گنجانده شود.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'پایگاه داده';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'همیشه گنجانده می‌شود';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'فراداده';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'زیرنویس‌ها';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'تصاویر Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'در حال ایجاد پشتیبان...';
@@ -5972,7 +5970,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminBaseUrl => 'URL پایه';
 
   @override
-  String get adminBaseUrlHint => 'مثلاً /jellyfin';
+  String get adminBaseUrlHint => 'به عنوان مثال /ژله فین';
 
   @override
   String get https => 'HTTPS';
@@ -6021,7 +6019,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get adminRefreshMetadata => 'به‌روزرسانی فراداده';
+  String get adminRefreshMetadata => 'Refresh Metadata';
 
   @override
   String get recursive => 'بازگشتی';
@@ -6133,59 +6131,60 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminAddTuner => 'تیونر را اضافه کنید';
 
   @override
-  String get adminEditTuner => 'ویرایش تیونر';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'تیونر M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'فایل یا URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'آدرس IP تیونر';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'نام نمایشی';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'عامل کاربر';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'محدودیت اتصال هم‌زمان';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'حداکثر تعداد جریان‌هایی که تیونر به‌طور هم‌زمان اجازه می‌دهد. برای نامحدود روی 0 تنظیم کنید.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'حداکثر نرخ بیت پخش جریانی جایگزین';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'وارد کردن فقط کانال‌های دلخواه';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'اجازه ترنسکد سخت‌افزاری';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'اجازه کانتینر ترنسکد fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'اجازه اشتراک‌گذاری جریان';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'فعال کردن تکرار جریان';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'نادیده گرفتن DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
-  String get adminTunerReadAtNativeFramerate => 'خواندن ورودی با نرخ فریم اصلی';
+  String get adminTunerReadAtNativeFramerate =>
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ویرایش ارائه‌دهنده';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6194,50 +6193,50 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'فایل یا URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'پیشوند فیلم';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'دسته‌بندی‌های فیلم';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'چند دسته‌بندی را با خط عمودی از هم جدا کنید.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'دسته‌بندی‌های کودکان';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'دسته‌بندی‌های اخبار';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'دسته‌بندی‌های ورزشی';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'نام کاربری';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'رمز عبور';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'کشور';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'یک کشور انتخاب کنید';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'کد پستی';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'دریافت فهرست برنامه‌ها';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'فهرست برنامه‌ها';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'فعال کردن همه تیونرها';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'نوع تیونر';
@@ -6279,7 +6278,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'این نوع تیونر از بازنشانی پشتیبانی نمی‌کند.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6302,43 +6301,43 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'مسیر ضبط سریال';
 
   @override
-  String get adminMovieRecordingPath => 'مسیر ضبط فیلم';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'روزهای داده راهنما';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'خودکار';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days روز';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'مسیر برنامه پس‌پردازش';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'آرگومان‌های پس‌پردازنده';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'ذخیره فراداده NFO ضبط';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'ذخیره تصاویر ضبط';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'زمان‌بندی';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'مسیرهای ضبط';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'پس‌پردازش';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'داده راهنما: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6379,14 +6378,14 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminGuideProviders => 'ارائه دهندگان راهنما';
 
   @override
-  String get adminRefreshGuideData => 'به‌روزرسانی داده راهنما';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'به‌روزرسانی داده راهنما آغاز شد';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'وظیفه به‌روزرسانی راهنما در این سرور در دسترس نیست.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'ارائه دهنده را اضافه کنید';
@@ -6469,13 +6468,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminLiveTvTitle => 'مدیریت تلویزیون زنده';
 
   @override
-  String get adminApply => 'اعمال';
+  String get adminApply => 'درخواست کنید';
 
   @override
   String get adminNotSet => 'تنظیم نشده است';
 
   @override
-  String get adminReset => 'بازنشانی';
+  String get adminReset => 'بازنشانی کنید';
 
   @override
   String get adminLogsTitle => 'گزارش های سرور';
@@ -6521,7 +6520,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminMetadataEditorTitle => 'ویرایشگر فراداده';
 
   @override
-  String get adminMetadataIdentify => 'شناسایی';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'تایپ کنید';
@@ -6804,7 +6803,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'حذف';
+  String get adminReposRemove => 'حذف کنید';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6934,19 +6933,19 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'روشن کردن صفحه نمایش را فعال کنید';
 
   @override
-  String get adminBrandingSplashUpload => 'بارگذاری تصویر';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'صفحه شروع به‌روزرسانی شد';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'بارگذاری صفحه شروع ناموفق بود';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'صفحه شروع حذف شد';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'بدون صفحه شروع سفارشی';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'شتاب سخت افزاری';
@@ -6963,121 +6962,121 @@ class AppLocalizationsFa extends AppLocalizations {
       'فعال کردن رمزگشایی سخت افزاری برای:';
 
   @override
-  String get adminPlaybackQsvDevice => 'دستگاه QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'فعال کردن رمزگشای پیشرفته NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'ترجیح رمزگشای سخت‌افزاری بومی سیستم';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'عمق رنگ رمزگشایی سخت‌افزاری';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'رمزگشایی 10-بیتی HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'رمزگشایی 10-بیتی VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'رمزگشایی 8/10-بیتی HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'رمزگشایی 12-بیتی HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'کدگذاری سخت‌افزاری';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'اجازه کدگذاری HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'اجازه کدگذاری AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'فعال کردن کدگذار کم‌مصرف H.264 اینتل';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'فعال کردن کدگذار کم‌مصرف HEVC اینتل';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'نگاشت تُن';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'فعال کردن نگاشت تُن';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'فعال کردن نگاشت تُن VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'فعال کردن نگاشت تُن VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'الگوریتم نگاشت تُن';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'حالت نگاشت تُن';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'محدوده نگاشت تُن';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'کاهش اشباع نگاشت تُن';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'اوج نگاشت تُن';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'پارامتر نگاشت تُن';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'روشنایی نگاشت تُن VPP';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'کنتراست نگاشت تُن VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'پیش‌تنظیم‌ها و کیفیت';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'پیش‌تنظیم کدگذار';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF کدگذاری H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF کدگذاری H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'روش حذف درهم‌بافتگی';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'دو برابر کردن نرخ فریم هنگام حذف درهم‌بافتگی';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'صدا';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'فعال کردن کدگذاری VBR صدا';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'تقویت داون‌میکس صدا';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'الگوریتم داون‌میکس استریو';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'حداکثر اندازه صف مالتی‌پلکس';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'خودکار';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'رمزگذاری';
@@ -7192,10 +7191,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminTaskNeverRun => 'هرگز اجرا نکنید';
 
   @override
-  String get adminTaskStop => 'توقف';
+  String get adminTaskStop => 'توقف کنید';
 
   @override
-  String get adminRunningTasks => 'وظایف در حال اجرا';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'اجرا کنید';
@@ -7265,8 +7264,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ساعت',
-      one: '1 ساعت',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7312,17 +7311,17 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes دقیقه';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours ساعت';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days روز';
+    return '${days}d';
   }
 
   @override
@@ -7341,49 +7340,49 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'URL پایه';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'مثلاً /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'به عنوان مثال /ژله فین';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'پورت عمومی HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'الزام HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'همه درخواست‌های راه دور به HTTPS هدایت می‌شوند. اگر سرور گواهی معتبر نداشته باشد، تأثیری ندارد.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'رمز عبور گواهی';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'تنظیمات IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'فعال کردن IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'فعال کردن IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'فعال کردن نگاشت خودکار پورت';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'شبکه‌های LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'فهرست آدرس‌های IP یا زیرشبکه‌های CIDR که به‌عنوان شبکه محلی در نظر گرفته می‌شوند، جداشده با کاما یا خط جدید.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URIهای منتشرشده سرور';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'یک زیرشبکه یا آدرس را به یک URL منتشرشده نگاشت کنید، مثلاً all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'مسیر گواهینامه';
@@ -7413,11 +7412,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'بافر دریچه گاز';
 
   @override
-  String get adminPlaybackThrottleDelay => 'تأخیر محدودسازی (ثانیه)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'اجازه استخراج زیرنویس در لحظه';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'حداقل درصد رزومه';
@@ -7473,22 +7472,22 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'آستانه پاسخ آهسته (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'فعال کردن هشدارهای پاسخ کند';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'فعال کردن Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'سرور';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'فراداده';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'مسیرها';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'کارایی';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'مسیر کش';
@@ -7500,7 +7499,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminGeneralServerName => 'نام سرور';
 
   @override
-  String get adminGeneralDisplayLanguage => 'زبان نمایش ترجیحی';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'تنظیمات بارگیری نشد';
@@ -7522,7 +7521,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get folders => 'پوشه ها';
 
   @override
-  String get libraries => 'کتابخانه‌ها';
+  String get libraries => 'کتابخانه ها';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7552,8 +7551,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# شرکت‌کننده',
-      one: '# شرکت‌کننده',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7699,8 +7698,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ردیف کشف شد',
-      one: '# ردیف کشف شد',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7741,20 +7740,20 @@ class AppLocalizationsFa extends AppLocalizations {
   String get offlineSavedMedia => 'رسانه ذخیره شده';
 
   @override
-  String get offlineBannerTitle => 'آفلاین هستید';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'نمایش دانلودهای شما';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'دانلودها';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'دسترسی به سرور شما ممکن نیست';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'تا بازگشت سرور، پخش از دانلودها انجام می‌شود';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7833,34 +7832,33 @@ class AppLocalizationsFa extends AppLocalizations {
   String get pinBackspace => 'بک اسپیس';
 
   @override
-  String get quickConnectAuthorized => 'درخواست Quick Connect تأیید شد.';
+  String get quickConnectAuthorized => 'درخواست اتصال سریع مجاز است.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'کد Quick Connect نامعتبر یا منقضی شده است.';
+      'کد اتصال سریع نامعتبر یا منقضی شده است.';
 
   @override
   String get quickConnectNotSupported =>
       'Quick Connect در این سرور پشتیبانی نمی شود.';
 
   @override
-  String get quickConnectAuthorizeFailed =>
-      'تأیید کد Quick Connect ناموفق بود.';
+  String get quickConnectAuthorizeFailed => 'کد اتصال سریع تأیید نشد.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect در این سرور غیرفعال است.';
+  String get quickConnectDisabled => 'اتصال سریع در این سرور غیرفعال است.';
 
   @override
   String get quickConnectForbidden =>
-      'حساب شما نمی‌تواند این درخواست Quick Connect را تأیید کند.';
+      'حساب شما نمی‌تواند این درخواست اتصال سریع را تأیید کند.';
 
   @override
   String get quickConnectNotFound =>
-      'کد Quick Connect یافت نشد. کد جدیدی را امتحان کنید.';
+      'کد اتصال سریع پیدا نشد. یک کد جدید را امتحان کنید.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ناموفق بود: $message';
+    return 'اتصال سریع انجام نشد: $message';
   }
 
   @override
@@ -8025,7 +8023,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'پخش موقتاً متوقف شده است. هنوز هم تماشا می کنی؟';
 
   @override
-  String get stillWatchingStop => 'توقف';
+  String get stillWatchingStop => 'توقف کنید';
 
   @override
   String get stillWatchingContinue => 'ادامه دهید';
@@ -8110,13 +8108,13 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'پنهان کردن از «ادامه تماشا»';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'پنهان کردن از «بعدی»';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'افزودن به مجموعه';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8169,14 +8167,14 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsAlphabetical => 'حروف الفبا';
 
   @override
-  String get settingsConnectionSection => 'اتصال';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'اجازه گواهی‌های خودامضا';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'به سرورهایی که از گواهی‌های TLS خودامضا یا CA خصوصی استفاده می‌کنند اعتماد کنید. فقط برای سرورهایی که خودتان کنترل می‌کنید فعال کنید. این کار اعتبارسنجی گواهی را برای همه اتصال‌ها غیرفعال می‌کند.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'حریم خصوصی و ایمنی';
@@ -8192,11 +8190,11 @@ class AppLocalizationsFa extends AppLocalizations {
       'لهجه‌های تم، پس‌زمینه، شاخص‌های تماشا شده، و موسیقی تم';
 
   @override
-  String get settingsDetailsScreen => 'صفحه جزئیات';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'سبک، محوشدگی پس‌زمینه و رفتار برگه‌ها';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'صفحه اصلی';
@@ -8234,11 +8232,11 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'نمایش دکمه Seerr در نوار ناوبری';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'همیشه نمایش برچسب‌های متنی در نوار ناوبری بالا';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8340,8 +8338,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# اعلان مجوز',
-      one: '# اعلان مجوز',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8388,16 +8386,16 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'از معرفی و برون رفت بگذرید؟';
 
   @override
-  String get settingsMediaSegmentCountdown => 'شمارش معکوس بخش رسانه';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'نوار پیشرفت';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'زمان‌شمار';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'هیچ‌کدام';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'کاربر سریع';
@@ -8529,7 +8527,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value میلی‌ثانیه';
+    return '$value ms';
   }
 
   @override
@@ -8624,7 +8622,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName تازه‌منتشرشده';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8657,11 +8655,11 @@ class AppLocalizationsFa extends AppLocalizations {
       'اجباری پخش بدون تونل. برای دستگاه‌هایی با ناپیوستگی‌های صوتی/تصویری تونل‌سازی مفید است.';
 
   @override
-  String get enableTunnelingTitle => 'فعال کردن تونل‌سازی';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'پیشرفته. صدا و ویدیو را از یک مسیر سخت‌افزاری مشترک عبور می‌دهد. به‌طور پیش‌فرض خاموش است، زیرا در برخی دستگاه‌ها باعث قطعی صدا/تصویر می‌شود.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'نمایه 7 Dolby Vision را به HEVC نگاشت';
@@ -8687,14 +8685,14 @@ class AppLocalizationsFa extends AppLocalizations {
       'نکات اندازه فونت تعبیه شده در آهنگ زیرنویس را اعمال کنید. غیرفعال کردن استفاده از اندازه زیرنویس از تنظیمات برگزیده سبک.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'نمایش جزئیات رسانه';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'نمایش جزئیات مورد انتخاب‌شده در بالای صفحات کتابخانه.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'پنهان کردن پس‌زمینه‌ها هنگام مرور؟';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'از عناوین فرعی تفصیلی استفاده کنید';
@@ -8712,37 +8710,37 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'فروشگاه تم';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'مرور و ذخیره تم‌های انجمن';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'یک تم را ذخیره کنید تا مانند سایر تم‌های ذخیره‌شده از آن استفاده کنید.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'در حال حاضر هیچ تمی در دسترس نیست.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'بارگذاری فروشگاه تم ممکن نشد. اتصال خود را بررسی کرده و دوباره تلاش کنید.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'ذخیره';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'ذخیره و اعمال';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'ذخیره شد';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'این تم بارگذاری نشد.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '«$themeName» ذخیره شد.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8800,21 +8798,21 @@ class AppLocalizationsFa extends AppLocalizations {
   String get homeRowsSection => 'ردیف های صفحه اصلی';
 
   @override
-  String get homeRowDisplay => 'نمایش ردیف‌های صفحه اصلی';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'بخش‌های ردیف صفحه اصلی';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'کلیدهای ردیف صفحه اصلی';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'فعال یا غیرفعال کردن دسته‌بندی‌های ردیف صفحه اصلی مبتنی بر کتابخانه';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'کلیدهای زیر را فعال کنید تا ردیف‌ها در بخش‌های صفحه اصلی نمایش داده شوند.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'نوع ردیف';
@@ -8873,56 +8871,55 @@ class AppLocalizationsFa extends AppLocalizations {
       'نمایش فیلم، سریال یا هر دو در ردیف‌های ژانر.';
 
   @override
-  String get displayPlaylistsRows => 'نمایش ردیف‌های لیست پخش';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'نمایش ردیف‌های لیست پخش در بخش‌های صفحه اصلی.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'مرتب‌سازی ردیف لیست پخش';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'ردیف‌های لیست پخش را بر اساس تاریخ افزودن، تاریخ انتشار، ترتیب الفبا و موارد دیگر مرتب کنید.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'نمایش ردیف‌های صوتی';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'نمایش ردیف‌های صوتی در بخش‌های صفحه اصلی.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'مرتب‌سازی ردیف‌های صوتی';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ردیف‌های صوتی را بر اساس تاریخ افزودن، تاریخ انتشار، ترتیب الفبا و موارد دیگر مرتب کنید.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'لیست‌های پخش صوتی';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'ظاهر';
 
   @override
-  String get layout => 'چیدمان';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'تم';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'صفحه‌کلید';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'دکمه‌ها';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'رندرینگ';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'پیکربندی MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'اندازه کارت';
@@ -8932,7 +8929,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'پخش‌کننده خارجی را تنظیم کنید تا گزینه پخش با فشار طولانی فعال شود';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9198,7 +9195,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get appearancesSeerr => 'ظاهر (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'مشارکت‌های عوامل (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'با گروه تماشا کنید';
@@ -9282,8 +9279,8 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count کتابخانه',
-      one: '1 کتابخانه',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9374,7 +9371,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mixedMoviesAndShows => 'فیلم‌ها و نمایش‌های ترکیبی';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'همگام سازی سریع اینتل';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9441,13 +9438,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get loadingShuffle => 'در حال بارگیری ترکیبی...';
 
   @override
-  String get libraryShuffleLabel => 'پخش تصادفی کتابخانه';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'پخش تصادفی';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'پخش تصادفی ژانرها';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'سوئیچینگ خودکار HDR';
@@ -9460,222 +9457,222 @@ class AppLocalizationsFa extends AppLocalizations {
   String get whenFullscreen => 'وقتی تمام صفحه';
 
   @override
-  String get changeArtwork => 'تغییر تصویر';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'موجود نیست';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'محدودیت های رمزگذاری';
 
   @override
-  String get clearAllArtworkButton => 'همه تصاویر پاک شوند؟';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'آیا مطمئن هستید که می‌خواهید همه تصاویر دانلودشده را پاک کنید؟';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'تأیید پاک کردن';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'آیا مطمئن هستید که می‌خواهید این $itemType را پاک کنید؟';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'بارگذاری شود؟';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'وضوح: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'فقط نمایش تصاویر به زبان رابط کاربری';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'تأیید پاک کردن همه';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'تصویر با موفقیت بارگذاری شد!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'بارگذاری تصویر ناموفق بود: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'تنظیم تصویر ناموفق بود: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'حذف تصویر ناموفق بود: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'پاک کردن همه تصاویر ناموفق بود: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'بله';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'پوستر';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'پس‌زمینه‌ها';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'بنر';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'لوگو';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'تصویر بندانگشتی';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'تصویر هنری';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'تصویر دیسک';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'اسکرین‌شات';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'جلد جعبه';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'جلد پشت جعبه';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'تصویر منو';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'پوستر';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'پس‌زمینه';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'بنر';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'لوگو';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'تصویر بندانگشتی';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'تصویر هنری';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'تصویر دیسک';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'اسکرین‌شات';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'جلد جعبه';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'جلد پشت جعبه';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'تصویر منو';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'همه';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'بالا (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'متوسط (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'پایین (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'منابع';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'فصل‌ها';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'نشانک‌ها';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'یادداشت‌ها';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'صف پخش';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'خط زمانی';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'خط زمانی خالی است';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'کل کتاب';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'خط زمانی متمرکز';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'برون‌بری نشانک‌ها';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'برون‌بری یادداشت‌ها';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'برون‌بری همه';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'برون‌بری شد در $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'برون‌بری ناموفق بود: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'متن ترانه';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'افزودن نشانک';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'افزودن یادداشت';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'ویرایش یادداشت';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'برای این لحظه یادداشتی بنویسید';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'زمان‌سنج خواب';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'خاموش';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'پایان فصل';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'سفارشی';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining باقی‌مانده';
+    return '$remaining left';
   }
 
   @override
@@ -9683,58 +9680,58 @@ class AppLocalizationsFa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count دقیقه',
-      one: '1 دقیقه',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'سرعت پخش';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'باقی‌مانده';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'سپری‌شده';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds ثانیه عقب';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds ثانیه جلو';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'فصل قبلی';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'فصل بعدی';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'فصل $current از $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'بدون فصل';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'هنوز نشانکی نیست';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'هنوز یادداشتی نیست';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'نشانک در $position افزوده شد';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'بازنشانی به 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9742,249 +9739,249 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'ذخیره';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'لغو';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'حذف';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'ترجیحات زیرنویس';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'تغییر حالت‌های زیرنویس، زبان‌های پیش‌فرض، ظاهر و گزینه‌های رندر.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'رندر زیرنویس';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'گزینه‌های نمایش';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'تاریخ انتشار (صعودی)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'تاریخ انتشار (نزولی)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'گروه‌بندی مشارکت‌ها';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'گروه‌بندی چند نقش';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'هشدار دسترسی نوشتن در کتابخانه';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'روش رفع این مشکل:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. به کاربر سرویس Jellyfin (مثلاً jellyfin یا PUID/PGID داکر) برای پوشه‌های کتابخانه رسانه خود روی سرور، مجوز نوشتن بدهید.\n\n2. یا به داشبورد Jellyfin -> کتابخانه‌ها بروید، این کتابخانه را ویرایش کنید و «ذخیره آثار هنری در پوشه‌های رسانه» را غیرفعال کنید تا آثار هنری در پایگاه داده داخلی Jellyfin ذخیره شوند.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'بستن';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'کتابخانه «$libraryName» شما طوری پیکربندی شده که آثار هنری را مستقیماً در پوشه‌های رسانه ذخیره کند («ذخیره آثار هنری در پوشه‌های رسانه» فعال است). با این حال، Jellyfin دسترسی نوشتن را آزمایش کرده و مجوز نوشتن فایل در این پوشه را ندارد:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'به نظر می‌رسد Jellyfin نتوانسته آثار هنری را به‌روزرسانی کند. کتابخانه شما طوری پیکربندی شده که آثار هنری را مستقیماً در پوشه‌های رسانه ذخیره کند («ذخیره آثار هنری در پوشه‌های رسانه» فعال است). این خطا معمولاً زمانی رخ می‌دهد که فرایند سرور Jellyfin مجوز نوشتن فایل در پوشه‌های رسانه شما را نداشته باشد.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'فهرست‌های خارجی';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'پخش دوباره';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'اطلاعات فایل';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'اندازه: $size  •  قالب: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'نمایش همه ($count) ترک صوتی';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'نمایش همه ($count) ترک زیرنویس';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'در حال بررسی قابلیت پخش مستقیم...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'قابلیت پخش مستقیم: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'اجباری';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'قالب کانتینر توسط پخش‌کننده پشتیبانی نمی‌شود.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'کدک ویدیو پشتیبانی نمی‌شود.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'کدک صدا پشتیبانی نمی‌شود.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'قالب زیرنویس پشتیبانی نمی‌شود (نیاز به چاپ روی تصویر دارد).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'پروفایل صدا پشتیبانی نمی‌شود.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'پروفایل ویدیو پشتیبانی نمی‌شود.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'سطح ویدیو پشتیبانی نمی‌شود.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'وضوح ویدیو توسط این دستگاه پشتیبانی نمی‌شود.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'عمق بیت ویدیو پشتیبانی نمی‌شود.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'نرخ فریم ویدیو پشتیبانی نمی‌شود.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'نرخ بیت فایل از حد پخش جریانی پخش‌کننده فراتر است.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'نرخ بیت ویدیو از حد پخش جریانی فراتر است.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'نرخ بیت صدا از حد پخش جریانی فراتر است.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'تعداد کانال‌های صوتی پشتیبانی نمی‌شود.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'الفبایی';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'ترتیب انتشار (صعودی)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'ترتیب انتشار (نزولی)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'سفارشی (کشیدن و رها کردن)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'گزینه‌های مرتب‌سازی لیست پخش';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'بازنشانی مرتب‌سازی';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'تماشای دوباره فصل $season قسمت $episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'تماشای دوباره لیست پخش';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'زیرنویسی یافت نشد.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'کنترل‌های مدیر';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'موتور رندر (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller موتور رندر مدرن GPU در Flutter است که انیمیشن‌های روان‌تر و پرش کمتری ارائه می‌دهد. در برخی تی‌وی‌باکس‌ها و GPUهای قدیمی ممکن است باعث اشکال تصویری یا ویدیوی سیاه شود؛ در این صورت آن را خاموش کنید. خودکار بهترین حالت پیش‌فرض را برای دستگاه شما انتخاب می‌کند. برای اعمال، Moonfin را دوباره راه‌اندازی کنید.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'خودکار';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'روشن';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'خاموش';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'راه‌اندازی مجدد لازم است';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'برای تغییر موتور رندر، Moonfin باید دوباره راه‌اندازی شود. اکنون برنامه را ببندید و سپس دوباره باز کنید تا اعمال شود.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'اکنون برنامه بسته شود';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'به‌روزرسانی کتابخانه';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'به‌روزرسانی همه کتابخانه‌ها';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'تاریخ افزودن (قدیمی‌ترین اول)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'تاریخ افزودن (جدیدترین اول)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'الفبایی (الف تا ی)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'الفبایی (ی تا الف)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'در حال بارگذاری تحلیل‌های سرور... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'مطابق با منبع';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => '250 فیلم برتر IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => '250 سریال برتر IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'محبوب‌ترین فیلم‌های IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'محبوب‌ترین سریال‌های IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'کم‌امتیازترین فیلم‌های IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'برترین فیلم‌های انگلیسی‌زبان IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -12,19 +12,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'TILIASETUKSET';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Käyttöliittymän kieli';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Järjestelmän oletus';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Kirjaudu sisään';
 
   @override
-  String get empty => 'Tyhjä';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Pikayhteys';
 
   @override
   String get password => 'Salasana';
@@ -114,7 +114,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cancel => 'Peruuttaa';
 
   @override
-  String get remove => 'Poista';
+  String get remove => 'Poistaa';
 
   @override
   String get connectToServer => 'Yhdistä palvelimeen';
@@ -143,62 +143,62 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsAppearanceTheme => 'Sovelluksen teema';
 
   @override
-  String get detailScreenStyle => 'Tietonäkymän tyyli';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassinen on alkuperäinen keskitetty Moonfin-asettelu. Moderni on mukautuva, elokuvamainen asettelu.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassinen';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderni';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Laajennetut välilehdet';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Näytä välilehden sisältö automaattisesti välilehtiä selatessasi. Poista käytöstä, jos haluat avata ja sulkea jokaisen välilehden itse.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Näytetäänkö tekniset tiedot?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Näytä koodekki-, tarkkuus- ja suoratoistotiedot bannerin yhteenvedossa';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Suositusjärjestelmä';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Käytä paikalliseen kirjastoon perustuvaa Moonfin suosittelee -algoritmia tai TMDb:n verkossa toimivia samankaltaisuusmittareita. Huomaa: verkkosuositukset vaativat Seerr-integraation.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin suosittelee';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-samankaltaisuus';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Rajoitetaanko ikärajan mukaan?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Rajoita Moonfin suosittelee -ehdotuksia kohdemedian ikärajan mukaan';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Käyttöliittymätyyli';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automaattinen mukautuu laitteeseesi. Valitse Apple tai Material pakottaaksesi tietyn ulkoasun.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automaattinen';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -207,31 +207,31 @@ class AppLocalizationsFi extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Lasin laatu';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automaattinen valitsee parhaan lasitehosteen tälle laitteelle. Täysi pakottaa aidon sumennuksen, Kevennetty käyttää kevyttä lasia, joka säästää GPU:n tehoa.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automaattinen';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Täysi';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Kevennetty';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Vaihda Moonfin ja Neon Pulse välillä käynnistämättä sovellusta uudelleen';
 
   @override
-  String get customThemeTitle => 'Mukautettu teema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Mukautetut teemat muuttavat Moonfinin ulkoasua kauttaaltaan. Valitse tyyliisi sopiva vaihtoehto.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Suosi järjestelmän näppäimistöä';
@@ -255,18 +255,18 @@ class AppLocalizationsFi extends AppLocalizations {
       'Synthwave-tyyli magenta hehkulla, syaanilla tekstillä ja vahvemmalla kromikontrastilla';
 
   @override
-  String get themeGlass => 'Lasi';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Nestemäisen lasin tyyli, jossa on liukuva liukuväritausta, huurteiset pinnat ja Applen sininen korostusväri';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bittinen sankari';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retrohenkinen pikselitaidetyyli, jossa on karkea väripaletti, kulmikkaat reunat, terävät varjot ja pikselifontti';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -329,36 +329,35 @@ class AppLocalizationsFi extends AppLocalizations {
   String get exit => 'Poistu';
 
   @override
-  String get gameMenu => 'Valikko';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Tauolla';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Tallenna tila';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Pelit';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Lataa tila';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Pikakelaus';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulaattorin asetukset';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Tässä ytimessä ei ole säädettäviä asetuksia.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Avaa valikko pitämällä painettuna';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Pelaamista ei vielä tueta tällä laitteella.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Kotirivejä ei voitu ladata';
@@ -380,13 +379,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get schedule => 'Ajoittaa';
 
   @override
-  String get series => 'Sarjat';
+  String get series => 'Sarja';
 
   @override
   String get noItemsFound => 'Kohteita ei löytynyt';
 
   @override
-  String get home => 'Koti';
+  String get home => 'Kotiin';
 
   @override
   String get browseAll => 'Selaa kaikkia';
@@ -509,7 +508,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get albumArtists => 'Albumin artistit';
 
   @override
-  String get artists => 'Artistit';
+  String get artists => 'Taiteilijat';
 
   @override
   String get bookmarks => 'Kirjanmerkit';
@@ -605,7 +604,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get listen => 'Kuunnella';
 
   @override
-  String get resume => 'Jatka';
+  String get resume => 'Jatkaa';
 
   @override
   String get failedToLoadLibrary => 'Kirjaston lataaminen epäonnistui';
@@ -617,7 +616,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get savedForLater => 'Tallennettu myöhempää käyttöä varten';
 
   @override
-  String get topListens => 'Kuunnelluimmat';
+  String get topListens => 'Top Listens';
 
   @override
   String get unreadDiscoveries => 'Lukemattomat löydöt';
@@ -697,7 +696,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get titles => 'Nimikkeet';
+  String get titles => 'Otsikot';
 
   @override
   String get allTitles => 'Kaikki otsikot';
@@ -750,13 +749,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get readStatus => 'Lukea';
 
   @override
-  String get watched => 'Katsotut';
+  String get watched => 'Katsottu';
 
   @override
   String get unread => 'Lukematon';
 
   @override
-  String get unwatched => 'Katsomattomat';
+  String get unwatched => 'Katsomaton';
 
   @override
   String get seriesStatus => 'Sarjan tila';
@@ -768,43 +767,43 @@ class AppLocalizationsFi extends AppLocalizations {
   String get books => 'Kirjat';
 
   @override
-  String get latestBooks => 'Uusimmat kirjat';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Uusimmat äänikirjat';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kirjaa',
-      one: '1 kirja',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Kirja';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Äänikirja';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent % luettu';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time jäljellä';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lue';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Kuuntele';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Tekijä';
@@ -881,8 +880,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count äänikirjaa',
-      one: '1 äänikirja',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -897,10 +896,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get failedToLoad => 'Lataus epäonnistui';
 
   @override
-  String get delete => 'Poista';
+  String get delete => 'Poistaa';
 
   @override
-  String get save => 'Tallenna';
+  String get save => 'Tallentaa';
 
   @override
   String get moreLikeThis => 'Lisää tällaista';
@@ -918,7 +917,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get nextUp => 'Seuraavaksi';
 
   @override
-  String get seasons => 'Kaudet';
+  String get seasons => 'Vuodenajat';
 
   @override
   String get chapters => 'Luvut';
@@ -986,8 +985,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kautta',
-      one: '1 kausi',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -998,40 +997,40 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get items => 'Kohteet';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Lisämateriaali';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Kulissien takana';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Poistetut kohtaukset';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Lyhytdokumentit';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Haastattelut';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Kohtaukset';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Lyhytelokuvat';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailerit';
+  String get trailers => 'Perävaunut';
 
   @override
   String timeRemaining(String time) {
-    return '$time jäljellä';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Päättyy $time kuluttua';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,7 +1048,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get play => 'Toista';
+  String get play => 'Pelata';
 
   @override
   String get startOver => 'Aloita alusta';
@@ -1064,7 +1063,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get playOffline => 'Pelaa offline-tilassa';
 
   @override
-  String get audio => 'Ääni';
+  String get audio => 'Audio';
 
   @override
   String get subtitles => 'Tekstitykset';
@@ -1073,7 +1072,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get version => 'Versio';
 
   @override
-  String get cast => 'Lähetä laitteelle';
+  String get cast => 'Heittää';
 
   @override
   String get trailer => 'Traileri';
@@ -1269,13 +1268,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get director => 'JOHTAJA';
 
   @override
-  String get directors => 'OHJAUS';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'KÄSIKIRJOITUS';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'KÄSIKIRJOITTAJAT';
+  String get writers => 'KIRJOITTAJAT';
 
   @override
   String get studio => 'STUDIO';
@@ -1310,8 +1309,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kappaletta',
-      one: '1 kappale',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1321,8 +1320,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count lukua',
-      one: '1 luku',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1352,13 +1351,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get shuffle => 'Sekoita';
 
   @override
-  String get shuffleAllMusic => 'Soita kaikki musiikki satunnaisesti';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Kirjaudu Moonfiniin puhelimellasi';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Palvelimeen ei saada yhteyttä';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1370,14 +1369,14 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
   String get mono => 'Mono';
 
   @override
-  String get stereo => 'Stereo';
+  String get stereo => 'Stereot';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1455,7 +1454,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get unavailable => 'Ei saatavilla';
 
   @override
-  String get pause => 'Keskeytä';
+  String get pause => 'Tauko';
 
   @override
   String get syncPosition => 'Synkronointipaikka';
@@ -1502,7 +1501,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automaattinen';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1517,12 +1516,12 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1556,7 +1555,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get transcodeReasons => 'Transkoodauksen syyt';
 
   @override
-  String get player => 'Soitin';
+  String get player => 'Pelaaja';
 
   @override
   String get container => 'Säiliö';
@@ -1574,13 +1573,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'Koodekki';
+  String get codec => 'Codec';
 
   @override
   String get videoBitrate => 'Videon bittinopeus';
 
   @override
-  String get track => 'Raita';
+  String get track => 'Seurata';
 
   @override
   String get channels => 'Kanavat';
@@ -1797,22 +1796,22 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Seuraavaksi: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min jäljellä';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours t jäljellä';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours t $minutes min jäljellä';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1835,7 +1834,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get favoriteChannel => 'Suosikki kanava';
 
   @override
-  String get record => 'Tallenna';
+  String get record => 'Tallentaa';
 
   @override
   String get cancelRecordingAction => 'Peruuta tallennus';
@@ -1850,10 +1849,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get unableToCreateRecording => 'Tallennusta ei voi luoda';
 
   @override
-  String get watch => 'Katso';
+  String get watch => 'Katsella';
 
   @override
-  String get close => 'Sulje';
+  String get close => 'Lähellä';
 
   @override
   String failedToPlayChannel(String name) {
@@ -1938,7 +1937,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr-tilin tyyppi';
+  String get seerrAccountType => 'Näkijätilin tyyppi';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2020,7 +2019,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'K$season J$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2044,7 +2043,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'K$number';
+    return 'S$number';
   }
 
   @override
@@ -2063,8 +2062,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count jaksoa',
-      one: '1 jakso',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2292,11 +2291,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Tietosivut, aloitusnäytön rivit ja äänenvoimakkuus';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
-    return '$value %';
+    return '$value%';
   }
 
   @override
@@ -2306,18 +2305,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Toista aloitusnäyttöä selatessasi';
 
   @override
-  String get loopThemeMusic => 'Toista tunnusmusiikkia jatkuvasti';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Toista kappaletta jatkuvasti kertatoiston sijaan';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Tiedot taustan sumennus';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2333,23 +2332,23 @@ class AppLocalizationsFi extends AppLocalizations {
   String get playerZoomMode => 'Soittimen zoomaustila';
 
   @override
-  String get settingsScrollWheelAction => 'Hiiren rulla';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Valitse, mitä hiiren rullan pyörittäminen videon päällä tekee toiston aikana.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Pois';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Kelaus (eteen / taakse)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Äänenvoimakkuus';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Äänenvoimakkuus';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Sopiva';
@@ -2373,7 +2372,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get scaleOnDevice => 'Skaalaa laitteessa';
 
   @override
-  String get trickPlay => 'Kelauksen esikatselu';
+  String get trickPlay => 'Trick Play';
 
   @override
   String get showPreviewThumbnailsWhenSeeking =>
@@ -2403,37 +2402,37 @@ class AppLocalizationsFi extends AppLocalizations {
   String get defaultAudioLanguage => 'Äänen oletuskieli';
 
   @override
-  String get fallbackAudioLanguage => 'Varaäänen kieli';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Suosi oletusääniraitaa';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Suosi alkuperäistä ääniraitaa dubatun sijaan.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Suosi kuvailutulkkausraitoja';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Suosi kuvailutulkkausraitoja tavallisten raitojen sijaan.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkoodaus (ääni)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Suora suoratoisto (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkoodaus (bittinopeus tai tarkkuus)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkoodaus (video ja ääni)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkoodaus (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automaattinen (palvelinoletus)';
@@ -2493,10 +2492,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get polish => 'Kiillottaa';
 
   @override
-  String get ac3Passthrough => 'AC3-läpivienti';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'DTS-läpivienti';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'TrueHD-tuki';
@@ -2514,24 +2513,23 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Valitse, miten ääni puretaan. AVR-läpivienti lähettää Dolby- ja DTS-raakavirrat vahvistimeen, Automaattinen ja Alasmiksaus purkavat äänen laitteessa.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR-läpivienti';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Audion varakoodekki';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Valitse kohdemuoto, johon monikanavaääni transkoodataan, kun lähdevirtaa ei voi toistaa suoraan tai viedä läpi.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automaattinen tunnistus\n(suositus)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(oletus)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2540,27 +2538,26 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(häviötön)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(vain stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(tehokas)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(häviötön)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Äänikanavien enimmäismäärä';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Määritä äänilaitteistosi kanavien enimmäismäärä. Tämän rajan ylittävät monikanavavirrat alasmiksataan tai transkoodataan.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automaattinen tunnistus\n(laitteiston oletus)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2569,50 +2566,50 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 tilaääni';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 nelikanavaääni';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 tilaääni';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 tilaääni';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 tilaääni';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 tilaääni';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Läpivienti (edistynyt)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Koodekin läpivienti';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
       'Ota käyttöön vain muodot, joita AVR- tai HDMI-allas tukee.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3-läpivienti';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
   String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Läpivienti';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core -läpivienti';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'DTS-HD MA -läpivienti';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD-läpivienti';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos -läpivienti';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2665,11 +2662,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Kaiutin';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kuulokkeet';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2706,7 +2703,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Reitin HD-äänituki';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Yötila';
@@ -2755,7 +2752,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2847,45 +2844,45 @@ class AppLocalizationsFi extends AppLocalizations {
       'Mukauta tekstityksen ulkoasua';
 
   @override
-  String get subtitleMode => 'Tekstitystila';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Merkityt';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Aina';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Vieraskieliset';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Pakotetut';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Toistaa raidat, jotka on merkitty mediatiedoston metatiedoissa \"oletukseksi\" tai \"pakotetuiksi\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Lataa ja näyttää tekstitykset automaattisesti aina, kun video alkaa.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Ottaa tekstitykset käyttöön automaattisesti, jos oletusääniraita on vieraskielinen.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Lataa vain ne tekstitykset, jotka on nimenomaisesti merkitty pakotetuiksi.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Poistaa tekstitysten automaattisen lataamisen kokonaan käytöstä.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Varatekstityksen kieli';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Tekstitysvirta';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2895,13 +2892,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get verticalOffset => 'Pystysuuntainen siirtymä';
 
   @override
-  String get pgsDirectPlay => 'Suora PGS-toisto';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Suoratoisto PGS-tekstitykset';
 
   @override
-  String get assSsaDirectPlay => 'Suora ASS/SSA-toisto';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles => 'Suoratoisto ASS/SSA tekstityksellä';
@@ -3091,10 +3088,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showLibrariesInToolbar => 'Näytä kirjastot työkalupalkissa';
 
   @override
-  String get navbarAlwaysExpanded => 'Näytä navigointipalkin tekstit aina';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Näytä Seerr-painike';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbarin läpinäkyvyys';
@@ -3168,19 +3165,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showFolderBrowsingOption => 'Näytä kansion selausvaihtoehto';
 
   @override
-  String get groupItemsIntoCollections => 'Ryhmittele kohteet kokoelmiin';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Piilota kokoelmiin kuuluvat kirjastokohteet kirjastoja selatessa';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Kirjaston ryhmittelyn huomautus';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Jotta voit käyttää tätä asetusta, varmista, että kirjaston näyttöasetuksissa Jellyfin- tai Emby-palvelimellasi on käytössä \"Ryhmittele elokuvat kokoelmiin\" ja/tai \"Ryhmittele sarjat kokoelmiin\".';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Kirjaston näkyvyys';
@@ -3282,7 +3278,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get autoAdvanceSlides => 'Siirry automaattisesti seuraavaan diaan';
 
   @override
-  String get autoAdvanceInterval => 'Automaattisen vaihdon väli';
+  String get autoAdvanceInterval => 'Auto Advance Interval';
 
   @override
   String get trailerPreview => 'Trailerin esikatselu';
@@ -3292,10 +3288,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Toista trailerit automaattisesti mediapalkissa 3 sekunnin kuluttua';
 
   @override
-  String get trailerAudio => 'Trailerin ääni';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Ota trailerien ääni käyttöön mediapalkissa';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Jakson esikatselu';
@@ -3372,11 +3368,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get combineBothRows => 'Yhdistä molemmat rivit yhdeksi kotiosioon';
 
   @override
-  String get fullScreenRows => 'Laajennetut aloitusnäytön rivit';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Näytä vain yksi aloitusnäytön rivi kerrallaan';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Rivikuvatyypin mukaan';
@@ -3391,7 +3386,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get lastUser => 'Viimeinen käyttäjä';
 
   @override
-  String get currentUser => 'Nykyinen käyttäjä';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Todenna aina';
@@ -3452,7 +3447,7 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ota sisäänrakennettu näytönsäästäjä käyttöön';
 
   @override
-  String get mode => 'Tila';
+  String get mode => 'tila';
 
   @override
   String get libraryArt => 'Kirjasto Art';
@@ -3499,10 +3494,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä kello näytönsäästäjän aikana';
 
   @override
-  String get clockModeStatic => 'Paikallaan';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Pomppiva';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (kriitikot)';
@@ -3574,7 +3569,7 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ota käyttöön ja järjestele uudelleen sovelluksessa näkyvät luokituslähteet';
 
   @override
-  String get pluginLabel => 'Moonbase-laajennus';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin havaittu';
@@ -3646,7 +3641,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get networks => 'Verkot';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-löytörivit';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Palauta rivit oletusarvoihin';
@@ -3670,28 +3665,28 @@ class AppLocalizationsFi extends AppLocalizations {
       'Piilota vain aikuisille suunnattu sisältö tuloksissa';
 
   @override
-  String get seerrNotificationsSection => 'Ilmoitukset';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Ilmoitukset uusista pyynnöistä';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Ilmoita minulle, kun joku lähettää pyynnön';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Pyyntöjen päivitykset';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Hyväksytty, hylätty ja lisätty kirjastoosi';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ongelmien päivitykset';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Uudet ongelmat, vastaukset ja ratkaisut';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3699,15 +3694,15 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerrin Discover-sivu';
+  String get discoverRows => 'Tutustu riviin';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Ota käyttöön rivit, jotka haluat nähdä Seerrin etusivulla. Järjestä uudelleen vetämällä. Mukautettu järjestys synkronoituu Moonbasen kanssa.';
+      'Järjestä uudelleen vetämällä. Ota rivit käyttöön tai poista ne käytöstä. Käytössä oleva rivijärjestys synkronoituu Moonfin-laajennuksen kanssa.';
 
   @override
   String get discoverRowsDescription =>
-      'Ota käyttöön rivit, jotka haluat nähdä Seerrin etusivulla. Järjestä uudelleen vetämällä. Mukautettu järjestys synkronoituu Moonbasen kanssa.';
+      'Järjestä uudelleen vetämällä. Ota rivit käyttöön tai poista ne käytöstä.';
 
   @override
   String get enabled => 'Käytössä';
@@ -3844,7 +3839,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get imageCacheCleared => 'Kuvavälimuisti tyhjennetty';
 
   @override
-  String get clear => 'Tyhjennä';
+  String get clear => 'Selkeä';
 
   @override
   String get browse => 'Selaa';
@@ -3860,11 +3855,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Ladataan · $percent %';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Tuodaan';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3872,7 +3867,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Seerrin asetukset';
+  String get seerrSettings => 'Näkijän asetukset';
 
   @override
   String get requestMore => 'Pyydä lisää';
@@ -3968,7 +3963,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showMore => 'Näytä lisää';
 
   @override
-  String get appearances => 'Esiintymiset';
+  String get appearances => 'Ulkonäkö';
 
   @override
   String get crewSection => 'Miehistö';
@@ -4006,148 +4001,148 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deletedStatus => 'Poistettu';
 
   @override
-  String get failedStatus => 'Epäonnistui';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Käsitellään';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Muokkaaja: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Valmis';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Tämä nimike on jo pyydetty';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Pyyntöraja saavutettu';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Tämä nimike on estolistalla';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Ei enää pyydettäviä kausia';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Sinulla ei ole oikeutta tehdä tätä pyyntöä';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Pyynnöt';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Ongelmat';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Uusimmat';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Viimeksi muokattu';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Ei ongelmia';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining/$limit elokuvapyyntöä jäljellä';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining/$limit kausipyyntöä jäljellä';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Osa kokoelmaa: $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Näytä kokoelma';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Pyydä kokoelma';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total elokuvaa · $available saatavilla';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Pyydä $count elokuvaa';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Pyydetään $current/$total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Pyydettiin $count elokuvaa';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Pyydettiin $ok/$total elokuvasta';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Kaikki elokuvat ovat jo saatavilla tai pyydetty';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Ilmoita ongelmasta';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Ääni';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Mikä on vialla?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Kaikki jaksot';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Jakso';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Avoin';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Ratkaistu';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Merkitse ratkaistuksi';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Avaa uudelleen';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Ilmoittaja: $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommenttia';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Lisää kommentti';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Poistetaanko tämä ongelma?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Lähetä ilmoitus';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-pisteet';
@@ -4171,7 +4166,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get originalLanguageLabel => 'Alkuperäinen kieli';
 
   @override
-  String get seasonsLabel => 'Kaudet';
+  String get seasonsLabel => 'Vuodenajat';
 
   @override
   String get episodesLabel => 'Jaksot';
@@ -4180,13 +4175,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get access => 'Pääsy';
 
   @override
-  String get add => 'Lisää';
+  String get add => 'Lisätä';
 
   @override
   String get address => 'Osoite';
 
   @override
-  String get analytics => 'Analytiikka';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Luettelo';
@@ -4204,10 +4199,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get disable => 'Poista käytöstä';
 
   @override
-  String get done => 'Valmis';
+  String get done => 'Tehty';
 
   @override
-  String get edit => 'Muokkaa';
+  String get edit => 'Muokata';
 
   @override
   String get encoding => 'Koodaus';
@@ -4219,7 +4214,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get forward => 'Eteenpäin';
 
   @override
-  String get general => 'Yleiset';
+  String get general => 'Kenraali';
 
   @override
   String get go => 'Mennä';
@@ -4240,7 +4235,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get networking => 'Verkostoituminen';
 
   @override
-  String get next => 'Seuraava';
+  String get next => 'Seuraavaksi';
 
   @override
   String get path => 'Polku';
@@ -4264,7 +4259,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get refresh => 'Päivitä';
 
   @override
-  String get remote => 'Kaukosäädin';
+  String get remote => 'Kauko';
 
   @override
   String get rename => 'Nimeä uudelleen';
@@ -4297,10 +4292,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get set => 'Sarja';
 
   @override
-  String get status => 'Tila';
+  String get status => 'Status';
 
   @override
-  String get stop => 'Pysäytä';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Suoratoisto';
@@ -4336,7 +4331,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminDrawerDashboard => 'Kojelauta';
 
   @override
-  String get adminDrawerAnalytics => 'Analytiikka';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Asetukset';
@@ -4351,19 +4346,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminDrawerLibraries => 'Kirjastot';
 
   @override
-  String get adminDrawerDisplay => 'Näyttö';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metatiedot';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-asetukset';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkoodaus';
 
   @override
-  String get adminDrawerResume => 'Jatka';
+  String get adminDrawerResume => 'Jatkaa';
 
   @override
   String get adminDrawerStreaming => 'Suoratoisto';
@@ -4393,7 +4388,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminDrawerScheduledTasks => 'Aikataulutetut tehtävät';
 
   @override
-  String get adminDrawerPlugins => 'Laajennukset';
+  String get adminDrawerPlugins => 'Plugins';
 
   @override
   String get adminDrawerRepositories => 'Tietovarastot';
@@ -4544,13 +4539,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get sessionForward => 'Eteenpäin';
 
   @override
-  String get sessionNext => 'Seuraava';
+  String get sessionNext => 'Seuraavaksi';
 
   @override
-  String get sessionVolumeDown => 'Ääni –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Ääni +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4565,13 +4560,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get actions => 'Toiminnot';
 
   @override
-  String get videoCodec => 'Videokoodekki';
+  String get videoCodec => 'Video Codec';
 
   @override
   String get audioCodec => 'Äänikoodekki';
 
   @override
-  String get hwAccel => 'Laitteistokiihdytys';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Valmistuminen';
@@ -4586,10 +4581,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminClearDates => 'Selkeät päivämäärät';
 
   @override
-  String get adminActivitySeverityAll => 'Kaikki vakavuusasteet';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Aikaväli';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4626,23 +4621,23 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Poistetaanko laite \'$name\'? Käyttäjän on kirjauduttava tällä laitteella uudelleen sisään.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Poista kaikki laitteet';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Poistetaanko $count laitetta? Kyseisten käyttäjien on kirjauduttava uudelleen sisään. Nykyinen laitteesi ei muutu.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Laitteet poistettu';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Osa laitteista poistettiin, $count laitetta ei voitu poistaa.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4758,248 +4753,244 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminMetadataCountryHint => 'esim. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Polut';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Asetukset';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Lataajat';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metatietojen tallentajat';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Tekstitysten lataajat';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Sanoitusten lataajat';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metatietojen lataajat: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Kuvien hakijat: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Tämä palvelin ei tarjoa lataajia tälle kirjastotyypille.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Yleiset';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metatiedot';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Upotetut tiedot';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Tekstitykset';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Kuvat';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Sarjat';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musiikki';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Elokuvat';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Ota reaaliaikainen valvonta käyttöön';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Tunnista tiedostomuutokset ja käsittele ne automaattisesti.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Käsittele arkistot mediatiedostoina';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Näytä valokuvat';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Tallenna kuvitus mediakansioihin';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Metatietojen automaattinen päivitys';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Ei koskaan';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Oletus';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Näyttö';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Kirjaston näyttö';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Näytä kansionäkymä tavallisille mediakansioille';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Näytä erikoisjaksot niiden esityskausien sisällä';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Ryhmittele elokuvat kokoelmiin';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Ryhmittele sarjat kokoelmiin';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Näytä ulkoista sisältöä ehdotuksissa';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Lisäyspäivän toiminta';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Käytä lisäyspäivänä';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Kirjastoon skannauksen päivämäärä';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Tiedoston luontipäivämäärä';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metatiedot ja kuvat';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Ensisijainen metatietojen kieli';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Luvut';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Korvikelukujen kesto (sekuntia)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Lukujen pituus medialle, jolla ei ole omia lukuja. Poista käytöstä arvolla 0.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Lukukuvien tarkkuus';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-asetukset';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metatiedot ovat yhteensopivia Kodin ja vastaavien sovellusten kanssa. Asetukset koskevat kaikkia kirjastoja, jotka tallentavat NFO-metatietoja.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Käyttäjä, jonka katselutiedot tallennetaan NFO-tiedostoihin';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Tallenna kuvapolut NFO-tiedostoihin';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Ota polkujen korvaus käyttöön NFO-kuvapoluille';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopioi extrafanart-kuvat extrathumbs-kansioon';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ei mitään';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days päivää';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Käytä upotettuja nimikkeitä';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Käytä upotettuja nimikkeitä lisämateriaalille';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'Käytä upotettuja jaksotietoja';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Salli upotetut tekstitykset';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Salli kaikki';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Vain teksti';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Vain kuva';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ei mitään';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Ohita lataus, jos upotetut tekstitykset ovat olemassa';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Ohita lataus, jos ääniraita vastaa latauskieltä';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Vaadi täydellinen tekstitysosuma';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Tallenna tekstitykset mediakansioihin';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Pura lukukuvat';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Pura lukukuvat kirjastoskannauksen aikana';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Ota Trickplay-kuvien purku käyttöön';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Pura Trickplay-kuvat kirjastoskannauksen aikana';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Tallenna Trickplay-kuvat mediakansioihin';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Yhdistä automaattisesti sarjat, jotka on jaettu useaan kansioon';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Kauden nolla näyttönimi';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Ota LUFS-skannaus käyttöön äänen normalisointia varten';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Suosi epästandardia artistitunnistetta';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Lisää elokuvat kokoelmiin automaattisesti';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Kirjaston nimi on pakollinen';
@@ -5117,7 +5108,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminDeleteUser => 'Poista käyttäjä';
 
   @override
-  String get admin => 'Ylläpito';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5233,145 +5224,143 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminEnableAllChannels => 'Salli pääsy kaikille kanaville';
 
   @override
-  String get adminParentalControl => 'Lapsilukko';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Suurin sallittu ikäraja';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Tätä korkeamman ikärajan sisältö piilotetaan tältä käyttäjältä.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ei mitään';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Estä kohteet, joiden ikärajatieto puuttuu tai on tuntematon';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Kirjat';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanavat';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Live-TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Elokuvat';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musiikki';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailerit';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Sarjat';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Käyttöaikataulut';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Salli käyttö vain alla määritettyinä aikoina. Ilman aikataulua käyttö on sallittu koko päivän.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Lisää aikataulu';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Päivä';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Alkaa';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Päättyy';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Joka päivä';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Arkipäivä';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Viikonloppu';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Sunnuntai';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Maanantai';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Tiistai';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Keskiviikko';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Torstai';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Perjantai';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Lauantai';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Sallitut tunnisteet';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Vain näillä tunnisteilla merkitty sisältö näytetään. Jätä tyhjäksi salliaksesi kaiken.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Estetyt tunnisteet';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Näillä tunnisteilla merkitty sisältö piilotetaan tältä käyttäjältä.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Lisää tunniste';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Sallitut laitteet';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Sallitut kanavat';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Todennuksen tarjoaja';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Salasanan palautuksen tarjoaja';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Epäonnistuneiden kirjautumisyritysten enimmäismäärä ennen lukitusta';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Käytä oletusta arvolla 0 tai poista lukitus käytöstä arvolla -1.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-käyttöoikeus';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Salli ryhmien luominen ja niihin liittyminen';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Salli ryhmiin liittyminen';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Ei käyttöoikeutta';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Salli sisällön poistaminen kansioista';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5459,26 +5448,25 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Luo varmuuskopio';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Valitse, mitä varmuuskopioon sisällytetään.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Tietokanta';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Aina mukana';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metatiedot';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Tekstitykset';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-kuvat';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Luodaan varmuuskopiota...';
@@ -6191,62 +6179,60 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminAddTuner => 'Lisää viritin';
 
   @override
-  String get adminEditTuner => 'Muokkaa viritintä';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-viritin';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Tiedosto tai URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Virittimen IP-osoite';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Näyttönimi';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Samanaikaisten yhteyksien raja';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Virittimen kerralla sallimien lähetysvirtojen enimmäismäärä. Rajoittamaton arvolla 0.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Suoratoiston varabittinopeuden yläraja';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Tuo vain suosikkikanavat';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Salli laitteistotranskoodaus';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Salli fMP4-transkoodaussäiliö';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Salli lähetysvirran jakaminen';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Ota lähetysvirran silmukointi käyttöön';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ohita DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Lue syöte natiivilla kuvataajuudella';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Muokkaa tarjoajaa';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6255,50 +6241,50 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Tiedosto tai URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Elokuvien etuliite';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Elokuvakategoriat';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Erota useat kategoriat pystyviivalla.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Lastenohjelmien kategoriat';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Uutiskategoriat';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Urheilukategoriat';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Käyttäjätunnus';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Salasana';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Maa';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Valitse maa';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postinumero';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Hae ohjelmatiedot';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Ohjelmatiedot';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Ota kaikki virittimet käyttöön';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Virittimen tyyppi';
@@ -6340,7 +6326,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Tämä viritintyyppi ei tue nollausta.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6363,43 +6349,43 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Sarjan tallennuspolku';
 
   @override
-  String get adminMovieRecordingPath => 'Elokuvatallenteiden polku';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Ohjelmaoppaan päivien määrä';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automaattinen';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days päivää';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Jälkikäsittelysovelluksen polku';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Jälkikäsittelijän argumentit';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Tallenna tallenteen NFO-metatiedot';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Tallenna tallenteen kuvat';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Ajoitus';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Tallennuspolut';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Jälkikäsittely';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Ohjelmaopas: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6441,14 +6427,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminGuideProviders => 'Opaspalveluntarjoajat';
 
   @override
-  String get adminRefreshGuideData => 'Päivitä ohjelmaoppaan tiedot';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Ohjelmaoppaan päivitys aloitettu';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Ohjelmaoppaan päivitystehtävä ei ole käytettävissä tällä palvelimella.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Lisää Palveluntarjoaja';
@@ -6582,7 +6568,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metatietoeditori';
 
   @override
-  String get adminMetadataIdentify => 'Tunnista';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tyyppi';
@@ -6597,7 +6583,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminMetadataImages => 'Kuvat';
 
   @override
-  String get adminMetadataFieldTitle => 'Nimi';
+  String get adminMetadataFieldTitle => 'Otsikko';
 
   @override
   String get adminMetadataFieldSortTitle => 'Lajittele otsikko';
@@ -6867,7 +6853,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Poista';
+  String get adminReposRemove => 'Poistaa';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6999,20 +6985,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Ota aloitusnäyttö käyttöön';
 
   @override
-  String get adminBrandingSplashUpload => 'Lataa kuva';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Aloitusruutu päivitetty';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Aloitusruudun lataaminen epäonnistui';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Aloitusruutu poistettu';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Ei mukautettua aloitusruutua';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Laitteistokiihdytys';
@@ -7028,126 +7013,121 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ota laitteiston dekoodaus käyttöön:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-laite';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ota tehostettu NVDEC-purkaja käyttöön';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Suosi järjestelmän natiivia laitteistopurkajaa';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Laitteistopurun värisyvyys';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bittinen HEVC-purku';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bittinen VP9-purku';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bittinen purku';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bittinen purku';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Laitteistokoodaus';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Salli HEVC-koodaus';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Salli AV1-koodaus';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Ota Intelin vähävirtainen H.264-koodain käyttöön';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Ota Intelin vähävirtainen HEVC-koodain käyttöön';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Sävykartoitus';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Ota sävykartoitus käyttöön';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Ota VPP-sävykartoitus käyttöön';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Ota VideoToolbox-sävykartoitus käyttöön';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Sävykartoituksen algoritmi';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Sävykartoituksen tila';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Sävykartoituksen alue';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Sävykartoituksen värikylläisyyden vähennys';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Sävykartoituksen huippuarvo';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Sävykartoituksen parametri';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP-sävykartoituksen kirkkaus';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP-sävykartoituksen kontrasti';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Esiasetukset ja laatu';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Koodaimen esiasetus';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264-koodauksen CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) -koodauksen CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Lomituksenpoiston menetelmä';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Kaksinkertaista kuvataajuus lomitusta poistettaessa';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Ääni';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Ota äänen VBR-koodaus käyttöön';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Äänen alasmiksauksen korostus';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Stereoalasmiksauksen algoritmi';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Muksausjonon enimmäiskoko';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automaattinen';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Koodaus';
@@ -7267,10 +7247,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminTaskNeverRun => 'Älä koskaan juokse';
 
   @override
-  String get adminTaskStop => 'Pysäytä';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Käynnissä olevat tehtävät';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Juokse';
@@ -7340,8 +7320,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tuntia',
-      one: '1 tunti',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7387,22 +7367,22 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours t';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days pv';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month.';
+    return '$month/$day';
   }
 
   @override
@@ -7422,45 +7402,43 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Julkinen HTTP-portti';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Vaadi HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Ohjaa kaikki etäpyynnöt HTTPS:ään. Ei vaikutusta, jos palvelimella ei ole voimassa olevaa varmennetta.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Varmenteen salasana';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-asetukset';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Ota IPv4 käyttöön';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Ota IPv6 käyttöön';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Ota automaattinen porttien ohjaus käyttöön';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Lähiverkot';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Pilkulla tai rivinvaihdolla erotettu luettelo IP-osoitteista tai CIDR-aliverkoista, jotka katsotaan lähiverkoksi.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris =>
-      'Julkaistut palvelimen URI-osoitteet';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Yhdistä aliverkko tai osoite julkaistuun URL-osoitteeseen, esim. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Varmenteen polku';
@@ -7490,11 +7468,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Kaasun puskurointi';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Kuristuksen viive (sekuntia)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Salli tekstitysten purku lennossa';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimi jatkamisprosentti';
@@ -7551,23 +7529,22 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Hitaan vasteen kynnys (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ota hitaiden vastausten varoitukset käyttöön';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Ota Quick Connect käyttöön';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Palvelin';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metatiedot';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Polut';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Suorituskyky';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Välimuistin polku';
@@ -7579,7 +7556,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminGeneralServerName => 'Palvelimen nimi';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Ensisijainen näyttökieli';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Asetusten lataaminen epäonnistui';
@@ -7631,8 +7608,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# osallistujaa',
-      one: '# osallistuja',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7778,8 +7755,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# riviä löytyi',
-      one: '# rivi löytyi',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7820,20 +7797,20 @@ class AppLocalizationsFi extends AppLocalizations {
   String get offlineSavedMedia => 'Tallennettu media';
 
   @override
-  String get offlineBannerTitle => 'Olet offline-tilassa';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Näytetään lataamasi sisältö';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Lataukset';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Palvelimeen ei saada yhteyttä';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Toistetaan latauksista, kunnes yhteys palaa';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7869,7 +7846,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get audioLabel => 'Ääni';
+  String get audioLabel => 'Audio';
 
   @override
   String get subtitlesLabel => 'Tekstitykset';
@@ -7906,41 +7883,41 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pinForgot => 'Unohditko PIN-koodin?';
 
   @override
-  String get pinClear => 'Tyhjennä';
+  String get pinClear => 'Selkeä';
 
   @override
   String get pinBackspace => 'Askelpalautin';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect -pyyntö hyväksytty.';
+  String get quickConnectAuthorized => 'Pikayhteyspyyntö hyväksytty.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect -koodi on virheellinen tai vanhentunut.';
+      'Pikayhteyskoodi on virheellinen tai vanhentunut.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connectia ei tueta tällä palvelimella.';
+      'Pikayhteyttä ei tueta tällä palvelimella.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect -koodin valtuuttaminen epäonnistui.';
+      'Pikayhteyskoodin valtuuttaminen epäonnistui.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect on poistettu käytöstä tällä palvelimella.';
+      'Pikayhteys on poistettu käytöstä tällä palvelimella.';
 
   @override
   String get quickConnectForbidden =>
-      'Tilisi ei voi valtuuttaa tätä Quick Connect -pyyntöä.';
+      'Tilisi ei voi valtuuttaa tätä pikayhteyspyyntöä.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect -koodia ei löytynyt. Kokeile uutta koodia.';
+      'Pikayhteyskoodia ei löytynyt. Kokeile uutta koodia.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect epäonnistui: $message';
+    return 'Pikayhteys epäonnistui: $message';
   }
 
   @override
@@ -8036,7 +8013,7 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ladattua tiedostoa ei voitu poistaa';
 
   @override
-  String get shuffleBy => 'Satunnaistoiston peruste';
+  String get shuffleBy => 'Shuffle By';
 
   @override
   String get shuffleSelectLibrary => 'Valitse Kirjasto';
@@ -8106,7 +8083,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get stillWatchingContent => 'Toisto on keskeytetty. Katsotko vielä?';
 
   @override
-  String get stillWatchingStop => 'Pysäytä';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Jatkaa';
@@ -8191,13 +8168,13 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Piilota Jatka katselua -osiosta';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Piilota Seuraavaksi-osiosta';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Lisää kokoelmaan';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8252,15 +8229,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsAlphabetical => 'Aakkosellinen';
 
   @override
-  String get settingsConnectionSection => 'YHTEYS';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Salli itse allekirjoitetut varmenteet';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Luota palvelimiin, jotka käyttävät itse allekirjoitettuja tai yksityisen CA:n TLS-varmenteita. Ota käyttöön vain hallitsemillesi palvelimille. Tämä poistaa varmenteiden tarkistuksen kaikista yhteyksistä.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection =>
@@ -8277,11 +8253,11 @@ class AppLocalizationsFi extends AppLocalizations {
       'Teeman korostukset, taustat, katsotut indikaattorit ja teemamusiikki';
 
   @override
-  String get settingsDetailsScreen => 'Tietonäkymä';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Tyyli, taustan sumennus ja välilehtien toiminta';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Kotisivu';
@@ -8319,11 +8295,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Näytä Seerr-painike navigointipalkissa';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Näytä tekstit aina ylänavigointipalkissa';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8425,8 +8401,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# lisenssi-ilmoitusta',
-      one: '# lisenssi-ilmoitus',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8475,16 +8451,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Ohitetaanko introt ja loppupalat?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Mediasegmentin ajastin';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Edistymispalkki';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Ajastin';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ei mitään';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Kehota käyttäjää';
@@ -8508,7 +8484,7 @@ class AppLocalizationsFi extends AppLocalizations {
       'Kuinka video tulee skaalata näytölle sopivaksi.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv => 'Toistomoottori (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8712,7 +8688,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Äskettäin julkaistut: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8744,11 +8720,11 @@ class AppLocalizationsFi extends AppLocalizations {
       'Pakota ei-tunneloitu toisto. Hyödyllinen laitteissa, joissa tunneloidaan audio-/videokatkoksia.';
 
   @override
-  String get enableTunnelingTitle => 'Ota tunnelointi käyttöön';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Lisäasetus. Reitittää äänen ja videon kytketyn laitteistopolun kautta. Oletuksena pois päältä, koska se aiheuttaa ääni- ja kuvakatkoja joillakin laitteilla.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8774,15 +8750,14 @@ class AppLocalizationsFi extends AppLocalizations {
       'Käytä tekstitysrataan upotettuja kirjasinkokoisia vihjeitä. Poista käytöstä tekstityskoon käyttö tyyliasetuksistasi.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Näytä median tiedot';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Näytä valitun kohteen tiedot kirjastosivujen yläosassa.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Piilotetaanko taustakuvat selattaessa?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Käytä yksityiskohtaisia ​​alaotsikoita';
@@ -8800,37 +8775,37 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Teemakauppa';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Selaa ja tallenna yhteisön teemoja';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Tallenna teema, niin voit käyttää sitä muiden tallentamiesi teemojen tapaan.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Teemoja ei ole juuri nyt saatavilla.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Teemakauppaa ei voitu ladata. Tarkista yhteytesi ja yritä uudelleen.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Tallenna';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Tallenna ja ota käyttöön';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Tallennettu';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Tätä teemaa ei voitu ladata.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Teema \"$themeName\" tallennettu.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8888,21 +8863,21 @@ class AppLocalizationsFi extends AppLocalizations {
   String get homeRowsSection => 'Kotirivit';
 
   @override
-  String get homeRowDisplay => 'Aloitusnäytön rivien näyttö';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Aloitusnäytön riviosiot';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Aloitusnäytön rivivalinnat';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Ota käyttöön tai poista käytöstä kirjastopohjaiset aloitusnäytön riviluokat';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Ota alla olevat valinnat käyttöön, niin rivit näkyvät aloitusnäytön osioissa.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rivien tyyppi';
@@ -8930,7 +8905,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Näytä kokoelmarivit aloitusnäytön osioissa.';
+      'Show Collections rows in Home Sections.';
 
   @override
   String get collectionsRowSorting => 'Kokoelmat rivien lajittelu';
@@ -8960,56 +8935,55 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä elokuvat, sarjat tai molemmat lajityypit-riveillä.';
 
   @override
-  String get displayPlaylistsRows => 'Näytä soittolistarivit';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Näytä soittolistarivit aloitusnäytön osioissa.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Soittolistarivien järjestys';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Järjestä soittolistarivit lisäyspäivän, julkaisupäivän, aakkosten ja muiden perusteiden mukaan.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Näytä äänirivit';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Näytä äänirivit aloitusnäytön osioissa.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Äänirivien järjestys';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Järjestä äänirivit lisäyspäivän, julkaisupäivän, aakkosten ja muiden perusteiden mukaan.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Äänisoittolistat';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Ulkoasu';
+  String get appearance => 'Ulkonäkö';
 
   @override
-  String get layout => 'Asettelu';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Teema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Näppäimistö';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Painikkeet';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderöinti';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-määritykset';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kortin koko';
@@ -9019,7 +8993,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Määritä ulkoinen soitin, niin pitkä painallus tarjoaa toistovaihtoehdon';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9263,7 +9237,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get programs => 'Ohjelmat';
 
   @override
-  String get songs => 'Kappaleet';
+  String get songs => 'Songs';
 
   @override
   String get photoAlbums => 'Valokuva-albumit';
@@ -9284,10 +9258,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get guestAppearances => 'Vierasesityksiä';
 
   @override
-  String get appearancesSeerr => 'Esiintymiset (Seerr)';
+  String get appearancesSeerr => 'Ulkonäkö (näkijä)';
 
   @override
-  String get crewContributionsSeerr => 'Työryhmän osuudet (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Katso ryhmän kanssa';
@@ -9372,8 +9346,8 @@ class AppLocalizationsFi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kirjastoa',
-      one: '1 kirjasto',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9446,7 +9420,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminDrawerSectionAdvanced => 'Edistynyt';
 
   @override
-  String get adminDrawerSectionPlugins => 'Laajennukset';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
   String get adminDrawerSectionLiveTv => 'Live-TV';
@@ -9532,13 +9506,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get loadingShuffle => 'Ladataan satunnaistoistoa...';
 
   @override
-  String get libraryShuffleLabel => 'KIRJASTON SEKOITUS';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'SATUNNAINEN SEKOITUS';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'GENREJEN SEKOITUS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automaattinen HDR-vaihto';
@@ -9551,222 +9525,222 @@ class AppLocalizationsFi extends AppLocalizations {
   String get whenFullscreen => 'Kun koko näyttö';
 
   @override
-  String get changeArtwork => 'Vaihda kuvitus';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Puuttuu';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Transkoodausrajat';
 
   @override
-  String get clearAllArtworkButton => 'Tyhjennetäänkö kaikki kuvitus?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Haluatko varmasti tyhjentää kaiken ladatun kuvituksen?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Vahvista tyhjennys';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Haluatko varmasti tyhjentää tämän: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Ladataanko?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Tarkkuus: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Näytä vain käyttöliittymän kielinen kuvitus';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Vahvista kaikkien tyhjennys';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Kuvan lataus onnistui!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Kuvan lataus epäonnistui: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Kuvan asettaminen epäonnistui: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Kuvan poistaminen epäonnistui: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kaiken kuvituksen tyhjentäminen epäonnistui: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Kyllä';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Juliste';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Taustakuvat';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Banneri';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Pienoiskuva';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Kuvitus';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Levykuvitus';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Kuvakaappaus';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Kotelon kansi';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Kotelon takakansi';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Valikkokuvitus';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'juliste';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'taustakuva';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'banneri';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'pienoiskuva';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'kuvitus';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'levykuvitus';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'kuvakaappaus';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'kotelon kansi';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'kotelon takakansi';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'valikkokuvitus';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Kaikki';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Korkea (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Keskitaso (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Matala (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Lähteet';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Luvut';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Kirjanmerkit';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Muistiinpanot';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Jono';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Aikajana';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Aikajana on tyhjä';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Koko kirja';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Rajattu aikajana';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Vie kirjanmerkit';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Vie muistiinpanot';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Vie kaikki';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Viety sijaintiin $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Vienti epäonnistui: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Sanoitukset';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Lisää kirjanmerkki';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Lisää muistiinpano';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Muokkaa muistiinpanoa';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Kirjoita muistiinpano tähän kohtaan';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Uniajastin';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Pois';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Luvun loppu';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Mukautettu';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining jäljellä';
+    return '$remaining left';
   }
 
   @override
@@ -9781,51 +9755,51 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Toistonopeus';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Jäljellä';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Kulunut';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Taakse $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Eteen $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Edellinen luku';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Seuraava luku';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Luku $current/$total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Ei lukuja';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Ei vielä kirjanmerkkejä';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Ei vielä muistiinpanoja';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Kirjanmerkki lisätty kohtaan $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Palauta nopeuteen 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9833,248 +9807,249 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Tallenna';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Peruuta';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Poista';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Tekstitysasetukset';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Muuta tekstitystiloja, oletuskieliä, ulkoasua ja renderöintiasetuksia.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Tekstitysten renderöinti';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Näyttöasetukset';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Julkaisupäivä (nouseva)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Julkaisupäivä (laskeva)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Ryhmittele osuudet';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Ryhmittele useat roolit';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Varoitus kirjaston kirjoitusoikeuksista';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Näin korjaat tämän:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Myönnä Jellyfin-palvelun käyttäjälle (esim. jellyfin tai Dockerin PUID/PGID) kirjoitusoikeudet palvelimella oleviin mediakirjastokansioihisi.\n\n2. Tai siirry Jellyfinin hallintapaneeliin -> Kirjastot, muokkaa tätä kirjastoa ja poista käytöstä \'Tallenna kuvitus mediakansioihin\', jolloin kuvitus tallennetaan Jellyfinin sisäiseen tietokantaan.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Sulje';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Kirjastosi \'$libraryName\' on määritetty tallentamaan kuvitus suoraan mediakansioihin (\'Tallenna kuvitus mediakansioihin\' on käytössä). Jellyfin on kuitenkin testannut kirjoitusoikeudet, eikä sillä ole oikeutta kirjoittaa tiedostoja tähän hakemistoon:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin ei ilmeisesti onnistunut päivittämään kuvitusta. Kirjastosi on määritetty tallentamaan kuvitus suoraan mediakansioihin (\'Tallenna kuvitus mediakansioihin\' on käytössä). Tämä virhe johtuu yleensä siitä, ettei Jellyfin-palvelinprosessilla ole oikeutta kirjoittaa tiedostoja mediahakemistoihisi.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Ulkoiset listat';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Toista uudelleen';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Tiedoston tiedot';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Koko: $size  •  Muoto: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Näytä kaikki ($count) ääniraitaa';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Näytä kaikki ($count) tekstitysraitaa';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Tarkistetaan suoran toiston tukea...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Suoran toiston tuki: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Pakotettu';
+  String get forced => 'Forced';
 
   @override
-  String get transcodeContainerNotSupported => 'Soitin ei tue säiliömuotoa.';
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Videokoodekkia ei tueta.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Äänikoodekkia ei tueta.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Tekstitysmuotoa ei tueta (vaatii polttamisen kuvaan).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Ääniprofiilia ei tueta.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Videoprofiilia ei tueta.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Videotasoa ei tueta.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Tämä laite ei tue videon tarkkuutta.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Videon bittisyvyyttä ei tueta.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Videon kuvataajuutta ei tueta.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Tiedoston bittinopeus ylittää soittimen suoratoistorajan.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Videon bittinopeus ylittää suoratoistorajan.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Äänen bittinopeus ylittää suoratoistorajan.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Äänikanavien määrää ei tueta.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Aakkosjärjestys';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Julkaisujärjestys (nouseva)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Julkaisujärjestys (laskeva)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Mukautettu (vedä ja pudota)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Soittolistan järjestysasetukset';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Palauta järjestys';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Katso uudelleen K$season:J$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Katso soittolista uudelleen';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Tekstityksiä ei löytynyt.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Ylläpidon hallinta';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Renderöintimoottori (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller on Flutterin moderni GPU-renderöijä, joka tuo sulavammat animaatiot ja vähemmän nykimistä. Joissakin TV-bokseissa ja vanhemmissa GPU:issa se voi aiheuttaa häiriöitä tai mustan kuvan; valitse silloin Ei käytössä. Automaattinen valitsee laitteellesi parhaan oletuksen. Ota muutos käyttöön käynnistämällä Moonfin uudelleen.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automaattinen';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Käytössä';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Ei käytössä';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Uudelleenkäynnistys vaaditaan';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin on käynnistettävä uudelleen renderöintimoottorin vaihtamiseksi. Sulje sovellus nyt ja avaa se uudelleen, niin muutos tulee voimaan.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Sulje sovellus nyt';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Päivitä kirjasto';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Päivitä kaikki kirjastot';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Lisäyspäivä (vanhimmat ensin)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Lisäyspäivä (uusimmat ensin)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Aakkosjärjestys (A–Ö)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Aakkosjärjestys (Ö–A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Ladataan palvelimen analytiikkaa... $percentage %';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Sama kuin lähteessä';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 -elokuvat';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 -sarjat';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb:n suosituimmat elokuvat';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb:n suosituimmat sarjat';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb:n huonoimmin arvostellut elokuvat';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb:n parhaat englanninkieliset elokuvat';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -32,7 +32,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Connexion rapide';
 
   @override
   String get password => 'Mot de passe';
@@ -113,7 +113,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancel => 'Annuler';
 
   @override
-  String get remove => 'Retirer';
+  String get remove => 'Supprimer';
 
   @override
   String get connectToServer => 'Se connecter au serveur';
@@ -141,11 +141,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAppearanceTheme => 'Thème de l\'application';
 
   @override
-  String get detailScreenStyle => 'Style de l\'écran de détails';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Classique correspond à la mise en page centrée d\'origine de Moonfin. Moderne propose une mise en page cinématographique et adaptative.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
   String get detailScreenStyleMoonfin => 'Classique';
@@ -154,39 +154,39 @@ class AppLocalizationsFr extends AppLocalizations {
   String get detailScreenStyleModern => 'Moderne';
 
   @override
-  String get expandedTabs => 'Onglets déployés';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Affiche automatiquement le contenu des onglets pendant que vous les parcourez. Désactivez cette option pour ouvrir et fermer chaque onglet manuellement.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Afficher les détails techniques ?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Afficher le codec, la résolution et les informations de flux dans le résumé de la bannière';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
   String get recommendationSystem => 'Système de recommandation';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Utilisez l\'algorithme local « Moonfin recommande » ou les mesures de similarité TMDb en ligne. Remarque : les recommandations en ligne nécessitent l\'intégration Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin recommande';
 
   @override
-  String get recommendationSystemTmdb => 'Similarité TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Appliquer la limite de classification parentale ?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limiter les suggestions de « Moonfin recommande » selon la classification parentale du média ciblé';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
   String get interfaceStyle => 'Style d\'interface';
@@ -205,11 +205,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Qualité de l\'effet verre';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto choisit le meilleur effet verre pour cet appareil. Complet force un vrai flou ; Réduite utilise un effet verre léger qui économise le GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
@@ -229,7 +229,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get customThemeSubtitle =>
-      'Les thèmes personnalisés modifient les éléments visuels dans tout Moonfin. Choisissez l\'une de ces options selon votre style.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Préférer le clavier système';
@@ -264,7 +264,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Style pixel-art rétro avec une palette épaisse, des bordures carrées, des ombres portées franches et une police pixelisée';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -335,7 +335,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gameSaveState => 'Sauvegarder';
 
   @override
-  String get games => 'Jeux';
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Charger une sauvegarde';
@@ -347,14 +347,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gameEmulatorSettings => 'Paramètres d\'émulateur';
 
   @override
-  String get gameNoCoreOptions => 'Ce cœur ne propose aucune option réglable.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
   String get gameHoldToOpenMenu => 'Gardez appuyé pour ouvrir le menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'La lecture de jeux n\'est pas encore prise en charge sur cet appareil.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -768,43 +768,43 @@ class AppLocalizationsFr extends AppLocalizations {
   String get books => 'Livres';
 
   @override
-  String get latestBooks => 'Livres récemment ajoutés';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Livres audio récemment ajoutés';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count livres',
-      one: '1 livre',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Livre';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Livre audio';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% lu';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time restant';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lire';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Écouter';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Auteur';
@@ -1007,10 +1007,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Coulisses';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Scènes supprimées';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
@@ -1019,13 +1019,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scènes';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Courts-métrages';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Bandes-annonces';
+  String get trailers => 'Remorques';
 
   @override
   String timeRemaining(String time) {
@@ -1362,13 +1362,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shuffle => 'Aléatoire';
 
   @override
-  String get shuffleAllMusic => 'Lire toute la musique en aléatoire';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Connectez-vous à Moonfin sur votre téléphone';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Impossible de joindre votre serveur';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1380,7 +1380,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count canaux';
+    return '${count}ch';
   }
 
   @override
@@ -2311,7 +2311,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Pages de détails, rangées d\'accueil et volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2326,11 +2326,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Lire lors de la navigation sur l’écran d’accueil';
 
   @override
-  String get loopThemeMusic => 'Lire le thème musical en boucle';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Répéter la piste au lieu de la lire une seule fois';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Flou d’arrière-plan des détails';
@@ -2446,17 +2446,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get transcodingAudio => 'Transcodage (audio)';
 
   @override
-  String get directStreamRemux => 'Flux direct (remuxage)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodage (débit ou résolution)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodage (vidéo et audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodage (vidéo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (par défaut du serveur)';
@@ -2540,7 +2540,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Choisissez comment l\'audio est décodé. AVR Passthrough envoie les flux Dolby/DTS directement à votre ampli sans traitements ; Auto ou Downmix décode localement.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Passthrough AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Codec audio de secours';
@@ -2563,16 +2563,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sans perte)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
   String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stéréo uniquement)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficace)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sans perte)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
   String get settingsMaxAudioChannels => 'Nombre maximum de canaux audio';
@@ -3117,8 +3117,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les bibliothèques dans la barre d’outils';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Toujours afficher les libellés de la barre de navigation';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
   String get showSeerrButton => 'Afficher le bouton Seerr';
@@ -3323,11 +3322,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Lire automatiquement les bandes-annonces dans la barre média après 3 secondes';
 
   @override
-  String get trailerAudio => 'Audio des bandes-annonces';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Activer l\'audio des bandes-annonces dans la barre média';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Aperçu de l\'épisode';
@@ -3548,7 +3546,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get imdb => 'IMDb';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'BDTM';
 
   @override
   String get metacritic => 'Métacritique';
@@ -3608,7 +3606,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer et réorganiser les sources de notes affichées dans l’app';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Moonbase Plugin';
 
   @override
   String get pluginDetected => 'Plugin détecté';
@@ -3706,26 +3704,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notifications de nouvelles demandes';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'M\'avertir lorsque quelqu\'un soumet une demande';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Suivi des demandes';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Approuvées, refusées et ajoutées à votre bibliothèque';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Suivi des problèmes';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nouveaux problèmes, réponses et résolutions';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3863,7 +3860,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value Go';
+    return '$value GB';
   }
 
   @override
@@ -3897,11 +3894,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Téléchargement · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importation en cours';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -4044,148 +4041,148 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deletedStatus => 'Supprimé';
 
   @override
-  String get failedStatus => 'Échoué';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'En cours de traitement';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modifié par $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Terminé';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ce titre a déjà été demandé';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Limite de demandes atteinte';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Ce titre est sur la liste de blocage';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Aucune saison à demander';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Vous n\'avez pas l\'autorisation d\'effectuer cette demande';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Demandes';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problèmes';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Plus récentes';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Dernière modification';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Aucun problème';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining demandes de films restantes sur $limit';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining demandes de saisons restantes sur $limit';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Fait partie de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Voir la collection';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Demander la collection';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total films · $available disponibles';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Demander $count films';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Demande de $current sur $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count films demandés';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok films demandés sur $total';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Tous les films sont déjà disponibles ou demandés';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Signaler un problème';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vidéo';
+  String get issueTypeVideo => 'Video';
 
   @override
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Quel est le problème ?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Tous les épisodes';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Épisode';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Ouvert';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Résolu';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Résoudre';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Rouvrir';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Signalé par $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count commentaires';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Ajouter un commentaire';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Supprimer ce problème ?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Envoyer le signalement';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Score TMDB';
@@ -4302,7 +4299,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get refresh => 'Actualiser';
 
   @override
-  String get remote => 'Télécommande';
+  String get remote => 'À distance';
 
   @override
   String get rename => 'Renommer';
@@ -4347,7 +4344,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get time => 'Heure';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Jeu de trucs';
 
   @override
   String get uninstall => 'Désinstaller';
@@ -4389,25 +4386,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliothèques';
 
   @override
-  String get adminDrawerDisplay => 'Affichage';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Métadonnées';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Paramètres NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodage';
 
   @override
-  String get adminDrawerResume => 'Reprendre';
+  String get adminDrawerResume => 'Reprise';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Jeu de trucs';
 
   @override
   String get adminDrawerDevices => 'Appareils';
@@ -4579,10 +4576,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sessionRewind => 'Retour rapide';
 
   @override
-  String get sessionForward => 'Avancer';
+  String get sessionForward => 'Avance rapide';
 
   @override
-  String get sessionNext => 'Suivant';
+  String get sessionNext => 'Suiv.';
 
   @override
   String get sessionVolumeDown => 'Vol –';
@@ -4624,10 +4621,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminClearDates => 'Effacer les dates';
 
   @override
-  String get adminActivitySeverityAll => 'Toutes les gravités';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Plage de dates';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4664,23 +4661,23 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Supprimer l\'appareil « $name » ? L\'utilisateur devra se reconnecter sur cet appareil.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Supprimer tous les appareils';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Supprimer $count appareils ? Les utilisateurs concernés devront se reconnecter. Votre appareil actuel n\'est pas affecté.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Appareils supprimés';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Certains appareils ont été supprimés ; $count n\'ont pas pu l\'être.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4799,258 +4796,244 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminMetadataCountryHint => 'ex. : US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Chemins';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
   String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Téléchargeurs';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Enregistreurs de métadonnées';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Téléchargeurs de sous-titres';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Téléchargeurs de paroles';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Téléchargeurs de métadonnées : $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Récupérateurs d\'images : $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ce serveur ne propose aucun téléchargeur pour ce type de bibliothèque.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Général';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Métadonnées';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Informations intégrées';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Sous-titres';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
   String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Séries';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musique';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Films';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Activer la surveillance en temps réel';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Détecter les modifications de fichiers et les traiter automatiquement.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Traiter les archives comme des fichiers multimédias';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Afficher les photos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Enregistrer les visuels dans les dossiers multimédias';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval =>
-      'Actualisation automatique des métadonnées';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Jamais';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Par défaut';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Affichage';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Affichage de la bibliothèque';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Afficher une vue dossier pour montrer les dossiers multimédias bruts';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Afficher les épisodes spéciaux dans les saisons où ils ont été diffusés';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Regrouper les films en collections';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Regrouper les séries en collections';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Afficher du contenu externe dans les suggestions';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportement de la date d\'ajout';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Utiliser la date d\'ajout provenant de';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Date d\'analyse dans la bibliothèque';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Date de création du fichier';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Métadonnées et images';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Langue préférée des métadonnées';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Chapitres';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Durée des chapitres factices (secondes)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Durée des chapitres générés pour les médias qui n\'en ont pas. Réglez sur 0 pour désactiver.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Résolution des images de chapitre';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Paramètres NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Les métadonnées NFO sont compatibles avec Kodi et les clients similaires. Ces paramètres s\'appliquent à toutes les bibliothèques qui enregistrent des métadonnées NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Utilisateur dont les données de visionnage sont enregistrées dans les fichiers NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Enregistrer les chemins d\'images dans les fichiers NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Activer la substitution de chemin pour les chemins d\'images NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copier les images extrafanart dans un dossier extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Aucun';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days jours';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Utiliser les titres intégrés';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Utiliser les titres intégrés pour les extras';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Utiliser les informations d\'épisode intégrées';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Autoriser les sous-titres intégrés';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Tout autoriser';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Texte uniquement';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Image uniquement';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Aucun';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Ignorer le téléchargement si des sous-titres intégrés sont présents';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Ignorer le téléchargement si la piste audio correspond à la langue de téléchargement';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Exiger une correspondance parfaite des sous-titres';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Enregistrer les sous-titres dans les dossiers multimédias';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Extraire les images de chapitre';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extraire les images de chapitre pendant l\'analyse de la bibliothèque';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Activer l\'extraction des images trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extraire les images trickplay pendant l\'analyse de la bibliothèque';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Enregistrer les images trickplay dans les dossiers multimédias';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Fusionner automatiquement les séries réparties sur plusieurs dossiers';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nom d\'affichage de la saison zéro';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Activer l\'analyse LUFS pour la normalisation audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Préférer le tag d\'artistes non standard';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Ajouter automatiquement les films aux collections';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Le nom de la bibliothèque est requis';
@@ -5295,147 +5278,143 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminEnableAllChannels => 'Activer l\'accès à toutes les chaînes';
 
   @override
-  String get adminParentalControl => 'Contrôle parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Classification parentale maximale autorisée';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Le contenu dont la classification est supérieure sera masqué à cet utilisateur.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Aucune';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloquer les éléments sans classification ou dont la classification n\'est pas reconnue';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Livres';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Chaînes';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV en direct';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Films';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musique';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Bandes-annonces';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Séries';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Horaires d\'accès';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'N\'autoriser l\'accès que pendant les plages horaires ci-dessous. L\'accès est autorisé toute la journée si aucun horaire n\'est défini.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Ajouter un horaire';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Jour';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Début';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fin';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Tous les jours';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'En semaine';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Week-end';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Dimanche';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Lundi';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Mardi';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Mercredi';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Jeudi';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Vendredi';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Samedi';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tags autorisés';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Seul le contenu portant ces tags est affiché. Laissez vide pour tout autoriser.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Tags bloqués';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Le contenu portant ces tags est masqué à cet utilisateur.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Ajouter un tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Appareils activés';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Chaînes activées';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Fournisseur d\'authentification';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Fournisseur de réinitialisation du mot de passe';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Nombre maximal de tentatives de connexion échouées avant verrouillage';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Réglez sur 0 pour la valeur par défaut, ou sur -1 pour désactiver le verrouillage.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Accès SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Autoriser la création de groupes et la participation';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Autoriser la participation aux groupes';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Aucun accès';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Autoriser la suppression de contenu depuis';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5523,26 +5502,25 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Créer une sauvegarde';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Choisissez ce qui doit être inclus dans la sauvegarde.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Base de données';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Toujours incluse';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Métadonnées';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Sous-titres';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Images trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Création de la sauvegarde...';
@@ -6259,65 +6237,60 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminAddTuner => 'Ajouter un tuner';
 
   @override
-  String get adminEditTuner => 'Modifier le tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fichier ou URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Adresse IP du tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nom convivial';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limite de connexions simultanées';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Nombre maximal de flux que le tuner autorise simultanément. Réglez sur 0 pour un nombre illimité.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Débit de streaming maximal de secours';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importer uniquement les chaînes favorites';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Autoriser le transcodage matériel';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Autoriser le conteneur de transcodage fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Autoriser le partage de flux';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Activer la lecture en boucle du flux';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorer les DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Lire l\'entrée à la fréquence d\'images native';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Modifier le fournisseur';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6326,50 +6299,50 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fichier ou URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Préfixe des films';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Catégories de films';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Séparez plusieurs catégories par une barre verticale.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Catégories jeunesse';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Catégories actualités';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Catégories sports';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nom d\'utilisateur';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Mot de passe';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Pays';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Sélectionner un pays';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Code postal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obtenir les grilles de programmes';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Grilles de programmes';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Activer tous les tuners';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Type de tuner';
@@ -6411,7 +6384,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ce type de tuner ne prend pas en charge la réinitialisation.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6434,46 +6407,43 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Chemin d\'enregistrement des séries';
 
   @override
-  String get adminMovieRecordingPath => 'Chemin d\'enregistrement des films';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Jours de données du guide';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatique';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days jours';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Chemin de l\'application de post-traitement';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Arguments du post-traitement';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Enregistrer les métadonnées NFO des enregistrements';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages =>
-      'Enregistrer les images des enregistrements';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Minutage';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Chemins d\'enregistrement';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Post-traitement';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Données du guide : $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6518,15 +6488,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminGuideProviders => 'Fournisseurs de guide';
 
   @override
-  String get adminRefreshGuideData => 'Actualiser les données du guide';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Actualisation des données du guide lancée';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'La tâche d\'actualisation du guide n\'est pas disponible sur ce serveur.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Ajouter un fournisseur';
@@ -6660,7 +6629,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Éditeur de métadonnées';
 
   @override
-  String get adminMetadataIdentify => 'Identifier';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Taper';
@@ -6945,7 +6914,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Retirer';
+  String get adminReposRemove => 'Supprimer';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7076,20 +7045,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Activer l’écran de démarrage';
 
   @override
-  String get adminBrandingSplashUpload => 'Téléverser une image';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Écran de démarrage mis à jour';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Échec du téléversement de l\'écran de démarrage';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Écran de démarrage supprimé';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Aucun écran de démarrage personnalisé';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Accélération matérielle';
@@ -7105,122 +7073,118 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer le décodage matériel pour :';
 
   @override
-  String get adminPlaybackQsvDevice => 'Périphérique QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Activer le décodeur NVDEC amélioré';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Préférer le décodeur matériel natif du système';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profondeur de couleur du décodage matériel';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Décodage HEVC 10 bits';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Décodage VP9 10 bits';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Décodage HEVC RExt 8/10 bits';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'Décodage HEVC RExt 12 bits';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Encodage matériel';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Autoriser l\'encodage HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Autoriser l\'encodage AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Activer l\'encodeur H.264 basse consommation Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Activer l\'encodeur HEVC basse consommation Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Activer le tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Activer le tone mapping VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Activer le tone mapping VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algorithme de tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Mode de tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Plage de tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Désaturation du tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pic de tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Paramètre de tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Luminosité du tone mapping VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste du tone mapping VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Préréglages et qualité';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Préréglage de l\'encodeur';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF d\'encodage H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF d\'encodage H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Méthode de désentrelacement';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Doubler la fréquence d\'images lors du désentrelacement';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Activer l\'encodage audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Amplification du downmix audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algorithme de downmix stéréo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Taille maximale de la file de multiplexage';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7347,7 +7311,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminTaskStop => 'Arrêter';
 
   @override
-  String get adminRunningTasks => 'Tâches en cours';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Exécuter';
@@ -7464,7 +7428,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '${minutes}min';
+    return '${minutes}m';
   }
 
   @override
@@ -7474,12 +7438,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String adminActivityDaysShort(int days) {
-    return '${days}j';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7499,44 +7463,43 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Port HTTP public';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Exiger HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Rediriger toutes les requêtes distantes vers HTTPS. Sans effet si le serveur ne possède pas de certificat valide.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Mot de passe du certificat';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Paramètres IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Activer IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Activer IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Activer le mappage automatique des ports';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Réseaux locaux (LAN)';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Liste d\'adresses IP ou de sous-réseaux CIDR, séparés par des virgules ou des retours à la ligne, considérés comme faisant partie du réseau local.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI de serveur publiées';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Associez un sous-réseau ou une adresse à une URL publiée, ex. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Chemin du certificat';
@@ -7569,11 +7532,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Limiter la mise en mémoire tampon';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Délai de limitation (secondes)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Autoriser l\'extraction des sous-titres à la volée';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Pourcentage minimum de reprise';
@@ -7629,23 +7592,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Seuil de réponse lente (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Activer les avertissements de réponse lente';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Activer Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Serveur';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Métadonnées';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Chemins';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Performances';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Chemin du cache';
@@ -7657,7 +7619,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminGeneralServerName => 'Nom du serveur';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Langue d\'affichage préférée';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Échec du chargement des paramètres';
@@ -7900,21 +7862,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get offlineSavedMedia => 'Médias enregistrés';
 
   @override
-  String get offlineBannerTitle => 'Vous êtes hors ligne';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Affichage de vos téléchargements';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Téléchargements';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Impossible de joindre votre serveur';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Lecture depuis vos téléchargements en attendant son retour';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7994,35 +7955,35 @@ class AppLocalizationsFr extends AppLocalizations {
   String get pinBackspace => 'Retour arrière';
 
   @override
-  String get quickConnectAuthorized => 'Requête Quick Connect autorisée.';
+  String get quickConnectAuthorized => 'Demande de connexion rapide autorisée.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Le code Quick Connect est invalide ou expiré.';
+      'Le code de connexion rapide est invalide ou expiré.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect n\'est pas pris en charge sur ce serveur.';
+      'La connexion rapide n\'est pas prise en charge sur ce serveur.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Échec de l\'autorisation du code Quick Connect.';
+      'Échec de l\'autorisation du code de connexion rapide.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect est désactivé sur ce serveur.';
+      'La connexion rapide est désactivée sur ce serveur.';
 
   @override
   String get quickConnectForbidden =>
-      'Votre compte ne peut pas autoriser cette requête Quick Connect.';
+      'Votre compte ne peut pas autoriser cette demande de connexion rapide.';
 
   @override
   String get quickConnectNotFound =>
-      'Code Quick Connect introuvable. Essayez un nouveau code.';
+      'Code de connexion rapide introuvable. Essayez un nouveau code.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Échec de Quick Connect : $message';
+    return 'Échec de la connexion rapide : $message';
   }
 
   @override
@@ -8276,13 +8237,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Masquer de « Continuer de regarder »';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Masquer de « À suivre »';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Ajouter à une collection';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8345,7 +8306,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Faire confiance aux serveurs utilisant des certificats TLS auto-signés ou émis par une autorité privée. N\'activez cette option que pour les serveurs que vous contrôlez. Elle désactive la validation des certificats pour toutes les connexions.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'CONFIDENTIALITÉ ET SÉCURITÉ';
@@ -8361,11 +8322,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Couleurs d\'accentuation, vignettes, indicateurs de visionnage et musique de thème';
 
   @override
-  String get settingsDetailsScreen => 'Écran de détails';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Style, flou d\'arrière-plan et comportement des onglets';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Page d\'accueil';
@@ -8407,7 +8368,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Toujours afficher les libellés dans la barre de navigation supérieure';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8870,8 +8831,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les détails de l\'élément sélectionné en haut des pages de la bibliothèque.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Masquer les arrière-plans pendant la navigation ?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Informations détaillées sous le titre';
@@ -9086,22 +9046,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appearance => 'Apparence';
 
   @override
-  String get layout => 'Mise en page';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Thème';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Clavier';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Boutons';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Rendu';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configuration mpv';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Taille des visuels des rangées d\'accueil';
@@ -9560,7 +9520,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mixedMoviesAndShows => 'Films et émissions mixtes';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Synchronisation rapide Intel';
 
   @override
   String get rockchipMpp => 'Député de Rockchip';
@@ -9791,28 +9751,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Chapitres';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marque-pages';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
   String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'File d\'attente';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Chronologie';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'La chronologie est vide';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
   String get audiobookWholeBook => 'Livre entier';
 
   @override
-  String get audiobookFocusedTimeline => 'Chronologie ciblée';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
   String get audiobookExportBookmarks => 'Exporter les marque-pages';
@@ -9887,12 +9847,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Reculer de ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Avancer de ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
@@ -9929,7 +9889,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Enregistrer';
+  String get audiobookSave => 'Sauvegarder';
 
   @override
   String get audiobookCancel => 'Annuler';
@@ -10047,8 +10007,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le profil vidéo n\'est pas supporté.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Le niveau vidéo n\'est pas supporté.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
@@ -10056,7 +10015,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'La profondeur de bits vidéo n\'est pas supportée.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
@@ -10091,95 +10050,92 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sortCustomDragDrop => 'Personnalisé (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Options de tri de la playlist';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Réinitialiser le tri';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Revoir S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Revoir la playlist';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Aucun sous-titre trouvé.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Contrôles d\'administration';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Moteur de rendu (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller est le moteur de rendu GPU moderne de Flutter : animations plus fluides et moins de saccades. Sur certains boîtiers TV et GPU anciens, il peut provoquer des artefacts ou une image noire ; désactivez-le si vous constatez ces problèmes. Automatique choisit le meilleur réglage pour votre appareil. Redémarrez Moonfin pour appliquer.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatique';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Activé';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Désactivé';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Redémarrage requis';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin doit redémarrer pour changer de moteur de rendu. Fermez l\'application maintenant, puis rouvrez-la pour appliquer le changement.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
   String get impellerCloseNow => 'Fermer l\'application immédiatement';
 
   @override
-  String get adminRefreshLibrary => 'Actualiser la bibliothèque';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Actualiser toutes les bibliothèques';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Date d\'ajout (les plus anciens d\'abord)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Date d\'ajout (les plus récents d\'abord)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alphabétique (A à Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alphabétique (Z à A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Chargement des analyses du serveur... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Identique à la source';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 des films';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 des séries TV';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Films les plus populaires';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Séries TV les plus populaires';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Films les moins bien notés';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb Meilleurs films anglophones';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -12,19 +12,19 @@ class AppLocalizationsGl extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERENCIAS DA CONTA';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Idioma da interface';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Predeterminado do sistema';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Iniciar sesión';
 
   @override
-  String get empty => 'Baleiro';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Conexión rápida';
 
   @override
   String get password => 'Contrasinal';
@@ -51,7 +51,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get waitingForAuthorization => 'Agardando autorización...';
 
   @override
-  String get back => 'Atrás';
+  String get back => 'De volta';
 
   @override
   String get serverUnavailable => 'O servidor non está dispoñible';
@@ -113,7 +113,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get cancel => 'Cancelar';
 
   @override
-  String get remove => 'Retirar';
+  String get remove => 'Eliminar';
 
   @override
   String get connectToServer => 'Conectar ao servidor';
@@ -122,7 +122,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get serverAddress => 'Enderezo do servidor';
 
   @override
-  String get serverAddressHint => 'https://o-teu-servidor.exemplo.com';
+  String get serverAddressHint => 'https://your-server.example.com';
 
   @override
   String get connect => 'Conectar';
@@ -141,62 +141,62 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema da aplicación';
 
   @override
-  String get detailScreenStyle => 'Estilo da pantalla de detalles';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Clásico é a disposición centrada orixinal de Moonfin. Moderno é unha disposición cinematográfica adaptable.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Clásico';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderno';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Pestanas despregadas';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Mostra automaticamente o contido das pestanas mentres navegas por elas. Desactívao para abrir e pechar cada pestana manualmente.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Mostrar os detalles técnicos?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Mostra o códec, a resolución e a información do fluxo no resumo do báner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistema de recomendacións';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Usa o algoritmo local de recomendacións de Moonfin (Recomendacións Moonfin) ou as métricas de similitude en liña de TMDb. Nota: as recomendacións en liña requiren a integración con Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Recomendacións Moonfin';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Similitude de TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Aplicar o límite de clasificación parental?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limita as suxestións de Recomendacións Moonfin segundo a clasificación parental do contido de destino';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Estilo da interface';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automático adáptase ao teu dispositivo. Escolle Apple ou Material para forzar un aspecto concreto.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automático';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsGl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Calidade de Glass';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto escolle o mellor efecto Glass para este dispositivo. Completo forza un desenfoque real; Reducido usa un efecto lixeiro que aforra enerxía da GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Completo';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reducido';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Cambia entre Moonfin e Neon Pulse sen reiniciar a aplicación';
 
   @override
-  String get customThemeTitle => 'Tema personalizado';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Os temas personalizados modifican os elementos visuais de todo Moonfin. Escolle unha destas opcións segundo o teu estilo.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Prefire o teclado do sistema';
@@ -257,14 +257,14 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Estilo Liquid Glass cun fondo de degradado en movemento, superficies esmeriladas e acento azul Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Estilo retro de pixel art cunha paleta contundente, bordos cadrados, sombras marcadas e unha tipografía de píxeles';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -328,35 +328,35 @@ class AppLocalizationsGl extends AppLocalizations {
   String get exit => 'Saír';
 
   @override
-  String get gameMenu => 'Menú';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pausado';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Gardar estado';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Xogos';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Cargar estado';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Avance rápido';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Configuración do emulador';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Este núcleo non ten opcións axustables.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Mantén premido para abrir o menú';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Aínda non se poden executar xogos neste dispositivo.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Non se puideron cargar filas de inicio';
@@ -378,13 +378,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get schedule => 'Horario';
 
   @override
-  String get series => 'Series';
+  String get series => 'Serie';
 
   @override
   String get noItemsFound => 'Non se atoparon elementos';
 
   @override
-  String get home => 'Inicio';
+  String get home => 'Casa';
 
   @override
   String get browseAll => 'Explorar todo';
@@ -557,7 +557,7 @@ class AppLocalizationsGl extends AppLocalizations {
       'Escolle que fontes de temas queres mostrar en Discover.';
 
   @override
-  String get apply => 'Aplicar';
+  String get apply => 'Solicitar';
 
   @override
   String get openLink => 'Abrir ligazón';
@@ -607,7 +607,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get listen => 'Escoita';
 
   @override
-  String get resume => 'Retomar';
+  String get resume => 'Currículo';
 
   @override
   String get failedToLoadLibrary => 'Produciuse un erro ao cargar a biblioteca';
@@ -752,13 +752,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get readStatus => 'Ler';
 
   @override
-  String get watched => 'Visto';
+  String get watched => 'Vixiado';
 
   @override
   String get unread => 'Non lido';
 
   @override
-  String get unwatched => 'Non visto';
+  String get unwatched => 'Sen vixiar';
 
   @override
   String get seriesStatus => 'Estado da serie';
@@ -770,43 +770,43 @@ class AppLocalizationsGl extends AppLocalizations {
   String get books => 'Libros';
 
   @override
-  String get latestBooks => 'Últimos libros';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Últimos audiolibros';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count libros',
-      one: '1 libro',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Libro';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiolibro';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% lido';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Quedan $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Ler';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Escoitar';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -884,8 +884,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiolibros',
-      one: '1 audiolibro',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -921,7 +921,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get nextUp => 'A continuación';
 
   @override
-  String get seasons => 'Tempadas';
+  String get seasons => 'Estacións';
 
   @override
   String get chapters => 'Capítulos';
@@ -989,8 +989,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tempadas',
-      one: '1 tempada',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1001,40 +1001,40 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get items => 'Elementos';
+  String get items => 'Items';
 
   @override
   String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Tras as cámaras';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Escenas eliminadas';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Reportaxes';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Entrevistas';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Escenas';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Curtametraxes';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Tráilers';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'Quedan $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Remata en $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1052,7 +1052,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get play => 'Reproducir';
+  String get play => 'Xogar';
 
   @override
   String get startOver => 'Comezar de novo';
@@ -1076,7 +1076,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Tráiler';
@@ -1277,13 +1277,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
-  String get directors => 'DIRECTORES';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'GUIONISTA';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'GUIONISTAS';
+  String get writers => 'ESCRITORES';
 
   @override
   String get studio => 'ESTUDIO';
@@ -1318,8 +1318,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pistas',
-      one: '1 pista',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1329,8 +1329,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count capítulos',
-      one: '1 capítulo',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1357,16 +1357,16 @@ class AppLocalizationsGl extends AppLocalizations {
   String get readMore => 'Ler máis';
 
   @override
-  String get shuffle => 'Aleatorio';
+  String get shuffle => 'Barallar';
 
   @override
-  String get shuffleAllMusic => 'Reproducir toda a música en modo aleatorio';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Inicia sesión en Moonfin no teu teléfono';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Non se pode conectar co teu servidor';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1378,7 +1378,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count can.';
+    return '${count}ch';
   }
 
   @override
@@ -1568,7 +1568,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get transcodeReasons => 'Razóns de transcodificación';
 
   @override
-  String get player => 'Reprodutor';
+  String get player => 'Xogador';
 
   @override
   String get container => 'Recipiente';
@@ -1809,22 +1809,22 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'A continuación: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min restantes';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours h restantes';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours h $minutes min restantes';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1862,7 +1862,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get unableToCreateRecording => 'Non se puido crear a gravación';
 
   @override
-  String get watch => 'Ver';
+  String get watch => 'Observa';
 
   @override
   String get close => 'Pechar';
@@ -2037,7 +2037,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2061,7 +2061,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -2080,8 +2080,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episodios',
-      one: '1 episodio',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2310,7 +2310,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Páxinas de detalle, filas de inicio e volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2325,11 +2325,11 @@ class AppLocalizationsGl extends AppLocalizations {
       'Xoga ao navegar pola pantalla de inicio';
 
   @override
-  String get loopThemeMusic => 'Música do tema en bucle';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repite a pista en vez de reproducila unha soa vez';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detalles desenfoque de fondo';
@@ -2352,17 +2352,17 @@ class AppLocalizationsGl extends AppLocalizations {
   String get playerZoomMode => 'Modo de zoom do xogador';
 
   @override
-  String get settingsScrollWheelAction => 'Roda do rato';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Escolle o que fai desprazar a roda do rato sobre o vídeo durante a reprodución.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Desactivado';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Buscar (adiante / atrás)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2422,38 +2422,37 @@ class AppLocalizationsGl extends AppLocalizations {
   String get defaultAudioLanguage => 'Idioma de audio predeterminado';
 
   @override
-  String get fallbackAudioLanguage => 'Idioma de audio alternativo';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Preferir a pista de audio predeterminada';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Prefire a pista de audio orixinal en vez da dobraxe localizada.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferir as pistas de audiodescrición';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Prefire as pistas de audiodescrición en vez das normais.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcodificación (audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Transmisión directa (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodificación (taxa de bits ou resolución)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodificación (vídeo e audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodificación (vídeo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automático (Servidor predeterminado)';
@@ -2534,7 +2533,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Escolle como se decodifica o audio. AVR Passthrough envía os fluxos Dolby/DTS en bruto ao teu receptor; Auto ou Downmix decodifican localmente.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Paso AVR';
@@ -2544,14 +2543,13 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Escolle o formato de destino para transcodificar o audio multicanle cando o fluxo de orixe non se pode reproducir de forma nativa nin transmitir directamente.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detección automática\n(Recomendado)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Predeterminado)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2560,39 +2558,38 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sen perdas)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Só estéreo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficiente)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sen perdas)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Máximo de canles de audio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configura o número máximo de canles da túa configuración de audio. Os fluxos multicanle que superen este límite reduciranse (downmix) ou transcodificaranse.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detección automática\n(Predeterminado do hardware)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estéreo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Cuadrafónico';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2610,7 +2607,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAudioPassthroughAdvanced => 'Paso directo (avanzado)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough do códec';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
@@ -2620,19 +2617,19 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAudioEac3Passthrough => 'Paso EAC3';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'Paso DTS-HD MA';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2640,35 +2637,34 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Envía o bitstream Dolby Atmos sobre EAC3 (JOC) ao decodificador externo.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Envía o bitstream DTS-HD MA (inclúe o DTS core) ao decodificador externo.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Envía o bitstream Dolby TrueHD con metadatos Atmos ao decodificador externo.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Capacidades de audio detectadas';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Aínda non hai ningunha captura de capacidades en tempo de execución.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Ruta';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Decodificación';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Ruta de audio HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2683,50 +2679,50 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Altofalante';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Auriculares';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count can. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnóstico';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Nivel de vídeo';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Rango de vídeo';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Códec de subtítulos';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Códecs de audio permitidos';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Códecs de audio HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Códecs de audio HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'passthrough audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Ruta de audio activa';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Compatibilidade de audio HD da ruta';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Modo nocturno';
@@ -2790,7 +2786,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Despois de $episodes episodios / $hours h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2867,45 +2863,45 @@ class AppLocalizationsGl extends AppLocalizations {
       'Personaliza o aspecto dos subtítulos';
 
   @override
-  String get subtitleMode => 'Modo de subtítulos';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Marcados';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Sempre';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Estranxeiro';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Forzados';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Reproduce as pistas marcadas internamente nos metadatos do ficheiro como \"predeterminada\" ou \"forzada\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Carga e mostra automaticamente os subtítulos cada vez que comeza un vídeo.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Activa automaticamente os subtítulos se a pista de audio predeterminada está nun idioma estranxeiro.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Só carga os subtítulos marcados explicitamente co indicador de metadatos \"forzado\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Desactiva completamente a carga automática de subtítulos.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Idioma de subtítulos alternativo';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Fluxo de subtítulos';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2915,13 +2911,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get verticalOffset => 'Desfase vertical';
 
   @override
-  String get pgsDirectPlay => 'Reprodución directa de PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Subtítulos PGS de reprodución directa';
 
   @override
-  String get assSsaDirectPlay => 'Reprodución directa de ASS/SSA';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles =>
@@ -2965,17 +2961,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Cargouse a configuración do perfil $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Non se puido cargar a configuración do perfil $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Sincronizouse a configuración local co perfil $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3112,11 +3108,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostrar bibliotecas na barra de ferramentas';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Mostrar sempre as etiquetas da barra de navegación';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Mostrar o botón de Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacidade da barra de navegación';
@@ -3155,7 +3150,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get slate => 'Lousa';
 
   @override
-  String get indigo => 'Índigo';
+  String get indigo => 'Indigo';
 
   @override
   String get libraryDisplay => 'Exposición da biblioteca';
@@ -3192,19 +3187,18 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostrar a opción de navegación por cartafoles';
 
   @override
-  String get groupItemsIntoCollections => 'Agrupar os elementos en coleccións';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ocultar os elementos asociados a coleccións ao navegar polas bibliotecas';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Aviso sobre a agrupación de bibliotecas';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Para usar esta opción, asegúrate de que as opcións de biblioteca \"Agrupar as películas en coleccións\" e/ou \"Agrupar as series en coleccións\" estean activadas na configuración de visualización da túa biblioteca no servidor de Jellyfin ou Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilidade da biblioteca';
@@ -3233,7 +3227,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count seleccionados';
+    return '$count selected';
   }
 
   @override
@@ -3317,11 +3311,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Reproduce automaticamente tráilers na barra multimedia despois de 3 segundos';
 
   @override
-  String get trailerAudio => 'Audio dos tráilers';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Activar o audio dos tráilers na barra multimedia';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Vista previa do episodio';
@@ -3399,11 +3392,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Combina ambas filas nunha única sección de inicio';
 
   @override
-  String get fullScreenRows => 'Filas de inicio expandidas';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limita as filas de inicio a 1 fila por pantalla';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Tipo de imaxe por fila';
@@ -3418,7 +3410,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get lastUser => 'Último Usuario';
 
   @override
-  String get currentUser => 'Usuario actual';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autenticarse sempre';
@@ -3526,10 +3518,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostra o reloxo durante o protector de pantalla';
 
   @override
-  String get clockModeStatic => 'Estático';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Rebotando';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (críticos)';
@@ -3603,7 +3595,7 @@ class AppLocalizationsGl extends AppLocalizations {
       'Activa e reordena as fontes de valoración que se mostran na aplicación';
 
   @override
-  String get pluginLabel => 'Engadido Moonbase';
+  String get pluginLabel => 'Engadido';
 
   @override
   String get pluginDetected => 'Complemento detectado';
@@ -3621,7 +3613,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersión: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3675,7 +3667,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get networks => 'Redes';
 
   @override
-  String get seerrDiscoveryRows => 'Filas de descubrimento de Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3699,45 +3691,44 @@ class AppLocalizationsGl extends AppLocalizations {
   String get hideAdultContent => 'Ocultar contido para adultos nos resultados';
 
   @override
-  String get seerrNotificationsSection => 'Notificacións';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notificacións de solicitudes novas';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Avísame cando alguén envíe unha solicitude';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Actualizacións das solicitudes';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprobadas, rexeitadas e engadidas á túa biblioteca';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Actualizacións dos problemas';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Problemas novos, respostas e resolucións';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Sesión iniciada como: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Páxina de descubrimento de Seerr';
+  String get discoverRows => 'Descubre filas';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Activa as filas que queres ver na páxina principal de Seerr. Arrastra para reordenar. A orde personalizada sincronízase con Moonbase.';
+      'Arrastra para reordenar. Activa ou desactiva filas. As sincronizacións de orde de filas activadas co complemento Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Activa as filas que queres ver na páxina principal de Seerr. Arrastra para reordenar. A orde personalizada sincronízase con Moonbase.';
+      'Arrastra para reordenar. Activa ou desactiva filas.';
 
   @override
   String get enabled => 'Activado';
@@ -3750,7 +3741,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Versión $version';
+    return 'Version $version';
   }
 
   @override
@@ -3800,7 +3791,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Actualización dispoñible: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3812,7 +3803,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version dispoñible';
+    return 'v$version Available';
   }
 
   @override
@@ -3892,15 +3883,15 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Descargando · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importando';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count elementos';
+    return '$count Items';
   }
 
   @override
@@ -3920,7 +3911,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Solicitado por $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3937,12 +3928,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Cancelar a solicitude de \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Cancelar $count solicitudes de \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3958,12 +3949,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Orzamento: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Ingresos: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3973,7 +3964,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Solicitar $type';
+    return 'Request $type';
   }
 
   @override
@@ -4002,14 +3993,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get showMore => 'Mostrar máis';
 
   @override
-  String get appearances => 'Aparicións';
+  String get appearances => 'Aparencias';
 
   @override
   String get crewSection => 'Tripulación';
 
   @override
   String ageValue(int age) {
-    return 'idade $age';
+    return 'age $age';
   }
 
   @override
@@ -4040,148 +4031,148 @@ class AppLocalizationsGl extends AppLocalizations {
   String get deletedStatus => 'Eliminado';
 
   @override
-  String get failedStatus => 'Fallou';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'En proceso';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificado por $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Completada';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Este título xa se solicitou';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Acadaches o límite de solicitudes';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Este título está na lista de bloqueo';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Non quedan tempadas por solicitar';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Non tes permiso para facer esta solicitude';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Solicitudes';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemas';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Máis recentes';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Última modificación';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Non hai problemas';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Quédanche $remaining de $limit solicitudes de películas';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Quédanche $remaining de $limit solicitudes de tempadas';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Forma parte de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Ver a colección';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Solicitar a colección';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total películas · $available dispoñibles';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Solicitar $count películas';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Solicitando $current de $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Solicitáronse $count películas';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Solicitáronse $ok de $total películas';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Todas as películas xa están dispoñibles ou solicitadas';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Informar dun problema';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vídeo';
+  String get issueTypeVideo => 'Video';
 
   @override
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Que ocorre?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Todos os episodios';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episodio';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Aberto';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Resolto';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Resolver';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Reabrir';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Informado por $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comentarios';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Engadir un comentario';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Eliminar este problema?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Enviar o informe';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Puntuación TMDB';
@@ -4205,7 +4196,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get originalLanguageLabel => 'Lingua orixinal';
 
   @override
-  String get seasonsLabel => 'Tempadas';
+  String get seasonsLabel => 'Estacións';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -4250,7 +4241,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get error => 'Erro';
 
   @override
-  String get forward => 'Avanzar';
+  String get forward => 'Adiante';
 
   @override
   String get general => 'Xeral';
@@ -4274,7 +4265,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get networking => 'Rede';
 
   @override
-  String get next => 'Seguinte';
+  String get next => 'A continuación';
 
   @override
   String get path => 'Camiño';
@@ -4316,7 +4307,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get run => 'Corre';
 
   @override
-  String get search => 'Buscar';
+  String get search => 'Busca';
 
   @override
   String get select => 'Seleccione';
@@ -4334,7 +4325,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get status => 'Estado';
 
   @override
-  String get stop => 'Deter';
+  String get stop => 'Pare';
 
   @override
   String get streaming => 'Transmisión en directo';
@@ -4385,19 +4376,19 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotecas';
 
   @override
-  String get adminDrawerDisplay => 'Visualización';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadatos';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Configuración NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodificación';
 
   @override
-  String get adminDrawerResume => 'Retomar';
+  String get adminDrawerResume => 'Currículo';
 
   @override
   String get adminDrawerStreaming => 'Transmisión en directo';
@@ -4454,22 +4445,22 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Actualizacións de complementos dispoñibles: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Complementos que requiren reinicio: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Tarefas programadas fallidas: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Entradas recentes de aviso/erro: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4528,7 +4519,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Erro: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4556,7 +4547,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Fallou o comando: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4569,16 +4560,16 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminSetVolume => 'Establecer volume';
 
   @override
-  String get sessionPrev => 'Ant.';
+  String get sessionPrev => 'Prev';
 
   @override
   String get sessionRewind => 'Rebobinar';
 
   @override
-  String get sessionForward => 'Avanzar';
+  String get sessionForward => 'Adiante';
 
   @override
-  String get sessionNext => 'Seguinte';
+  String get sessionNext => 'A continuación';
 
   @override
   String get sessionVolumeDown => 'Vol -';
@@ -4605,7 +4596,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audioCodec => 'Codec de audio';
 
   @override
-  String get hwAccel => 'Acel. HW';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Finalización';
@@ -4620,14 +4611,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminClearDates => 'Datas claras';
 
   @override
-  String get adminActivitySeverityAll => 'Todas as gravidades';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Intervalo de datas';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar o rexistro de actividade: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4644,7 +4635,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Produciuse un erro ao actualizar o dispositivo: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4655,28 +4646,28 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar o dispositivo: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Eliminar o dispositivo \'$name\'? O usuario terá que iniciar sesión de novo neste dispositivo.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Eliminar todos os dispositivos';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Eliminar $count dispositivos? Os usuarios afectados terán que iniciar sesión de novo. O teu dispositivo actual non se verá afectado.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Elimináronse os dispositivos';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Elimináronse algúns dispositivos; $count non se puideron eliminar.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4707,7 +4698,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Produciuse un erro ao iniciar a exploración: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4718,12 +4709,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Renomeouse a biblioteca como \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Produciuse un erro ao renomear: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4731,17 +4722,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Eliminouse a biblioteca \"$name\"';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar a biblioteca: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Produciuse un erro ao engadir o camiño: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4749,12 +4740,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Quitar \"$path\" desta biblioteca?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Produciuse un erro ao quitar o camiño: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4762,7 +4753,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar as opcións: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4795,265 +4786,251 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminMetadataCountryHint => 'p.ex. EU, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Camiños';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcións';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Descargadores';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Gardadores de metadatos';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Descargadores de subtítulos';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Descargadores de letras';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Descargadores de metadatos: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Obtedores de imaxes: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Este servidor non ofrece ningún descargador para este tipo de biblioteca.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Xeral';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadatos';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Información incrustada';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtítulos';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imaxes';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
   String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Música';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Películas';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Activar a supervisión en tempo real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detecta os cambios nos ficheiros e procésaos automaticamente.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratar os arquivos como ficheiros multimedia';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Mostrar as fotos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Gardar as ilustracións nos cartafoles multimedia';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval =>
-      'Actualización automática dos metadatos';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nunca';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Predeterminado';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visualización';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Visualización da biblioteca';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Mostrar unha vista de cartafoles para ver os cartafoles multimedia simples';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Mostrar os especiais dentro das tempadas nas que se emitiron';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Agrupar as películas en coleccións';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Agrupar as series en coleccións';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Mostrar contido externo nas suxestións';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportamento da data de engadido';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Usar a data de engadido de';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data de exploración na biblioteca';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data de creación do ficheiro';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadatos e imaxes';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Idioma de metadatos preferido';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capítulos';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Duración dos capítulos simulados (segundos)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Duración dos capítulos xerados para o contido que non ten ningún. Establece 0 para desactivalo.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolución das imaxes dos capítulos';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Configuración NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Os metadatos NFO son compatibles con Kodi e clientes similares. A configuración aplícase a todas as bibliotecas que gardan metadatos NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Usuario do que se gardarán os datos de visualización nos ficheiros NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Gardar os camiños das imaxes nos ficheiros NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Activar a substitución de camiños para os camiños de imaxe dos NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copiar as imaxes de extrafanart nun cartafol extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ningún';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days días';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Usar os títulos incrustados';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usar os títulos incrustados para os extras';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usar a información de episodio incrustada';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Permitir os subtítulos incrustados';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permitir todo';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Só texto';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Só imaxe';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ningún';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Omitir a descarga se hai subtítulos incrustados';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Omitir a descarga se a pista de audio coincide co idioma de descarga';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Esixir unha coincidencia perfecta dos subtítulos';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Gardar os subtítulos nos cartafoles multimedia';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Extraer as imaxes dos capítulos';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extraer as imaxes dos capítulos durante a exploración da biblioteca';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Activar a extracción de imaxes de Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extraer as imaxes de Trickplay durante a exploración da biblioteca';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Gardar as imaxes de Trickplay nos cartafoles multimedia';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Combinar automaticamente as series repartidas en varios cartafoles';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nome que se mostra para a tempada cero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Activar a análise LUFS para a normalización do audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferir a etiqueta de artistas non estándar';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Engadir automaticamente as películas ás coleccións';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'O nome da biblioteca é necesario';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Produciuse un erro ao crear a biblioteca: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5080,27 +5057,27 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Desactivar a $name? Non poderá iniciar sesión.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Activar a $name? Poderá iniciar sesión de novo.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Desactivouse o usuario \"$name\"';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Activouse o usuario \"$name\"';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Produciuse un erro ao actualizar a política do usuario: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5117,7 +5094,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Produciuse un erro ao crear o usuario: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5138,7 +5115,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5149,7 +5126,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Fallou: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5289,147 +5266,143 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminEnableAllChannels => 'Activa o acceso a todas as canles';
 
   @override
-  String get adminParentalControl => 'Control parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Clasificación parental máxima permitida';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'O contido cunha clasificación superior ocultarase a este usuario.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ningunha';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloquear os elementos sen clasificación ou con clasificación non recoñecida';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Libros';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canles';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV en directo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Películas';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Música';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Tráilers';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Series';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Horarios de acceso';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permite o acceso só durante os horarios programados a continuación. Se non se define ningún horario, o acceso permítese todo o día.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Engadir un horario';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Día';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Inicio';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fin';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Todos os días';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Día laborable';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Fin de semana';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Domingo';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Luns';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Martes';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Mércores';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Xoves';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Venres';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sábado';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etiquetas permitidas';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Só se mostra o contido con estas etiquetas. Déixao baleiro para permitir todo.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etiquetas bloqueadas';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'O contido con estas etiquetas ocúltase a este usuario.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Engadir unha etiqueta';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispositivos activados';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canles activadas';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Provedor de autenticación';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Provedor de restablecemento do contrasinal';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Máximo de intentos de inicio de sesión fallidos antes do bloqueo';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Establece 0 para o valor predeterminado, ou -1 para desactivar o bloqueo.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Acceso a SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Permitir crear grupos e unirse a eles';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permitir unirse a grupos';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Sen acceso';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Permitir a eliminación de contido de';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5437,22 +5410,22 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'O servidor devolveu HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Seguro que queres eliminar a $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Eliminouse o usuario \"$name\"';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar o usuario: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5473,7 +5446,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Produciuse un erro ao crear a clave: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5485,7 +5458,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Revogar a clave de $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5493,7 +5466,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Produciuse un erro ao revogar a clave: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5514,30 +5487,29 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nCreada: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Crear unha copia de seguranza';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Escolle que queres incluír na copia de seguranza.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Base de datos';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Sempre incluída';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadatos';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtítulos';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imaxes de Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Creando copia de seguranza...';
@@ -5547,7 +5519,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Produciuse un erro ao crear a copia de seguranza: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5556,12 +5528,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Manifesto: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar o manifesto: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5572,7 +5544,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Produciuse un erro ao restaurar a copia de seguranza: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5606,17 +5578,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Gardouse en $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar o ficheiro: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Produciuse un erro ao cargar $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5627,7 +5599,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar as tarefas: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5639,17 +5611,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Produciuse un erro ao iniciar a tarefa: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Produciuse un erro ao deter a tarefa: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar a tarefa: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5657,12 +5629,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Produciuse un erro ao quitar o disparador: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Produciuse un erro ao engadir o disparador: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5688,7 +5660,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours hora(s)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5699,7 +5671,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Produciuse un erro ao activar ou desactivar o complemento: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5707,27 +5679,27 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Seguro que queres desinstalar \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Produciuse un erro ao desinstalar o complemento: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Produciuse un erro ao instalar o paquete: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Produciuse un erro ao instalar a actualización: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar os complementos: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5739,12 +5711,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Instalar a actualización (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar o catálogo: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5766,17 +5738,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" quitarase despois de reiniciar o servidor';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Produciuse un erro ao desinstalar: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Actualizando \"$name\" á v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5785,7 +5757,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar o complemento: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5793,7 +5765,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versión $version';
+    return 'Version $version';
   }
 
   @override
@@ -5814,17 +5786,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Seguro que queres quitar \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar os repositorios: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar os repositorios: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5841,12 +5813,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Non foi posible cargar a configuración do complemento: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Non foi posible abrir $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5975,7 +5947,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Produciuse un erro ao cargar a configuración de Trickplay';
+      'Produciuse un erro ao cargar a configuración de truco';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6091,7 +6063,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminBaseUrl => 'URL base';
 
   @override
-  String get adminBaseUrlHint => 'p.ex. /jellyfin';
+  String get adminBaseUrlHint => 'p.ex. /aleta';
 
   @override
   String get https => 'HTTPS';
@@ -6131,12 +6103,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar os metadatos: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar os metadatos: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6157,7 +6129,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Produciuse un erro ao actualizar os metadatos: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6171,7 +6143,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Fallou a busca remota: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6185,7 +6157,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Produciuse un erro ao actualizar o tipo de contido: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6200,12 +6172,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Actualizouse a imaxe $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Produciuse un erro ao descargar a imaxe: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6217,27 +6189,27 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Cargouse a imaxe $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Produciuse un erro ao cargar a imaxe: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Eliminar a imaxe $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Eliminouse a imaxe $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar a imaxe: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6248,70 +6220,67 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Produciuse un erro no descubrimento do sintonizador: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Engadir sintonizador';
 
   @override
-  String get adminEditTuner => 'Editar o sintonizador';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Sintonizador M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Ficheiro ou URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Enderezo IP do sintonizador';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nome descritivo';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Axente de usuario';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Límite de conexións simultáneas';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Número máximo de fluxos que permite o sintonizador á vez. Establece 0 para ilimitado.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Taxa de bits máxima de transmisión alternativa';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importar só as canles favoritas';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permitir a transcodificación por hardware';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Permitir o contedor de transcodificación fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Permitir compartir fluxos';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Activar a repetición de fluxos';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorar DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Ler a entrada á velocidade de fotogramas nativa';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Editar o provedor';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6320,50 +6289,50 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Ficheiro ou URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefixo de película';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorías de películas';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separa as categorías cunha barra vertical.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorías infantís';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorías de novas';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorías de deportes';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nome de usuario';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Contrasinal';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'País';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selecciona un país';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Código postal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obter a programación';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programación';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Activar todos os sintonizadores';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipo de sintonizador';
@@ -6373,7 +6342,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Produciuse un erro ao engadir o sintonizador: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6387,12 +6356,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Produciuse un erro ao engadir o provedor: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Produciuse un erro ao quitar o sintonizador: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6401,16 +6370,16 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Produciuse un erro ao restablecer o sintonizador: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Este tipo de sintonizador non admite o restablecemento.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Produciuse un erro ao quitar o provedor: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6429,44 +6398,43 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Camiño de gravación da serie';
 
   @override
-  String get adminMovieRecordingPath => 'Camiño de gravación de películas';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Días de datos da guía';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automático';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days días';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Camiño da aplicación de posprocesamento';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumentos do posprocesador';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Gardar os metadatos NFO das gravacións';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Gardar as imaxes das gravacións';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Temporización';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Camiños de gravación';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Posprocesamento';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Datos da guía: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6475,7 +6443,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar a configuración: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6493,7 +6461,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Produciuse un erro ao actualizar as asignacións: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6510,15 +6478,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminGuideProviders => 'Provedores de guías';
 
   @override
-  String get adminRefreshGuideData => 'Actualizar os datos da guía';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Comezou a actualización dos datos da guía';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'A tarefa de actualización da guía non está dispoñible neste servidor.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Engadir provedor';
@@ -6529,22 +6496,22 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Camiño de gravación: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Camiño da serie: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Recheo previo: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Recheo posterior: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6578,7 +6545,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Restaurar agora a copia de seguranza $name?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6602,7 +6569,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminLiveTvTitle => 'Administración de TV en directo';
 
   @override
-  String get adminApply => 'Aplicar';
+  String get adminApply => 'Solicitar';
 
   @override
   String get adminNotSet => 'Non definido';
@@ -6624,27 +6591,27 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'hai $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'hai $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'hai $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Produciuse un erro ao cargar $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count coincidencias';
+    return '$count matches';
   }
 
   @override
@@ -6654,7 +6621,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor de metadatos';
 
   @override
-  String get adminMetadataIdentify => 'Identificar';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -6754,22 +6721,22 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Actualizouse a imaxe $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Cargouse a imaxe $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Eliminouse a imaxe $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Produciuse un erro ao descargar a imaxe: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6778,12 +6745,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Produciuse un erro ao cargar a imaxe: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Eliminar a imaxe $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6792,12 +6759,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar a imaxe: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Escoller a imaxe $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6830,7 +6797,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Actualización dispoñible: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6854,7 +6821,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Instalar a actualización (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6866,7 +6833,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return 'Estase instalando \"$name\"...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6886,7 +6853,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Configuración de $name';
+    return '$name Settings';
   }
 
   @override
@@ -6926,7 +6893,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Produciuse un erro ao cargar os repositorios: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6934,15 +6901,15 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Seguro que queres quitar \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Retirar';
+  String get adminReposRemove => 'Eliminar';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Produciuse un erro ao gardar os repositorios: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7070,21 +7037,19 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Activar a pantalla de inicio';
 
   @override
-  String get adminBrandingSplashUpload => 'Cargar unha imaxe';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Actualizouse a pantalla de inicio';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Produciuse un erro ao cargar a pantalla de inicio';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Eliminouse a pantalla de inicio';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash =>
-      'Non hai ningunha pantalla de inicio personalizada';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aceleración de hardware';
@@ -7101,128 +7066,118 @@ class AppLocalizationsGl extends AppLocalizations {
       'Activar a decodificación de hardware para:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Activar o decodificador NVDEC mellorado';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferir o decodificador por hardware nativo do sistema';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profundidade de cor da decodificación por hardware';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodificación HEVC de 10 bits';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodificación VP9 de 10 bits';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodificación HEVC RExt de 8/10 bits';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodificación HEVC RExt de 12 bits';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codificación por hardware';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permitir a codificación HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permitir a codificación AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Activar o codificador H.264 de baixo consumo de Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Activar o codificador HEVC de baixo consumo de Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapeamento de tons';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Activar o mapeamento de tons';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Activar o mapeamento de tons VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Activar o mapeamento de tons de VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoritmo de mapeamento de tons';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modo de mapeamento de tons';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Rango de mapeamento de tons';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Desaturación do mapeamento de tons';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pico do mapeamento de tons';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parámetro do mapeamento de tons';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Brillo do mapeamento de tons VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste do mapeamento de tons VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Predefinicións e calidade';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Predefinición do codificador';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF de codificación H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF de codificación H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Método de desentrelazado';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Duplicar a velocidade de fotogramas ao desentrelazar';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Activar a codificación de audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Amplificación do downmix de audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo de downmix a estéreo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Tamaño máximo da cola de multiplexación';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7346,10 +7301,10 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminTaskNeverRun => 'Nunca corras';
 
   @override
-  String get adminTaskStop => 'Deter';
+  String get adminTaskStop => 'Pare';
 
   @override
-  String get adminRunningTasks => 'Tarefas en execución';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Corre';
@@ -7371,17 +7326,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Diariamente ás $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Cada $day ás $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Cada $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7419,8 +7374,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count horas',
-      one: '1 hora',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7448,17 +7403,17 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'hai $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'hai $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'hai $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7466,27 +7421,27 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Configura a xeración de imaxes de Trickplay para as miniaturas de vista previa ao buscar.';
+      'Configura a xeración de imaxes de truco para buscar miniaturas de vista previa.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Porto HTTPS público';
@@ -7495,50 +7450,49 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'URL base';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'p.ex. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'p.ex. /aleta';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Porto HTTP público';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Esixir HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Redirixe todas as solicitudes remotas a HTTPS. Non ten efecto se o servidor non ten un certificado válido.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Contrasinal do certificado';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Configuración de IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Activar IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Activar IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Activar a asignación automática de portos';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Redes LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Lista de enderezos IP ou subredes CIDR, separados por comas ou saltos de liña, que se consideran da rede local.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI publicados do servidor';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Asigna unha subrede ou enderezo a un URL publicado, p. ex. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Camiño do certificado';
@@ -7570,11 +7524,11 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Buffer do acelerador';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Atraso de limitación (segundos)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permitir a extracción de subtítulos sobre a marcha';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Porcentaxe mínima de currículo';
@@ -7624,7 +7578,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Produciuse un erro ao actualizar o tipo de contido: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7632,23 +7586,22 @@ class AppLocalizationsGl extends AppLocalizations {
       'Limiar de resposta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Activar os avisos de resposta lenta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Activar Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Servidor';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadatos';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Camiños';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Rendemento';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Ruta da caché';
@@ -7660,7 +7613,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminGeneralServerName => 'Nome do servidor';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Idioma de visualización preferido';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7671,12 +7624,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Produciuse un erro ao actualizar as asignacións: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Límite de tempo: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7713,8 +7666,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# participantes',
-      one: '# participante',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7758,7 +7711,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Elemento $index';
+    return 'Item $index';
   }
 
   @override
@@ -7806,12 +7759,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName uniuse ao grupo de SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName saíu do grupo de SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7823,7 +7776,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Sincronizando a reprodución con $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7861,8 +7814,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# filas descubertas',
-      one: '# fila descuberta',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7903,21 +7856,20 @@ class AppLocalizationsGl extends AppLocalizations {
   String get offlineSavedMedia => 'Medios gardados';
 
   @override
-  String get offlineBannerTitle => 'Non tes conexión';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Móstranse as túas descargas';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Descargas';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Non se pode conectar co teu servidor';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Reproducindo desde as descargas ata que volva';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7933,12 +7885,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Fallou o control de Cast: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Controis de $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7949,7 +7901,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Deter $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7972,12 +7924,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Introduce un PIN de $length díxitos';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Introduce o teu PIN de $length díxitos';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7997,35 +7949,35 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get quickConnectAuthorized =>
-      'Solicitude de Quick Connect autorizada.';
+      'Solicitude de conexión rápida autorizada.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'O código de Quick Connect non é válido ou caducou.';
+      'O código de conexión rápida non é válido ou caducou.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect non é compatible neste servidor.';
+      'A conexión rápida non é compatible neste servidor.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Produciuse un erro ao autorizar o código de Quick Connect.';
+      'Produciuse un erro ao autorizar o código de conexión rápida.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect está desactivado neste servidor.';
+      'A conexión rápida está desactivada neste servidor.';
 
   @override
   String get quickConnectForbidden =>
-      'A túa conta non pode autorizar esta solicitude de Quick Connect.';
+      'A túa conta non pode autorizar esta solicitude de conexión rápida.';
 
   @override
   String get quickConnectNotFound =>
-      'Non se atopou o código de Quick Connect. Proba cun novo código.';
+      'Non se atopou o código de conexión rápida. Proba cun novo código.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Fallou Quick Connect: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -8036,7 +7988,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Fallou o comando: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8066,7 +8018,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Produciuse un erro ao iniciar o Cast: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8113,7 +8065,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Descargando $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8198,14 +8150,14 @@ class AppLocalizationsGl extends AppLocalizations {
       'Detívose a reprodución. Aínda estás vendo?';
 
   @override
-  String get stillWatchingStop => 'Deter';
+  String get stillWatchingStop => 'Pare';
 
   @override
   String get stillWatchingContinue => 'Continuar';
 
   @override
   String skipSegment(String segment) {
-    return 'Omitir $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8216,12 +8168,12 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Descargando $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Descargando $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8283,13 +8235,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get contextMenuGoToSeries => 'Ir á Serie';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Ocultar de Seguir vendo';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ocultar de A continuación';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Engadir a unha colección';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8344,15 +8297,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabético';
 
   @override
-  String get settingsConnectionSection => 'CONEXIÓN';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permitir os certificados autoasinados';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confía nos servidores que usan certificados TLS autoasinados ou dunha CA privada. Actívao só para os servidores que controles. Isto desactiva a validación de certificados en todas as conexións.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIDADE E SEGURIDADE';
@@ -8368,11 +8320,11 @@ class AppLocalizationsGl extends AppLocalizations {
       'Acentos temáticos, fondos, indicadores vistos e música temática';
 
   @override
-  String get settingsDetailsScreen => 'Pantalla de detalles';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Estilo, desenfoque do fondo e comportamento das pestanas';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Páxina de inicio';
@@ -8410,11 +8362,11 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Mostrar o botón de Seerr na barra de navegación';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Mostrar sempre as etiquetas de texto na barra de navegación superior';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8484,7 +8436,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Invita a un café ao desenvolvedor';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'LEGAL';
@@ -8518,8 +8470,8 @@ class AppLocalizationsGl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# avisos de licenza',
-      one: '# aviso de licenza',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8569,17 +8521,16 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Omitir intros e outros?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Conta atrás dos segmentos multimedia';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Barra de progreso';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Temporizador';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ningún';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Usuario avisado';
@@ -8614,13 +8565,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (recomendado)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (antigo)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (herdado)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (recomendado)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Alternativa';
@@ -8811,767 +8762,749 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Lanzamentos recentes de $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode =>
-      'Reproducir automaticamente o seguinte episodio';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Reproduce automaticamente o seguinte episodio cando estea dispoñible.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Omitir os silencios';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Omite automaticamente os segmentos de audio silenciosos cando o fluxo o admita.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Permitir efectos de audio externos';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Permite que as aplicacións de ecualización e efectos (p. ex. Wavelet) se conecten ás sesións de reprodución de Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Desactivar a tunelización';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Forza a reprodución sen tunelización. Útil en dispositivos con descontinuidades de audio/vídeo ao tunelizar.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Activar a tunelización';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avanzado. Encamiña o audio e o vídeo por unha ruta de hardware acoplada. Está desactivado de forma predeterminada porque provoca cortes de audio/vídeo nalgúns dispositivos.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Asignar o perfil 7 de Dolby Vision a HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Reproduce os fluxos do perfil 7 de Dolby Vision como HEVC compatible con HDR10 en dispositivos sen Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Usar os estilos de subtítulos incrustados';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Aplica as cores, os tipos de letra e a posición incrustados na pista de subtítulos. Desactívao para usar as túas preferencias de estilo.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Usar os tamaños de letra dos subtítulos incrustados';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Aplica as suxestións de tamaño de letra incrustadas na pista de subtítulos. Desactívao para usar o tamaño dos subtítulos das túas preferencias de estilo.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostrar os detalles do contido';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostra os detalles do elemento seleccionado na parte superior das páxinas de Biblioteca.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Ocultar as imaxes de fondo mentres navegas?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Usar subcabeceiras detalladas';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Mostra unha subfila detallada ou mínima nas páxinas de Biblioteca.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Eliminar o tema gardado?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Quitar \"$themeName\" da caché deste dispositivo?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Tenda de temas';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Explora e garda temas da comunidade';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Garda un tema para usalo como os demais temas gardados.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Non hai ningún tema dispoñible neste momento.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Non foi posible cargar a Tenda de temas. Comproba a túa conexión e téntao de novo.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Gardar';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Gardar e aplicar';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Gardado';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Non foi posible cargar este tema.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Gardouse \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Eliminouse \"$themeName\" deste dispositivo.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Non foi posible eliminar \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Temas gardados';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Estes son os temas descargados desde o complemento de Moonfin para o servidor actual. Ao eliminalos só se quita esta copia local.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Non se atopou ningún tema gardado para este servidor.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Activo actualmente';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Eliminar o tema gardado';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Xestiona os temas do complemento descargados neste dispositivo';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Editor de temas';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Abre o Editor de temas de Moonfin no teu navegador';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Pantalla de inicio';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Barra inferior';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Clásico';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderno';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Filas de inicio';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Visualización das filas de inicio';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Seccións das filas de inicio';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Interruptores das filas de inicio';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Activa ou desactiva as categorías de filas de inicio baseadas en bibliotecas';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Activa os seguintes interruptores para mostrar as filas nas seccións de inicio.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Clásico mantén o tipo de imaxe e a superposición de información por fila. Moderno usa filas de retrato a imaxe de fondo.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Mostrar as filas de favoritos';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Mostra as filas de películas favoritas, series e outras filas de favoritos nas seccións de inicio.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Ordenación das filas de favoritos';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Ordena as filas de favoritos por data de engadido, data de lanzamento, alfabeticamente e máis.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Mostrar as filas de coleccións';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Mostra as filas de coleccións nas seccións de inicio.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Ordenación das filas de coleccións';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Ordena as filas de coleccións por data de engadido, data de lanzamento, alfabeticamente e máis.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Mostrar as filas de xéneros';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Mostra as filas de xéneros nas seccións de inicio.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Ordenación das filas de xéneros';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Ordena as filas de xéneros por data de engadido, data de lanzamento, alfabeticamente e máis.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementos das filas de xéneros';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Mostra películas, series ou ambas nas filas de xéneros.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows =>
-      'Mostrar as filas de listas de reprodución';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Mostra as filas de listas de reprodución nas seccións de inicio.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting =>
-      'Ordenación das filas de listas de reprodución';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordena as filas de listas de reprodución por data de engadido, data de lanzamento, alfabeticamente e máis.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Mostrar as filas de audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Mostra as filas de audio nas seccións de inicio.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ordenación das filas de audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordena as filas de audio por data de engadido, data de lanzamento, alfabeticamente e máis.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Listas de reprodución de audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Aparencia';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Disposición';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Teclado';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Botóns';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderización';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configuración de MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Aplicación de reprodutor externo';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Define un reprodutor externo para activar a opción de reproducir cunha pulsación longa';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Mostra o selector de aplicacións cando comece a reprodución.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Cargando os reprodutores instalados...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Conexión';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Destino da transcodificación de audio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Compatible con este dispositivo';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Non compatible con este dispositivo';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Envía o bitstream DTS:X (DTS UHD) ao decodificador externo.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD con Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Comportamento do reprodutor multimedia';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Melloras da reprodución';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Sempre activo.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Substituír Omitir créditos pola vista de A continuación';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Mostra a superposición de A continuación en vez do botón Omitir créditos.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Encamiñamento do reprodutor';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders =>
-      'Preferir os decodificadores por software';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Usa FFmpeg (audio) e libgav1 (AV1) antes que os decodificadores por hardware. Desactívao se falla o passthrough de audio por HDMI.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Abre a reprodución de vídeo na aplicación externa seleccionada en Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Cola automática';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferir os subtítulos SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Prioriza as pistas de subtítulos SDH/CC ao seleccionar automaticamente.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnóstico web';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnóstico web de Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Usa esta páxina para diagnosticar problemas de conectividade do navegador (CORS, contido mixto e configuración de descubrimento).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Detectouse un fallo de contido mixto';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Detectouse un fallo de CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin detectou unha páxina HTTPS que tenta chamar a un URL de servidor HTTP. Os navegadores bloquean esta solicitude antes de que chegue ao teu servidor.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin detectou un fallo de solicitude a nivel de navegador que adoita deberse á falta de cabeceiras CORS ou de preflight no servidor multimedia.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL de destino: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detalle: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Contexto de execución actual';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Orixe';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Esquema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Modo de complemento';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Exploración WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL de servidor forzado';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL de servidor predeterminado';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL do proxy de descubrimento';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'non configurado';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Contido mixto';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Esta páxina cárgase por HTTPS, pero un ou máis URL configurados son HTTP. Os navegadores bloquean que as páxinas HTTPS chamen a API HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Solución: serve o teu servidor multimedia ou o punto final do proxy por HTTPS, ou carga Moonfin por HTTP só en redes locais de confianza.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Non se detectou ningunha configuración obvia de contido mixto na configuración de execución actual.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Lista de comprobación de CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Permite a orixe do navegador en Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Inclúe Authorization, X-Emby-Authorization e X-Emby-Token en Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Expón Content-Range e Accept-Ranges para o comportamento de transmisión e busca.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Devolve 204 ás solicitudes de preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Exemplo de fragmento de cabeceiras (estilo nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Nota';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Esta ruta de diagnóstico está pensada para compilacións web. Se ves isto noutra plataforma, é posible que estas comprobacións non se apliquen.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Volver á selección de servidor';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Pechar a sesión de todos os usuarios';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'O permiso do micrófono está denegado permanentemente. Actívao na configuración do sistema.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Requírese o permiso do micrófono para a busca por voz.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Non se entendeu. Téntao de novo.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Non se detectou ningunha fala.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Erro do micrófono.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'A busca por voz precisa conexión a internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'O servizo de voz está ocupado. Téntao de novo.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'O permiso do micrófono está denegado permanentemente.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'O permiso do micrófono está denegado.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'O recoñecemento de voz non está dispoñible neste dispositivo.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Abrir o selector de rutas de iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'O selector de rutas de AirPlay non está dispoñible neste dispositivo.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Vídeos';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programas';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Cancións';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Álbums de fotos';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotos';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Persoas';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Episodios lanzados recentemente';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Ver de novo';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Aparicións como convidado';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Aparicións (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Contribucións do equipo (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Ver co grupo';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Erros';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Avisos';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Disco';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Abrir no navegador';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'O navegador incrustado non está dispoñible nesta plataforma.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Seguro que queres reiniciar o servidor?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Seguro que queres apagar o servidor? Terás que reinicialo manualmente.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Interno';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inactivo';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Non se atopou ningún usuario';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Ningún usuario coincide coa túa busca';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Non se atopou ningún dispositivo';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Ningún dispositivo coincide cos filtros actuais';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Contrasinal definido';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Non hai ningún contrasinal configurado';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Acceso remoto';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Só local';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Produciuse un erro ao cargar a analítica multimedia';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Analítica combinada de todas as bibliotecas multimedia.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Artistas principais';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Autores principais';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Colaboradores principais';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bibliotecas',
-      one: '1 biblioteca',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Aínda non hai totais de contido indexado para esta selección.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Detalles da biblioteca';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Distribución por biblioteca';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'Non hai ningunha biblioteca dispoñible.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administración do servidor';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Datos';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Caché de imaxes';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Caché';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Rexistros';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadatos';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcodificación';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Este servidor non devolveu ningún camiño.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% usado';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Actividade dos usuarios';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Eventos do sistema';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Precisa atención';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Servidor';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Reprodución';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Dispositivos';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avanzado';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Complementos';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV en directo';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Vídeos caseiros';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Contido mixto';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Vídeos caseiros e fotos';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Películas e series mixtas';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9583,300 +9516,299 @@ class AppLocalizationsGl extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Non se atopou ningunha gravación';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Non se atoparon páxinas de imaxe no arquivo .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Fallou o renderizador incrustado ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Fallou o renderizador de EPUB ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Falta o ficheiro local para o lector: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status ao abrir os datos do libro desde $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Non hai ningún punto final de libro lexible dispoñible';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Formato de arquivo de banda deseñada non admitido: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'O complemento de extracción de CBR non está dispoñible nesta plataforma.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Produciuse un erro ao extraer o arquivo .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'A extracción de CB7 non está dispoñible nesta plataforma.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'O complemento de extracción de CB7 non está dispoñible nesta plataforma.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Pechar o panel de xéneros';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Cargando a reprodución aleatoria...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ALEATORIO POR BIBLIOTECA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ALEATORIO TOTAL';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ALEATORIO POR XÉNEROS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Cambio automático a HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Activa automaticamente o HDR na reprodución de vídeo HDR e restaura o modo de pantalla ao saír.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'En pantalla completa';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Cambiar a ilustración';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Falta';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Límites de transcodificación';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Limpar todas as ilustracións?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Seguro que queres limpar todas as ilustracións descargadas?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirmar a limpeza';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Seguro que queres limpar esta imaxe ($itemType)?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Cargar?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolución: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Mostrar só as ilustracións no idioma da interface';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirmar a limpeza de todo';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'A imaxe cargouse correctamente!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Produciuse un erro ao cargar a imaxe: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Produciuse un erro ao definir a imaxe: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Produciuse un erro ao eliminar a imaxe: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Produciuse un erro ao limpar todas as ilustracións: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Si';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Cartel';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fondos';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Báner';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotipo';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Arte';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Arte do disco';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Captura de pantalla';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Portada da caixa';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Contraportada da caixa';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Arte do menú';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'cartel';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fondo';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'báner';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotipo';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'arte';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'arte do disco';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'captura de pantalla';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'portada da caixa';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'contraportada da caixa';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'arte do menú';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Todas';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Media (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Baixa (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fontes';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capítulos';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marcadores';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notas';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Cola';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Cronoloxía';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'A cronoloxía está baleira';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Todo o libro';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Cronoloxía enfocada';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportar os marcadores';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportar as notas';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportar todo';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportouse a $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Fallou a exportación: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Letras';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Engadir un marcador';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Engadir unha nota';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Editar a nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Escribe unha nota para este momento';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Temporizador de sono';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Desactivado';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fin do capítulo';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalizado';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Quedan $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9891,51 +9823,51 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Velocidade de reprodución';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Restante';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Transcorrido';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Atrás ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Adiante ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capítulo anterior';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Capítulo seguinte';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capítulo $current de $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Non hai capítulos';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Aínda non hai marcadores';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Aínda non hai notas';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Marcador engadido en $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Restablecer a 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9943,257 +9875,249 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Gardar';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Cancelar';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Eliminar';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferencias dos subtítulos';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Cambia os modos de subtítulos, os idiomas predeterminados, a aparencia e as opcións de renderización.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderización dos subtítulos';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opcións de visualización';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data de lanzamento (ascendente)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data de lanzamento (descendente)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Agrupar as contribucións';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Agrupar múltiples roles';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Aviso de acceso de escritura á biblioteca';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Como solucionalo:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Concede permisos de escritura ao usuario do servizo Jellyfin (p. ex., jellyfin ou o PUID/PGID de Docker) para os cartafoles da túa biblioteca multimedia no servidor.\n\n2. Ou ben vai ao panel de control de Jellyfin -> Bibliotecas, edita esta biblioteca e desactiva \'Gardar as ilustracións nos cartafoles multimedia\' para almacenalas na base de datos interna de Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Descartar';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'A túa biblioteca \'$libraryName\' está configurada para gardar as ilustracións directamente nos cartafoles multimedia (\'Gardar as ilustracións nos cartafoles multimedia\' está activado). Non obstante, Jellyfin comprobou o acceso de escritura e non ten permiso para escribir ficheiros neste directorio:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Semella que Jellyfin non puido actualizar a ilustración. A túa biblioteca está configurada para gardar as ilustracións directamente nos cartafoles multimedia (\'Gardar as ilustracións nos cartafoles multimedia\' está activado). Este erro adoita producirse cando o proceso do servidor Jellyfin non ten permiso para escribir ficheiros nos teus directorios multimedia.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Listas externas';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Reproducir de novo';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Información do ficheiro';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Tamaño: $size  •  Formato: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Mostrar todas as pistas de audio ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Mostrar todas as pistas de subtítulos ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Comprobando a capacidade de reprodución directa...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Capacidade de reprodución directa: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Forzado';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'O reprodutor non admite o formato do contedor.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'O códec de vídeo non é compatible.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'O códec de audio non é compatible.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'O formato dos subtítulos non é compatible (require incrustalos no vídeo).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'O perfil de audio non é compatible.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'O perfil de vídeo non é compatible.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'O nivel de vídeo non é compatible.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Este dispositivo non admite a resolución do vídeo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'A profundidade de bits do vídeo non é compatible.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'A velocidade de fotogramas do vídeo non é compatible.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'A taxa de bits do ficheiro supera o límite de transmisión do reprodutor.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'A taxa de bits do vídeo supera o límite de transmisión.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'A taxa de bits do audio supera o límite de transmisión.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'O número de canles de audio non é compatible.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabético';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Orde de lanzamento (ascendente)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Orde de lanzamento (descendente)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personalizado (arrastrar e soltar)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Opcións de ordenación da lista de reprodución';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Restablecer a ordenación';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Ver de novo T$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Ver de novo a lista de reprodución';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Non se atoparon subtítulos.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Controis de administración';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motor de renderización (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller é o renderizador de GPU moderno de Flutter, para animacións máis fluídas e menos interrupcións. Nalgúns descodificadores de TV e GPU antigas pode provocar defectos visuais ou vídeo en negro; desactívao se os detectas. Automático escolle o mellor valor predeterminado para o teu dispositivo. Reinicia Moonfin para aplicalo.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automático';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Activado';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Desactivado';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Cómpre reiniciar';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin ten que reiniciarse para cambiar o motor de renderización. Pecha a aplicación agora e ábrea de novo para aplicalo.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Pechar a aplicación agora';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Actualizar a biblioteca';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Actualizar todas as bibliotecas';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Data de engadido (máis antigas primeiro)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Data de engadido (máis recentes primeiro)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabético (A a Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabético (Z a A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Cargando a analítica do servidor... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual que a orixe';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'Top 250 películas de IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'Top 250 series de TV de IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Películas máis populares de IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Series de TV máis populares de IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Películas peor valoradas de IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Mellores películas en inglés de IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -9,30 +9,30 @@ class AppLocalizationsHe extends AppLocalizations {
   AppLocalizationsHe([String locale = 'he']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'סנפיר ירח';
 
   @override
-  String get accountPreferences => 'העדפות חשבון';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'שפת הממשק';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'ברירת המחדל של המערכת';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'היכנס';
 
   @override
-  String get empty => 'ריק';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'מתחבר אל $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'חיבור מהיר';
 
   @override
   String get password => 'סִיסמָה';
@@ -51,7 +51,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get waitingForAuthorization => 'ממתין לאישור...';
 
   @override
-  String get back => 'חזרה';
+  String get back => 'בְּחֲזָרָה';
 
   @override
   String get serverUnavailable => 'השרת אינו זמין';
@@ -61,12 +61,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect אינו זמין: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect אינו זמין ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin גרסה $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'להסיר את \"$serverName\" מרשימת השרתים שלך?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'לְבַטֵל';
 
   @override
-  String get remove => 'הסר';
+  String get remove => 'לְהַסִיר';
 
   @override
   String get connectToServer => 'התחבר לשרת';
@@ -141,62 +141,62 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsAppearanceTheme => 'ערכת נושא לאפליקציה';
 
   @override
-  String get detailScreenStyle => 'סגנון מסך הפרטים';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'קלאסי הוא הפריסה הממורכזת המקורית של Moonfin. מודרני הוא פריסה קולנועית רספונסיבית.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'קלאסי';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'מודרני';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'לשוניות מורחבות';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'הצג אוטומטית את תוכן הלשונית בעת מעבר בין לשוניות. כבה כדי לפתוח ולסגור כל לשונית ידנית.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'להציג פרטים טכניים?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'הצג מידע על קודק, רזולוציה וזרם בתקציר הכרזה';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'מערכת ההמלצות';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'השתמש באלגוריתם הספרייה המקומית של Moonfin Recommends או במדדי הדמיון המקוונים של TMDb. לתשומת לבך: המלצות מקוונות מחייבות שילוב עם Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'דמיון TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'להחיל מגבלת דירוג הורים?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'הגבל את ההצעות של Moonfin Recommends לפי דירוג ההורים של המדיה';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'סגנון הממשק';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'אוטומטי מתאים את עצמו למכשיר שלך. בחר Apple או Material כדי לכפות מראה מסוים.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'אוטומטי';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsHe extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'איכות הזכוכית';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'אוטומטי בוחר את אפקט הזכוכית הטוב ביותר למכשיר זה. מלא כופה טשטוש אמיתי; מופחת משתמש בזכוכית קלת משקל שחוסכת בצריכת ה-GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'אוטומטי';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'מלא';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'מופחת';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'מעבר בין Moonfin ל-Neon Pulse מבלי להפעיל מחדש את האפליקציה';
 
   @override
-  String get customThemeTitle => 'ערכת נושא מותאמת';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ערכות נושא מותאמות משנות רכיבים חזותיים ברחבי Moonfin. בחר אחת מהאפשרויות כדי להתאים לסגנון שלך.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'העדף את מקלדת המערכת';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'השתמש בשיטת הקלט של המכשיר כברירת מחדל להזנת טקסט';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'סנפיר ירח';
 
   @override
   String get themeMoonfinSubtitle => 'מראה Moonfin נוכחי שכולכם למדתם לאהוב';
@@ -252,18 +252,18 @@ class AppLocalizationsHe extends AppLocalizations {
       'עיצוב גלי סינת\' עם זוהר מגנטה, טקסט בצבע ציאן וניגודיות כרום חזקה יותר';
 
   @override
-  String get themeGlass => 'זכוכית';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'עיצוב זכוכית נוזלית עם רקע מדורג נע, משטחים חלביים ונגיעת כחול של Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'גיבור 8-ביט';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'עיצוב פיקסל-ארט רטרו עם פלטה עבה, מסגרות מרובעות, צללים חדים וגופן פיקסלים';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'היכנס עם חשבון Emby Connect שלך';
@@ -311,7 +311,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'לא ניתן להתחבר אל $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -324,35 +324,35 @@ class AppLocalizationsHe extends AppLocalizations {
   String get exit => 'יְצִיאָה';
 
   @override
-  String get gameMenu => 'תפריט';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'מושהה';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'שמור מצב';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'משחקים';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'טען מצב';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'הרצה מהירה';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'הגדרות אמולטור';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'לליבה זו אין אפשרויות להתאמה.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'החזק כדי לפתוח את התפריט';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'הפעלת משחקים אינה נתמכת עדיין במכשיר זה.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'לא ניתן היה לטעון שורות בית';
@@ -373,13 +373,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get schedule => 'לוּחַ זְמַנִים';
 
   @override
-  String get series => 'סדרות';
+  String get series => 'סִדרָה';
 
   @override
   String get noItemsFound => 'לא נמצאו פריטים';
 
   @override
-  String get home => 'דף הבית';
+  String get home => 'בַּיִת';
 
   @override
   String get browseAll => 'עיין בהכל';
@@ -409,7 +409,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get noLibrariesFound => 'לא נמצאו ספריות';
 
   @override
-  String get library => 'ספרייה';
+  String get library => 'סִפְרִיָה';
 
   @override
   String get displaySettings => 'הגדרות תצוגה';
@@ -422,7 +422,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'טעינת התיקייה נכשלה: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -430,7 +430,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count פריטים';
+    return '$count items';
   }
 
   @override
@@ -447,7 +447,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count פריטים';
+    return '$count Items';
   }
 
   @override
@@ -488,7 +488,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ז\'אנרים';
+    return '$name — Genres';
   }
 
   @override
@@ -526,17 +526,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'לפני $count דק\'';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'לפני $count שע\'';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'לפני $count ימים';
+    return '${count}d ago';
   }
 
   @override
@@ -547,7 +547,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'בחר אילו עדכוני נושאים להציג ב-Discover.';
 
   @override
-  String get apply => 'החל';
+  String get apply => 'לִפְנוֹת';
 
   @override
   String get openLink => 'פתח קישור';
@@ -570,7 +570,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count כותרים';
+    return '$count titles';
   }
 
   @override
@@ -595,7 +595,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get listen => 'לְהַקְשִׁיב';
 
   @override
-  String get resume => 'המשך';
+  String get resume => 'קוֹרוֹת חַיִים';
 
   @override
   String get failedToLoadLibrary => 'טעינת הספרייה נכשלה';
@@ -653,17 +653,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count מחברים';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count ז\'אנרים';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% הושלמו';
+    return '$percent% completed';
   }
 
   @override
@@ -680,11 +680,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count כותרים מסודרים לעיון שמתמקד בקריאה.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => 'כותרים';
+  String get titles => 'כותרות';
 
   @override
   String get allTitles => 'כל הכותרות';
@@ -717,7 +717,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'לא נמצאו $label';
+    return 'No $label found';
   }
 
   @override
@@ -736,7 +736,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get readStatus => 'לִקְרוֹא';
 
   @override
-  String get watched => 'נצפה';
+  String get watched => 'צפו';
 
   @override
   String get unread => 'לא נקרא';
@@ -754,44 +754,43 @@ class AppLocalizationsHe extends AppLocalizations {
   String get books => 'ספרים';
 
   @override
-  String get latestBooks => 'הספרים האחרונים';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'ספרי השמע האחרונים';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ספרים',
-      two: 'שני ספרים',
-      one: 'ספר אחד',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'ספר';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ספר שמע';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% נקראו';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'נותרו $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'קרא';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'האזן';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'מְחַבֵּר';
@@ -829,12 +828,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count חלקים';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'פורסם לראשונה ב-$year';
+    return 'First published $year';
   }
 
   @override
@@ -849,7 +848,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count ספרים';
+    return '$count books';
   }
 
   @override
@@ -860,7 +859,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count מחברים';
+    return '$count Authors';
   }
 
   @override
@@ -868,9 +867,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ספרי שמע',
-      two: 'שני ספרי שמע',
-      one: 'ספר שמע אחד',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -885,10 +883,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get failedToLoad => 'הטעינה נכשלה';
 
   @override
-  String get delete => 'מחק';
+  String get delete => 'לִמְחוֹק';
 
   @override
-  String get save => 'שמור';
+  String get save => 'לְהַצִיל';
 
   @override
   String get moreLikeThis => 'עוד כאלה';
@@ -918,7 +916,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get movies => 'סרטים';
 
   @override
-  String get musicVideos => 'קליפים';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'אַחֵר';
@@ -937,7 +935,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'דיסק $number';
+    return 'Disc $number';
   }
 
   @override
@@ -961,7 +959,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'פורסם ב-$year';
+    return 'Published $year';
   }
 
   @override
@@ -972,53 +970,52 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count עונות',
-      two: 'שתי עונות',
-      one: 'עונה אחת',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'מסתיים ב-$time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'פריטים';
+  String get items => 'Items';
 
   @override
-  String get extras => 'תוספות';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'מאחורי הקלעים';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'סצנות שנמחקו';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'סרטונים נלווים';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'ראיונות';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'סצנות';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'סרטים קצרים';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'טריילרים';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'נותרו $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'מסתיים בעוד $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1032,11 +1029,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'המשך מ-$position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'נגן';
+  String get play => 'לְשַׂחֵק';
 
   @override
   String get startOver => 'התחל מחדש';
@@ -1060,10 +1057,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get version => 'גִרְסָה';
 
   @override
-  String get cast => 'שידור';
+  String get cast => 'יָצוּק';
 
   @override
-  String get trailer => 'טריילר';
+  String get trailer => 'גְרוֹר';
 
   @override
   String get finished => 'גָמוּר';
@@ -1130,7 +1127,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'למחוק את הרצועות שהורדו עבור \"$title\"?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1145,17 +1142,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'לא נטענו $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'מוריד את $title ($count פריטים)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'האם למחוק את \"$name\" מהשרת? לא ניתן לבטל פעולה זו.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1166,7 +1163,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'פורמט ספר לא נתמך: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1176,7 +1173,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get subtitleTrack => 'רצועת כתוביות';
 
   @override
-  String get none => 'ללא';
+  String get none => 'אַף לֹא אֶחָד';
 
   @override
   String get downloadSubtitlesLabel => 'הורד כתוביות...';
@@ -1192,7 +1189,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'הכתובית הורדה ונבחרה: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1201,7 +1198,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'לא נמצאו כתוביות מרוחקות עבור $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1209,7 +1206,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'גרסה $number';
+    return 'Version $number';
   }
 
   @override
@@ -1229,7 +1226,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'מוריד את $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1237,7 +1234,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'למחוק את הקבצים המקומיים של $typeLabel?\n\nפעולה זו תפנה שטח אחסון. תוכל להוריד אותם שוב מאוחר יותר.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1253,25 +1250,25 @@ class AppLocalizationsHe extends AppLocalizations {
   String get director => 'מְנַהֵל';
 
   @override
-  String get directors => 'במאים';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'תסריטאי';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'תסריטאים';
+  String get writers => 'סופרים';
 
   @override
   String get studio => 'סטוּדִיוֹ';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count נוספים';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count פרקים';
+    return '$count Episodes';
   }
 
   @override
@@ -1281,12 +1278,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'פרק $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'פרק $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1294,9 +1291,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count רצועות',
-      two: 'שתי רצועות',
-      one: 'רצועה אחת',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1306,26 +1302,25 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count פרקים',
-      two: 'שני פרקים',
-      one: 'פרק אחד',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'נולד ב-$date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'נפטר ב-$date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'גיל $age';
+    return 'Age $age';
   }
 
   @override
@@ -1335,20 +1330,20 @@ class AppLocalizationsHe extends AppLocalizations {
   String get readMore => 'קרא עוד';
 
   @override
-  String get shuffle => 'ערבוב';
+  String get shuffle => 'לְעַרְבֵּב';
 
   @override
-  String get shuffleAllMusic => 'ערבב את כל המוזיקה';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'היכנס ל-Moonfin בטלפון שלך';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'לא ניתן להגיע לשרת שלך';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count הורדות';
+    return '$count downloads';
   }
 
   @override
@@ -1356,7 +1351,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count ערוצים';
+    return '${count}ch';
   }
 
   @override
@@ -1367,32 +1362,32 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '$action של כתוביות מרוחקות מחייב הרשאת ניהול כתוביות של Jellyfin עבור משתמש זה.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'הפריט לא נמצא בשרת עבור $action של כתוביות מרוחקות.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '$action של כתוביות מרוחקות נכשל: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '$action של כתוביות מרוחקות נכשל (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'לא ניתן לבצע $action לכתוביות מרוחקות.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'כל הפרקים שהורדו עבור \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1421,17 +1416,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'פעולת $label נכשלה: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'הגדרת עוצמת הקול של ה-Cast נכשלה: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'פקדי $label';
+    return '$label Controls';
   }
 
   @override
@@ -1441,14 +1436,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unavailable => 'לא זמין';
 
   @override
-  String get pause => 'השהה';
+  String get pause => 'הַפסָקָה';
 
   @override
   String get syncPosition => 'מיקום סנכרון';
 
   @override
   String stopCast(String label) {
-    return 'עצור את $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1456,7 +1451,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'רצועה $number';
+    return 'Track $number';
   }
 
   @override
@@ -1473,7 +1468,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds שניות';
+    return '$seconds seconds';
   }
 
   @override
@@ -1515,7 +1510,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get subtitleDelay => 'עיכוב כתוביות';
 
   @override
-  String get reset => 'איפוס';
+  String get reset => 'אִתחוּל';
 
   @override
   String get unknown => 'לֹא יְדוּעַ';
@@ -1542,7 +1537,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get transcodeReasons => 'סיבות להמרה';
 
   @override
-  String get player => 'נגן';
+  String get player => 'נַגָן';
 
   @override
   String get container => 'מְכוֹלָה';
@@ -1560,13 +1555,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'קודק';
+  String get codec => 'Codec';
 
   @override
   String get videoBitrate => 'קצב סיביות של וידאו';
 
   @override
-  String get track => 'רצועה';
+  String get track => 'מַסלוּל';
 
   @override
   String get channels => 'ערוצים';
@@ -1588,12 +1583,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'שגיאת הפעלה של $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'טעינת פרטי הספר נכשלה: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1602,7 +1597,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'פורמט זה (.$extension) עדיין לא ניתן להצגה בתוך האפליקציה.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1615,17 +1610,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'פתיחת הקורא המובנה נכשלה: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'סימנייה כבר נשמרה ב-$label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'סימנייה נוספה: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1637,7 +1632,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'עמוד $number';
+    return 'Page $number';
   }
 
   @override
@@ -1648,12 +1643,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'פורמט: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% נקראו';
+    return '$percent% read';
   }
 
   @override
@@ -1676,7 +1671,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'אפס תקריב (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1699,7 +1694,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'עדכון מצב הקריאה נכשל: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1731,7 +1726,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'פלטפורמה זו אינה תומכת במנוע המסמכים המובנה עבור קובצי $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1770,7 +1765,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'טעינת לוח השידורים נכשלה: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1781,22 +1776,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'הבא: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'נותרו $minutes דק\'';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'נותרו $hours שע\'';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'נותרו $hours שע\' $minutes דק\'';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1818,29 +1813,29 @@ class AppLocalizationsHe extends AppLocalizations {
   String get favoriteChannel => 'ערוץ אהוב';
 
   @override
-  String get record => 'הקלט';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'בטל הקלטה';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'התוכנית נקבעה להקלטה';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'ההקלטה בוטלה';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'לא ניתן ליצור הקלטה';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'צפה';
+  String get watch => 'לִצְפּוֹת';
 
   @override
-  String get close => 'סגור';
+  String get close => 'לִסְגוֹר';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'לא ניתן להפעיל את $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1866,11 +1861,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'לבטל את ההקלטה המתוכננת של \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'לא';
+  String get no => 'לֹא';
 
   @override
   String get yesCancel => 'כן, בטל';
@@ -1892,7 +1887,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'להפסיק את ההקלטה של \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1906,19 +1901,19 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'אין תוצאות עבור \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'החיפוש נכשל: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'סוג חשבון Seerr';
+  String get seerrAccountType => 'סוג חשבון רואה';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1952,12 +1947,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'להסיר את \"$name\" ואת הקבצים שלו?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count רצועות';
+    return '$count tracks';
   }
 
   @override
@@ -1968,16 +1963,16 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'טעינת האלבום נכשלה: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'לא נמצאו רצועות שהורדו עבור $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'עונה';
+  String get season => 'עוֹנָה';
 
   @override
   String get errorLoadingEpisodes => 'שגיאה בטעינת פרקים';
@@ -1990,22 +1985,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'להסיר את \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes דק\'';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'ע$season פ$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'פרק $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2019,12 +2014,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'עונה $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'ע$number';
+    return 'S$number';
   }
 
   @override
@@ -2035,7 +2030,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'למחוק את כל הפרקים שהורדו ב$season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2043,9 +2038,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count פרקים',
-      two: 'שני פרקים',
-      one: 'פרק אחד',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2080,7 +2074,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'למחוק $count פריטים שהורדו?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2094,7 +2088,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'מתוך מגבלה של $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2175,7 +2169,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count אפשרויות';
+    return '$count options';
   }
 
   @override
@@ -2266,7 +2260,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'דפי פרטים, שורות במסך הבית ועוצמת קול';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2280,10 +2274,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'הפעל בעת גלישה במסך הבית';
 
   @override
-  String get loopThemeMusic => 'נגן מוזיקת נושא בלולאה';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'חזור על הרצועה במקום לנגן אותה פעם אחת';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'פרטים טשטוש רקע';
@@ -2306,23 +2301,23 @@ class AppLocalizationsHe extends AppLocalizations {
   String get playerZoomMode => 'מצב זום לנגן';
 
   @override
-  String get settingsScrollWheelAction => 'גלגל העכבר';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'בחר מה תעשה גלילת גלגל העכבר מעל הווידאו במהלך ההפעלה.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'כבוי';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'דילוג (קדימה / אחורה)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'עוצמת קול';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'עוצמת קול';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'לְהַתְאִים';
@@ -2337,7 +2332,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get refreshRateSwitching => 'החלפת קצב רענון';
 
   @override
-  String get disabled => 'מושבת';
+  String get disabled => 'נָכֶה';
 
   @override
   String get scaleOnTv => 'קנה מידה בטלוויזיה';
@@ -2376,37 +2371,37 @@ class AppLocalizationsHe extends AppLocalizations {
   String get defaultAudioLanguage => 'שפת אודיו ברירת מחדל';
 
   @override
-  String get fallbackAudioLanguage => 'שפת שמע חלופית';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'העדף רצועת אודיו ברירת מחדל';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'העדף את רצועת האודיו המקורית על פני דיבוב מתורגם.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'העדף רצועות תיאור קולי';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'העדף רצועות תיאור קולי על פני רצועות רגילות.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'המרת קידוד (אודיו)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'הזרמה ישירה (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'המרת קידוד (קצב סיביות או רזולוציה)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'המרת קידוד (וידאו ואודיו)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'המרת קידוד (וידאו)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'אוטומטי (ברירת מחדל של שרת)';
@@ -2483,27 +2478,27 @@ class AppLocalizationsHe extends AppLocalizations {
       'הפעל אודיו TrueHD (ייתכן שלא יפעל בכל הפלטפורמות)';
 
   @override
-  String get settingsAudioOutputMode => 'מצב פלט אודיו';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'בחר כיצד מפוענח האודיו. מעבר AVR שולח זרמי Dolby/DTS גולמיים למקלט שלך; אוטומטי או Downmix מפענחים במכשיר.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'מעבר AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'קודק אודיו חלופי';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'בחר את פורמט היעד להמרת אודיו רב-ערוצי כאשר לא ניתן להפעיל את זרם המקור ישירות או להעבירו במעבר.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'זיהוי אוטומטי\n(מומלץ)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ברירת מחדל)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2512,114 +2507,113 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ללא אובדן)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(סטריאו בלבד)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(יעיל)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ללא אובדן)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'מספר ערוצי אודיו מרבי';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'הגדר את מספר הערוצים המרבי של מערכת האודיו שלך. זרמים רב-ערוציים שחורגים מהמגבלה ימוזגו למטה או יומרו.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'זיהוי אוטומטי\n(ברירת מחדל של החומרה)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 מונו';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 סטריאו';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 סראונד';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 קוואדרופוני';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 סראונד';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 סראונד';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 סראונד';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 סראונד';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'מעבר (מתקדם)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'מעבר קודקים';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'הפעל רק פורמטים שה-AVR או יעד ה-HDMI שלך תומכים בהם.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'מעבר EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'מעבר EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'מעבר DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'מעבר DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'מעבר TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'מעבר TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'שולח זרם סיביות של Dolby Digital Plus (EAC3) למפענח חיצוני.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'שולח זרם סיביות של Dolby Atmos על גבי EAC3 (JOC) למפענח חיצוני.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'שולח זרם סיביות של DTS-HD MA (כולל DTS core) למפענח חיצוני.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'שולח זרם סיביות של Dolby TrueHD עם מטא-נתוני Atmos למפענח חיצוני.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'יכולות אודיו שזוהו';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'אין עדיין תמונת מצב של יכולות זמן ריצה.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'נתיב';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'פענוח';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'מעבר';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'נתיב אודיו HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2634,49 +2628,50 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'רמקול';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'אוזניות';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count ערוצי PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'אבחון';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'רמת וידאו';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'טווח וידאו';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'קודק כתוביות';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => 'קודקי אודיו מותרים';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'קודקי אודיו של HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'קודקי אודיו של HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'מעבר audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'נתיב אודיו פעיל';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'תמיכת הנתיב באודיו HD';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'מצב לילה';
@@ -2725,7 +2720,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value שנ\'';
+    return '${value}s';
   }
 
   @override
@@ -2739,7 +2734,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'אחרי $episodes פרקים / $hours שע\'';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2814,45 +2809,45 @@ class AppLocalizationsHe extends AppLocalizations {
   String get subtitleCustomizationDescription => 'התאם אישית את מראה הכתוביות';
 
   @override
-  String get subtitleMode => 'מצב כתוביות';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'מסומנות';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'תמיד';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'שפה זרה';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'כפויות';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'מפעיל רצועות המסומנות במטא-נתונים של קובץ המדיה כ\"ברירת מחדל\" או כ\"כפויות\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'טוען ומציג כתוביות אוטומטית בכל פעם שווידאו מתחיל.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'מפעיל כתוביות אוטומטית אם רצועת האודיו שנבחרה כברירת מחדל היא בשפה זרה.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'טוען רק כתוביות המתויגות במפורש בדגל המטא-נתונים forced.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'משבית לחלוטין את הטעינה האוטומטית של כתוביות.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'שפת כתוביות חלופית';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'זרם כתוביות';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'השועל החום המהיר קופץ מעל הכלב העצלן';
@@ -2910,17 +2905,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'הגדרות הפרופיל $profile נטענו.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'טעינת הגדרות הפרופיל $profile נכשלה.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'ההגדרות המקומיות סונכרנו לפרופיל $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3055,10 +3050,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showLibrariesInToolbar => 'הצג ספריות בסרגל הכלים';
 
   @override
-  String get navbarAlwaysExpanded => 'הצג תמיד את תוויות סרגל הניווט';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'הצג את כפתור Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'אטימות Navbar';
@@ -3130,18 +3125,18 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showFolderBrowsingOption => 'הצג אפשרות גלישה בתיקייה';
 
   @override
-  String get groupItemsIntoCollections => 'קבץ פריטים לאוספים';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'הסתר פריטי ספרייה המשויכים לאוסף בעת עיון בספריות';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'הודעה על קיבוץ ספריות';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'כדי להשתמש בהגדרה זו, ודא שהגדרות הספרייה \"קבץ סרטים לאוספים\" ו/או \"קבץ סדרות לאוספים\" מופעלות בהגדרות התצוגה של הספרייה בשרת Jellyfin או Emby שלך.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'נראות הספרייה';
@@ -3170,7 +3165,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count נבחרו';
+    return '$count selected';
   }
 
   @override
@@ -3200,7 +3195,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'בחרו בין סגנונות שונים של סרגל מדיה, או כבו את סרגל המדיה';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'סנפיר ירח';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3252,10 +3247,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'הפעל אוטומטית טריילרים בסרגל המדיה לאחר 3 שניות';
 
   @override
-  String get trailerAudio => 'אודיו של טריילרים';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'הפעל אודיו לטריילרים בסרגל המדיה';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'תצוגה מקדימה של פרק';
@@ -3331,11 +3326,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get combineBothRows => 'שלב את שתי השורות למקטע בית אחד';
 
   @override
-  String get fullScreenRows => 'שורות מורחבות במסך הבית';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'הגבל את שורות מסך הבית לשורה אחת לכל מסך';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'סוג תמונה לפי שורה';
@@ -3350,7 +3344,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get lastUser => 'משתמש אחרון';
 
   @override
-  String get currentUser => 'משתמש נוכחי';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'אימות תמיד';
@@ -3422,7 +3416,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes דק\'';
+    return '$minutes min';
   }
 
   @override
@@ -3452,10 +3446,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get displayClockDuringScreensaver => 'הצג שעון במהלך שומר מסך';
 
   @override
-  String get clockModeStatic => 'קבוע';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'מקפץ';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'עגבניות רקובות (מבקרים)';
@@ -3476,7 +3470,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get metacriticUser => 'Metacritic (משתמש)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'טראקט';
 
   @override
   String get letterboxd => 'Letterboxd';
@@ -3525,7 +3519,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'אפשר וסדר מחדש את מקורות הדירוג המוצגים בכל האפליקציה';
 
   @override
-  String get pluginLabel => 'תוסף Moonbase';
+  String get pluginLabel => 'תוסף';
 
   @override
   String get pluginDetected => 'תוסף זוהה';
@@ -3543,7 +3537,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nגרסה: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3596,7 +3590,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get networks => 'רשתות';
 
   @override
-  String get seerrDiscoveryRows => 'שורות גילוי של Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'אפס שורות לברירות המחדל';
@@ -3618,42 +3612,44 @@ class AppLocalizationsHe extends AppLocalizations {
   String get hideAdultContent => 'הסתר תוכן למבוגרים בתוצאות';
 
   @override
-  String get seerrNotificationsSection => 'התראות';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'התראות על בקשות חדשות';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => 'התריע לי כשמישהו שולח בקשה';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'עדכוני בקשות';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'אושרו, נדחו ונוספו לספרייה שלך';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'עדכוני תקלות';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'תקלות חדשות, תגובות ופתרונות';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'מחובר בתור: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'עמוד הגילוי של Seerr';
+  String get discoverRows => 'גלה שורות';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'הפעל את השורות שיוצגו בעמוד הראשי של Seerr. גרור כדי לשנות את הסדר. הסדר המותאם מסונכרן עם Moonbase.';
+      'גרור כדי לסדר מחדש. הפעל או השבת שורות. סדר שורות זמין מסתנכרן עם תוסף Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'הפעל את השורות שיוצגו בעמוד הראשי של Seerr. גרור כדי לשנות את הסדר. הסדר המותאם מסונכרן עם Moonbase.';
+      'גרור כדי לסדר מחדש. הפעל או השבת שורות.';
 
   @override
   String get enabled => 'מופעל';
@@ -3666,7 +3662,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'גרסה $version';
+    return 'Version $version';
   }
 
   @override
@@ -3712,7 +3708,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'עדכון זמין: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3723,7 +3719,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'גרסה v$version זמינה';
+    return 'v$version Available';
   }
 
   @override
@@ -3785,7 +3781,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get imageCacheCleared => 'מטמון התמונות נוקה';
 
   @override
-  String get clear => 'נקה';
+  String get clear => 'בָּרוּר';
 
   @override
   String get browse => 'לְדַפדֵף';
@@ -3801,19 +3797,19 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'מוריד · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'מייבא';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count פריטים';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'הגדרות Seerr';
+  String get seerrSettings => 'הגדרות רואה';
 
   @override
   String get requestMore => 'בקש עוד';
@@ -3829,7 +3825,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'התבקש על ידי $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3846,12 +3842,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'לבטל את הבקשה עבור \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'לבטל $count בקשות עבור \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3865,12 +3861,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'תקציב: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'הכנסות: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3880,7 +3876,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'בקש $type';
+    return 'Request $type';
   }
 
   @override
@@ -3915,7 +3911,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'גיל $age';
+    return 'age $age';
   }
 
   @override
@@ -3946,146 +3942,148 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deletedStatus => 'נמחק';
 
   @override
-  String get failedStatus => 'נכשל';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'בעיבוד';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'שונה על ידי $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'הושלם';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'כותר זה כבר התבקש';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'הגעת למגבלת הבקשות';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'כותר זה נמצא ברשימת החסומים';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'לא נותרו עונות לבקש';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'אין לך הרשאה לבצע בקשה זו';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'בקשות';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'תקלות';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'החדשים ביותר';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'שונו לאחרונה';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'אין תקלות';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'נותרו $remaining מתוך $limit בקשות סרטים';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'נותרו $remaining מתוך $limit בקשות עונות';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'חלק מ-$name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'הצג אוסף';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'בקש אוסף';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total סרטים · $available זמינים';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'בקש $count סרטים';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'מבקש $current מתוך $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'התבקשו $count סרטים';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'התבקשו $ok מתוך $total סרטים';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'כל הסרטים כבר זמינים או שכבר התבקשו';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'דווח על תקלה';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'וידאו';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'אודיו';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'מה הבעיה?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'כל הפרקים';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'פרק';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'פתוח';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'נפתרה';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'פתור';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'פתח מחדש';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'דווח על ידי $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count תגובות';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'הוסף תגובה';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'למחוק את התקלה הזו?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'שלח דיווח';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'ציון TMDB';
@@ -4118,7 +4116,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get access => 'גִישָׁה';
 
   @override
-  String get add => 'הוסף';
+  String get add => 'לְהוֹסִיף';
 
   @override
   String get address => 'כְּתוֹבֶת';
@@ -4142,10 +4140,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get disable => 'השבת';
 
   @override
-  String get done => 'סיום';
+  String get done => 'נַעֲשָׂה';
 
   @override
-  String get edit => 'עריכה';
+  String get edit => 'לַעֲרוֹך';
 
   @override
   String get encoding => 'הַצפָּנָה';
@@ -4154,10 +4152,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get error => 'שְׁגִיאָה';
 
   @override
-  String get forward => 'קדימה';
+  String get forward => 'קָדִימָה';
 
   @override
-  String get general => 'כללי';
+  String get general => 'כְּלָלִי';
 
   @override
   String get go => 'לָלֶכֶת';
@@ -4178,7 +4176,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get networking => 'רשת';
 
   @override
-  String get next => 'הבא';
+  String get next => 'הַבָּא';
 
   @override
   String get path => 'נָתִיב';
@@ -4202,7 +4200,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get refresh => 'לְרַעֲנֵן';
 
   @override
-  String get remote => 'שלט רחוק';
+  String get remote => 'מְרוּחָק';
 
   @override
   String get rename => 'שנה שם';
@@ -4220,7 +4218,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get run => 'לָרוּץ';
 
   @override
-  String get search => 'חיפוש';
+  String get search => 'לְחַפֵּשׂ';
 
   @override
   String get select => 'לִבחוֹר';
@@ -4238,7 +4236,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get status => 'סטָטוּס';
 
   @override
-  String get stop => 'עצור';
+  String get stop => 'לְהַפְסִיק';
 
   @override
   String get streaming => 'נְהִירָה';
@@ -4247,7 +4245,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get time => 'זְמַן';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'משחק טריק';
 
   @override
   String get uninstall => 'הסר את ההתקנה';
@@ -4265,7 +4263,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unmute => 'בטל השתקה';
 
   @override
-  String get mute => 'השתק';
+  String get mute => 'לְהַשְׁתִיק';
 
   @override
   String get branding => 'מיתוג';
@@ -4289,25 +4287,25 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminDrawerLibraries => 'ספריות';
 
   @override
-  String get adminDrawerDisplay => 'תצוגה';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'מטא-נתונים';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'הגדרות NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'המרת קידוד';
 
   @override
-  String get adminDrawerResume => 'המשך';
+  String get adminDrawerResume => 'קוֹרוֹת חַיִים';
 
   @override
   String get adminDrawerStreaming => 'נְהִירָה';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'משחק טריק';
 
   @override
   String get adminDrawerDevices => 'מכשירים';
@@ -4358,22 +4356,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'עדכוני תוספים זמינים: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'תוספים הדורשים הפעלה מחדש: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'משימות מתוזמנות שנכשלו: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'רשומות אזהרה/שגיאה אחרונות: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4432,7 +4430,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'שגיאה: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4459,7 +4457,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'הפקודה נכשלה: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4478,10 +4476,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get sessionRewind => 'החזר לאחור';
 
   @override
-  String get sessionForward => 'קדימה';
+  String get sessionForward => 'קָדִימָה';
 
   @override
-  String get sessionNext => 'הבא';
+  String get sessionNext => 'הַבָּא';
 
   @override
   String get sessionVolumeDown => 'כרך -';
@@ -4496,7 +4494,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get nowPlaying => 'עכשיו משחק';
 
   @override
-  String get volume => 'עוצמת קול';
+  String get volume => 'כֶּרֶך';
 
   @override
   String get actions => 'פעולות';
@@ -4508,7 +4506,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audioCodec => 'Codec אודיו';
 
   @override
-  String get hwAccel => 'האצת חומרה';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'סִיוּם';
@@ -4523,14 +4521,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminClearDates => 'תאריכים ברורים';
 
   @override
-  String get adminActivitySeverityAll => 'כל רמות החומרה';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'טווח תאריכים';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'טעינת יומן הפעילות נכשלה: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4547,7 +4545,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'עדכון המכשיר נכשל: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4558,28 +4556,28 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'מחיקת המכשיר נכשלה: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'להסיר את המכשיר \'$name\'? המשתמש יצטרך להתחבר שוב במכשיר זה.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'מחק את כל המכשירים';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'להסיר $count מכשירים? המשתמשים המושפעים יצטרכו להתחבר שוב. המכשיר הנוכחי שלך לא יושפע.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'המכשירים הוסרו';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'חלק מהמכשירים הוסרו; לא ניתן היה להסיר $count.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4608,7 +4606,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'לא ניתן היה להתחיל את הסריקה: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4619,12 +4617,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'שם הספרייה שונה ל-\"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'שינוי השם נכשל: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4632,17 +4630,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'הספרייה \"$name\" נמחקה';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'מחיקת הספרייה נכשלה: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'הוספת הנתיב נכשלה: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4650,12 +4648,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'להסיר את \"$path\" מספרייה זו?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'הסרת הנתיב נכשלה: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4663,7 +4661,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'שמירת האפשרויות נכשלה: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4694,246 +4692,251 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminMetadataCountryHint => 'לְמָשָׁל ארה\"ב, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'נתיבים';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'אפשרויות';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'מנועי הורדה';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'שומרי מטא-נתונים';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'מנועי הורדת כתוביות';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'מנועי הורדת מילות שירים';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'מנועי הורדת מטא-נתונים: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'מאחזרי תמונות: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'השרת אינו מציע מנועי הורדה עבור סוג ספרייה זה.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'כללי';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'מטא-נתונים';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'מידע מוטמע';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'כתוביות';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'תמונות';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'סדרות';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'מוזיקה';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'סרטים';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'הפעל ניטור בזמן אמת';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'זהה שינויים בקבצים ועבד אותם אוטומטית.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'התייחס לארכיונים כאל קובצי מדיה';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'הצג תמונות';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'שמור עטיפות בתיקיות המדיה';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'רענון אוטומטי של מטא-נתונים';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'אף פעם';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ברירת מחדל';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'תצוגה';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'תצוגת ספרייה';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
-  String get adminLibFolderView => 'הצג תצוגת תיקיות עבור תיקיות מדיה רגילות';
+  String get adminLibFolderView =>
+      'Display a folder view to show plain media folders';
 
   @override
-  String get adminLibSpecialsInSeasons => 'הצג פרקים מיוחדים בעונות שבהן שודרו';
+  String get adminLibSpecialsInSeasons =>
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'קבץ סרטים לאוספים';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'קבץ סדרות לאוספים';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'הצג תוכן חיצוני בהצעות';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'התנהגות תאריך ההוספה';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'השתמש בתאריך ההוספה מתוך';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'התאריך שבו נסרק לספרייה';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'התאריך שבו נוצר הקובץ';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'מטא-נתונים ותמונות';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'שפת מטא-נתונים מועדפת';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'פרקים';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'משך פרק מדומה (שניות)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'אורך הפרקים שנוצרים עבור מדיה שאין בה פרקים. הגדר 0 כדי להשבית.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'רזולוציית תמונות הפרקים';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'הגדרות NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'מטא-נתוני NFO תואמים ל-Kodi וללקוחות דומים. ההגדרות חלות על כל הספריות ששומרות מטא-נתוני NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'המשתמש שעבורו יישמרו נתוני הצפייה בקובצי NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'שמור נתיבי תמונות בתוך קובצי NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'הפעל החלפת נתיבים עבור נתיבי תמונות ב-NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'העתק תמונות extrafanart לתיקיית extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ללא';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ימים';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'השתמש בכותרים מוטמעים';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'השתמש בכותרים מוטמעים עבור תוספות';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'השתמש במידע מוטמע על פרקים';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'אפשר כתוביות מוטמעות';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'אפשר הכל';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'טקסט בלבד';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'תמונה בלבד';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ללא';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'דלג על ההורדה אם קיימות כתוביות מוטמעות';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'דלג על ההורדה אם רצועת האודיו תואמת לשפת ההורדה';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'דרוש התאמת כתוביות מושלמת';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => 'שמור כתוביות בתיקיות המדיה';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'חלץ תמונות פרקים';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'חלץ תמונות פרקים במהלך סריקת הספרייה';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'הפעל חילוץ תמונות Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'חלץ תמונות Trickplay במהלך סריקת הספרייה';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'שמור תמונות Trickplay בתיקיות המדיה';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'מזג אוטומטית סדרות המפוזרות בכמה תיקיות';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'שם התצוגה של עונה אפס';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'הפעל סריקת LUFS לנרמול עוצמת האודיו';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
-  String get adminLibPreferNonstandardArtist => 'העדף תג אמנים לא סטנדרטי';
+  String get adminLibPreferNonstandardArtist =>
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => 'הוסף סרטים לאוספים אוטומטית';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'נדרש שם הספרייה';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'יצירת הספרייה נכשלה: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4959,27 +4962,27 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'להשבית את $name? הוא לא יוכל להתחבר.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'להפעיל את $name? הוא יוכל להתחבר שוב.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'המשתמש \"$name\" הושבת';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'המשתמש \"$name\" הופעל';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'עדכון מדיניות המשתמש נכשל: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -4996,7 +4999,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'יצירת המשתמש נכשלה: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5016,7 +5019,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'השמירה נכשלה: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5027,7 +5030,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'נכשל: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5157,142 +5160,143 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminEnableAllChannels => 'אפשר גישה לכל הערוצים';
 
   @override
-  String get adminParentalControl => 'בקרת הורים';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'דירוג הורים מרבי מותר';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'תוכן בעל דירוג גבוה יותר יוסתר ממשתמש זה.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ללא';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'חסום פריטים ללא מידע דירוג או עם דירוג לא מזוהה';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'ספרים';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ערוצים';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'טלוויזיה בשידור חי';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'סרטים';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'מוזיקה';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'טריילרים';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'סדרות';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'לוחות זמנים לגישה';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'אפשר גישה רק בזמנים המתוזמנים שלהלן. כאשר לא הוגדר לוח זמנים, הגישה מותרת כל היום.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'הוסף לוח זמנים';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'יום';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'התחלה';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'סיום';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'כל יום';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'יום חול';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'סוף שבוע';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'יום ראשון';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'יום שני';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'יום שלישי';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'יום רביעי';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'יום חמישי';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'יום שישי';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'שבת';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'תגיות מותרות';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'רק תוכן עם התגיות האלה יוצג. השאר ריק כדי לאפשר הכל.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'תגיות חסומות';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
-  String get adminBlockedTagsHint => 'תוכן עם התגיות האלה יוסתר ממשתמש זה.';
+  String get adminBlockedTagsHint =>
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'הוסף תגית';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'מכשירים מופעלים';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'ערוצים מופעלים';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ספק אימות';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'ספק איפוס סיסמה';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'מספר ניסיונות ההתחברות הכושלים המרבי לפני נעילה';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'הגדר 0 לברירת המחדל, או -1 כדי להשבית את הנעילה.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'גישה ל-SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'אפשר יצירת קבוצות והצטרפות אליהן';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'אפשר הצטרפות לקבוצות';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'אין גישה';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'אפשר מחיקת תוכן מתוך';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5300,22 +5304,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'השרת החזיר HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'האם אתה בטוח שברצונך למחוק את $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'המשתמש \"$name\" נמחק';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'מחיקת המשתמש נכשלה: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5336,7 +5340,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'יצירת המפתח נכשלה: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5347,7 +5351,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'לבטל את המפתח עבור $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5355,7 +5359,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'ביטול המפתח נכשל: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5375,29 +5379,29 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'אסימון: $token\\nנוצר: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'צור גיבוי';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'בחר מה לכלול בגיבוי.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'מסד נתונים';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'תמיד נכלל';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'מטא נתונים';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'כתוביות';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'תמונות Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'יוצר גיבוי...';
@@ -5407,7 +5411,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'יצירת הגיבוי נכשלה: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5415,12 +5419,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'מניפסט: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'טעינת המניפסט נכשלה: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5431,7 +5435,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'שחזור הגיבוי נכשל: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5463,17 +5467,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'נשמר אל $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'שמירת הקובץ נכשלה: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'טעינת $fileName נכשלה';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5484,7 +5488,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'טעינת המשימות נכשלה: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5495,17 +5499,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'הפעלת המשימה נכשלה: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'עצירת המשימה נכשלה: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'טעינת המשימה נכשלה: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5513,12 +5517,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'הסרת הטריגר נכשלה: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'הוספת הטריגר נכשלה: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5544,7 +5548,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours שעות';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5555,7 +5559,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'החלפת מצב התוסף נכשלה: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5563,27 +5567,27 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'האם להסיר את ההתקנה של \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'הסרת ההתקנה של התוסף נכשלה: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'התקנת החבילה נכשלה: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'התקנת העדכון נכשלה: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'טעינת התוספים נכשלה: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5594,12 +5598,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'התקן עדכון (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'טעינת הקטלוג נכשלה: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5620,17 +5624,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" יוסר לאחר הפעלה מחדש של השרת';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'הסרת ההתקנה נכשלה: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'מעדכן את \"$name\" לגרסה v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5638,7 +5642,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'טעינת התוסף נכשלה: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5646,7 +5650,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'גרסה $version';
+    return 'Version $version';
   }
 
   @override
@@ -5666,17 +5670,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'האם להסיר את \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'שמירת המאגרים נכשלה: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'טעינת המאגרים נכשלה: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5693,12 +5697,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'לא ניתן לטעון את הגדרות התוסף: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'לא ניתן לפתוח את $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5815,10 +5819,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminThrottleBuffering => 'חציצה של מצערת';
 
   @override
-  String get adminTrickplaySaved => 'הגדרות Trickplay נשמרו';
+  String get adminTrickplaySaved => 'הגדרות הטריק פליי נשמרו';
 
   @override
-  String get adminTrickplayLoadFailed => 'טעינת הגדרות Trickplay נכשלה';
+  String get adminTrickplayLoadFailed => 'טעינת הגדרות טריק פליי נכשלה';
 
   @override
   String get adminEnableHardwareAcceleration => 'אפשר האצת חומרה';
@@ -5926,7 +5930,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminBaseUrl => 'כתובת האתר הבסיסית';
 
   @override
-  String get adminBaseUrlHint => 'למשל /jellyfin';
+  String get adminBaseUrlHint => 'לְמָשָׁל /ג\'ליפין';
 
   @override
   String get https => 'HTTPS';
@@ -5966,12 +5970,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'טעינת המטא נתונים נכשלה: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'שמירת המטא נתונים נכשלה: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -5991,7 +5995,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'רענון המטא נתונים נכשל: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6005,7 +6009,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'החיפוש המרוחק נכשל: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6019,7 +6023,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'עדכון סוג התוכן נכשל: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6033,12 +6037,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'תמונת $imageType עודכנה';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'הורדת התמונה נכשלה: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6049,27 +6053,27 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'תמונת $imageType הועלתה';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'העלאת התמונה נכשלה: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'מחק את תמונת $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'תמונת $imageType נמחקה';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'מחיקת התמונה נכשלה: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6080,67 +6084,67 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'גילוי הטיונר נכשל: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'הוסף טיונר';
 
   @override
-  String get adminEditTuner => 'ערוך טיונר';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'טיונר M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'קובץ או URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'כתובת IP של הטיונר';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'שם ידידותי';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'סוכן משתמש';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'מגבלת חיבורים בו-זמניים';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'המספר המרבי של זרמים שהטיונר מאפשר בו-זמנית. הגדר 0 ללא הגבלה.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'קצב סיביות מרבי חלופי להזרמה';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'ייבא רק ערוצים מועדפים';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'אפשר טרנסקודינג בחומרה';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'אפשר קונטיינר טרנסקודינג fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'אפשר שיתוף זרמים';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'הפעל לולאת זרם';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'התעלם מ-DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'קרא את הקלט בקצב הפריימים המקורי';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ערוך ספק';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6149,49 +6153,50 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'קובץ או URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'קידומת סרטים';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'קטגוריות סרטים';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => 'הפרד בין קטגוריות מרובות בקו אנכי.';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'קטגוריות ילדים';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'קטגוריות חדשות';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'קטגוריות ספורט';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'שם משתמש';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'סיסמה';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'מדינה';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'בחר מדינה';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'מיקוד';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'קבל לוחות שידורים';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'לוחות שידורים';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'הפעל את כל הטיונרים';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'סוג טיונר';
@@ -6201,7 +6206,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'הוספת הטיונר נכשלה: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6215,12 +6220,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'הוספת הספק נכשלה: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'הסרת הטיונר נכשלה: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6228,15 +6233,16 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'איפוס הטיונר נכשל: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported => 'סוג טיונר זה אינו תומך באיפוס.';
+  String get adminTunerResetNotSupported =>
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'הסרת הספק נכשלה: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6255,43 +6261,43 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminSeriesRecordingPath => 'נתיב הקלטת סדרה';
 
   @override
-  String get adminMovieRecordingPath => 'נתיב הקלטת סרטים';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'ימי נתוני מדריך';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'אוטומטי';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ימים';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'נתיב יישום לעיבוד מאוחר';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'ארגומנטים לעיבוד מאוחר';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'שמור מטא נתוני NFO של ההקלטה';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'שמור תמונות של ההקלטה';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'תזמון';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'נתיבי הקלטה';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'עיבוד מאוחר';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'נתוני מדריך: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6299,7 +6305,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'שמירת ההגדרות נכשלה: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6316,7 +6322,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'עדכון המיפויים נכשל: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6332,14 +6338,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminGuideProviders => 'ספקי מדריכים';
 
   @override
-  String get adminRefreshGuideData => 'רענן את נתוני המדריך';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'רענון נתוני המדריך התחיל';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'משימת רענון המדריך אינה זמינה בשרת זה.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'הוסף ספק';
@@ -6349,22 +6355,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'נתיב הקלטה: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'נתיב סדרות: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'תוספת לפני: $minutes דק׳';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'תוספת אחרי: $minutes דק׳';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6395,7 +6401,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'לשחזר את הגיבוי $name עכשיו?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6419,13 +6425,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminLiveTvTitle => 'מנהלת טלוויזיה בשידור חי';
 
   @override
-  String get adminApply => 'החל';
+  String get adminApply => 'לִפְנוֹת';
 
   @override
   String get adminNotSet => 'לא מוגדר';
 
   @override
-  String get adminReset => 'איפוס';
+  String get adminReset => 'אִתחוּל';
 
   @override
   String get adminLogsTitle => 'יומני שרת';
@@ -6441,27 +6447,27 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'לפני $minutes דק׳';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'לפני $hours שע׳';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'לפני $days ימים';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'טעינת $fileName נכשלה';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count התאמות';
+    return '$count matches';
   }
 
   @override
@@ -6471,7 +6477,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminMetadataEditorTitle => 'עורך מטא נתונים';
 
   @override
-  String get adminMetadataIdentify => 'זהה';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'סוּג';
@@ -6486,7 +6492,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminMetadataImages => 'תמונות';
 
   @override
-  String get adminMetadataFieldTitle => 'כותרת';
+  String get adminMetadataFieldTitle => 'כּוֹתֶרֶת';
 
   @override
   String get adminMetadataFieldSortTitle => 'מיון כותרת';
@@ -6571,22 +6577,22 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'תמונת $imageType עודכנה';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'תמונת $imageType הועלתה';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'תמונת $imageType נמחקה';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'הורדת התמונה נכשלה: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6594,12 +6600,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'העלאת התמונה נכשלה: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'מחק את תמונת $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6608,12 +6614,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'מחיקת התמונה נכשלה: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'בחר תמונת $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6645,7 +6651,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'עדכון זמין: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6668,7 +6674,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'התקן עדכון (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6680,7 +6686,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" בהתקנה...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6700,7 +6706,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'הגדרות $name';
+    return '$name Settings';
   }
 
   @override
@@ -6740,7 +6746,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'טעינת המאגרים נכשלה: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6748,15 +6754,15 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'האם להסיר את \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'הסר';
+  String get adminReposRemove => 'לְהַסִיר';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'שמירת המאגרים נכשלה: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6880,19 +6886,19 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminBrandingEnableSplash => 'אפשר מסך פתיחה';
 
   @override
-  String get adminBrandingSplashUpload => 'העלה תמונה';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'מסך הפתיחה עודכן';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'העלאת מסך הפתיחה נכשלה';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'מסך הפתיחה הוסר';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'אין מסך פתיחה מותאם אישית';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'האצת חומרה';
@@ -6907,121 +6913,121 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'אפשר פענוח חומרה עבור:';
 
   @override
-  String get adminPlaybackQsvDevice => 'התקן QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'הפעל מפענח NVDEC משופר';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'העדף מפענח חומרה מובנה של המערכת';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'עומק צבע בפענוח חומרה';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'פענוח HEVC ב-10 סיביות';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'פענוח VP9 ב-10 סיביות';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'פענוח HEVC RExt ב-8/10 סיביות';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'פענוח HEVC RExt ב-12 סיביות';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'קידוד בחומרה';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'אפשר קידוד HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'אפשר קידוד AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'הפעל מקודד H.264 חסכוני של Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'הפעל מקודד HEVC חסכוני של Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'מיפוי גוונים';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'הפעל מיפוי גוונים';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'הפעל מיפוי גוונים VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'הפעל מיפוי גוונים VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'אלגוריתם מיפוי גוונים';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'מצב מיפוי גוונים';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'טווח מיפוי גוונים';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'הפחתת רוויה במיפוי גוונים';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'שיא מיפוי גוונים';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'פרמטר מיפוי גוונים';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'בהירות מיפוי גוונים VPP';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'ניגודיות מיפוי גוונים VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'הגדרות מראש ואיכות';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'הגדרה מראש של המקודד';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF לקידוד H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF לקידוד H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'שיטת ביטול שזירה';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'הכפל את קצב הפריימים בעת ביטול שזירה';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'שמע';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'הפעל קידוד שמע VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'הגברת דאונמיקס שמע';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'אלגוריתם דאונמיקס לסטריאו';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'גודל מרבי של תור ה-muxing';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'אוטומטי';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'הַצפָּנָה';
@@ -7138,10 +7144,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminTaskNeverRun => 'לעולם אל תברח';
 
   @override
-  String get adminTaskStop => 'עצור';
+  String get adminTaskStop => 'לְהַפְסִיק';
 
   @override
-  String get adminRunningTasks => 'משימות פעילות';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'לָרוּץ';
@@ -7163,17 +7169,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'מדי יום בשעה $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'כל $day בשעה $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'כל $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7211,9 +7217,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count שעות',
-      two: 'שעתיים',
-      one: 'שעה אחת',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7241,17 +7246,17 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'לפני $days ימים';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'לפני $hours שע׳';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'לפני $minutes דק׳';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7259,27 +7264,27 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes דק׳';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours שע׳';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days ימים';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'הגדר יצירת תמונות Trickplay לתמונות ממוזערות של תצוגה מקדימה בחיפוש.';
+      'הגדר יצירת תמונות טריק פליי לחיפוש תמונות ממוזערות של תצוגה מקדימה.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'יציאת HTTPS ציבורית';
@@ -7288,49 +7293,49 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'כתובת האתר הבסיסית';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'למשל /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'לְמָשָׁל /ג\'ליפין';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'יציאת HTTP ציבורית';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'דרוש HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'הפנה את כל הבקשות המרוחקות ל-HTTPS. אין לכך השפעה אם לשרת אין תעודה תקפה.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'סיסמת התעודה';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'הגדרות IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'הפעל IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'הפעל IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'הפעל מיפוי יציאות אוטומטי';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'רשתות LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'רשימה של כתובות IP או תת-רשתות CIDR, מופרדות בפסיקים או בשורות, שייחשבו כחלק מהרשת המקומית.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'כתובות URI מפורסמות של השרת';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'מפה תת-רשת או כתובת לכתובת URL מפורסמת, למשל all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'נתיב תעודה';
@@ -7360,11 +7365,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'חציצה של מצערת';
 
   @override
-  String get adminPlaybackThrottleDelay => 'השהיית ויסות (שניות)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'אפשר חילוץ כתוביות בזמן אמת';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'אחוז מינימלי של קורות חיים';
@@ -7412,29 +7417,29 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'עדכון סוג התוכן נכשל: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'סף תגובה איטית (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'הפעל אזהרות על תגובה איטית';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'הפעל את Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'שרת';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'מטא נתונים';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'נתיבים';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'ביצועים';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'נתיב מטמון';
@@ -7446,7 +7451,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminGeneralServerName => 'שם השרת';
 
   @override
-  String get adminGeneralDisplayLanguage => 'שפת תצוגה מועדפת';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'טעינת ההגדרות נכשלה';
@@ -7456,12 +7461,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'עדכון המיפויים נכשל: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'מגבלת זמן: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7498,9 +7503,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# משתתפים',
-      two: '# משתתפים',
-      one: '# משתתף',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7543,7 +7547,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'פריט $index';
+    return 'Item $index';
   }
 
   @override
@@ -7591,12 +7595,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName הצטרף לקבוצת SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName עזב את קבוצת SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7608,7 +7612,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'מסנכרן את ההפעלה עם $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7646,9 +7650,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# שורות התגלו',
-      two: '# שורות התגלו',
-      one: '# שורה התגלתה',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7688,19 +7691,20 @@ class AppLocalizationsHe extends AppLocalizations {
   String get offlineSavedMedia => 'מדיה שמורה';
 
   @override
-  String get offlineBannerTitle => 'אתה במצב לא מקוון';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'מוצגות ההורדות שלך';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'הורדות';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'לא ניתן להגיע לשרת שלך';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
-  String get serverUnreachableBannerSubtitle => 'מפעיל מההורדות עד שיחזור';
+  String get serverUnreachableBannerSubtitle =>
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7716,12 +7720,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'בקרת Cast נכשלה: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'בקרות $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7732,7 +7736,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'עצור $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7755,12 +7759,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'הזן PIN בן $length ספרות';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'הזן את ה-PIN בן $length הספרות שלך';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7773,37 +7777,37 @@ class AppLocalizationsHe extends AppLocalizations {
   String get pinForgot => 'שכחת PIN?';
 
   @override
-  String get pinClear => 'נקה';
+  String get pinClear => 'בָּרוּר';
 
   @override
-  String get pinBackspace => 'מחיקה לאחור';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'בקשת Quick Connect אושרה.';
+  String get quickConnectAuthorized => 'בקשת חיבור מהיר אושרה.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'קוד Quick Connect אינו חוקי או שפג תוקפו.';
+      'קוד החיבור המהיר אינו חוקי או שפג תוקפו.';
 
   @override
-  String get quickConnectNotSupported => 'Quick Connect אינו נתמך בשרת זה.';
+  String get quickConnectNotSupported => 'חיבור מהיר אינו נתמך בשרת זה.';
 
   @override
-  String get quickConnectAuthorizeFailed => 'אישור קוד Quick Connect נכשל.';
+  String get quickConnectAuthorizeFailed => 'נכשל הרשאה של קוד חיבור מהיר.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect מושבת בשרת זה.';
+  String get quickConnectDisabled => 'חיבור מהיר מושבת בשרת זה.';
 
   @override
   String get quickConnectForbidden =>
-      'החשבון שלך אינו יכול לאשר בקשת Quick Connect זו.';
+      'החשבון שלך לא יכול לאשר בקשת חיבור מהיר זו.';
 
   @override
-  String get quickConnectNotFound => 'קוד Quick Connect לא נמצא. נסה קוד חדש.';
+  String get quickConnectNotFound => 'קוד חיבור מהיר לא נמצא. נסה קוד חדש.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect נכשל: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7814,7 +7818,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'הפקודה נכשלה: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7843,7 +7847,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'התחלת ה-Cast נכשלה: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7888,7 +7892,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'מוריד את $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -7907,7 +7911,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get shuffleSelectGenre => 'בחר ז\'אנר';
 
   @override
-  String get shuffleLibrary => 'ספרייה';
+  String get shuffleLibrary => 'סִפְרִיָה';
 
   @override
   String get shuffleGenre => 'ז\'ָאנר';
@@ -7967,14 +7971,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get stillWatchingContent => 'ההשמעה הושהתה. אתה עדיין צופה?';
 
   @override
-  String get stillWatchingStop => 'עצור';
+  String get stillWatchingStop => 'לְהַפְסִיק';
 
   @override
   String get stillWatchingContinue => 'לְהַמשִׁיך';
 
   @override
   String skipSegment(String segment) {
-    return 'דלג על $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -7985,12 +7989,12 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'מוריד $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'מוריד את $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8027,7 +8031,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'אפשר סיבוב';
 
   @override
-  String get playerTooltipPrevious => 'הקודם';
+  String get playerTooltipPrevious => 'קוֹדֵם';
 
   @override
   String get playerTooltipSeekBack => 'חפש בחזרה';
@@ -8051,13 +8055,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get contextMenuGoToSeries => 'לך לסדרה';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'הסתר מ\"המשך לצפות\"';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'הסתר מ\"הבא בתור\"';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'הוסף לאוסף';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'גש ללוח ניהול השרת';
@@ -8108,14 +8113,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsAlphabetical => 'אָלֶף בֵּיתִי';
 
   @override
-  String get settingsConnectionSection => 'חיבור';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'אפשר תעודות בחתימה עצמית';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'תן אמון בשרתים המשתמשים בתעודות TLS בחתימה עצמית או מרשות אישורים פרטית. הפעל רק עבור שרתים שבשליטתך. פעולה זו משביתה את אימות התעודות בכל החיבורים.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'פרטיות ובטיחות';
@@ -8131,11 +8136,11 @@ class AppLocalizationsHe extends AppLocalizations {
       'הדגשות נושא, תפאורות, מחוונים שנצפו ומוזיקת ​​נושא';
 
   @override
-  String get settingsDetailsScreen => 'מסך פרטים';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'סגנון, טשטוש רקע והתנהגות לשוניות';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'עמוד הבית';
@@ -8173,11 +8178,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'הצג את לחצן Seerr בסרגל הניווט';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'הצג תמיד תוויות טקסט בסרגל הניווט העליון';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8244,7 +8249,8 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsSupportMoonfin => 'תמכו ב- Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'תרום כוס קפה למפתח';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'מִשׁפָּטִי';
@@ -8276,9 +8282,8 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# הודעות רישיון',
-      two: '# הודעות רישיון',
-      one: '# הודעת רישיון',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8324,16 +8329,16 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'לדלג על Intros ו-Outros?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'ספירה לאחור של מקטע מדיה';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'סרגל התקדמות';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'טיימר';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ללא';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'משתמש מהיר';
@@ -8367,13 +8372,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (מומלץ)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (מיושן)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (מורשת)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (מומלץ)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision סתירה';
@@ -8557,745 +8562,749 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName שיצאו לאחרונה';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'הפעלה אוטומטית של הפרק הבא';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'הפעל אוטומטית את הפרק הבא כשהוא זמין.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'דלג על שקט';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'דלג אוטומטית על מקטעי שמע שקטים כשהזרם תומך בכך.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'אפשר אפקטי שמע חיצוניים';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'אפשר לאפליקציות אקולייזר ואפקטים (למשל Wavelet) להתחבר להפעלות Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'השבת מנהור';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'אלץ הפעלה ללא מנהור. שימושי במכשירים שבהם המנהור גורם לקטיעות בשמע/וידאו.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'הפעל מנהור';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'מתקדם. מנתב שמע ווידאו דרך נתיב חומרה משולב. כבוי כברירת מחדל מכיוון שהוא גורם לנפילות שמע/וידאו בחלק מהמכשירים.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'מפה את Dolby Vision פרופיל 7 ל-HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'הפעל זרמי Dolby Vision פרופיל 7 כ-HEVC תואם HDR10 במכשירים ללא תמיכה ב-Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'השתמש בסגנונות כתוביות מוטמעים';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'החל צבעים, גופנים ומיקום המוטמעים ברצועת הכתוביות. השבת כדי להשתמש במקום זאת בהעדפות סגנון הכתוביות שלך.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'השתמש בגדלי גופן מוטמעים של הכתוביות';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'החל רמזי גודל גופן המוטמעים ברצועת הכתוביות. השבת כדי להשתמש בגודל הכתוביות מהעדפות הסגנון שלך.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'הצג פרטי מדיה';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'הצג את פרטי הפריט הנבחר בראש דפי הספרייה.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'להסתיר תמונות רקע בעת גלישה?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'השתמש בכותרות משנה מפורטות';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'הצג שורת משנה מפורטת או מינימלית בדפי הספרייה.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'למחוק את ערכת הנושא השמורה?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'להסיר את \"$themeName\" ממטמון המכשיר הזה?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'חנות ערכות הנושא';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'עיין ושמור ערכות נושא של הקהילה';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'שמור ערכת נושא כדי להשתמש בה כמו בערכות השמורות האחרות שלך.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'אין ערכות נושא זמינות כרגע.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'לא ניתן היה לטעון את חנות ערכות הנושא. בדוק את החיבור ונסה שוב.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'שמור';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'שמור והחל';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'נשמר';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'לא ניתן היה לטעון את ערכת הנושא הזו.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" נשמרה.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" נמחקה מהמכשיר הזה.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'לא ניתן היה למחוק את \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'ערכות נושא שמורות';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'אלו ערכות נושא שהורדו מתוסף Moonfin עבור השרת הנוכחי. מחיקה מסירה רק את העותק המקומי הזה.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'לא נמצאו ערכות נושא שמורות עבור שרת זה.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • פעילה כעת';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'מחק ערכת נושא שמורה';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'נהל ערכות נושא של התוסף שהורדו למכשיר הזה';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'עורך ערכות הנושא';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'פתח את עורך ערכות הנושא של Moonfin בדפדפן';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'מסך הבית';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'הסרגל התחתון';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'קלאסי';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'מודרני';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'שורות הבית';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'תצוגת שורות הבית';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'מקטעי שורות הבית';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'מתגי שורות הבית';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'הפעל או השבת קטגוריות של שורות בית מבוססות ספרייה';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'הפעל את המתגים הבאים כדי להציג את השורות במקטעי הבית.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'קלאסי שומר על סוג תמונה ושכבת מידע לכל שורה. מודרני משתמש בשורות מפוסטר לתמונת רקע.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'הצג שורות מועדפים';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'הצג סרטים מועדפים, סדרות ושורות מועדפים אחרות במקטעי הבית.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'מיון שורות המועדפים';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'מיין את שורות המועדפים לפי תאריך הוספה, תאריך יציאה, סדר אלפביתי ועוד.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'הצג שורות אוספים';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
-  String get displayCollectionsRowsSubtitle => 'הצג שורות אוספים במקטעי הבית.';
+  String get displayCollectionsRowsSubtitle =>
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'מיון שורות האוספים';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'מיין את שורות האוספים לפי תאריך הוספה, תאריך יציאה, סדר אלפביתי ועוד.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'הצג שורות ז\'אנרים';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'הצג שורות ז\'אנרים במקטעי הבית.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'מיון שורות הז\'אנרים';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'מיין את שורות הז\'אנרים לפי תאריך הוספה, תאריך יציאה, סדר אלפביתי ועוד.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'פריטים בשורות הז\'אנרים';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'הצג סרטים, סדרות או שניהם בשורות הז\'אנרים.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'הצג שורות רשימות השמעה';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'הצג שורות רשימות השמעה במקטעי הבית.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'מיון שורות רשימות ההשמעה';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'מיין את שורות רשימות ההשמעה לפי תאריך הוספה, תאריך יציאה, סדר אלפביתי ועוד.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'הצג שורות שמע';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'הצג שורות שמע במקטעי הבית.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'מיון שורות השמע';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'מיין את שורות השמע לפי תאריך הוספה, תאריך יציאה, סדר אלפביתי ועוד.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'רשימות השמעה של שמע';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'מראה';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'פריסה';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'ערכת נושא';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'מקלדת';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'כפתורים';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'רינדור';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'תצורת MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'אפליקציית נגן חיצוני';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'הגדר נגן חיצוני כדי לאפשר הפעלה בלחיצה ארוכה';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'הצג בורר אפליקציות בתחילת ההפעלה.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'טוען נגנים מותקנים...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'חיבור';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'יעד המרת קידוד שמע';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'העברה ישירה';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'נתמך במכשיר זה';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'לא נתמך במכשיר זה';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'העברה ישירה של DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'העברת DTS:X (DTS UHD) כזרם ביטים למפענח חיצוני.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'העברה ישירה של TrueHD עם Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'התנהגות נגן המדיה';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'שיפורי הפעלה';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'תמיד פעיל.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'החלפת דילוג על הסיום בתצוגת הבא בתור';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'הצג את שכבת הבא בתור במקום את כפתור דילוג על הסיום.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'ניתוב הנגן';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'העדף מפענחי תוכנה';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'השתמש ב-FFmpeg (שמע) וב-libgav1 (AV1) לפני מפענחי חומרה. השבת אם העברת השמע הישירה ב-HDMI מפסיקה לעבוד.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'פתח הפעלת וידאו באפליקציה החיצונית שבחרת ב-Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'הוספה אוטומטית לתור';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'העדף כתוביות SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'תעדף רצועות כתוביות SDH/CC בבחירה אוטומטית.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'אבחון ווב';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'אבחון ווב של Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'השתמש בעמוד זה כדי לאבחן בעיות קישוריות בדפדפן (CORS, תוכן מעורב והגדרות איתור).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
-  String get webDiagnosticsDetectedMixedContentFailure => 'זוהה כשל תוכן מעורב';
+  String get webDiagnosticsDetectedMixedContentFailure =>
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'זוהה כשל CORS/Preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin זיהה עמוד HTTPS שמנסה לפנות לכתובת שרת HTTP. דפדפנים חוסמים בקשה זו עוד לפני שהיא מגיעה לשרת שלך.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin זיהה כשל בקשה ברמת הדפדפן, שנגרם בדרך כלל מכותרות CORS או preflight חסרות בשרת המדיה.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'כתובת יעד: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'פירוט: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'הקשר זמן הריצה הנוכחי';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'מקור';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'סכמה';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'מצב תוסף';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'סריקת WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'כתובת שרת כפויה';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'כתובת שרת ברירת מחדל';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'כתובת פרוקסי לאיתור';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'לא מוגדר';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'תוכן מעורב';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'עמוד זה נטען דרך HTTPS, אך אחת או יותר מהכתובות המוגדרות הן HTTP. דפדפנים חוסמים פנייה של עמודי HTTPS לממשקי API מסוג HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'פתרון: הגש את שרת המדיה או את נקודת הקצה של הפרוקסי דרך HTTPS, או טען את Moonfin דרך HTTP ברשתות מקומיות מהימנות בלבד.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'לא זוהתה תצורת תוכן מעורב מובהקת מהגדרות זמן הריצה הנוכחיות.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'רשימת בדיקה ל-CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• אפשר את מקור הדפדפן ב-Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• כלול את Authorization, X-Emby-Authorization ו-X-Emby-Token ב-Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• חשוף את Content-Range ואת Accept-Ranges עבור הזרמה ודילוג בזמן.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• החזר 204 לבקשות preflight מסוג OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'דוגמה לקטע כותרות (בסגנון nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'הערה';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'מסלול אבחון זה מיועד לגרסאות ווב. אם אתה רואה אותו בפלטפורמה אחרת, ייתכן שהבדיקות אינן רלוונטיות.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'חזרה לבחירת שרת';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'נתק את כל המשתמשים';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'ההרשאה למיקרופון נדחתה לצמיתות. הפעל אותה בהגדרות המערכת.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'נדרשת הרשאה למיקרופון לחיפוש קולי.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'לא הצלחנו לקלוט. נסה שוב.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'לא זוהה דיבור.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'שגיאת מיקרופון.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'חיפוש קולי דורש חיבור לאינטרנט.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => 'שירות הקול עסוק. נסה שוב.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'ההרשאה למיקרופון נדחתה לצמיתות.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'ההרשאה למיקרופון נדחתה.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
-  String get speechRecognitionUnavailable => 'זיהוי דיבור אינו זמין במכשיר זה.';
+  String get speechRecognitionUnavailable =>
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'פתח את בורר המסלולים של iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'בורר המסלולים של AirPlay אינו זמין במכשיר זה.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'סרטונים';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'תוכניות';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'שירים';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'אלבומי תמונות';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'תמונות';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'אנשים';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'פרקים ששוחררו לאחרונה';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'צפה שוב';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'הופעות אורח';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'הופעות (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'תרומות צוות (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'צפה עם קבוצה';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'שגיאות';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'אזהרות';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'דיסק';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'פתח בדפדפן';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'דפדפן מוטמע אינו זמין בפלטפורמה זו.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'האם אתה בטוח שברצונך להפעיל מחדש את השרת?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'האם אתה בטוח שברצונך לכבות את השרת? תצטרך להפעיל אותו מחדש באופן ידני.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'פנימי';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'לא פעיל';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'לא נמצאו משתמשים';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'אין משתמשים התואמים לחיפוש שלך';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'לא נמצאו מכשירים';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'אין מכשירים התואמים למסננים הנוכחיים';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'סיסמה הוגדרה';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'לא הוגדרה סיסמה';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'גישה מרחוק';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'מקומי בלבד';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => 'טעינת ניתוח המדיה נכשלה';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'ניתוח משולב מכל ספריות המדיה.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'אמנים מובילים';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'סופרים מובילים';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'תורמים מובילים';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ספריות',
-      two: 'שתי ספריות',
-      one: 'ספרייה אחת',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'עדיין אין סיכומי מדיה מאונדקסת עבור בחירה זו.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'פרטי הספרייה';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'פילוח לפי ספרייה';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'אין ספריות זמינות.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'ניהול השרת';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'נתונים';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'מטמון תמונות';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'מטמון';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'יומנים';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'מטא-נתונים';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'המרת קידוד';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'שרת זה לא החזיר נתיבי שרת.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% בשימוש';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'פעילות משתמשים';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'אירועי מערכת';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'דורש טיפול';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'שרת';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'הפעלה';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'מכשירים';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'מתקדם';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'תוספים';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'טלוויזיה בשידור חי';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'סרטוני בית';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'תוכן מעורב';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'סרטוני בית ותמונות';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'סרטים וסדרות מעורבים';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9307,296 +9316,299 @@ class AppLocalizationsHe extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'לא נמצאו הקלטות';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'לא נמצאו עמודי תמונה בארכיון .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'מנוע הרינדור המוטמע נכשל ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'מנוע הרינדור של EPUB נכשל ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'חסר קובץ מקומי עבור הקורא: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status בעת פתיחת נתוני הספר מ-$uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => 'לא זמינה נקודת קצה קריאה לספר';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'פורמט ארכיון קומיקס שאינו נתמך: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'תוסף החילוץ של CBR אינו זמין בפלטפורמה זו.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'חילוץ ארכיון .cbr נכשל.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => 'חילוץ CB7 אינו זמין בפלטפורמה זו.';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'תוסף החילוץ של CB7 אינו זמין בפלטפורמה זו.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'סגור את פאנל הז\'אנרים';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'טוען ערבוב...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ערבוב ספרייה';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ערבוב אקראי';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ערבוב ז\'אנרים';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'מעבר אוטומטי ל-HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'הפעל אוטומטית HDR בהפעלת וידאו HDR ושחזר את מצב התצוגה ביציאה.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'במסך מלא';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'החלף גרפיקה';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'חסר';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'מגבלות המרת קידוד';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'לנקות את כל הגרפיקה?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'האם אתה בטוח שברצונך לנקות את כל הגרפיקה שהורדה?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'אישור ניקוי';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'האם אתה בטוח שברצונך לנקות את $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'להעלות?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'רזולוציה: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => 'הצג גרפיקה בשפת הממשק בלבד';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'אישור ניקוי הכול';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'התמונה הועלתה בהצלחה!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'העלאת התמונה נכשלה: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'הגדרת התמונה נכשלה: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'מחיקת התמונה נכשלה: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'ניקוי כל הגרפיקה נכשל: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'כן';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'פוסטר';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'רקעים';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'באנר';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'לוגו';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'תמונה ממוזערת';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'גרפיקה';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'גרפיקת דיסק';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'צילום מסך';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'עטיפת קופסה';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'עטיפה אחורית של קופסה';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'גרפיקת תפריט';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'הפוסטר';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'הרקע';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'הבאנר';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'הלוגו';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'התמונה הממוזערת';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'הגרפיקה';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'גרפיקת הדיסק';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'צילום המסך';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'עטיפת הקופסה';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'העטיפה האחורית של הקופסה';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'גרפיקת התפריט';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'הכול';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'גבוהה (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'בינונית (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'נמוכה (מתחת ל-720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'מקורות';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'פרקים';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'סימניות';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'הערות';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'תור';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ציר זמן';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ציר הזמן ריק';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'הספר כולו';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'ציר זמן ממוקד';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ייצוא סימניות';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'ייצוא הערות';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'ייצוא הכול';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'הייצוא נשמר ב-$path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'הייצוא נכשל: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'מילות השיר';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'הוסף סימנייה';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'הוסף הערה';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'ערוך הערה';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'כתוב הערה לרגע הזה';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'טיימר שינה';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'כבוי';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'סוף הפרק';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'מותאם אישית';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'נותרו $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9604,59 +9616,58 @@ class AppLocalizationsHe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count דקות',
-      two: 'שתי דקות',
-      one: 'דקה אחת',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'מהירות הפעלה';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'נותר';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'חלף';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'אחורה $seconds שניות';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'קדימה $seconds שניות';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'הפרק הקודם';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'הפרק הבא';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'פרק $current מתוך $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'אין פרקים';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'אין עדיין סימניות';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'אין עדיין הערות';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'סימנייה נוספה ב-$position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'איפוס ל-1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9664,248 +9675,249 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'שמור';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'בטל';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'מחק';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'העדפות כתוביות';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'שנה מצבי כתוביות, שפות ברירת מחדל, מראה ואפשרויות רינדור.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'רינדור כתוביות';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'אפשרויות תצוגה';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'תאריך יציאה (מהישן לחדש)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'תאריך יציאה (מהחדש לישן)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'קיבוץ תרומות';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'קבץ תפקידים מרובים';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'אזהרת הרשאת כתיבה לספרייה';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'איך לתקן זאת:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. הענק הרשאות כתיבה למשתמש השירות של Jellyfin (למשל jellyfin או PUID/PGID של Docker) לתיקיות ספריית המדיה שלך בשרת.\n\n2. לחלופין, עבור אל לוח הבקרה של Jellyfin -> ספריות, ערוך את הספרייה הזו והשבת את \'שמירת גרפיקה בתיקיות המדיה\' כדי לאחסן את הגרפיקה במסד הנתונים הפנימי של Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'סגור';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'הספרייה \'$libraryName\' שלך מוגדרת לשמור גרפיקה ישירות בתיקיות המדיה (האפשרות \'שמירת גרפיקה בתיקיות המדיה\' מופעלת). עם זאת, Jellyfin בדק את הרשאות הכתיבה ואין לו הרשאה לכתוב קבצים לתיקייה הזו:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'נראה ש-Jellyfin לא הצליח לעדכן את הגרפיקה. הספרייה שלך מוגדרת לשמור גרפיקה ישירות בתיקיות המדיה (האפשרות \'שמירת גרפיקה בתיקיות המדיה\' מופעלת). שגיאה זו מתרחשת בדרך כלל כאשר לתהליך שרת Jellyfin אין הרשאה לכתוב קבצים לתיקיות המדיה שלך.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'רשימות חיצוניות';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'הפעל שוב';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'פרטי הקובץ';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'גודל: $size  •  פורמט: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'הצג את כל רצועות השמע ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'הצג את כל רצועות הכתוביות ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'בודק יכולת הפעלה ישירה...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'יכולת הפעלה ישירה: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'כפוי';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'פורמט המכל אינו נתמך על ידי הנגן.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'קודק הווידאו אינו נתמך.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'קודק השמע אינו נתמך.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'פורמט הכתוביות אינו נתמך (נדרשת צריבה).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'פרופיל השמע אינו נתמך.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'פרופיל הווידאו אינו נתמך.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'רמת הווידאו אינה נתמכת.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'רזולוציית הווידאו אינה נתמכת במכשיר זה.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'עומק הסיביות של הווידאו אינו נתמך.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'קצב הפריימים של הווידאו אינו נתמך.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'קצב הסיביות של הקובץ חורג ממגבלת ההזרמה של הנגן.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'קצב הסיביות של הווידאו חורג ממגבלת ההזרמה.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'קצב הסיביות של השמע חורג ממגבלת ההזרמה.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioChannelsNotSupported => 'מספר ערוצי השמע אינו נתמך.';
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'לפי סדר האלפבית';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'סדר יציאה (מהישן לחדש)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'סדר יציאה (מהחדש לישן)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'מותאם אישית (גרירה ושחרור)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'אפשרויות מיון של רשימת ההשמעה';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'אפס מיון';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'צפה שוב בעונה $season פרק $episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'צפה שוב ברשימת ההשמעה';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'לא נמצאו כתוביות.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'בקרות מנהל';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'מנוע רינדור (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller הוא מנוע ה-GPU המודרני של Flutter, לאנימציות חלקות יותר ולפחות קפיצות. בחלק ממכשירי הטלוויזיה ובמעבדים גרפיים ישנים הוא עלול לגרום לתקלות תצוגה או לווידאו שחור; כבה אותו אם אתה נתקל בכך. אוטומטי בוחר את ברירת המחדל הטובה ביותר עבור המכשיר שלך. הפעל מחדש את Moonfin כדי להחיל.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'אוטומטי';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'פועל';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'כבוי';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'נדרשת הפעלה מחדש';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'יש להפעיל מחדש את Moonfin כדי לשנות את מנוע הרינדור. סגור את האפליקציה עכשיו ופתח אותה שוב כדי להחיל.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'סגור את האפליקציה עכשיו';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'רענן ספרייה';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'רענן את כל הספריות';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'תאריך הוספה (הישן ביותר תחילה)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'תאריך הוספה (החדש ביותר תחילה)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'לפי סדר האלפבית (א-ת)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'לפי סדר האלפבית (ת-א)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'טוען ניתוח שרת... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'התאם למקור';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => '250 הסרטים המובילים ב-IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => '250 סדרות הטלוויזיה המובילות ב-IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'הסרטים הפופולריים ביותר ב-IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows =>
-      'סדרות הטלוויזיה הפופולריות ביותר ב-IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'הסרטים בעלי הדירוג הנמוך ביותר ב-IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'הסרטים באנגלית עם הדירוג הגבוה ביותר ב-IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -9,30 +9,30 @@ class AppLocalizationsHi extends AppLocalizations {
   AppLocalizationsHi([String locale = 'hi']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'मूनफ़िन';
 
   @override
-  String get accountPreferences => 'खाता प्राथमिकताएँ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'इंटरफ़ेस भाषा';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'सिस्टम डिफ़ॉल्ट';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'दाखिल करना';
 
   @override
-  String get empty => 'खाली';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName से कनेक्ट हो रहा है';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'त्वरित कनेक्ट';
 
   @override
   String get password => 'पासवर्ड';
@@ -51,7 +51,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get waitingForAuthorization => 'प्राधिकरण के लिए इंतजार करो...';
 
   @override
-  String get back => 'वापस';
+  String get back => 'पीछे';
 
   @override
   String get serverUnavailable => 'सर्वर अनुपलब्ध है';
@@ -61,12 +61,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect उपलब्ध नहीं: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect उपलब्ध नहीं ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin वर्शन $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '\"$serverName\" को अपने सर्वर से हटाएँ?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'रद्द करना';
 
   @override
-  String get remove => 'हटाएँ';
+  String get remove => 'निकालना';
 
   @override
   String get connectToServer => 'सर्वर से कनेक्ट करें';
@@ -141,62 +141,62 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsAppearanceTheme => 'ऐप थीम';
 
   @override
-  String get detailScreenStyle => 'विवरण स्क्रीन शैली';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'क्लासिक मूल, केंद्र में सजा moonfin लेआउट है। मॉडर्न एक रिस्पॉन्सिव सिनेमैटिक लेआउट है।';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'क्लासिक';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'मॉडर्न';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'विस्तृत टैब';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'टैब ब्राउज़ करते समय टैब की सामग्री अपने आप दिखाएँ। हर टैब को खुद खोलने और बंद करने के लिए इसे बंद करें।';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'तकनीकी विवरण दिखाएँ?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'बैनर सारांश में कोडेक, रिज़ॉल्यूशन और स्ट्रीम जानकारी दिखाएँ';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'अनुशंसा सिस्टम';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends का लोकल-लाइब्रेरी एल्गोरिदम या ऑनलाइन TMDb की समानता मेट्रिक्स इस्तेमाल करें। ध्यान दें: ऑनलाइन अनुशंसाओं के लिए Seerr इंटीग्रेशन ज़रूरी है।';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb समानता';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'पैरेंटल रेटिंग सीमा लागू करें?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Moonfin Recommends के सुझावों को लक्षित मीडिया की पैरेंटल रेटिंग के अनुसार सीमित करें';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'इंटरफ़ेस शैली';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'स्वचालित आपके डिवाइस के अनुसार चलता है। कोई खास लुक चाहिए तो Apple या Material चुनें।';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'स्वचालित';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsHi extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glass क्वालिटी';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ऑटो इस डिवाइस के लिए सबसे अच्छा Glass इफ़ेक्ट चुनता है। फ़ुल असली ब्लर लागू करता है; रिड्यूस्ड हल्का Glass इस्तेमाल करता है जो GPU पावर बचाता है।';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ऑटो';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'फ़ुल';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'रिड्यूस्ड';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'ऐप को पुनरारंभ किए बिना Moonfin और Neon Pulse के बीच स्विच करें';
 
   @override
-  String get customThemeTitle => 'कस्टम थीम';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'कस्टम थीम पूरे Moonfin में विज़ुअल एलिमेंट बदल देती हैं। अपनी पसंद के अनुसार इनमें से कोई विकल्प चुनें।';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'सिस्टम कीबोर्ड को प्राथमिकता दें';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'टेक्स्ट लिखने के लिए डिफ़ॉल्ट रूप से अपने डिवाइस की इनपुट विधि इस्तेमाल करें';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'मूनफ़िन';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -257,14 +257,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'लिक्विड-ग्लास स्टाइलिंग, बहते ग्रेडिएंट बैकड्रॉप, फ़्रॉस्टेड सतहों और Apple-ब्लू एक्सेंट के साथ';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'रेट्रो पिक्सेल-आर्ट स्टाइलिंग, चंकी पैलेट, ब्लॉकी बॉर्डर, गहरे ड्रॉप-शैडो और पिक्सेल फ़ॉन्ट के साथ';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +313,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target से कनेक्ट नहीं हो सका';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,36 +327,35 @@ class AppLocalizationsHi extends AppLocalizations {
   String get exit => 'बाहर निकलना';
 
   @override
-  String get gameMenu => 'मेन्यू';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'पॉज़ किया गया';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'स्टेट सेव करें';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'गेम्स';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'स्टेट लोड करें';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'फ़ास्ट-फ़ॉरवर्ड';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'एमुलेटर सेटिंग्स';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'इस कोर में कोई एडजस्ट करने लायक विकल्प नहीं है।';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'मेन्यू खोलने के लिए दबाए रखें';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'इस डिवाइस पर अभी गेम खेलना समर्थित नहीं है।';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'कोई होम रो लोड नहीं किया जा सका';
@@ -378,13 +377,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get schedule => 'अनुसूची';
 
   @override
-  String get series => 'सीरीज़';
+  String get series => 'शृंखला';
 
   @override
   String get noItemsFound => 'कोई आइटम नहीं मिला';
 
   @override
-  String get home => 'होम';
+  String get home => 'घर';
 
   @override
   String get browseAll => 'सभी ब्राउज़ करें';
@@ -415,7 +414,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get noLibrariesFound => 'कोई लाइब्रेरी नहीं मिली';
 
   @override
-  String get library => 'लाइब्रेरी';
+  String get library => 'पुस्तकालय';
 
   @override
   String get displaySettings => 'प्रदर्शन सेटिंग्स';
@@ -428,7 +427,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'फ़ोल्डर लोड नहीं हो सका: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count आइटम';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count आइटम';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — शैलियाँ';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +532,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$countमि पहले';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$countघं पहले';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$countदि पहले';
+    return '${count}d ago';
   }
 
   @override
@@ -554,7 +553,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'चुनें कि डिस्कवर में कौन सा विषय फ़ीड दिखाना है।';
 
   @override
-  String get apply => 'लागू करें';
+  String get apply => 'आवेदन करना';
 
   @override
   String get openLink => 'खुला लिंक';
@@ -578,7 +577,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count टाइटल';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +602,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get listen => 'सुनना';
 
   @override
-  String get resume => 'जारी रखें';
+  String get resume => 'फिर शुरू करना';
 
   @override
   String get failedToLoadLibrary => 'लाइब्रेरी लोड करने में विफल';
@@ -663,17 +662,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count लेखक';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count शैलियाँ';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% पूरा';
+    return '$percent% completed';
   }
 
   @override
@@ -690,7 +689,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'पढ़ने को प्राथमिकता देकर सजाए गए $count टाइटल।';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -727,7 +726,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'कोई $label नहीं मिला';
+    return 'No $label found';
   }
 
   @override
@@ -746,7 +745,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get readStatus => 'पढ़ना';
 
   @override
-  String get watched => 'देखा गया';
+  String get watched => 'देखे';
 
   @override
   String get unread => 'अपठित ग';
@@ -764,43 +763,43 @@ class AppLocalizationsHi extends AppLocalizations {
   String get books => 'किताबें';
 
   @override
-  String get latestBooks => 'नवीनतम किताबें';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'नवीनतम ऑडियोबुक';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count किताबें',
-      one: '1 किताब',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'किताब';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ऑडियोबुक';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% पढ़ा';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time बाकी';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'पढ़ें';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'सुनें';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'लेखक';
@@ -838,12 +837,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count सेक्शन';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'पहली बार प्रकाशित $year';
+    return 'First published $year';
   }
 
   @override
@@ -858,7 +857,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count किताबें';
+    return '$count books';
   }
 
   @override
@@ -869,7 +868,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count लेखक';
+    return '$count Authors';
   }
 
   @override
@@ -877,8 +876,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ऑडियोबुक',
-      one: '1 ऑडियोबुक',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -893,10 +892,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get failedToLoad => 'लोड करने में विफल';
 
   @override
-  String get delete => 'मिटाएँ';
+  String get delete => 'मिटाना';
 
   @override
-  String get save => 'सहेजें';
+  String get save => 'बचाना';
 
   @override
   String get moreLikeThis => 'इसे और भी पसंद करें';
@@ -914,7 +913,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get nextUp => 'अगला ऊपर';
 
   @override
-  String get seasons => 'सीज़न';
+  String get seasons => 'मौसम के';
 
   @override
   String get chapters => 'अध्याय';
@@ -926,7 +925,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get movies => 'चलचित्र';
 
   @override
-  String get musicVideos => 'म्यूज़िक वीडियो';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'अन्य';
@@ -945,7 +944,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'डिस्क $number';
+    return 'Disc $number';
   }
 
   @override
@@ -969,7 +968,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'प्रकाशित $year';
+    return 'Published $year';
   }
 
   @override
@@ -980,52 +979,52 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count सीज़न',
-      one: '1 सीज़न',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time पर खत्म';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'आइटम';
+  String get items => 'Items';
 
   @override
-  String get extras => 'एक्स्ट्रा';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'बिहाइंड द सीन्स';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'डिलीट किए गए सीन';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'फ़ीचरेट';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'इंटरव्यू';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'सीन';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'शॉर्ट्स';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ट्रेलर';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time बाकी';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time में खत्म';
+    return 'Ends in $time';
   }
 
   @override
@@ -1039,11 +1038,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position से जारी रखें';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'चलाएँ';
+  String get play => 'खेल';
 
   @override
   String get startOver => 'प्रारंभ करें';
@@ -1067,7 +1066,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get version => 'संस्करण';
 
   @override
-  String get cast => 'कास्ट करें';
+  String get cast => 'ढालना';
 
   @override
   String get trailer => 'ट्रेलर';
@@ -1137,7 +1136,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" के डाउनलोड किए गए ट्रैक हटाएँ?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1152,17 +1151,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'कोई $itemLabel लोड नहीं हुआ';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title डाउनलोड हो रहा है ($count आइटम)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'क्या आप वाकई \"$name\" को सर्वर से हटाना चाहते हैं? यह क्रिया वापस नहीं ली जा सकती।';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1173,7 +1172,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'असमर्थित किताब फ़ॉर्मैट: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1200,7 +1199,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'सबटाइटल डाउनलोड होकर चुना गया: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1209,7 +1208,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language के लिए कोई रिमोट सबटाइटल नहीं मिला।';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1217,7 +1216,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'वर्शन $number';
+    return 'Version $number';
   }
 
   @override
@@ -1238,7 +1237,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name डाउनलोड हो रहा है ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1246,7 +1245,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel की लोकल फ़ाइलें हटाएँ?\n\nइससे स्टोरेज खाली होगा। आप बाद में फिर से डाउनलोड कर सकते हैं।';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1262,25 +1261,25 @@ class AppLocalizationsHi extends AppLocalizations {
   String get director => 'निदेशक';
 
   @override
-  String get directors => 'निर्देशक';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'लेखक';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'लेखक';
 
   @override
-  String get studio => 'स्टूडियो';
+  String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count और';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count एपिसोड';
+    return '$count Episodes';
   }
 
   @override
@@ -1290,12 +1289,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'एपिसोड $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'अध्याय $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1303,8 +1302,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ट्रैक',
-      one: '1 ट्रैक',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1314,25 +1313,25 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count अध्याय',
-      one: '1 अध्याय',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'जन्म $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'निधन $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'उम्र $age';
+    return 'Age $age';
   }
 
   @override
@@ -1342,20 +1341,20 @@ class AppLocalizationsHi extends AppLocalizations {
   String get readMore => 'और पढ़ें';
 
   @override
-  String get shuffle => 'शफ़ल';
+  String get shuffle => 'मिश्रण';
 
   @override
-  String get shuffleAllMusic => 'सारा संगीत शफ़ल करें';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'अपने फ़ोन पर Moonfin में साइन इन करें';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'आपका सर्वर नहीं मिल रहा';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count डाउनलोड';
+    return '$count downloads';
   }
 
   @override
@@ -1374,32 +1373,32 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'रिमोट सबटाइटल $action के लिए इस उपयोगकर्ता को Jellyfin की सबटाइटल प्रबंधन अनुमति चाहिए।';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'रिमोट सबटाइटल $action के लिए यह आइटम सर्वर पर नहीं मिला।';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'रिमोट सबटाइटल $action विफल: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'रिमोट सबटाइटल $action विफल (HTTP $status)।';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'रिमोट सबटाइटल $action करने में विफल।';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" के सभी डाउनलोड किए गए एपिसोड';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1428,17 +1427,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label क्रिया विफल: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'कास्ट वॉल्यूम सेट नहीं हो सका: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label नियंत्रण';
+    return '$label Controls';
   }
 
   @override
@@ -1448,14 +1447,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get unavailable => 'अनुपलब्ध';
 
   @override
-  String get pause => 'पॉज़ करें';
+  String get pause => 'विराम';
 
   @override
   String get syncPosition => 'सिंक स्थिति';
 
   @override
   String stopCast(String label) {
-    return '$label रोकें';
+    return 'Stop $label';
   }
 
   @override
@@ -1463,7 +1462,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ट्रैक $number';
+    return 'Track $number';
   }
 
   @override
@@ -1480,7 +1479,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds सेकंड';
+    return '$seconds seconds';
   }
 
   @override
@@ -1549,7 +1548,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get transcodeReasons => 'ट्रांसकोड कारण';
 
   @override
-  String get player => 'प्लेयर';
+  String get player => 'खिलाड़ी';
 
   @override
   String get container => 'पात्र';
@@ -1573,7 +1572,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get videoBitrate => 'वीडियो बिटरेट';
 
   @override
-  String get track => 'ट्रैक';
+  String get track => 'रास्ता';
 
   @override
   String get channels => 'चैनल';
@@ -1595,12 +1594,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol सत्र त्रुटि';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'किताब का विवरण लोड नहीं हो सका: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1609,7 +1608,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'यह फ़ॉर्मैट (.$extension) अभी ऐप में नहीं दिखाया जा सकता।';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1621,17 +1620,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'इन-ऐप रीडर नहीं खुल सका: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label पर बुकमार्क पहले से सहेजा है।';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'बुकमार्क जोड़ा गया: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1644,7 +1643,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'पेज $number';
+    return 'Page $number';
   }
 
   @override
@@ -1655,12 +1654,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'फ़ॉर्मैट: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% पढ़ा';
+    return '$percent% read';
   }
 
   @override
@@ -1683,7 +1682,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'ज़ूम रीसेट करें (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1706,7 +1705,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'पढ़ने की स्थिति अपडेट नहीं हो सकी: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1738,7 +1737,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'यह प्लेटफ़ॉर्म $extension फ़ाइलों के लिए एम्बेडेड डॉक्यूमेंट इंजन नहीं चला सकता।';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1770,14 +1769,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get kids => 'बच्चे';
 
   @override
-  String get premiere => 'प्रीमियर';
+  String get premiere => 'Premiere';
 
   @override
   String get guideTimeline => 'गाइड टाइमलाइन';
 
   @override
   String failedToLoadGuide(String error) {
-    return 'गाइड लोड नहीं हो सकी: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1788,22 +1787,22 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'अगला: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesमि बाकी';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursघं बाकी';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursघं $minutesमि बाकी';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1826,29 +1825,29 @@ class AppLocalizationsHi extends AppLocalizations {
   String get favoriteChannel => 'पसंदीदा चैनल';
 
   @override
-  String get record => 'रिकॉर्ड करें';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'रिकॉर्डिंग रद्द करें';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'प्रोग्राम रिकॉर्ड करने के लिए सेट किया गया';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'रिकॉर्डिंग रद्द की गई';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'रिकॉर्डिंग नहीं बनाई जा सकी';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'देखें';
+  String get watch => 'घड़ी';
 
   @override
-  String get close => 'बंद करें';
+  String get close => 'बंद करना';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name चलाया नहीं जा सका';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1874,7 +1873,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" की निर्धारित रिकॉर्डिंग रद्द करें?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1901,7 +1900,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" की रिकॉर्डिंग रोकें?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1916,19 +1915,19 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" के लिए कोई नतीजा नहीं';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'खोज विफल: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr खाता प्रकार';
+  String get seerrAccountType => 'द्रष्टा खाता प्रकार';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1962,12 +1961,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" और इसकी फ़ाइलें हटाएँ?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ट्रैक';
+    return '$count tracks';
   }
 
   @override
@@ -1978,16 +1977,16 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'एल्बम लोड नहीं हो सका: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name के लिए कोई डाउनलोड किया गया ट्रैक नहीं मिला।';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'सीज़न';
+  String get season => 'मौसम';
 
   @override
   String get errorLoadingEpisodes => 'एपिसोड लोड करने में त्रुटि';
@@ -2000,12 +1999,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" हटाएँ?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes मिनट';
+    return '$minutes min';
   }
 
   @override
@@ -2015,7 +2014,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'एपिसोड $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2029,7 +2028,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'सीज़न $number';
+    return 'Season $number';
   }
 
   @override
@@ -2045,7 +2044,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season के सभी डाउनलोड किए गए एपिसोड हटाएँ?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2053,8 +2052,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count एपिसोड',
-      one: '1 एपिसोड',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2089,7 +2088,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '$count डाउनलोड किए गए आइटम हटाएँ?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2103,7 +2102,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit की सीमा में से';
+    return 'of $limit limit';
   }
 
   @override
@@ -2185,7 +2184,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count विकल्प';
+    return '$count options';
   }
 
   @override
@@ -2275,7 +2274,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get themeMusicVolume => 'थीम संगीत वॉल्यूम';
 
   @override
-  String get themeMusicSettingsSubtitle => 'विवरण पेज, होम रो और वॉल्यूम';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2289,10 +2289,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'होम स्क्रीन ब्राउज़ करते समय चलाएं';
 
   @override
-  String get loopThemeMusic => 'थीम संगीत लूप करें';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'ट्रैक को एक बार चलाने के बजाय दोहराएँ';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'विवरण पृष्ठभूमि धुंधला';
@@ -2315,23 +2316,23 @@ class AppLocalizationsHi extends AppLocalizations {
   String get playerZoomMode => 'प्लेयर ज़ूम मोड';
 
   @override
-  String get settingsScrollWheelAction => 'माउस स्क्रॉल व्हील';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'चुनें कि प्लेबैक के दौरान वीडियो पर माउस व्हील स्क्रॉल करने से क्या हो।';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'बंद';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'सीक (आगे / पीछे)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'वॉल्यूम';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'वॉल्यूम';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'उपयुक्त';
@@ -2385,39 +2386,37 @@ class AppLocalizationsHi extends AppLocalizations {
   String get defaultAudioLanguage => 'डिफ़ॉल्ट ऑडियो भाषा';
 
   @override
-  String get fallbackAudioLanguage => 'फ़ॉलबैक ऑडियो भाषा';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'डिफ़ॉल्ट ऑडियो ट्रैक को प्राथमिकता दें';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'लोकलाइज़्ड डब के बजाय मूल ऑडियो ट्रैक को प्राथमिकता दें।';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'ऑडियो डिस्क्रिप्शन ट्रैक को प्राथमिकता दें';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'सामान्य ट्रैक के बजाय ऑडियो डिस्क्रिप्शन ट्रैक को प्राथमिकता दें।';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ट्रांसकोडिंग (ऑडियो)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'डायरेक्ट स्ट्रीम (रीमक्स)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ट्रांसकोडिंग (बिटरेट या रिज़ॉल्यूशन)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ट्रांसकोडिंग (वीडियो और ऑडियो)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ट्रांसकोडिंग (वीडियो)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ऑटो (सर्वर डिफ़ॉल्ट)';
@@ -2483,7 +2482,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get dtsPassthrough => 'डीटीएस पासथ्रू';
 
   @override
-  String get trueHdSupport => 'TrueHD समर्थन';
+  String get trueHdSupport => 'ट्रूएचडी सपोर्ट';
 
   @override
   String get enableDtsPassthrough =>
@@ -2491,30 +2490,30 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get enableTrueHdAudio =>
-      'TrueHD ऑडियो चालू करें (सभी प्लेटफ़ॉर्म पर काम न करे)';
+      'ट्रूएचडी ऑडियो सक्षम करें (सभी प्लेटफ़ॉर्म पर काम नहीं कर सकता)';
 
   @override
-  String get settingsAudioOutputMode => 'ऑडियो आउटपुट मोड';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'चुनें कि ऑडियो कैसे डिकोड हो। AVR पासथ्रू रॉ Dolby/DTS स्ट्रीम आपके रिसीवर को भेजता है; ऑटो या डाउनमिक्स लोकल रूप से डिकोड करता है।';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR पासथ्रू';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'ऑडियो फ़ॉलबैक कोडेक';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'जब सोर्स स्ट्रीम डायरेक्ट-प्ले या पासथ्रू न हो सके, तो मल्टी-चैनल ऑडियो को ट्रांसकोड करने का लक्ष्य फ़ॉर्मैट चुनें।';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'ऑटो डिटेक्ट\n(अनुशंसित)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(डिफ़ॉल्ट)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2523,114 +2522,113 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(लॉसलेस)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(केवल स्टीरियो)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(कुशल)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(लॉसलेस)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'अधिकतम ऑडियो चैनल';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'अपने ऑडियो सेटअप के अधिकतम चैनल कॉन्फ़िगर करें। इस सीमा से ज़्यादा चैनल वाली स्ट्रीम डाउनमिक्स या ट्रांसकोड होंगी।';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ऑटो डिटेक्ट\n(हार्डवेयर डिफ़ॉल्ट)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 मोनो';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 स्टीरियो';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 सराउंड';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 क्वाड्राफ़ोनिक';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 सराउंड';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 सराउंड';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 सराउंड';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 सराउंड';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'पासथ्रू (उन्नत)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'कोडेक पासथ्रू';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'केवल वही फ़ॉर्मैट चालू करें जो आपका AVR या HDMI सिंक सपोर्ट करता है।';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 पासथ्रू';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) पासथ्रू';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core पासथ्रू';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA पासथ्रू';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD पासथ्रू';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos पासथ्रू';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) को बाहरी डिकोडर पर बिटस्ट्रीम करें।';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Dolby Atmos को EAC3 (JOC) पर बाहरी डिकोडर तक बिटस्ट्रीम करें।';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS core सहित) को बाहरी डिकोडर पर बिटस्ट्रीम करें।';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos मेटाडेटा वाले Dolby TrueHD को बाहरी डिकोडर पर बिटस्ट्रीम करें।';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'पहचानी गई ऑडियो क्षमताएँ';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'अभी तक कोई रनटाइम क्षमता स्नैपशॉट उपलब्ध नहीं है।';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'रूट';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'डिकोड';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'पासथ्रू';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ऑडियो रूट';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2645,49 +2643,50 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'स्पीकर';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'हेडफ़ोन';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count चैनल PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'डायग्नोस्टिक्स';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'वीडियो लेवल';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'वीडियो रेंज';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'सबटाइटल कोडेक';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => 'अनुमत ऑडियो कोडेक';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ऑडियो कोडेक';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ऑडियो कोडेक';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif पासथ्रू';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'सक्रिय ऑडियो रूट';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'रूट HD ऑडियो सपोर्ट';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'रात का मोड';
@@ -2736,7 +2735,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value सेकंड';
+    return '${value}s';
   }
 
   @override
@@ -2750,7 +2749,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes एपिसोड / $hours घंटे के बाद';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2827,45 +2826,45 @@ class AppLocalizationsHi extends AppLocalizations {
       'उपशीर्षक उपस्थिति को अनुकूलित करें';
 
   @override
-  String get subtitleMode => 'सबटाइटल मोड';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'फ़्लैग किए गए';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'हमेशा';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'विदेशी भाषा';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'फ़ोर्स्ड';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'मीडिया फ़ाइल के मेटाडेटा में \"default\" या \"forced\" के रूप में फ़्लैग किए गए ट्रैक चलाता है।';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'हर बार वीडियो शुरू होने पर सबटाइटल अपने आप लोड करके दिखाता है।';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'अगर डिफ़ॉल्ट ऑडियो ट्रैक किसी विदेशी भाषा में है, तो सबटाइटल अपने आप चालू कर देता है।';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'सिर्फ़ वही सबटाइटल लोड करता है जिन पर स्पष्ट रूप से forced मेटाडेटा फ़्लैग लगा हो।';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'सबटाइटल की स्वचालित लोडिंग पूरी तरह बंद कर देता है।';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'फ़ॉलबैक सबटाइटल भाषा';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'सबटाइटल स्ट्रीम';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'तेज, भूरी लोमडी आलसी कुत्ते के उपर कूद गई';
@@ -2923,17 +2922,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile प्रोफ़ाइल सेटिंग्स लोड हो गईं।';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile प्रोफ़ाइल सेटिंग्स लोड नहीं हो सकीं।';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'स्थानीय सेटिंग्स $profile प्रोफ़ाइल से सिंक हो गईं।';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3068,10 +3067,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showLibrariesInToolbar => 'टूलबार में लाइब्रेरी दिखाएं';
 
   @override
-  String get navbarAlwaysExpanded => 'नेवबार लेबल हमेशा दिखाएँ';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr बटन दिखाएँ';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'नेवबार अपारदर्शिता';
@@ -3146,18 +3145,18 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showFolderBrowsingOption => 'फ़ोल्डर ब्राउज़िंग विकल्प दिखाएँ';
 
   @override
-  String get groupItemsIntoCollections => 'आइटम को कलेक्शन में समूहित करें';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'लाइब्रेरी ब्राउज़ करते समय कलेक्शन से जुड़े लाइब्रेरी आइटम छिपाएँ';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'लाइब्रेरी ग्रुपिंग सूचना';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'इस सेटिंग का उपयोग करने के लिए, कृपया सुनिश्चित करें कि आपके Jellyfin या Emby सर्वर पर आपकी लाइब्रेरी की Display सेटिंग्स में \"Group movies into collections\" और/या \"Group shows into collections\" लाइब्रेरी सेटिंग्स चालू हैं।';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'पुस्तकालय दृश्यता';
@@ -3186,7 +3185,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count चुने गए';
+    return '$count selected';
   }
 
   @override
@@ -3216,7 +3215,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'अलग-अलग मीडिया बार स्टाइल में से चुनें, या मीडिया बार को बंद कर दें।';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'मूनफ़िन';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3269,11 +3268,10 @@ class AppLocalizationsHi extends AppLocalizations {
       '3 सेकंड के बाद मीडिया बार में ट्रेलरों को ऑटो-प्ले करें';
 
   @override
-  String get trailerAudio => 'ट्रेलर ऑडियो';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'मीडिया बार में ट्रेलर के लिए ऑडियो चालू करें';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'एपिसोड पूर्वावलोकन';
@@ -3351,11 +3349,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'दोनों पंक्तियों को एक ही होम सेक्शन में संयोजित करें';
 
   @override
-  String get fullScreenRows => 'विस्तृत होम पंक्तियाँ';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'प्रति स्क्रीन होम पंक्तियाँ 1 तक सीमित करें';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'प्रति पंक्ति छवि प्रकार';
@@ -3370,7 +3367,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get lastUser => 'अंतिम उपयोगकर्ता';
 
   @override
-  String get currentUser => 'मौजूदा उपयोगकर्ता';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'हमेशा प्रमाणित करें';
@@ -3431,7 +3428,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get enableBuiltInScreensaver => 'अंतर्निर्मित स्क्रीनसेवर सक्षम करें';
 
   @override
-  String get mode => 'मोड';
+  String get mode => 'तरीका';
 
   @override
   String get libraryArt => 'पुस्तकालय कला';
@@ -3447,7 +3444,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes मिनट';
+    return '$minutes min';
   }
 
   @override
@@ -3478,10 +3475,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'स्क्रीनसेवर के दौरान घड़ी प्रदर्शित करें';
 
   @override
-  String get clockModeStatic => 'स्थिर';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'उछलती हुई';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'सड़े हुए टमाटर (आलोचक)';
@@ -3490,10 +3487,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get rottenTomatoesAudience => 'सड़े हुए टमाटर (दर्शक)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'आईएमडीबी';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'टीएमडीबी';
 
   @override
   String get metacritic => 'मेटाक्रिटिक';
@@ -3523,7 +3520,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get additionalRatings => 'अतिरिक्त रेटिंग';
 
   @override
-  String get showMdbListAndTmdbRatings => 'MDBList और TMDB रेटिंग दिखाएँ';
+  String get showMdbListAndTmdbRatings =>
+      'एमडीबीलिस्ट और टीएमडीबी रेटिंग दिखाएं';
 
   @override
   String get ratingLabels => 'रेटिंग लेबल';
@@ -3551,7 +3549,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'पूरे ऐप में दिखाए गए रेटिंग स्रोतों को सक्षम और पुन: व्यवस्थित करें';
 
   @override
-  String get pluginLabel => 'Moonbase प्लगइन';
+  String get pluginLabel => 'लगाना';
 
   @override
   String get pluginDetected => 'प्लगइन का पता चला';
@@ -3569,7 +3567,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nसंस्करण: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3622,21 +3620,21 @@ class AppLocalizationsHi extends AppLocalizations {
   String get networks => 'नेटवर्क';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr डिस्कवरी पंक्तियाँ';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'पंक्तियों को डिफ़ॉल्ट पर रीसेट करें';
 
   @override
-  String get enableSeerr => 'Seerr चालू करें';
+  String get enableSeerr => 'सीरर सक्षम करें';
 
   @override
   String get showSeerrInNavigation =>
-      'नेविगेशन में Seerr दिखाएँ (सर्वर प्लगइन ज़रूरी है)';
+      'नेविगेशन में सीरर दिखाएं (सर्वर प्लगइन की आवश्यकता है)';
 
   @override
   String get seerrUnavailable =>
-      'उपलब्ध नहीं, क्योंकि सर्वर प्लगइन में Seerr सपोर्ट बंद है।';
+      'अनुपलब्ध है क्योंकि सर्वर प्लगइन सीरर समर्थन अक्षम है।';
 
   @override
   String get nsfwFilter => 'एनएसएफडब्ल्यू फ़िल्टर';
@@ -3645,46 +3643,47 @@ class AppLocalizationsHi extends AppLocalizations {
   String get hideAdultContent => 'परिणामों में वयस्क सामग्री छिपाएँ';
 
   @override
-  String get seerrNotificationsSection => 'सूचनाएँ';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'नई अनुरोध सूचनाएँ';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'जब कोई अनुरोध भेजे तो मुझे बताएँ';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'अनुरोध अपडेट';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'स्वीकृत, अस्वीकृत, और आपकी लाइब्रेरी में जोड़े गए';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'समस्या अपडेट';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'नई समस्याएँ, जवाब, और समाधान';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'इस रूप में लॉग इन: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr डिस्कवरी पेज';
+  String get discoverRows => 'पंक्तियों की खोज करें';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr मुख्य पेज पर दिखाने के लिए पंक्तियाँ चालू करें। क्रम बदलने के लिए खींचें। कस्टम क्रम Moonbase के साथ सिंक होता है।';
+      'पुन: व्यवस्थित करने के लिए खींचें। पंक्तियों को सक्षम या अक्षम करें. सक्षम पंक्ति क्रम Moonfin प्लगइन के साथ समन्वयित होता है।';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr मुख्य पेज पर दिखाने के लिए पंक्तियाँ चालू करें। क्रम बदलने के लिए खींचें। कस्टम क्रम Moonbase के साथ सिंक होता है।';
+      'पुन: व्यवस्थित करने के लिए खींचें। पंक्तियों को सक्षम या अक्षम करें.';
 
   @override
-  String get enabled => 'सक्षम';
+  String get enabled => 'सक्रिय';
 
   @override
   String get hidden => 'छिपा हुआ';
@@ -3694,7 +3693,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'संस्करण $version';
+    return 'Version $version';
   }
 
   @override
@@ -3743,7 +3742,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'अपडेट उपलब्ध: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3754,7 +3753,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version उपलब्ध है';
+    return 'v$version Available';
   }
 
   @override
@@ -3797,7 +3796,8 @@ class AppLocalizationsHi extends AppLocalizations {
       'पोस्टर का आकार, छवि प्रकार, फ़ोल्डर दृश्य';
 
   @override
-  String get mdbListTmdbRatingSources => 'MDBList, TMDB, और रेटिंग स्रोत';
+  String get mdbListTmdbRatingSources =>
+      'एमडीबीलिस्ट, टीएमडीबी, और रेटिंग स्रोत';
 
   @override
   String gbValue(String value) {
@@ -3819,7 +3819,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get imageCacheCleared => 'इमेज कैश साफ़ हो गया';
 
   @override
-  String get clear => 'साफ़ करें';
+  String get clear => 'स्पष्ट';
 
   @override
   String get browse => 'ब्राउज़';
@@ -3835,19 +3835,19 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'डाउनलोड हो रहा है · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'इंपोर्ट हो रहा है';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count आइटम';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr सेटिंग्स';
+  String get seerrSettings => 'द्रष्टा सेटिंग्स';
 
   @override
   String get requestMore => 'अधिक अनुरोध करें';
@@ -3863,7 +3863,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name द्वारा अनुरोधित';
+    return 'Requested by $name';
   }
 
   @override
@@ -3880,12 +3880,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" का अनुरोध रद्द करें?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" के $count अनुरोध रद्द करें?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3900,12 +3900,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'बजट: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'आय: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3915,7 +3915,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type का अनुरोध करें';
+    return 'Request $type';
   }
 
   @override
@@ -3944,14 +3944,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showMore => 'और दिखाएँ';
 
   @override
-  String get appearances => 'भूमिकाएँ';
+  String get appearances => 'दिखावे';
 
   @override
   String get crewSection => 'कर्मी दल';
 
   @override
   String ageValue(int age) {
-    return 'उम्र $age';
+    return 'age $age';
   }
 
   @override
@@ -3982,153 +3982,151 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deletedStatus => 'हटाए गए';
 
   @override
-  String get failedStatus => 'विफल';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'प्रोसेस हो रहा है';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name द्वारा संशोधित';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'पूरा हुआ';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate =>
-      'इस टाइटल का अनुरोध पहले ही किया जा चुका है';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'अनुरोध की सीमा पूरी हो गई';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'यह टाइटल ब्लॉकलिस्ट में है';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'अनुरोध करने के लिए कोई सीज़न बाकी नहीं है';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'आपके पास यह अनुरोध करने की अनुमति नहीं है';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'अनुरोध';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'समस्याएँ';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'सबसे नए';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'अंतिम बार संशोधित';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'कोई समस्या नहीं';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit में से $remaining फ़िल्म अनुरोध बाकी';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit में से $remaining सीज़न अनुरोध बाकी';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name का हिस्सा';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'कलेक्शन देखें';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'कलेक्शन का अनुरोध करें';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total फ़िल्में · $available उपलब्ध';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count फ़िल्मों का अनुरोध करें';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total में से $current का अनुरोध हो रहा है...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count फ़िल्मों का अनुरोध किया गया';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total में से $ok फ़िल्मों का अनुरोध किया गया';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'सभी फ़िल्में पहले से उपलब्ध या अनुरोधित हैं';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'समस्या बताएँ';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'वीडियो';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ऑडियो';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'क्या समस्या है?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'सभी एपिसोड';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'एपिसोड';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'खुला';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'हल हो गई';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'हल करें';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'फिर से खोलें';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name द्वारा रिपोर्ट की गई';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count टिप्पणियाँ';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'टिप्पणी जोड़ें';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'यह समस्या हटाएँ?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'रिपोर्ट भेजें';
+  String get submitReport => 'Submit Report';
 
   @override
-  String get tmdbScore => 'TMDB स्कोर';
+  String get tmdbScore => 'टीएमडीबी स्कोर';
 
   @override
   String get releaseDateLabel => 'रिलीज़ की तारीख';
@@ -4149,7 +4147,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get originalLanguageLabel => 'मूल भाषा';
 
   @override
-  String get seasonsLabel => 'सीज़न';
+  String get seasonsLabel => 'मौसम के';
 
   @override
   String get episodesLabel => 'एपिसोड';
@@ -4158,7 +4156,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get access => 'पहुँच';
 
   @override
-  String get add => 'जोड़ें';
+  String get add => 'जोड़ना';
 
   @override
   String get address => 'पता';
@@ -4185,7 +4183,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get done => 'हो गया';
 
   @override
-  String get edit => 'संपादित करें';
+  String get edit => 'संपादन करना';
 
   @override
   String get encoding => 'एन्कोडिंग';
@@ -4242,7 +4240,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get refresh => 'ताज़ा करना';
 
   @override
-  String get remote => 'रिमोट';
+  String get remote => 'दूर';
 
   @override
   String get rename => 'नाम बदलें';
@@ -4260,7 +4258,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get run => 'दौड़ना';
 
   @override
-  String get search => 'खोजें';
+  String get search => 'खोज';
 
   @override
   String get select => 'चुनना';
@@ -4278,7 +4276,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get status => 'स्थिति';
 
   @override
-  String get stop => 'रोकें';
+  String get stop => 'रुकना';
 
   @override
   String get streaming => 'स्ट्रीमिंग';
@@ -4287,7 +4285,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get time => 'समय';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'चालाकी';
 
   @override
   String get uninstall => 'अनइंस्टॉल करें';
@@ -4305,7 +4303,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get unmute => 'अनम्यूट';
 
   @override
-  String get mute => 'म्यूट करें';
+  String get mute => 'आवाज़ बंद करना';
 
   @override
   String get branding => 'ब्रांडिंग';
@@ -4326,28 +4324,28 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminDrawerUsers => 'उपयोगकर्ताओं';
 
   @override
-  String get adminDrawerLibraries => 'लाइब्रेरीज़';
+  String get adminDrawerLibraries => 'पुस्तकालय';
 
   @override
-  String get adminDrawerDisplay => 'डिस्प्ले';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'मेटाडेटा';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO सेटिंग्स';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ट्रांसकोडिंग';
 
   @override
-  String get adminDrawerResume => 'जारी रखें';
+  String get adminDrawerResume => 'फिर शुरू करना';
 
   @override
   String get adminDrawerStreaming => 'स्ट्रीमिंग';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'चालाकी';
 
   @override
   String get adminDrawerDevices => 'उपकरण';
@@ -4397,22 +4395,22 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'प्लगइन अपडेट उपलब्ध: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'पुनः आरंभ की ज़रूरत वाले प्लगइन: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'विफल शेड्यूल्ड कार्य: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'हाल की चेतावनी/त्रुटि प्रविष्टियाँ: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4471,7 +4469,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'त्रुटि: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4498,7 +4496,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'कमांड विफल: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4535,7 +4533,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get nowPlaying => 'अब खेल रहे हैं';
 
   @override
-  String get volume => 'वॉल्यूम';
+  String get volume => 'आयतन';
 
   @override
   String get actions => 'कार्रवाई';
@@ -4562,14 +4560,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminClearDates => 'स्पष्ट तिथियाँ';
 
   @override
-  String get adminActivitySeverityAll => 'सभी गंभीरता स्तर';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'तारीख़ की सीमा';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'गतिविधि लॉग लोड नहीं हो सका: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4586,7 +4584,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'डिवाइस अपडेट नहीं हो सका: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4597,28 +4595,28 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'डिवाइस हटाया नहीं जा सका: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'डिवाइस \'$name\' हटाएँ? उपयोगकर्ता को इस डिवाइस पर फिर से साइन इन करना होगा।';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'सभी डिवाइस हटाएँ';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count डिवाइस हटाएँ? प्रभावित उपयोगकर्ताओं को फिर से साइन इन करना होगा। आपका मौजूदा डिवाइस प्रभावित नहीं होगा।';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'डिवाइस हटा दिए गए';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'कुछ डिवाइस हटा दिए गए; $count नहीं हटाए जा सके।';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4647,7 +4645,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'स्कैन शुरू नहीं हो सका: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4658,12 +4656,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'लाइब्रेरी का नाम बदलकर \"$name\" किया गया';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'नाम नहीं बदला जा सका: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4671,17 +4669,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'लाइब्रेरी \"$name\" हटा दी गई';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'लाइब्रेरी हटाई नहीं जा सकी: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'पथ जोड़ा नहीं जा सका: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4689,12 +4687,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'इस लाइब्रेरी से \"$path\" हटाएँ?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'पथ हटाया नहीं जा सका: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4702,7 +4700,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'विकल्प सहेजे नहीं जा सके: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4733,256 +4731,251 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminMetadataCountryHint => 'जैसे यूएस, डीई, एफआर';
 
   @override
-  String get adminLibraryTabPaths => 'पथ';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'विकल्प';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'डाउनलोडर';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'मेटाडेटा सेवर';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'सबटाइटल डाउनलोडर';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'लिरिक्स डाउनलोडर';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'मेटाडेटा डाउनलोडर: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'इमेज फ़ेचर: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'यह सर्वर इस लाइब्रेरी प्रकार के लिए कोई डाउनलोडर उपलब्ध नहीं कराता।';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'सामान्य';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'मेटाडेटा';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'एम्बेडेड जानकारी';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'सबटाइटल';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'इमेज';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'सीरीज़';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'संगीत';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'फ़िल्में';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'रीयल-टाइम मॉनिटरिंग चालू करें';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'फ़ाइल बदलावों का पता लगाकर उन्हें अपने आप प्रोसेस करें।';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'आर्काइव को मीडिया फ़ाइलों की तरह मानें';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'फ़ोटो दिखाएँ';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'आर्टवर्क मीडिया फ़ोल्डर में सहेजें';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'स्वचालित मेटाडेटा रीफ़्रेश';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'कभी नहीं';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'डिफ़ॉल्ट';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'डिस्प्ले';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'लाइब्रेरी डिस्प्ले';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'सादे मीडिया फ़ोल्डर दिखाने के लिए फ़ोल्डर व्यू दिखाएँ';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'स्पेशल एपिसोड उसी सीज़न में दिखाएँ जिसमें वे प्रसारित हुए थे';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'फ़िल्मों को कलेक्शन में समूहित करें';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'शो को कलेक्शन में समूहित करें';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'सुझावों में बाहरी सामग्री दिखाएँ';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'जोड़ने की तारीख़ का व्यवहार';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'जोड़ने की तारीख़ यहाँ से लें';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'लाइब्रेरी में स्कैन होने की तारीख़';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'फ़ाइल बनने की तारीख़';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'मेटाडेटा और इमेज';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'पसंदीदा मेटाडेटा भाषा';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'चैप्टर';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'डमी चैप्टर अवधि (सेकंड)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'जिस मीडिया में चैप्टर नहीं हैं, उसके लिए बनाए गए चैप्टर की लंबाई। बंद करने के लिए 0 सेट करें।';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'चैप्टर इमेज रिज़ॉल्यूशन';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO सेटिंग्स';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO मेटाडेटा Kodi और इस तरह के अन्य क्लाइंट के साथ काम करता है। ये सेटिंग्स उन सभी लाइब्रेरी पर लागू होती हैं जो NFO मेटाडेटा सहेजती हैं।';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'वह उपयोगकर्ता जिसका देखने का डेटा NFO फ़ाइलों में सहेजा जाए';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO फ़ाइलों में इमेज पथ सहेजें';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO इमेज पथ के लिए पथ प्रतिस्थापन चालू करें';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart इमेज को extrathumbs फ़ोल्डर में कॉपी करें';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'कोई नहीं';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days दिन';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'एम्बेडेड टाइटल का उपयोग करें';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'एक्स्ट्रा के लिए एम्बेडेड टाइटल का उपयोग करें';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'एम्बेडेड एपिसोड जानकारी का उपयोग करें';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'एम्बेडेड सबटाइटल की अनुमति दें';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'सभी की अनुमति दें';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'केवल टेक्स्ट';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'केवल इमेज';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'कोई नहीं';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'एम्बेडेड सबटाइटल मौजूद होने पर डाउनलोड छोड़ दें';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ऑडियो ट्रैक डाउनलोड भाषा से मेल खाने पर डाउनलोड छोड़ दें';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'सबटाइटल का पूरी तरह मेल खाना ज़रूरी करें';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'सबटाइटल मीडिया फ़ोल्डर में सहेजें';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'चैप्टर इमेज निकालें';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'लाइब्रेरी स्कैन के दौरान चैप्टर इमेज निकालें';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Trickplay इमेज निकालना चालू करें';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'लाइब्रेरी स्कैन के दौरान Trickplay इमेज निकालें';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay इमेज मीडिया फ़ोल्डर में सहेजें';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'कई फ़ोल्डर में फैली सीरीज़ को अपने आप मर्ज करें';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'सीज़न शून्य का प्रदर्शित नाम';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'ऑडियो नॉर्मलाइज़ेशन के लिए LUFS स्कैन चालू करें';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'गैर-मानक आर्टिस्ट टैग को प्राथमिकता दें';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'फ़िल्मों को अपने आप कलेक्शन में जोड़ें';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'लाइब्रेरी का नाम आवश्यक है';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'लाइब्रेरी बनाई नहीं जा सकी: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5009,27 +5002,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name को बंद करें? वे साइन इन नहीं कर पाएँगे।';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name को चालू करें? वे फिर से साइन इन कर पाएँगे।';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'उपयोगकर्ता \"$name\" बंद कर दिया गया';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'उपयोगकर्ता \"$name\" चालू कर दिया गया';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'उपयोगकर्ता नीति अपडेट नहीं हो सकी: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5046,7 +5039,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'उपयोगकर्ता नहीं बनाया जा सका: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5067,7 +5060,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'सहेजा नहीं जा सका: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5078,7 +5071,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'विफल: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5214,145 +5207,143 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminEnableAllChannels => 'सभी चैनलों तक पहुंच सक्षम करें';
 
   @override
-  String get adminParentalControl => 'अभिभावक नियंत्रण';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'अधिकतम अनुमत आयु रेटिंग';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'इससे ऊँची रेटिंग वाला कॉन्टेंट इस उपयोगकर्ता से छिपा रहेगा।';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'कोई नहीं';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'बिना रेटिंग या अपरिचित रेटिंग वाली आइटम ब्लॉक करें';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'किताबें';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'चैनल';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'लाइव TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'फ़िल्में';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'संगीत';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ट्रेलर';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'शोज़';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'एक्सेस शेड्यूल';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'केवल नीचे दिए गए शेड्यूल के समय पर ही एक्सेस दें। कोई शेड्यूल न होने पर पूरे दिन एक्सेस मिलता है।';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'शेड्यूल जोड़ें';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'दिन';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'शुरू';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'समाप्त';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'हर दिन';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'कार्यदिवस';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'सप्ताहांत';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'रविवार';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'सोमवार';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'मंगलवार';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'बुधवार';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'गुरुवार';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'शुक्रवार';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'शनिवार';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'अनुमत टैग';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'केवल इन टैग वाला कॉन्टेंट दिखेगा। सब कुछ दिखाने के लिए खाली छोड़ें।';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'ब्लॉक किए गए टैग';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'इन टैग वाला कॉन्टेंट इस उपयोगकर्ता से छिपा रहेगा।';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'टैग जोड़ें';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'सक्षम डिवाइस';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'सक्षम चैनल';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'प्रमाणीकरण प्रदाता';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'पासवर्ड रीसेट प्रदाता';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'लॉकआउट से पहले अधिकतम विफल लॉगिन प्रयास';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'डिफ़ॉल्ट के लिए 0 सेट करें, या लॉकआउट बंद करने के लिए -1।';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay एक्सेस';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'ग्रुप बनाने और उनमें शामिल होने की अनुमति दें';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'ग्रुप में शामिल होने की अनुमति दें';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'कोई एक्सेस नहीं';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'यहाँ से कॉन्टेंट हटाने की अनुमति दें';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5360,22 +5351,22 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'सर्वर ने HTTP $status लौटाया';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'क्या आप वाकई $name को हटाना चाहते हैं?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'उपयोगकर्ता \"$name\" हटा दिया गया';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'उपयोगकर्ता हटाया नहीं जा सका: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5396,7 +5387,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'की नहीं बनाई जा सकी: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5407,7 +5398,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name की की रद्द करें?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5415,7 +5406,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'की रद्द नहीं की जा सकी: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5435,29 +5426,29 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'टोकन: $token\\nबनाया गया: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'बैकअप बनाएँ';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'चुनें कि बैकअप में क्या शामिल करना है।';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'डेटाबेस';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'हमेशा शामिल';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'मेटाडेटा';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'सबटाइटल';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay इमेज';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'बैकअप बनाया जा रहा है...';
@@ -5467,7 +5458,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'बैकअप नहीं बनाया जा सका: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5475,12 +5466,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'मैनिफ़ेस्ट: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'मैनिफ़ेस्ट लोड नहीं हो सका: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5491,7 +5482,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'बैकअप रीस्टोर नहीं हो सका: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5523,17 +5514,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path में सहेजा गया';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'फ़ाइल सहेजी नहीं जा सकी: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName लोड नहीं हो सकी';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5544,7 +5535,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'टास्क लोड नहीं हो सके: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5556,17 +5547,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'टास्क शुरू नहीं हो सका: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'टास्क रोका नहीं जा सका: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'टास्क लोड नहीं हो सका: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5574,12 +5565,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'ट्रिगर हटाया नहीं जा सका: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'ट्रिगर जोड़ा नहीं जा सका: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5605,7 +5596,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours घंटे';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5616,7 +5607,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'प्लगइन चालू/बंद नहीं हो सका: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5624,27 +5615,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'क्या आप वाकई \"$name\" अनइंस्टॉल करना चाहते हैं?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'प्लगइन अनइंस्टॉल नहीं हो सका: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'पैकेज इंस्टॉल नहीं हो सका: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'अपडेट इंस्टॉल नहीं हो सका: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'प्लगइन लोड नहीं हो सके: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5656,12 +5647,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'अपडेट इंस्टॉल करें (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'कैटलॉग लोड नहीं हो सका: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5683,17 +5674,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'सर्वर रीस्टार्ट होने के बाद \"$name\" हटा दिया जाएगा';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'अनइंस्टॉल नहीं हो सका: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" को v$version पर अपडेट किया जा रहा है...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5702,7 +5693,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'प्लगइन लोड नहीं हो सका: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5710,7 +5701,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'वर्शन $version';
+    return 'Version $version';
   }
 
   @override
@@ -5730,17 +5721,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'क्या आप वाकई \"$name\" हटाना चाहते हैं?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'रिपॉज़िटरी सहेजी नहीं जा सकीं: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'रिपॉज़िटरी लोड नहीं हो सकीं: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5757,12 +5748,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'प्लगइन सेटिंग्स लोड नहीं हो सकीं: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri नहीं खोला जा सका';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5881,10 +5872,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminThrottleBuffering => 'थ्रॉटल बफ़रिंग';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay सेटिंग्स सहेजी गईं';
+  String get adminTrickplaySaved => 'ट्रिकप्ले सेटिंग्स सहेजी गईं';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay सेटिंग्स लोड नहीं हो सकीं';
+  String get adminTrickplayLoadFailed => 'ट्रिकप्ले सेटिंग लोड करने में विफल';
 
   @override
   String get adminEnableHardwareAcceleration => 'हार्डवेयर त्वरण सक्षम करें';
@@ -5993,7 +5984,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminBaseUrl => 'आधार यूआरएल';
 
   @override
-  String get adminBaseUrlHint => 'उदा. /jellyfin';
+  String get adminBaseUrlHint => 'जैसे /जेलीफ़िन';
 
   @override
   String get https => 'HTTPS के';
@@ -6033,12 +6024,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'मेटाडेटा लोड नहीं हो सका: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'मेटाडेटा सहेजा नहीं जा सका: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6059,7 +6050,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'मेटाडेटा रीफ़्रेश नहीं हो सका: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6073,7 +6064,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'रिमोट खोज विफल रही: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6087,7 +6078,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'कॉन्टेंट टाइप अपडेट नहीं हो सका: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6102,12 +6093,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType इमेज अपडेट हो गई';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'इमेज डाउनलोड नहीं हो सकी: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6118,27 +6109,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType इमेज अपलोड हो गई';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'इमेज अपलोड नहीं हो सकी: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType इमेज हटाएँ';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType इमेज हटा दी गई';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'इमेज हटाई नहीं जा सकी: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6149,68 +6140,67 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'ट्यूनर खोज विफल रही: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'ट्यूनर जोड़ें';
 
   @override
-  String get adminEditTuner => 'ट्यूनर संपादित करें';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ट्यूनर';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'फ़ाइल या URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ट्यूनर का IP पता';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'फ़्रेंडली नाम';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'यूज़र एजेंट';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'एक साथ कनेक्शन की सीमा';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ट्यूनर एक साथ जितनी अधिकतम स्ट्रीम की अनुमति देता है। असीमित के लिए 0 सेट करें।';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'फ़ॉलबैक अधिकतम स्ट्रीमिंग बिटरेट';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'केवल पसंदीदा चैनल इंपोर्ट करें';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'हार्डवेयर ट्रांसकोडिंग की अनुमति दें';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 ट्रांसकोडिंग कंटेनर की अनुमति दें';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'स्ट्रीम शेयरिंग की अनुमति दें';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'स्ट्रीम लूपिंग चालू करें';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS अनदेखा करें';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'इनपुट को नेटिव फ़्रेम रेट पर पढ़ें';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'प्रदाता संपादित करें';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6219,50 +6209,50 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'फ़ाइल या URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'फ़िल्म प्रीफ़िक्स';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'फ़िल्म श्रेणियाँ';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'एक से ज़्यादा श्रेणियों को वर्टिकल बार से अलग करें।';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'बच्चों की श्रेणियाँ';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'समाचार श्रेणियाँ';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'खेल श्रेणियाँ';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'उपयोगकर्ता नाम';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'पासवर्ड';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'देश';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'देश चुनें';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'पिन कोड';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'लिस्टिंग पाएँ';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'लिस्टिंग';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'सभी ट्यूनर चालू करें';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ट्यूनर प्रकार';
@@ -6272,7 +6262,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'ट्यूनर जोड़ा नहीं जा सका: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6286,12 +6276,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'प्रदाता जोड़ा नहीं जा सका: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'ट्यूनर हटाया नहीं जा सका: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6299,16 +6289,16 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'ट्यूनर रीसेट नहीं हो सका: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'यह ट्यूनर टाइप रीसेट करना सपोर्ट नहीं करता।';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'प्रदाता हटाया नहीं जा सका: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6327,43 +6317,43 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminSeriesRecordingPath => 'श्रृंखला रिकॉर्डिंग पथ';
 
   @override
-  String get adminMovieRecordingPath => 'फ़िल्म रिकॉर्डिंग पथ';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'गाइड डेटा के दिन';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'स्वचालित';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days दिन';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'पोस्ट-प्रोसेसिंग एप्लिकेशन का पथ';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'पोस्ट-प्रोसेसर आर्ग्युमेंट';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'रिकॉर्डिंग का NFO मेटाडेटा सहेजें';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'रिकॉर्डिंग की इमेज सहेजें';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'टाइमिंग';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'रिकॉर्डिंग पथ';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'पोस्ट-प्रोसेसिंग';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'गाइड डेटा: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6371,7 +6361,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'सेटिंग्स सहेजी नहीं जा सकीं: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6388,7 +6378,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'मैपिंग अपडेट नहीं हो सकीं: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6404,14 +6394,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminGuideProviders => 'मार्गदर्शक प्रदाता';
 
   @override
-  String get adminRefreshGuideData => 'गाइड डेटा रीफ़्रेश करें';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'गाइड डेटा रीफ़्रेश शुरू हुआ';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'इस सर्वर पर गाइड रीफ़्रेश टास्क उपलब्ध नहीं है।';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'प्रदाता जोड़ें';
@@ -6422,22 +6412,22 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'रिकॉर्डिंग पथ: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'सीरीज़ पथ: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'प्री-पैडिंग: $minutes मिनट';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'पोस्ट-पैडिंग: $minutes मिनट';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6470,7 +6460,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'बैकअप $name अभी रीस्टोर करें?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6494,7 +6484,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminLiveTvTitle => 'लाइव टीवी प्रशासन';
 
   @override
-  String get adminApply => 'लागू करें';
+  String get adminApply => 'आवेदन करना';
 
   @override
   String get adminNotSet => 'सेट नहीं';
@@ -6516,27 +6506,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes मि पहले';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours घं पहले';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days दि पहले';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName लोड नहीं हो सकी';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count मैच';
+    return '$count matches';
   }
 
   @override
@@ -6546,7 +6536,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminMetadataEditorTitle => 'मेटाडेटा संपादक';
 
   @override
-  String get adminMetadataIdentify => 'पहचानें';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'प्रकार';
@@ -6646,22 +6636,22 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType इमेज अपडेट हो गई';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType इमेज अपलोड हो गई';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType इमेज हटा दी गई';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'इमेज डाउनलोड नहीं हो सकी: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6669,12 +6659,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'इमेज अपलोड नहीं हो सकी: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType इमेज हटाएँ';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6683,12 +6673,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'इमेज हटाई नहीं जा सकी: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType इमेज चुनें';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6721,7 +6711,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'अपडेट उपलब्ध है: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6745,7 +6735,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'अपडेट इंस्टॉल करें (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6757,7 +6747,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" इंस्टॉल हो रहा है...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6777,7 +6767,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name सेटिंग्स';
+    return '$name Settings';
   }
 
   @override
@@ -6817,7 +6807,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'रिपॉज़िटरी लोड नहीं हो सकीं: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6825,15 +6815,15 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'क्या आप वाकई \"$name\" हटाना चाहते हैं?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'हटाएँ';
+  String get adminReposRemove => 'निकालना';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'रिपॉज़िटरी सहेजी नहीं जा सकीं: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6958,20 +6948,19 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminBrandingEnableSplash => 'स्प्लैश स्क्रीन सक्षम करें';
 
   @override
-  String get adminBrandingSplashUpload => 'इमेज अपलोड करें';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'स्प्लैशस्क्रीन अपडेट हो गई';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'स्प्लैशस्क्रीन अपलोड नहीं हो सकी';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'स्प्लैशस्क्रीन हटा दी गई';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'कोई कस्टम स्प्लैशस्क्रीन नहीं';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'हार्डवेयर एक्सिलरेशन';
@@ -6987,121 +6976,121 @@ class AppLocalizationsHi extends AppLocalizations {
       'इसके लिए हार्डवेयर डिकोडिंग सक्षम करें:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV डिवाइस';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'एन्हांस्ड NVDEC डिकोडर चालू करें';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'सिस्टम के नेटिव हार्डवेयर डिकोडर को प्राथमिकता दें';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'हार्डवेयर डिकोडिंग कलर डेप्थ';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-बिट HEVC डिकोडिंग';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-बिट VP9 डिकोडिंग';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-बिट डिकोडिंग';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-बिट डिकोडिंग';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'हार्डवेयर एन्कोडिंग';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC एन्कोडिंग की अनुमति दें';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 एन्कोडिंग की अनुमति दें';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel लो-पावर H.264 एन्कोडर चालू करें';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel लो-पावर HEVC एन्कोडर चालू करें';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'टोन मैपिंग';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'टोन मैपिंग चालू करें';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP टोन मैपिंग चालू करें';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox टोन मैपिंग चालू करें';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'टोन मैपिंग एल्गोरिदम';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'टोन मैपिंग मोड';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'टोन मैपिंग रेंज';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'टोन मैपिंग डीसैचुरेशन';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'टोन मैपिंग पीक';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'टोन मैपिंग पैरामीटर';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP टोन मैपिंग ब्राइटनेस';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP टोन मैपिंग कंट्रास्ट';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'प्रीसेट और क्वालिटी';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'एन्कोडर प्रीसेट';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 एन्कोडिंग CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) एन्कोडिंग CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'डीइंटरलेस विधि';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'डीइंटरलेस करते समय फ़्रेम रेट दोगुना करें';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ऑडियो';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'ऑडियो VBR एन्कोडिंग चालू करें';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ऑडियो डाउनमिक्स बूस्ट';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'स्टीरियो डाउनमिक्स एल्गोरिदम';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'अधिकतम मक्सिंग क्यू साइज़';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ऑटो';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'एन्कोडिंग';
@@ -7218,10 +7207,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminTaskNeverRun => 'कभी नहीं चला';
 
   @override
-  String get adminTaskStop => 'रोकें';
+  String get adminTaskStop => 'रुकना';
 
   @override
-  String get adminRunningTasks => 'चल रहे टास्क';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'दौड़ना';
@@ -7243,17 +7232,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'रोज़ $time पर';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'हर $day को $time पर';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'हर $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7291,8 +7280,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count घंटे',
-      one: '1 घंटा',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7320,17 +7309,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days दि पहले';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours घं पहले';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes मि पहले';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7338,17 +7327,17 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes मि';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours घं';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days दि';
+    return '${days}d';
   }
 
   @override
@@ -7358,7 +7347,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'सीक प्रीव्यू थंबनेल के लिए trickplay इमेज जनरेशन कॉन्फ़िगर करें।';
+      'पूर्वावलोकन थंबनेल खोजने के लिए ट्रिकप्ले छवि निर्माण कॉन्फ़िगर करें।';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'सार्वजनिक HTTPS पोर्ट';
@@ -7367,49 +7356,49 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'आधार यूआरएल';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'जैसे /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'जैसे /जेलीफ़िन';
 
   @override
   String get adminNetworkingHttps => 'HTTPS के';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'सार्वजनिक HTTP पोर्ट';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS अनिवार्य करें';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'सभी रिमोट अनुरोधों को HTTPS पर रीडायरेक्ट करें। यदि सर्वर पर वैध प्रमाणपत्र नहीं है तो इसका कोई असर नहीं होगा।';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'प्रमाणपत्र पासवर्ड';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP सेटिंग्स';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 चालू करें';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 चालू करें';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'स्वचालित पोर्ट मैपिंग चालू करें';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN नेटवर्क';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'IP पतों या CIDR सबनेट की कॉमा या लाइन से अलग की गई सूची, जिन्हें लोकल नेटवर्क का माना जाएगा।';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'प्रकाशित सर्वर URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'किसी सबनेट या पते को प्रकाशित URL से मैप करें, जैसे all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'प्रमाणपत्र पथ';
@@ -7439,11 +7428,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'थ्रॉटल बफ़रिंग';
 
   @override
-  String get adminPlaybackThrottleDelay => 'थ्रॉटल देरी (सेकंड)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'चलते समय सबटाइटल निकालने की अनुमति दें';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'न्यूनतम बायोडाटा प्रतिशत';
@@ -7493,7 +7482,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'कंटेंट टाइप अपडेट नहीं हो सका: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7501,23 +7490,22 @@ class AppLocalizationsHi extends AppLocalizations {
       'धीमी प्रतिक्रिया सीमा (एमएस)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'धीमी प्रतिक्रिया की चेतावनियाँ चालू करें';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect चालू करें';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'सर्वर';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'मेटाडेटा';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'पाथ';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'प्रदर्शन';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'कैश पथ';
@@ -7529,7 +7517,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminGeneralServerName => 'सर्वर का नाम';
 
   @override
-  String get adminGeneralDisplayLanguage => 'पसंदीदा डिस्प्ले भाषा';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'सेटिंग्स लोड करने में विफल';
@@ -7539,19 +7527,19 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'मैपिंग अपडेट नहीं हो सकी: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'समय सीमा: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'फ़ोल्डर';
 
   @override
-  String get libraries => 'लाइब्रेरीज़';
+  String get libraries => 'पुस्तकालय';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7581,8 +7569,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# प्रतिभागी',
-      one: '# प्रतिभागी',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7625,7 +7613,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'आइटम $index';
+    return 'Item $index';
   }
 
   @override
@@ -7673,12 +7661,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay ग्रुप में शामिल हुए';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName ने SyncPlay ग्रुप छोड़ा';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7690,7 +7678,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName के साथ प्लेबैक सिंक हो रहा है';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7728,8 +7716,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# पंक्तियाँ मिलीं',
-      one: '# पंक्ति मिली',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7770,20 +7758,20 @@ class AppLocalizationsHi extends AppLocalizations {
   String get offlineSavedMedia => 'सहेजा गया मीडिया';
 
   @override
-  String get offlineBannerTitle => 'आप ऑफ़लाइन हैं';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'आपके डाउनलोड दिखाए जा रहे हैं';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'डाउनलोड';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'आपके सर्वर तक नहीं पहुँच पा रहे';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'वापस आने तक डाउनलोड से चलाया जा रहा है';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7799,12 +7787,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'कास्ट नियंत्रण विफल: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind नियंत्रण';
+    return '$kind Controls';
   }
 
   @override
@@ -7815,7 +7803,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind रोकें';
+    return 'Stop $kind';
   }
 
   @override
@@ -7839,12 +7827,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length अंकों का PIN डालें';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'अपना $length अंकों का PIN डालें';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7857,40 +7845,40 @@ class AppLocalizationsHi extends AppLocalizations {
   String get pinForgot => 'पिन भूल गए?';
 
   @override
-  String get pinClear => 'साफ़ करें';
+  String get pinClear => 'स्पष्ट';
 
   @override
   String get pinBackspace => 'बैकस्पेस';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect अनुरोध अधिकृत हो गया।';
+  String get quickConnectAuthorized => 'त्वरित कनेक्ट अनुरोध अधिकृत।';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect कोड अमान्य है या उसकी अवधि समाप्त हो चुकी है।';
+      'क्विक कनेक्ट कोड अमान्य है या समाप्त हो गया है।';
 
   @override
   String get quickConnectNotSupported =>
-      'इस सर्वर पर Quick Connect समर्थित नहीं है।';
+      'इस सर्वर पर क्विक कनेक्ट समर्थित नहीं है.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect कोड अधिकृत नहीं हो सका।';
+      'त्वरित कनेक्ट कोड को अधिकृत करने में विफल।';
 
   @override
-  String get quickConnectDisabled => 'इस सर्वर पर Quick Connect बंद है।';
+  String get quickConnectDisabled => 'इस सर्वर पर त्वरित कनेक्ट अक्षम है.';
 
   @override
   String get quickConnectForbidden =>
-      'आपका खाता इस Quick Connect अनुरोध को अधिकृत नहीं कर सकता।';
+      'आपका खाता इस त्वरित कनेक्ट अनुरोध को अधिकृत नहीं कर सकता.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect कोड नहीं मिला। नया कोड आज़माएँ।';
+      'त्वरित कनेक्ट कोड नहीं मिला. नया कोड आज़माएँ.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect विफल: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7901,7 +7889,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'कमांड विफल: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7930,7 +7918,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'कास्ट शुरू नहीं हो सका: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7975,7 +7963,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name डाउनलोड हो रहा है...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -7995,7 +7983,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get shuffleSelectGenre => 'शैली चुनें';
 
   @override
-  String get shuffleLibrary => 'लाइब्रेरी';
+  String get shuffleLibrary => 'पुस्तकालय';
 
   @override
   String get shuffleGenre => 'शैली';
@@ -8056,14 +8044,14 @@ class AppLocalizationsHi extends AppLocalizations {
       'प्लेबैक रोक दिया गया है. क्या आप अभी भी देख रहे हैं?';
 
   @override
-  String get stillWatchingStop => 'रोकें';
+  String get stillWatchingStop => 'रुकना';
 
   @override
   String get stillWatchingContinue => 'जारी रखना';
 
   @override
   String skipSegment(String segment) {
-    return '$segment स्किप करें';
+    return 'Skip $segment';
   }
 
   @override
@@ -8074,12 +8062,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$current/$total डाउनलोड हो रहा है — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName डाउनलोड हो रहा है';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8116,7 +8104,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'घूमने की अनुमति दें';
 
   @override
-  String get playerTooltipPrevious => 'पिछला';
+  String get playerTooltipPrevious => 'पहले का';
 
   @override
   String get playerTooltipSeekBack => 'वापस खोजो';
@@ -8141,13 +8129,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Continue Watching से छिपाएँ';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Next Up से छिपाएँ';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'कलेक्शन में जोड़ें';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'सर्वर प्रशासन पैनल तक पहुंचें';
@@ -8181,7 +8169,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'प्लगइन सिंक, Seerr, रेटिंग और बहुत कुछ';
+      'प्लगइन सिंक, सीयर, रेटिंग और बहुत कुछ';
 
   @override
   String get settingsAboutSubtitle => 'ऐप संस्करण, कानूनी जानकारी और क्रेडिट';
@@ -8199,15 +8187,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsAlphabetical => 'वर्णमाला';
 
   @override
-  String get settingsConnectionSection => 'कनेक्शन';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'सेल्फ़-साइन्ड प्रमाणपत्रों की अनुमति दें';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'सेल्फ़-साइन्ड या निजी-CA TLS प्रमाणपत्र वाले सर्वरों पर भरोसा करें। इसे केवल अपने नियंत्रण वाले सर्वरों के लिए चालू करें। इससे सभी कनेक्शनों के लिए प्रमाणपत्र सत्यापन बंद हो जाता है।';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'गोपनीयता एवं सुरक्षा';
@@ -8223,11 +8210,11 @@ class AppLocalizationsHi extends AppLocalizations {
       'थीम उच्चारण, पृष्ठभूमि, देखे गए संकेतक और थीम संगीत';
 
   @override
-  String get settingsDetailsScreen => 'विवरण स्क्रीन';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'स्टाइल, बैकग्राउंड ब्लर और टैब व्यवहार';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'होम पेज';
@@ -8265,11 +8252,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'नेविगेशन बार में Seerr बटन दिखाएँ';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'ऊपरी नेविगेशन बार में टेक्स्ट लेबल हमेशा दिखाएँ';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8290,7 +8277,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'Moonbase सर्वर-साइड इंटीग्रेशन को सक्षम बनाता है, जिनमें अतिरिक्त रेटिंग स्रोत, Seerr अनुरोध और सिंक की गई प्राथमिकताएँ शामिल हैं।';
+      'Moonbase अतिरिक्त रेटिंग स्रोतों, सीयर अनुरोधों और सिंक की गई प्राथमिकताओं सहित सर्वर-साइड एकीकरण को शक्ति प्रदान करता है।';
 
   @override
   String get settingsOfflineDownloads => 'ऑफ़लाइन डाउनलोड';
@@ -8336,7 +8323,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsSupportMoonfin => 'समर्थन Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'डेवलपर को एक कॉफ़ी दान करें';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'कानूनी';
@@ -8369,8 +8357,8 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# लाइसेंस सूचनाएँ',
-      one: '# लाइसेंस सूचना',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8418,16 +8406,16 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'परिचय और बाह्य को छोड़ें?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'मीडिया सेगमेंट काउंटडाउन';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'प्रोग्रेस बार';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'टाइमर';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'कोई नहीं';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'शीघ्र उपयोगकर्ता';
@@ -8461,13 +8449,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (अनुशंसित)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (लेगेसी)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (विरासत)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (अनुशंसित)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision फ़ॉलबैक';
@@ -8656,756 +8644,749 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'हाल ही में रिलीज़ हुए $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'अगला एपिसोड अपने आप चलाएँ';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'उपलब्ध होने पर अगला एपिसोड अपने आप चलाएँ।';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'ख़ामोशी स्किप करें';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'स्ट्रीम में समर्थित होने पर ऑडियो के ख़ामोश हिस्से अपने आप स्किप करें।';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'बाहरी ऑडियो इफ़ेक्ट की अनुमति दें';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'इक्वलाइज़र और इफ़ेक्ट ऐप्स (जैसे Wavelet) को Media3 प्लेबैक सेशन से जुड़ने दें।';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'टनलिंग बंद करें';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'बिना टनलिंग वाला प्लेबैक ज़बरदस्ती करें। उन डिवाइस पर उपयोगी है जहाँ टनलिंग से ऑडियो/वीडियो में रुकावट आती है।';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'टनलिंग चालू करें';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'उन्नत। ऑडियो और वीडियो को एक जुड़े हुए हार्डवेयर पथ से भेजता है। डिफ़ॉल्ट रूप से बंद है क्योंकि कुछ डिवाइस पर इससे ऑडियो/वीडियो कट जाता है।';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision प्रोफ़ाइल 7 को HEVC पर मैप करें';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'गैर-DV डिवाइस पर Dolby Vision प्रोफ़ाइल 7 स्ट्रीम को HDR10-संगत HEVC के रूप में चलाएँ।';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'एम्बेडेड सबटाइटल स्टाइल इस्तेमाल करें';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'सबटाइटल ट्रैक में एम्बेड किए गए रंग, फ़ॉन्ट और पोज़िशनिंग लागू करें। इसके बजाय अपनी कैप्शन स्टाइल प्राथमिकताएँ इस्तेमाल करने के लिए इसे बंद करें।';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'एम्बेडेड सबटाइटल फ़ॉन्ट आकार इस्तेमाल करें';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'सबटाइटल ट्रैक में एम्बेड किए गए फ़ॉन्ट-आकार संकेत लागू करें। अपनी स्टाइल प्राथमिकताओं का सबटाइटल आकार इस्तेमाल करने के लिए इसे बंद करें।';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'मीडिया विवरण दिखाएँ';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'लाइब्रेरी पेजों के शीर्ष पर चुने गए आइटम का विवरण दिखाएँ।';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'ब्राउज़ करते समय बैकड्रॉप छिपाएँ?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'विस्तृत उप-शीर्षक इस्तेमाल करें';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'लाइब्रेरी पेजों पर विस्तृत या न्यूनतम सब-रो दिखाएँ।';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'सहेजी गई थीम हटाएँ?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '\"$themeName\" को इस डिवाइस के कैश से हटाएँ?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'थीम स्टोर';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'कम्युनिटी थीम ब्राउज़ करें और सहेजें';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'थीम को अपनी दूसरी सहेजी गई थीम की तरह इस्तेमाल करने के लिए उसे सहेजें।';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'अभी कोई थीम उपलब्ध नहीं है।';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'थीम स्टोर लोड नहीं हो सका। अपना कनेक्शन जाँचें और फिर कोशिश करें।';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'सहेजें';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'सहेजें और लागू करें';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'सहेजी गई';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'यह थीम लोड नहीं हो सकी।';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" सहेजी गई।';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" इस डिवाइस से हटा दी गई।';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" को हटाया नहीं जा सका।';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'सहेजी गई थीम';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'ये मौजूदा सर्वर के लिए Moonfin प्लगइन से डाउनलोड की गई थीम हैं। हटाने पर सिर्फ़ यह लोकल कॉपी हटती है।';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'इस सर्वर के लिए कोई सहेजी गई थीम नहीं मिली।';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • अभी सक्रिय';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'सहेजी गई थीम हटाएँ';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'इस डिवाइस पर डाउनलोड की गई प्लगइन थीम प्रबंधित करें';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'थीम एडिटर';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'अपने ब्राउज़र में Moonfin थीम एडिटर खोलें';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'होम स्क्रीन';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'नीचे का बार';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'क्लासिक';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'मॉडर्न';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'होम पंक्तियाँ';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'होम पंक्ति डिस्प्ले';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'होम पंक्ति सेक्शन';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'होम पंक्ति टॉगल';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'लाइब्रेरी आधारित होम पंक्ति श्रेणियाँ चालू या बंद करें';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'होम सेक्शन में पंक्तियाँ दिखाने के लिए नीचे दिए टॉगल चालू करें।';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'क्लासिक में हर पंक्ति का इमेज टाइप और इन्फ़ो ओवरले बना रहता है। मॉडर्न पोर्ट्रेट-से-बैकड्रॉप पंक्तियों का उपयोग करता है।';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'पसंदीदा पंक्तियाँ दिखाएँ';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'होम सेक्शन में पसंदीदा फ़िल्में, सीरीज़ और अन्य पसंदीदा पंक्तियाँ दिखाएँ।';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'पसंदीदा पंक्ति क्रम';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'पसंदीदा पंक्तियों को जोड़ने की तारीख़, रिलीज़ तारीख़, वर्णक्रम और अन्य आधार पर क्रमबद्ध करें।';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'कलेक्शन पंक्तियाँ दिखाएँ';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'होम सेक्शन में कलेक्शन पंक्तियाँ दिखाएँ।';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'कलेक्शन पंक्ति क्रम';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'कलेक्शन पंक्तियों को जोड़ने की तारीख़, रिलीज़ तारीख़, वर्णक्रम और अन्य आधार पर क्रमबद्ध करें।';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'शैली पंक्तियाँ दिखाएँ';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'होम सेक्शन में शैली पंक्तियाँ दिखाएँ।';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'शैली पंक्ति क्रम';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'शैली पंक्तियों को जोड़ने की तारीख़, रिलीज़ तारीख़, वर्णक्रम और अन्य आधार पर क्रमबद्ध करें।';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'शैली पंक्ति आइटम';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'शैली पंक्तियों में फ़िल्में, सीरीज़ या दोनों दिखाएँ।';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'प्लेलिस्ट पंक्तियाँ दिखाएँ';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'होम सेक्शन में प्लेलिस्ट पंक्तियाँ दिखाएँ।';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'प्लेलिस्ट पंक्ति क्रम';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'प्लेलिस्ट पंक्तियों को जोड़ने की तारीख़, रिलीज़ तारीख़, वर्णक्रम और अन्य आधार पर क्रमबद्ध करें।';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ऑडियो पंक्तियाँ दिखाएँ';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'होम सेक्शन में ऑडियो पंक्तियाँ दिखाएँ।';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ऑडियो पंक्तियों का क्रम';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ऑडियो पंक्तियों को जोड़ने की तारीख़, रिलीज़ तारीख़, वर्णक्रम और अन्य आधार पर क्रमबद्ध करें।';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ऑडियो प्लेलिस्ट';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'दिखावट';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'लेआउट';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'थीम';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'कीबोर्ड';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'बटन';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'रेंडरिंग';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV कॉन्फ़िगरेशन';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'बाहरी प्लेयर ऐप';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'लंबे प्रेस पर चलाने का विकल्प पाने के लिए बाहरी प्लेयर सेट करें';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'प्लेबैक शुरू होने पर ऐप चुनने का विकल्प दिखाएँ।';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'इंस्टॉल किए गए प्लेयर लोड हो रहे हैं...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'कनेक्शन';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ऑडियो ट्रांसकोड लक्ष्य';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'पासथ्रू';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'इस डिवाइस पर समर्थित';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'इस डिवाइस पर समर्थित नहीं';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) पासथ्रू';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) को बाहरी डिकोडर पर बिटस्ट्रीम करें।';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) के साथ TrueHD पासथ्रू';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'मीडिया प्लेयर व्यवहार';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'प्लेबैक सुधार';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'हमेशा चालू।';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Skip Outro की जगह Next Up डिस्प्ले दिखाएँ';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Skip Outro बटन के बजाय Next Up ओवरले दिखाएँ।';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'प्लेयर रूटिंग';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'सॉफ़्टवेयर डिकोडर को प्राथमिकता दें';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'हार्डवेयर डिकोडर से पहले FFmpeg (ऑडियो) और libgav1 (AV1) इस्तेमाल करें। अगर HDMI ऑडियो पासथ्रू काम न करे तो इसे बंद करें।';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV पर वीडियो प्लेबैक आपके चुने हुए बाहरी ऐप में खोलें।';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'स्वचालित क्यूइंग';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH सबटाइटल को प्राथमिकता दें';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'अपने आप चुनते समय SDH/CC सबटाइटल ट्रैक को प्राथमिकता दें।';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'वेब डायग्नोस्टिक्स';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin वेब डायग्नोस्टिक्स';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'ब्राउज़र कनेक्टिविटी समस्याओं (CORS, मिक्स्ड कंटेंट और डिस्कवरी सेटिंग्स) की जाँच के लिए इस पेज का उपयोग करें।';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'मिक्स्ड-कंटेंट विफलता मिली';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/प्रीफ़्लाइट विफलता मिली';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin ने पाया कि कोई HTTPS पेज किसी HTTP सर्वर URL को कॉल करने की कोशिश कर रहा है। ब्राउज़र यह अनुरोध आपके सर्वर तक पहुँचने से पहले ही रोक देते हैं।';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin ने ब्राउज़र-स्तर की अनुरोध विफलता पाई, जो आमतौर पर मीडिया सर्वर पर CORS या प्रीफ़्लाइट हेडर न होने से होती है।';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'लक्ष्य URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'विवरण: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'मौजूदा रनटाइम संदर्भ';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'ऑरिजिन';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'स्कीम';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'प्लगइन मोड';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC स्कैन';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'फ़ोर्स्ड सर्वर URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'डिफ़ॉल्ट सर्वर URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'डिस्कवरी प्रॉक्सी URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'कॉन्फ़िगर नहीं है';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'मिक्स्ड कंटेंट';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'यह पेज HTTPS पर लोड हुआ है, लेकिन एक या अधिक कॉन्फ़िगर किए गए URL HTTP हैं। ब्राउज़र HTTPS पेजों को HTTP API कॉल करने से रोकते हैं।';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'समाधान: अपने मीडिया सर्वर या प्रॉक्सी एंडपॉइंट को HTTPS पर चलाएँ, या Moonfin को HTTP पर सिर्फ़ भरोसेमंद लोकल नेटवर्क पर ही लोड करें।';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'मौजूदा रनटाइम सेटिंग्स में मिक्स्ड-कंटेंट से जुड़ी कोई स्पष्ट गड़बड़ी नहीं मिली।';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS चेकलिस्ट';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin में ब्राउज़र ऑरिजिन को अनुमति दें।';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers में Authorization, X-Emby-Authorization और X-Emby-Token शामिल करें।';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• स्ट्रीमिंग और सीक व्यवहार के लिए Content-Range और Accept-Ranges को एक्सपोज़ करें।';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS प्रीफ़्लाइट अनुरोधों पर 204 लौटाएँ।';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'उदाहरण हेडर स्निपेट (nginx-शैली)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'नोट';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'यह डायग्नोस्टिक्स रूट वेब बिल्ड के लिए है। अगर आप इसे किसी दूसरे प्लेटफ़ॉर्म पर देख रहे हैं, तो ये जाँचें लागू नहीं हो सकतीं।';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'सर्वर चुनने पर वापस जाएँ';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'सभी उपयोगकर्ताओं को साइन आउट करें';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'माइक्रोफ़ोन की अनुमति स्थायी रूप से अस्वीकृत है। इसे सिस्टम सेटिंग्स में चालू करें।';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'वॉइस सर्च के लिए माइक्रोफ़ोन की अनुमति ज़रूरी है।';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'यह समझ नहीं आया। फिर कोशिश करें।';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'कोई आवाज़ नहीं मिली।';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'माइक्रोफ़ोन त्रुटि।';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'वॉइस सर्च के लिए इंटरनेट ज़रूरी है।';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => 'वॉइस सेवा व्यस्त है। फिर कोशिश करें।';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'माइक्रोफ़ोन की अनुमति स्थायी रूप से अस्वीकृत है।';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'माइक्रोफ़ोन की अनुमति अस्वीकृत है।';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'इस डिवाइस पर वाक् पहचान उपलब्ध नहीं है।';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS रूट पिकर खोलें';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'इस डिवाइस पर AirPlay रूट पिकर उपलब्ध नहीं है।';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'वीडियो';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'प्रोग्राम';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'गाने';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'फ़ोटो एल्बम';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'फ़ोटो';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'लोग';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'हाल ही में रिलीज़ हुए एपिसोड';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'फिर से देखें';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'अतिथि भूमिकाएँ';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'भूमिकाएँ (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'क्रू योगदान (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'ग्रुप के साथ देखें';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'त्रुटियाँ';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'चेतावनियाँ';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'डिस्क';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'ब्राउज़र में खोलें';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'इस प्लेटफ़ॉर्म पर एम्बेडेड ब्राउज़र उपलब्ध नहीं है।';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'क्या आप वाकई सर्वर को रीस्टार्ट करना चाहते हैं?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'क्या आप वाकई सर्वर को बंद करना चाहते हैं? आपको इसे मैन्युअल रूप से फिर से शुरू करना होगा।';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'आंतरिक';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'निष्क्रिय';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'कोई उपयोगकर्ता नहीं मिला';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'आपकी खोज से कोई उपयोगकर्ता मेल नहीं खाता';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'कोई डिवाइस नहीं मिला';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'मौजूदा फ़िल्टर से कोई डिवाइस मेल नहीं खाता';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'पासवर्ड सेट है';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'कोई पासवर्ड कॉन्फ़िगर नहीं है';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'रिमोट एक्सेस';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'केवल लोकल';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'मीडिया एनालिटिक्स लोड नहीं हो सका';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'सभी मीडिया लाइब्रेरी का संयुक्त एनालिटिक्स।';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'टॉप कलाकार';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'टॉप लेखक';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'टॉप योगदानकर्ता';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count लाइब्रेरी',
-      one: '1 लाइब्रेरी',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'इस चयन के लिए अभी कोई इंडेक्स किया गया मीडिया कुल उपलब्ध नहीं है।';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'लाइब्रेरी विवरण';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'लाइब्रेरी ब्रेकडाउन';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'कोई लाइब्रेरी उपलब्ध नहीं है।';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'सर्वर प्रशासन';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'डेटा';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'इमेज कैश';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'कैश';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'लॉग';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'मेटाडेटा';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'ट्रांसकोड';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'इस सर्वर ने कोई सर्वर पाथ नहीं लौटाया।';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% उपयोग में';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'उपयोगकर्ता गतिविधि';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'सिस्टम इवेंट';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'ध्यान देने की ज़रूरत';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'सर्वर';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'प्लेबैक';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'डिवाइस';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'उन्नत';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'प्लगइन';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
   String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'होम वीडियो';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'मिश्रित सामग्री';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'होम वीडियो और फ़ोटो';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'मिश्रित फ़िल्में और शो';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9417,300 +9398,299 @@ class AppLocalizationsHi extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'कोई रिकॉर्डिंग नहीं मिली';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension आर्काइव में कोई इमेज पेज नहीं मिला।';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'एम्बेडेड रेंडरर विफल ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB रेंडरर विफल ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'रीडर के लिए लोकल फ़ाइल नहीं मिली: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri से बुक डेटा खोलते समय HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'कोई पठनीय बुक एंडपॉइंट उपलब्ध नहीं';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'असमर्थित कॉमिक आर्काइव फ़ॉर्मेट: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'इस प्लेटफ़ॉर्म पर CBR एक्सट्रैक्शन प्लगइन उपलब्ध नहीं है।';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr आर्काइव एक्सट्रैक्ट नहीं हो सका।';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'इस प्लेटफ़ॉर्म पर CB7 एक्सट्रैक्शन उपलब्ध नहीं है।';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'इस प्लेटफ़ॉर्म पर CB7 एक्सट्रैक्शन प्लगइन उपलब्ध नहीं है।';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'शैली पैनल बंद करें';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'शफ़ल लोड हो रहा है...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'लाइब्रेरी शफ़ल';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'रैंडम शफ़ल';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'शैली शफ़ल';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'ऑटो HDR स्विचिंग';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR वीडियो प्लेबैक के लिए HDR अपने आप चालू करें और बाहर निकलने पर डिस्प्ले मोड बहाल करें।';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'फ़ुलस्क्रीन में';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'आर्टवर्क बदलें';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'अनुपलब्ध';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'ट्रांसकोडिंग सीमाएँ';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'सारा आर्टवर्क हटाएँ?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'क्या आप वाकई सारा डाउनलोड किया गया आर्टवर्क हटाना चाहते हैं?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'हटाने की पुष्टि करें';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'क्या आप वाकई यह $itemType हटाना चाहते हैं?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'अपलोड करें?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'रिज़ॉल्यूशन: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'केवल इंटरफ़ेस भाषा वाला आर्टवर्क दिखाएँ';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'सब हटाने की पुष्टि करें';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'इमेज सफलतापूर्वक अपलोड हो गई!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'इमेज अपलोड नहीं हो सकी: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'इमेज सेट नहीं हो सकी: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'इमेज हटाई नहीं जा सकी: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'सारा आर्टवर्क हटाया नहीं जा सका: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'हाँ';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'पोस्टर';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'बैकड्रॉप';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'बैनर';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'लोगो';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'थंबनेल';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'आर्ट';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'डिस्क आर्ट';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'स्क्रीनशॉट';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'बॉक्स कवर';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'बॉक्स रियर कवर';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'मेन्यू आर्ट';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'पोस्टर';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'बैकड्रॉप';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'बैनर';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'लोगो';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'थंबनेल';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'आर्ट';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'डिस्क आर्ट';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'स्क्रीनशॉट';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'बॉक्स कवर';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'बॉक्स रियर कवर';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'मेन्यू आर्ट';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'सभी';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'उच्च (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'मध्यम (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'निम्न (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'स्रोत';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'अध्याय';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'बुकमार्क';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'नोट्स';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'कतार';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'टाइमलाइन';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'टाइमलाइन खाली है';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'पूरी किताब';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'केंद्रित टाइमलाइन';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'बुकमार्क एक्सपोर्ट करें';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'नोट्स एक्सपोर्ट करें';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'सब एक्सपोर्ट करें';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path में एक्सपोर्ट हो गया';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'एक्सपोर्ट विफल: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'बोल';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'बुकमार्क जोड़ें';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'नोट जोड़ें';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'नोट संपादित करें';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'इस पल के लिए एक नोट लिखें';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'स्लीप टाइमर';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'बंद';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'अध्याय के अंत में';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'कस्टम';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining बचे';
+    return '$remaining left';
   }
 
   @override
@@ -9718,58 +9698,58 @@ class AppLocalizationsHi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count मिनट',
-      one: '1 मिनट',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'प्लेबैक गति';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'शेष';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'बीता समय';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds से॰ पीछे';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds से॰ आगे';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'पिछला अध्याय';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'अगला अध्याय';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'अध्याय $current / $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'कोई अध्याय नहीं';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'अभी कोई बुकमार्क नहीं';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'अभी कोई नोट नहीं';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position पर बुकमार्क जोड़ा गया';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x पर रीसेट करें';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9777,249 +9757,249 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'सहेजें';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'रद्द करें';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'मिटाएँ';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'सबटाइटल प्राथमिकताएँ';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'सबटाइटल मोड, डिफ़ॉल्ट भाषाएँ, दिखावट और रेंडरिंग विकल्प बदलें।';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'सबटाइटल रेंडरिंग';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'प्रदर्शन विकल्प';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'रिलीज़ तिथि (बढ़ते क्रम में)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'रिलीज़ तिथि (घटते क्रम में)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'योगदान समूहित करें';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'एकाधिक भूमिकाएँ समूहित करें';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'लाइब्रेरी राइट एक्सेस चेतावनी';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'इसे कैसे ठीक करें:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. सर्वर पर अपने मीडिया लाइब्रेरी फ़ोल्डर के लिए Jellyfin सेवा उपयोगकर्ता (जैसे jellyfin या Docker PUID/PGID) को राइट अनुमतियाँ दें।\n\n2. या, अपने Jellyfin Dashboard -> Libraries पर जाएँ, इस लाइब्रेरी को संपादित करें, और आर्टवर्क को Jellyfin के आंतरिक डेटाबेस में सहेजने के लिए \'Save artwork into media folders\' बंद करें।';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'खारिज करें';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'आपकी \'$libraryName\' लाइब्रेरी आर्टवर्क को सीधे मीडिया फ़ोल्डर में सहेजने के लिए कॉन्फ़िगर है (\'Save artwork into media folders\' चालू है)। हालाँकि, Jellyfin ने राइट एक्सेस जाँचा और उसे इस डायरेक्टरी में फ़ाइलें लिखने की अनुमति नहीं है:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'लगता है Jellyfin आर्टवर्क अपडेट नहीं कर सका। आपकी लाइब्रेरी आर्टवर्क को सीधे मीडिया फ़ोल्डर में सहेजने के लिए कॉन्फ़िगर है (\'Save artwork into media folders\' चालू है)। यह त्रुटि आम तौर पर तब होती है जब Jellyfin सर्वर प्रोसेस के पास आपकी मीडिया डायरेक्टरी में फ़ाइलें लिखने की अनुमति नहीं होती।';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'बाहरी सूचियाँ';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'फिर से चलाएँ';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'फ़ाइल जानकारी';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'आकार: $size  •  फ़ॉर्मेट: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'सभी ($count) ऑडियो ट्रैक दिखाएँ';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'सभी ($count) सबटाइटल ट्रैक दिखाएँ';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Direct Play क्षमता जाँची जा रही है...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play क्षमता: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'फ़ोर्स्ड';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'प्लेयर इस कंटेनर फ़ॉर्मेट का समर्थन नहीं करता।';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'वीडियो कोडेक समर्थित नहीं है।';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'ऑडियो कोडेक समर्थित नहीं है।';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'सबटाइटल फ़ॉर्मेट समर्थित नहीं है (बर्निंग ज़रूरी है)।';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ऑडियो प्रोफ़ाइल समर्थित नहीं है।';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'वीडियो प्रोफ़ाइल समर्थित नहीं है।';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'वीडियो लेवल समर्थित नहीं है।';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'यह डिवाइस इस वीडियो रिज़ॉल्यूशन का समर्थन नहीं करता।';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'वीडियो बिट डेप्थ समर्थित नहीं है।';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'वीडियो फ़्रेमरेट समर्थित नहीं है।';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'फ़ाइल बिटरेट प्लेयर की स्ट्रीमिंग सीमा से अधिक है।';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'वीडियो बिटरेट स्ट्रीमिंग सीमा से अधिक है।';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ऑडियो बिटरेट स्ट्रीमिंग सीमा से अधिक है।';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ऑडियो चैनलों की संख्या समर्थित नहीं है।';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'वर्णानुक्रम';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'रिलीज़ क्रम (बढ़ते क्रम में)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'रिलीज़ क्रम (घटते क्रम में)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'कस्टम (ड्रैग-एंड-ड्रॉप)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'प्लेलिस्ट क्रम विकल्प';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'क्रम रीसेट करें';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode फिर से देखें';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'प्लेलिस्ट फिर से देखें';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'कोई सबटाइटल नहीं मिला।';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'एडमिन नियंत्रण';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'रेंडरिंग इंजन (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller, Flutter का आधुनिक GPU रेंडरर है जो एनिमेशन को स्मूद बनाता है और अटकन कम करता है। कुछ TV बॉक्स और पुराने GPU पर यह ग्लिच या ब्लैक वीडियो दे सकता है; ऐसा दिखे तो इसे बंद कर दें। स्वचालित आपके डिवाइस के लिए सबसे अच्छा डिफ़ॉल्ट चुनता है। लागू करने के लिए Moonfin को फिर से शुरू करें।';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'स्वचालित';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'चालू';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'बंद';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'पुनः आरंभ ज़रूरी';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'रेंडरिंग इंजन बदलने के लिए Moonfin को फिर से शुरू करना होगा। ऐप अभी बंद करें, फिर लागू करने के लिए उसे दोबारा खोलें।';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ऐप अभी बंद करें';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'लाइब्रेरी रिफ़्रेश करें';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'सभी लाइब्रेरी रिफ़्रेश करें';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'जोड़ने की तिथि (सबसे पुराना पहले)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'जोड़ने की तिथि (सबसे नया पहले)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'वर्णानुक्रम (A से Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'वर्णानुक्रम (Z से A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'सर्वर एनालिटिक्स लोड हो रहा है... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'स्रोत के अनुसार';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb टॉप 250 फ़िल्में';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb टॉप 250 टीवी शो';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb सबसे लोकप्रिय फ़िल्में';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb सबसे लोकप्रिय टीवी शो';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb सबसे कम रेटेड फ़िल्में';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb टॉप रेटेड अंग्रेज़ी फ़िल्में';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -9,30 +9,30 @@ class AppLocalizationsHr extends AppLocalizations {
   AppLocalizationsHr([String locale = 'hr']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Mjesečeva peraja';
 
   @override
-  String get accountPreferences => 'POSTAVKE RAČUNA';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Jezik sučelja';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Zadano sustavom';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Prijavite se';
 
   @override
-  String get empty => 'Prazno';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Povezivanje s poslužiteljem $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Brzo povezivanje';
 
   @override
   String get password => 'Lozinka';
@@ -51,7 +51,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get waitingForAuthorization => 'Čeka se autorizacija...';
 
   @override
-  String get back => 'Natrag';
+  String get back => 'Nazad';
 
   @override
   String get serverUnavailable => 'Poslužitelj je nedostupan';
@@ -61,12 +61,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect nije dostupan: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect nije dostupan ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin verzija $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Ukloniti „$serverName” s popisa poslužitelja?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'Otkazati';
 
   @override
-  String get remove => 'Ukloni';
+  String get remove => 'Ukloniti';
 
   @override
   String get connectToServer => 'Spojite se na poslužitelj';
@@ -141,62 +141,62 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema aplikacije';
 
   @override
-  String get detailScreenStyle => 'Stil zaslona s detaljima';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasični je izvorni centrirani Moonfin raspored. Moderni je responzivni filmski raspored.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasični';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderni';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Proširene kartice';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automatski prikazuj sadržaj kartice dok pregledavate kartice. Isključite za ručno otvaranje i zatvaranje svake kartice.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Prikazati tehničke detalje?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Prikaži kodek, razlučivost i podatke o streamu u sažetku na banneru';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sustav preporuka';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Koristite algoritam lokalne biblioteke Moonfin Recommends ili mrežne TMDb metrike sličnosti. Napomena: mrežne preporuke zahtijevaju Seerr integraciju.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb sličnost';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Primijeniti ograničenje dobne ocjene?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ograniči prijedloge značajke Moonfin Recommends prema dobnoj ocjeni odabranog sadržaja';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Stil sučelja';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatski se prilagođava vašem uređaju. Odaberite Apple ili Material za željeni izgled.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatski';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsHr extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kvaliteta stakla';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automatski odabire najbolji efekt stakla za ovaj uređaj. Puna nameće stvarno zamućenje, a Smanjena koristi lagano staklo koje štedi GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automatski';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Puna';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Smanjena';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Prebacite se između Moonfin i Neon Pulse bez ponovnog pokretanja aplikacije';
 
   @override
-  String get customThemeTitle => 'Prilagođena tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Prilagođene teme mijenjaju vizualne elemente u cijelom Moonfinu. Odaberite jednu od ovih opcija koja odgovara vašem stilu.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Preferiraj sistemsku tipkovnicu';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Za unos teksta zadano koristi način unosa vašeg uređaja';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Mjesečeva peraja';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsHr extends AppLocalizations {
       'Synthwave stil s magenta sjajem, cijan tekstom i jačim kromiranim kontrastom';
 
   @override
-  String get themeGlass => 'Staklo';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Stil tekućeg stakla s pomičnom gradijentnom pozadinom, matiranim površinama i Apple-plavim naglaskom';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bitni heroj';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixel-art stil s izraženom paletom, blokovskim rubovima, oštrim sjenama i pikselnim fontom';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Povezivanje s $target nije uspjelo';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,35 +327,35 @@ class AppLocalizationsHr extends AppLocalizations {
   String get exit => 'Izlaz';
 
   @override
-  String get gameMenu => 'Izbornik';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pauzirano';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Spremi stanje';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Igre';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Učitaj stanje';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Ubrzano naprijed';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Postavke emulatora';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Ova jezgra nema podesivih opcija.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Držite za otvaranje izbornika';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Pokretanje igara još nije podržano na ovom uređaju.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nije moguće učitati nijedan početni redak';
@@ -377,13 +377,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get schedule => 'Raspored';
 
   @override
-  String get series => 'Serije';
+  String get series => 'Niz';
 
   @override
   String get noItemsFound => 'Nema pronađenih stavki';
 
   @override
-  String get home => 'Početna';
+  String get home => 'Dom';
 
   @override
   String get browseAll => 'Pregledaj sve';
@@ -414,7 +414,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noLibrariesFound => 'Nisu pronađene knjižnice';
 
   @override
-  String get library => 'Biblioteka';
+  String get library => 'Knjižnica';
 
   @override
   String get displaySettings => 'Postavke zaslona';
@@ -427,7 +427,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Učitavanje mape nije uspjelo: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -435,14 +435,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count stavki',
-      few: '$count stavke',
-      one: '$count stavka',
-    );
-    return '$_temp0';
+    return '$count items';
   }
 
   @override
@@ -459,14 +452,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count stavki',
-      few: '$count stavke',
-      one: '$count stavka',
-    );
-    return '$_temp0';
+    return '$count Items';
   }
 
   @override
@@ -507,7 +493,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — žanrovi';
+    return '$name — Genres';
   }
 
   @override
@@ -520,7 +506,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get albumArtists => 'Izvođači albuma';
 
   @override
-  String get artists => 'Izvođači';
+  String get artists => 'Umjetnici';
 
   @override
   String get bookmarks => 'Knjižne oznake';
@@ -545,17 +531,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'prije $count min';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'prije $count h';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'prije $count d';
+    return '${count}d ago';
   }
 
   @override
@@ -566,7 +552,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Odaberite koji će se feedovi tema prikazati u Discoveru.';
 
   @override
-  String get apply => 'Primijeni';
+  String get apply => 'primijeniti';
 
   @override
   String get openLink => 'Otvori vezu';
@@ -590,14 +576,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count naslova',
-      few: '$count naslova',
-      one: '$count naslov',
-    );
-    return '$_temp0';
+    return '$count titles';
   }
 
   @override
@@ -684,31 +663,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count autora',
-      few: '$count autora',
-      one: '$count autor',
-    );
-    return '$_temp0';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count žanrova',
-      few: '$count žanra',
-      one: '$count žanr',
-    );
-    return '$_temp0';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% dovršeno';
+    return '$percent% completed';
   }
 
   @override
@@ -725,16 +690,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other:
-          '$count naslova raspoređeno za pregledavanje s naglaskom na čitanju.',
-      few:
-          '$count naslova raspoređena za pregledavanje s naglaskom na čitanju.',
-      one: '$count naslov raspoređen za pregledavanje s naglaskom na čitanju.',
-    );
-    return '$_temp0';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -771,7 +727,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Nema rezultata za $label';
+    return 'No $label found';
   }
 
   @override
@@ -790,13 +746,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get readStatus => 'čitati';
 
   @override
-  String get watched => 'Gledano';
+  String get watched => 'Gledao';
 
   @override
   String get unread => 'Nepročitano';
 
   @override
-  String get unwatched => 'Negledano';
+  String get unwatched => 'Negledan';
 
   @override
   String get seriesStatus => 'Status serije';
@@ -808,44 +764,43 @@ class AppLocalizationsHr extends AppLocalizations {
   String get books => 'knjige';
 
   @override
-  String get latestBooks => 'Najnovije knjige';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Najnovije audioknjige';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knjiga',
-      few: '$count knjige',
-      one: '$count knjiga',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Knjiga';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audioknjiga';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% pročitano';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'još $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Čitaj';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Slušaj';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -882,19 +837,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count odjeljaka',
-      few: '$count odjeljka',
-      one: '$count odjeljak',
-    );
-    return '$_temp0';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Prvi put objavljeno $year.';
+    return 'First published $year';
   }
 
   @override
@@ -909,14 +857,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count knjiga',
-      few: '$count knjige',
-      one: '$count knjiga',
-    );
-    return '$_temp0';
+    return '$count books';
   }
 
   @override
@@ -927,14 +868,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count autora',
-      few: '$count autora',
-      one: '$count autor',
-    );
-    return '$_temp0';
+    return '$count Authors';
   }
 
   @override
@@ -942,9 +876,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audioknjiga',
-      few: '$count audioknjige',
-      one: '$count audioknjiga',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -959,10 +892,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get failedToLoad => 'Učitavanje nije uspjelo';
 
   @override
-  String get delete => 'Izbriši';
+  String get delete => 'Izbrisati';
 
   @override
-  String get save => 'Spremi';
+  String get save => 'Uštedjeti';
 
   @override
   String get moreLikeThis => 'Više poput ovoga';
@@ -980,7 +913,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get nextUp => 'Sljedeći';
 
   @override
-  String get seasons => 'Sezone';
+  String get seasons => 'Godišnja doba';
 
   @override
   String get chapters => 'poglavlja';
@@ -992,7 +925,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get movies => 'Filmovi';
 
   @override
-  String get musicVideos => 'Glazbeni spotovi';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'ostalo';
@@ -1011,7 +944,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disk $number';
+    return 'Disc $number';
   }
 
   @override
@@ -1036,7 +969,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Objavljeno $year.';
+    return 'Published $year';
   }
 
   @override
@@ -1047,53 +980,52 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezona',
-      few: '$count sezone',
-      one: '$count sezona',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Završava u $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Stavke';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Dodaci';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Iza scene';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Izbrisane scene';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Kratki prilozi';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjui';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scene';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kratki filmovi';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Najave';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'još $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Završava za $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1107,11 +1039,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Nastavi od $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Reproduciraj';
+  String get play => 'Igrati';
 
   @override
   String get startOver => 'Počni ispočetka';
@@ -1135,10 +1067,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get version => 'Verzija';
 
   @override
-  String get cast => 'Prenesi';
+  String get cast => 'Cast';
 
   @override
-  String get trailer => 'Najava';
+  String get trailer => 'Prikolica';
 
   @override
   String get finished => 'Gotovo';
@@ -1207,7 +1139,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Izbrisati preuzete pjesme za „$title”?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1222,17 +1154,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Nema učitanih stavki: $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Preuzimanje: $title ($count stavki)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Jeste li sigurni da želite izbrisati „$name” s poslužitelja? Ova se radnja ne može poništiti.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1243,7 +1175,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Nepodržani format knjige: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1253,7 +1185,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get subtitleTrack => 'Zapis titlova';
 
   @override
-  String get none => 'Ništa';
+  String get none => 'Nijedan';
 
   @override
   String get downloadSubtitlesLabel => 'Preuzmi titlove...';
@@ -1270,7 +1202,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Titl preuzet i odabran: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1279,7 +1211,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Nisu pronađeni mrežni titlovi za $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1287,7 +1219,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Verzija $number';
+    return 'Version $number';
   }
 
   @override
@@ -1309,7 +1241,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Preuzimanje: $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1317,7 +1249,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Izbrisati lokalne datoteke za $typeLabel?\n\nTime ćete osloboditi prostor za pohranu. Možete ih ponovno preuzeti kasnije.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1333,32 +1265,25 @@ class AppLocalizationsHr extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
-  String get directors => 'REDATELJI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENARIST';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARISTI';
+  String get writers => 'KNJIŽEVNICI';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count više';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count epizoda',
-      few: '$count epizode',
-      one: '$count epizoda',
-    );
-    return '$_temp0';
+    return '$count Episodes';
   }
 
   @override
@@ -1368,12 +1293,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Epizoda $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Poglavlje $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1381,9 +1306,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pjesama',
-      few: '$count pjesme',
-      one: '$count pjesma',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1393,26 +1317,25 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count poglavlja',
-      few: '$count poglavlja',
-      one: '$count poglavlje',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Rođenje: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Smrt: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Dob: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1422,27 +1345,20 @@ class AppLocalizationsHr extends AppLocalizations {
   String get readMore => 'Pročitajte više';
 
   @override
-  String get shuffle => 'Nasumično';
+  String get shuffle => 'Promiješaj';
 
   @override
-  String get shuffleAllMusic => 'Nasumično pusti svu glazbu';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Prijavite se u Moonfin na telefonu';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Poslužitelj nije dostupan';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count preuzimanja',
-      few: '$count preuzimanja',
-      one: '$count preuzimanje',
-    );
-    return '$_temp0';
+    return '$count downloads';
   }
 
   @override
@@ -1450,7 +1366,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1461,32 +1377,32 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Radnja „$action” za mrežne titlove zahtijeva Jellyfin dopuštenje za upravljanje titlovima za ovog korisnika.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Ova stavka nije pronađena na poslužitelju za radnju „$action” s mrežnim titlovima.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Radnja „$action” za mrežne titlove nije uspjela: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Radnja „$action” za mrežne titlove nije uspjela (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Radnja „$action” za mrežne titlove nije uspjela.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'sve preuzete epizode za „$name”';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1516,17 +1432,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Radnja „$label” nije uspjela: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Postavljanje glasnoće za Cast nije uspjelo: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Kontrole – $label';
+    return '$label Controls';
   }
 
   @override
@@ -1543,7 +1459,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Zaustavi $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1551,11 +1467,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Pjesma $number';
+    return 'Track $number';
   }
 
   @override
-  String get remotePlayback => 'Udaljena reprodukcija';
+  String get remotePlayback => 'Remote Playback';
 
   @override
   String get castingToGoogleCast => 'Emitiranje na Google Cast';
@@ -1568,14 +1484,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    String _temp0 = intl.Intl.pluralLogic(
-      seconds,
-      locale: localeName,
-      other: '$seconds sekundi',
-      few: '$seconds sekunde',
-      one: '$seconds sekunda',
-    );
-    return '$_temp0';
+    return '$seconds seconds';
   }
 
   @override
@@ -1590,7 +1499,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automatski';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1605,12 +1514,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1644,13 +1553,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get transcodeReasons => 'Razlozi transkodiranja';
 
   @override
-  String get player => 'Player';
+  String get player => 'Igrač';
 
   @override
   String get container => 'Kontejner';
 
   @override
-  String get bitrate => 'Brzina prijenosa';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Video';
@@ -1668,7 +1577,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get videoBitrate => 'Brzina prijenosa videozapisa';
 
   @override
-  String get track => 'Zapis';
+  String get track => 'Staza';
 
   @override
   String get channels => 'Kanali';
@@ -1690,12 +1599,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Greška $protocol sesije';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Učitavanje podataka o knjizi nije uspjelo: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1704,7 +1613,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Ovaj format (.$extension) još se ne može prikazati u aplikaciji.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1717,17 +1626,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Otvaranje čitača u aplikaciji nije uspjelo: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Oznaka je već spremljena na $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Oznaka dodana: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1739,7 +1648,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Stranica $number';
+    return 'Page $number';
   }
 
   @override
@@ -1755,7 +1664,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String percentRead(String percent) {
-    return '$percent% pročitano';
+    return '$percent% read';
   }
 
   @override
@@ -1779,7 +1688,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Poništi zumiranje (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1802,7 +1711,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Ažuriranje statusa čitanja nije uspjelo: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1834,7 +1743,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ova platforma ne može pokrenuti ugrađeni mehanizam za dokumente za $extension datoteke.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1873,7 +1782,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Učitavanje TV vodiča nije uspjelo: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1884,22 +1793,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Sljedeće: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'još $minutes min';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'još $hours h';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'još $hours h $minutes min';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1922,29 +1831,29 @@ class AppLocalizationsHr extends AppLocalizations {
   String get favoriteChannel => 'Omiljeni kanal';
 
   @override
-  String get record => 'Snimi';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Otkaži snimanje';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Emisija je zakazana za snimanje';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Snimanje je otkazano';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Nije moguće stvoriti snimku';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Gledaj';
+  String get watch => 'Gledati';
 
   @override
-  String get close => 'Zatvori';
+  String get close => 'Zatvoriti';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Reprodukcija kanala $name nije uspjela';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1970,7 +1879,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Otkazati zakazano snimanje emisije „$name”?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1997,7 +1906,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Zaustaviti snimanje serije „$name”?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -2012,12 +1921,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Nema rezultata za „$query”';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Pretraživanje nije uspjelo: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -2058,19 +1967,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Ukloniti „$name” i pripadajuće datoteke?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count pjesama',
-      few: '$count pjesme',
-      one: '$count pjesma',
-    );
-    return '$_temp0';
+    return '$count tracks';
   }
 
   @override
@@ -2081,12 +1983,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Učitavanje albuma nije uspjelo: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Nema preuzetih pjesama za $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2103,7 +2005,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Ukloniti „$name”?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2118,7 +2020,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Epizoda $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2132,7 +2034,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sezona $number';
+    return 'Season $number';
   }
 
   @override
@@ -2148,7 +2050,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Izbrisati sve preuzete epizode u $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2156,9 +2058,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizoda',
-      few: '$count epizode',
-      one: '$count epizoda',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2193,14 +2094,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Izbrisati $count preuzetih stavki?',
-      few: 'Izbrisati $count preuzete stavke?',
-      one: 'Izbrisati $count preuzetu stavku?',
-    );
-    return '$_temp0';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2214,7 +2108,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'od ograničenja $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2298,14 +2192,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count opcija',
-      few: '$count opcije',
-      one: '$count opcija',
-    );
-    return '$_temp0';
+    return '$count options';
   }
 
   @override
@@ -2398,7 +2285,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Stranice s detaljima, redovi na početnom zaslonu i glasnoća';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2413,18 +2300,18 @@ class AppLocalizationsHr extends AppLocalizations {
       'Igrajte dok pregledavate početni zaslon';
 
   @override
-  String get loopThemeMusic => 'Ponavljaj tematsku glazbu';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ponavljaj pjesmu umjesto jednokratne reprodukcije';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Zamućenje pozadine detalja';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2440,23 +2327,23 @@ class AppLocalizationsHr extends AppLocalizations {
   String get playerZoomMode => 'Način zumiranja igrača';
 
   @override
-  String get settingsScrollWheelAction => 'Kotačić miša';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Odaberite što radi pomicanje kotačića miša preko videa tijekom reprodukcije.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Isključeno';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Premotavanje (naprijed / natrag)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Glasnoća';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Glasnoća';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2471,7 +2358,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get refreshRateSwitching => 'Promjena brzine osvježavanja';
 
   @override
-  String get disabled => 'Onemogućeno';
+  String get disabled => 'Onesposobljeno';
 
   @override
   String get scaleOnTv => 'Skala na TV-u';
@@ -2510,37 +2397,37 @@ class AppLocalizationsHr extends AppLocalizations {
   String get defaultAudioLanguage => 'Zadani audio jezik';
 
   @override
-  String get fallbackAudioLanguage => 'Rezervni jezik zvuka';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Preferiraj zadani audiozapis';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferiraj izvorni audiozapis umjesto lokalizirane sinkronizacije.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferiraj zapise s audiodeskripcijom';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferiraj zapise s audiodeskripcijom umjesto uobičajenih zapisa.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodiranje (zvuk)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Izravni stream (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodiranje (brzina prijenosa ili razlučivost)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodiranje (video i zvuk)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodiranje (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatski (zadano za poslužitelj)';
@@ -2617,28 +2504,27 @@ class AppLocalizationsHr extends AppLocalizations {
       'Omogući TrueHD audio (možda neće raditi na svim platformama)';
 
   @override
-  String get settingsAudioOutputMode => 'Način izlaza zvuka';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Odaberite kako se zvuk dekodira. AVR Passthrough šalje neobrađene Dolby/DTS streamove vašem prijamniku, dok Auto ili Downmix dekodiraju lokalno.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Rezervni audiokodek';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Odaberite ciljni format za transkodiranje višekanalnog zvuka kada se izvorni stream ne može izravno reproducirati ni proslijediti.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automatsko otkrivanje\n(preporučeno)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(zadano)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2647,27 +2533,26 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(bez gubitaka)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(samo stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(učinkovit)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(bez gubitaka)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Najveći broj audiokanala';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Postavite najveći broj kanala vaše audiokonfiguracije. Višekanalni streamovi koji premašuju ovo ograničenje bit će downmiksani ili transkodirani.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automatsko otkrivanje\n(zadano hardverom)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2679,7 +2564,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 kvadrofonija';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2694,14 +2579,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (napredno)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough kodeka';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Omogućite samo formate koje podržava vaš AVR ili HDMI uređaj.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
   String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
@@ -2723,38 +2608,38 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Šalji Dolby Digital Plus (EAC3) bitstream vanjskom dekoderu.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Šalji Dolby Atmos preko EAC3 (JOC) bitstream vanjskom dekoderu.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Šalji DTS-HD MA bitstream (uključuje DTS core) vanjskom dekoderu.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Šalji Dolby TrueHD bitstream s Atmos metapodacima vanjskom dekoderu.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Otkrivene audiomogućnosti';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Snimka mogućnosti tijekom izvođenja još nije dostupna.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Ruta';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekodiranje';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD audioruta';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2769,50 +2654,50 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Zvučnik';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Slušalice';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Dijagnostika';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Video razina';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Video raspon';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodek titlova';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Dopušteni audiokodeci';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS audiokodeci';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 audiokodeci';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktivna audioruta';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Podrška rute za HD zvuk';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Noćni način rada';
@@ -2861,7 +2746,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2876,7 +2761,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Nakon $episodes epizoda / $hours h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2901,7 +2786,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get thirtySeconds => '30 sekundi';
 
   @override
-  String get skipBackLength => 'Duljina premotavanja unatrag';
+  String get skipBackLength => 'Skip Back Length';
 
   @override
   String get skipForwardLength => 'Duljina preskakanja unaprijed';
@@ -2917,7 +2802,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get selectMpvConf => 'Odaberite mpv.conf';
 
   @override
-  String get pathToMpvConf => '/putanja/do/mpv.conf';
+  String get pathToMpvConf => '/path/to/mpv.conf';
 
   @override
   String get subtitleStyleDescription =>
@@ -2953,45 +2838,45 @@ class AppLocalizationsHr extends AppLocalizations {
       'Prilagodite izgled podnaslova';
 
   @override
-  String get subtitleMode => 'Način titlova';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Označeni';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Uvijek';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Strani jezik';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Prisilni';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Reproducira zapise koji su u metapodacima medijske datoteke označeni kao „default” ili „forced”.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automatski učitava i prikazuje titlove svaki put kad video započne.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automatski uključuje titlove ako je zadani audiozapis na stranom jeziku.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Učitava samo titlove izričito označene oznakom „forced” u metapodacima.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Potpuno onemogućuje automatsko učitavanje titlova.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Rezervni jezik titlova';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream titlova';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Brza smeđa lisica preskače lijenog psa';
@@ -3050,17 +2935,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Učitane su postavke profila $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Učitavanje postavki profila $profile nije uspjelo.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Lokalne postavke sinkronizirane su s profilom $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3195,11 +3080,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showLibrariesInToolbar => 'Prikaži biblioteke na alatnoj traci';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Uvijek proširi natpise navigacijske trake';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Prikaži Seerr gumb';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Neprozirnost navigacijske trake';
@@ -3217,7 +3101,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get purple => 'Ljubičasta';
 
   @override
-  String get teal => 'Tirkizna';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Mornarica';
@@ -3244,7 +3128,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get libraryDisplay => 'Prikaz knjižnice';
 
   @override
-  String get posterLabel => 'Plakat';
+  String get posterLabel => 'Poster';
 
   @override
   String get thumbnailLabel => 'Sličica';
@@ -3273,19 +3157,18 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showFolderBrowsingOption => 'Prikaži opciju pregledavanja mape';
 
   @override
-  String get groupItemsIntoCollections => 'Grupiraj stavke u kolekcije';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Sakrij stavke biblioteke povezane s kolekcijom pri pregledavanju biblioteka';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Obavijest o grupiranju biblioteke';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Da biste koristili ovu postavku, provjerite jesu li postavke biblioteke „Grupiraj filmove u kolekcije” i/ili „Grupiraj serije u kolekcije” omogućene u postavkama prikaza vaše biblioteke na Jellyfin ili Emby poslužitelju.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Vidljivost knjižnice';
@@ -3314,14 +3197,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count odabrano',
-      few: '$count odabrane',
-      one: '$count odabrana',
-    );
-    return '$_temp0';
+    return '$count selected';
   }
 
   @override
@@ -3404,10 +3280,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Automatski reproduciraj najave na medijskoj traci nakon 3 sekunde';
 
   @override
-  String get trailerAudio => 'Zvuk najava';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Omogući zvuk za najave u medijskoj traci';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Pregled epizode';
@@ -3484,10 +3360,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Kombinirajte oba reda u jedan početni odjeljak';
 
   @override
-  String get fullScreenRows => 'Prošireni redovi početnog zaslona';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => 'Ograniči na 1 red po zaslonu';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Vrsta slike po redu';
@@ -3502,7 +3378,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get lastUser => 'Zadnji korisnik';
 
   @override
-  String get currentUser => 'Trenutni korisnik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Uvijek provjeri autentičnost';
@@ -3561,13 +3437,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get enableBuiltInScreensaver => 'Omogućite ugrađeni čuvar zaslona';
 
   @override
-  String get mode => 'Način';
+  String get mode => 'Način rada';
 
   @override
   String get libraryArt => 'Knjižnica čl';
 
   @override
-  String get logo => 'Logotip';
+  String get logo => 'Logo';
 
   @override
   String get clock => 'Sat';
@@ -3608,10 +3484,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Prikaz sata tijekom čuvara zaslona';
 
   @override
-  String get clockModeStatic => 'Statični';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Odbijajući';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritičari)';
@@ -3681,7 +3557,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Omogućite i promijenite redoslijed izvora ocjenjivanja prikazanih u cijeloj aplikaciji';
 
   @override
-  String get pluginLabel => 'Moonbase dodatak';
+  String get pluginLabel => 'Dodatak';
 
   @override
   String get pluginDetected => 'Dodatak otkriven';
@@ -3699,7 +3575,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVerzija: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3753,7 +3629,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get networks => 'mreže';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr redovi otkrivanja';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Vrati retke na zadane vrijednosti';
@@ -3776,43 +3652,44 @@ class AppLocalizationsHr extends AppLocalizations {
   String get hideAdultContent => 'Sakrij sadržaj za odrasle u rezultatima';
 
   @override
-  String get seerrNotificationsSection => 'Obavijesti';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Obavijesti o novim zahtjevima';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Obavijesti me kad netko pošalje zahtjev';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Ažuriranja zahtjeva';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Odobreno, odbijeno i dodano u vašu biblioteku';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ažuriranja problema';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Novi problemi, odgovori i rješenja';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Prijavljeni ste kao: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr stranica za otkrivanje';
+  String get discoverRows => 'Otkrijte redove';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Omogućite retke koje želite vidjeti na Seerr početnoj stranici. Povucite za promjenu redoslijeda. Prilagođeni redoslijed sinkronizira se s dodatkom Moonbase.';
+      'Povucite za promjenu redoslijeda. Omogućite ili onemogućite retke. Omogućeni redoslijed sinkronizira se s dodatkom Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Omogućite retke koje želite vidjeti na Seerr početnoj stranici. Povucite za promjenu redoslijeda. Prilagođeni redoslijed sinkronizira se s dodatkom Moonbase.';
+      'Povucite za promjenu redoslijeda. Omogućite ili onemogućite retke.';
 
   @override
   String get enabled => 'Omogućeno';
@@ -3825,7 +3702,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Verzija $version';
+    return 'Version $version';
   }
 
   @override
@@ -3875,7 +3752,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Dostupno ažuriranje: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3886,7 +3763,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Dostupna verzija v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3950,7 +3827,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get imageCacheCleared => 'Predmemorija slika je očišćena';
 
   @override
-  String get clear => 'Očisti';
+  String get clear => 'Jasan';
 
   @override
   String get browse => 'Pregledaj';
@@ -3966,22 +3843,15 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Preuzimanje · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Uvoz';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count stavki',
-      few: '$count stavke',
-      one: '$count stavka',
-    );
-    return '$_temp0';
+    return '$count Items';
   }
 
   @override
@@ -4001,7 +3871,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Zatražio/la: $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -4018,19 +3888,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Otkazati zahtjev za „$title”?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Otkazati $count zahtjeva za „$title”?',
-      few: 'Otkazati $count zahtjeva za „$title”?',
-      one: 'Otkazati $count zahtjev za „$title”?',
-    );
-    return '$_temp0';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -4045,12 +3908,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Proračun: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Prihod: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -4060,7 +3923,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Zatraži $type';
+    return 'Request $type';
   }
 
   @override
@@ -4089,14 +3952,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showMore => 'Prikaži više';
 
   @override
-  String get appearances => 'Filmografija';
+  String get appearances => 'Pojave';
 
   @override
   String get crewSection => 'Posada';
 
   @override
   String ageValue(int age) {
-    return 'dob $age';
+    return 'age $age';
   }
 
   @override
@@ -4127,169 +3990,148 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deletedStatus => 'Izbrisano';
 
   @override
-  String get failedStatus => 'Neuspješno';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'U obradi';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Izmijenio/la: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Dovršeno';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ovaj je naslov već zatražen';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Dosegnuto je ograničenje zahtjeva';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Ovaj je naslov na popisu blokiranih';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Nema više sezona koje se mogu zatražiti';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Nemate dopuštenje za slanje ovog zahtjeva';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Zahtjevi';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemi';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Najnovije';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Zadnje izmijenjeno';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Nema problema';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Preostalo $remaining od $limit zahtjeva za filmove';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Preostalo $remaining od $limit zahtjeva za sezone';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Dio kolekcije $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Prikaži kolekciju';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Zatraži kolekciju';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmova · $available dostupno';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Zatraži $count filmova',
-      few: 'Zatraži $count filma',
-      one: 'Zatraži $count film',
-    );
-    return '$_temp0';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Slanje zahtjeva $current od $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Zatraženo $count filmova',
-      few: 'Zatražena $count filma',
-      one: 'Zatražen $count film',
-    );
-    return '$_temp0';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Zatraženo $ok od $total filmova';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Svi su filmovi već dostupni ili zatraženi';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Prijavi problem';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Zvuk';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Što nije u redu?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Sve epizode';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizoda';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Otvoreno';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Riješeno';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Riješi';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Ponovno otvori';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Prijavio/la: $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count komentara',
-      few: '$count komentara',
-      one: '$count komentar',
-    );
-    return '$_temp0';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Dodajte komentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Izbrisati ovaj problem?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Pošalji prijavu';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB rezultat';
@@ -4304,7 +4146,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get revenueLabel => 'Prihod';
 
   @override
-  String get runtimeLabel => 'Trajanje';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'Proračun';
@@ -4313,7 +4155,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get originalLanguageLabel => 'Izvorni jezik';
 
   @override
-  String get seasonsLabel => 'Sezone';
+  String get seasonsLabel => 'Godišnja doba';
 
   @override
   String get episodesLabel => 'Epizode';
@@ -4322,7 +4164,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get access => 'Pristup';
 
   @override
-  String get add => 'Dodaj';
+  String get add => 'Dodati';
 
   @override
   String get address => 'Adresa';
@@ -4361,7 +4203,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get forward => 'Naprijed';
 
   @override
-  String get general => 'Općenito';
+  String get general => 'General';
 
   @override
   String get go => 'Ići';
@@ -4382,7 +4224,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get networking => 'umrežavanje';
 
   @override
-  String get next => 'Dalje';
+  String get next => 'Sljedeći';
 
   @override
   String get path => 'Put';
@@ -4406,7 +4248,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get refresh => 'Osvježiti';
 
   @override
-  String get remote => 'Udaljeno';
+  String get remote => 'Daljinski';
 
   @override
   String get rename => 'Preimenovati';
@@ -4424,7 +4266,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get run => 'Trčanje';
 
   @override
-  String get search => 'Pretraži';
+  String get search => 'Pretraživanje';
 
   @override
   String get select => 'Odaberite';
@@ -4442,7 +4284,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get status => 'Status';
 
   @override
-  String get stop => 'Zaustavi';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Streaming';
@@ -4451,7 +4293,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get time => 'Vrijeme';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trik igra';
 
   @override
   String get uninstall => 'Deinstaliraj';
@@ -4463,7 +4305,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get update => 'Ažurirati';
 
   @override
-  String get upload => 'Prijenos';
+  String get upload => 'Upload';
 
   @override
   String get unmute => 'Uključi zvuk';
@@ -4490,16 +4332,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminDrawerUsers => 'Korisnici';
 
   @override
-  String get adminDrawerLibraries => 'Biblioteke';
+  String get adminDrawerLibraries => 'Knjižnice';
 
   @override
-  String get adminDrawerDisplay => 'Prikaz';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metapodaci';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO postavke';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodiranje';
@@ -4511,7 +4353,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trik igra';
 
   @override
   String get adminDrawerDevices => 'Uređaji';
@@ -4563,22 +4405,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Dostupna ažuriranja dodataka: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Dodaci koji zahtijevaju ponovno pokretanje: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Neuspjeli zakazani zadaci: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Nedavna upozorenja/greške: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4637,7 +4479,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Greška: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4665,7 +4507,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Naredba nije uspjela: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4687,13 +4529,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get sessionForward => 'Naprijed';
 
   @override
-  String get sessionNext => 'Sljedeće';
+  String get sessionNext => 'Sljedeći';
 
   @override
   String get sessionVolumeDown => 'svezak –';
 
   @override
-  String get sessionVolumeUp => 'Gl. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4702,7 +4544,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get nowPlaying => 'Sada svira';
 
   @override
-  String get volume => 'Glasnoća';
+  String get volume => 'Volumen';
 
   @override
   String get actions => 'Radnje';
@@ -4714,7 +4556,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audioCodec => 'Audio kodek';
 
   @override
-  String get hwAccel => 'HW ubrzanje';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Završetak';
@@ -4729,14 +4571,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminClearDates => 'Jasni datumi';
 
   @override
-  String get adminActivitySeverityAll => 'Sve razine ozbiljnosti';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Raspon datuma';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Učitavanje zapisnika aktivnosti nije uspjelo: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4753,7 +4595,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Ažuriranje uređaja nije uspjelo: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4764,38 +4606,28 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Brisanje uređaja nije uspjelo: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Ukloniti uređaj „$name”? Korisnik će se morati ponovno prijaviti na ovom uređaju.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Izbriši sve uređaje';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other:
-          'Ukloniti $count uređaja? Zahvaćeni korisnici morat će se ponovno prijaviti. Vaš trenutni uređaj nije zahvaćen.',
-      few:
-          'Ukloniti $count uređaja? Zahvaćeni korisnici morat će se ponovno prijaviti. Vaš trenutni uređaj nije zahvaćen.',
-      one:
-          'Ukloniti $count uređaj? Zahvaćeni korisnici morat će se ponovno prijaviti. Vaš trenutni uređaj nije zahvaćen.',
-    );
-    return '$_temp0';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Uređaji su uklonjeni';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Neki su uređaji uklonjeni; $count nije bilo moguće ukloniti.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4824,7 +4656,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Pokretanje skeniranja nije uspjelo: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4835,12 +4667,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Biblioteka je preimenovana u „$name”';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Preimenovanje nije uspjelo: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4848,17 +4680,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Biblioteka „$name” je izbrisana';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Brisanje biblioteke nije uspjelo: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Dodavanje putanje nije uspjelo: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4866,12 +4698,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Ukloniti „$path” iz ove biblioteke?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Uklanjanje putanje nije uspjelo: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4879,7 +4711,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Spremanje opcija nije uspjelo: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4911,265 +4743,251 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminMetadataCountryHint => 'npr. SAD, Njemačka, Francuska';
 
   @override
-  String get adminLibraryTabPaths => 'Putanje';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcije';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Preuzimatelji';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Spremanje metapodataka';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Preuzimatelji titlova';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Preuzimatelji tekstova pjesama';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Preuzimatelji metapodataka: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Dohvaćanje slika: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ovaj poslužitelj ne nudi preuzimatelje za ovu vrstu biblioteke.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Općenito';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metapodaci';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Ugrađeni podaci';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Titlovi';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Slike';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serije';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Glazba';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmovi';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Omogući nadzor u stvarnom vremenu';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Otkrij promjene datoteka i automatski ih obradi.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tretiraj arhive kao medijske datoteke';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Prikaži fotografije';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Spremi grafiku u medijske mape';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatsko osvježavanje metapodataka';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nikad';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Zadano';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Prikaz';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Prikaz biblioteke';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Prikaži prikaz mapa za obične medijske mape';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Prikaži specijalne epizode unutar sezona u kojima su emitirane';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupiraj filmove u kolekcije';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupiraj serije u kolekcije';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Prikaži vanjski sadržaj u prijedlozima';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Ponašanje datuma dodavanja';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Koristi datum dodavanja iz';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Datum skeniranja u biblioteku';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum stvaranja datoteke';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metapodaci i slike';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Željeni jezik metapodataka';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Poglavlja';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Trajanje zamjenskog poglavlja (sekunde)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Duljina poglavlja koja se generiraju za medije bez njih. Postavite na 0 za onemogućivanje.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Razlučivost slike poglavlja';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO postavke';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO metapodaci kompatibilni su s Kodijem i sličnim klijentima. Postavke se primjenjuju na sve biblioteke koje spremaju NFO metapodatke.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Korisnik čiji se podaci o gledanju spremaju u NFO datoteke';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Spremi putanje slika u NFO datoteke';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Omogući zamjenu putanja za putanje slika u NFO datotekama';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopiraj extrafanart slike u mapu extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ništa';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    String _temp0 = intl.Intl.pluralLogic(
-      days,
-      locale: localeName,
-      other: '$days dana',
-      few: '$days dana',
-      one: '$days dan',
-    );
-    return '$_temp0';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Koristi ugrađene naslove';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Koristi ugrađene naslove za dodatke';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Koristi ugrađene podatke o epizodama';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Dopusti ugrađene titlove';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Dopusti sve';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Samo tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Samo slika';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ništa';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Preskoči preuzimanje ako postoje ugrađeni titlovi';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Preskoči preuzimanje ako se audiozapis podudara s jezikom preuzimanja';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Zahtijevaj savršeno podudaranje titlova';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => 'Spremi titlove u medijske mape';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Izdvoji slike poglavlja';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Izdvoji slike poglavlja tijekom skeniranja biblioteke';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Omogući izdvajanje trickplay slika';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Izdvoji trickplay slike tijekom skeniranja biblioteke';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Spremi trickplay slike u medijske mape';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automatski spoji serije raspoređene u više mapa';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Prikazani naziv sezone nula';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Omogući LUFS skeniranje za normalizaciju zvuka';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferiraj nestandardnu oznaku izvođača';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automatski dodaj filmove u kolekcije';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Potreban je naziv biblioteke';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Stvaranje biblioteke nije uspjelo: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5195,27 +5013,27 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Onemogućiti korisnika $name? Neće se moći prijaviti.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Omogućiti korisnika $name? Moći će se ponovno prijaviti.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Korisnik „$name” je onemogućen';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Korisnik „$name” je omogućen';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Ažuriranje pravila korisnika nije uspjelo: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5232,7 +5050,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Stvaranje korisnika nije uspjelo: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5252,7 +5070,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Spremanje nije uspjelo: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5263,7 +5081,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Neuspješno: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5398,144 +5216,143 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminEnableAllChannels => 'Omogući pristup svim kanalima';
 
   @override
-  String get adminParentalControl => 'Roditeljski nadzor';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Najviša dopuštena dobna ocjena';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Sadržaj s višom ocjenom bit će skriven ovom korisniku.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ništa';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokiraj stavke bez ocjene ili s neprepoznatom ocjenom';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Knjige';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanali';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV uživo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmovi';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Glazba';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Najave';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serije';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Rasporedi pristupa';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Dopusti pristup samo tijekom dolje navedenih termina. Ako raspored nije postavljen, pristup je dopušten cijeli dan.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Dodaj raspored';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dan';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Početak';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Kraj';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Svaki dan';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Radni dan';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Vikend';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Nedjelja';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Ponedjeljak';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Utorak';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Srijeda';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Četvrtak';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Petak';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Subota';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Dopuštene oznake';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Prikazuje se samo sadržaj s ovim oznakama. Ostavite prazno za dopuštanje svega.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokirane oznake';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Sadržaj s ovim oznakama skriven je ovom korisniku.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Dodaj oznaku';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Omogućeni uređaji';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Omogućeni kanali';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Pružatelj autentifikacije';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Pružatelj poništavanja lozinke';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Najveći broj neuspjelih pokušaja prijave prije zaključavanja';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Postavite na 0 za zadano ili -1 za onemogućivanje zaključavanja.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay pristup';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Dopusti stvaranje grupa i pridruživanje grupama';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Dopusti pridruživanje grupama';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Bez pristupa';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Dopusti brisanje sadržaja iz';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5543,22 +5360,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Poslužitelj je vratio HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Jeste li sigurni da želite izbrisati korisnika $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Korisnik „$name” je izbrisan';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Brisanje korisnika nije uspjelo: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5579,7 +5396,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Stvaranje ključa nije uspjelo: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5591,7 +5408,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Opozvati ključ za $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5599,7 +5416,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Opoziv ključa nije uspio: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5619,30 +5436,29 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nStvoreno: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Stvori sigurnosnu kopiju';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Odaberite što će biti uključeno u sigurnosnu kopiju.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Baza podataka';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Uvijek uključeno';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metapodaci';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Titlovi';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay slike';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Izrada sigurnosne kopije...';
@@ -5652,7 +5468,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Stvaranje sigurnosne kopije nije uspjelo: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5666,7 +5482,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Učitavanje manifesta nije uspjelo: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5677,7 +5493,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Vraćanje sigurnosne kopije nije uspjelo: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5711,17 +5527,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Spremljeno u $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Spremanje datoteke nije uspjelo: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Učitavanje datoteke $fileName nije uspjelo';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5732,7 +5548,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Učitavanje zadataka nije uspjelo: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5744,17 +5560,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Pokretanje zadatka nije uspjelo: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Zaustavljanje zadatka nije uspjelo: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Učitavanje zadatka nije uspjelo: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5762,12 +5578,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Uklanjanje okidača nije uspjelo: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Dodavanje okidača nije uspjelo: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5793,7 +5609,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours h';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5804,7 +5620,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Promjena stanja dodatka nije uspjela: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5812,27 +5628,27 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Jeste li sigurni da želite deinstalirati „$name”?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Deinstalacija dodatka nije uspjela: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Instalacija paketa nije uspjela: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Instalacija ažuriranja nije uspjela: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Učitavanje dodataka nije uspjelo: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5844,12 +5660,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Instaliraj ažuriranje (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Učitavanje kataloga nije uspjelo: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5871,17 +5687,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '„$name” bit će uklonjen nakon ponovnog pokretanja poslužitelja';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Deinstalacija nije uspjela: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Ažuriranje „$name” na v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5890,7 +5706,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Učitavanje dodatka nije uspjelo: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5898,7 +5714,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Verzija $version';
+    return 'Version $version';
   }
 
   @override
@@ -5918,17 +5734,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Jeste li sigurni da želite ukloniti „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Spremanje repozitorija nije uspjelo: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Učitavanje repozitorija nije uspjelo: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5945,12 +5761,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Nije moguće učitati postavke dodatka: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Nije moguće otvoriti $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6193,7 +6009,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminBaseUrl => 'Osnovni URL';
 
   @override
-  String get adminBaseUrlHint => 'npr. /jellyfin';
+  String get adminBaseUrlHint => 'npr. /želefina';
 
   @override
   String get https => 'HTTPS';
@@ -6233,12 +6049,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Učitavanje metapodataka nije uspjelo: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Spremanje metapodataka nije uspjelo: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6259,7 +6075,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Osvježavanje metapodataka nije uspjelo: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6273,7 +6089,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Udaljeno pretraživanje nije uspjelo: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6287,7 +6103,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Ažuriranje vrste sadržaja nije uspjelo: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6302,12 +6118,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Slika $imageType je ažurirana';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Preuzimanje slike nije uspjelo: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6318,27 +6134,27 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Slika $imageType je prenesena';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Prijenos slike nije uspio: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Izbriši sliku $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Slika $imageType je izbrisana';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Brisanje slike nije uspjelo: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6349,69 +6165,67 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Otkrivanje tunera nije uspjelo: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Dodaj tuner';
 
   @override
-  String get adminEditTuner => 'Uredi tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Datoteka ili URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP adresa tunera';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Prikazani naziv';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Korisnički agent';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Ograničenje istodobnih veza';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Najveći broj streamova koje tuner dopušta istodobno. Postavite na 0 za neograničeno.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Rezervna najveća brzina prijenosa streama';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Uvezi samo omiljene kanale';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Dopusti hardversko transkodiranje';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Dopusti fMP4 kontejner za transkodiranje';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Dopusti dijeljenje streama';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Omogući ponavljanje streama';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Zanemari DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Čitaj ulaz pri izvornoj brzini kadrova';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Uredi pružatelja';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6420,50 +6234,50 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Datoteka ili URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefiks filma';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategorije filmova';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Više kategorija odvojite okomitom crtom.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategorije za djecu';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategorije vijesti';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategorije sporta';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Korisničko ime';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Lozinka';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Država';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Odaberite državu';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Poštanski broj';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Dohvati programski raspored';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programski raspored';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Omogući sve tunere';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Vrsta tunera';
@@ -6473,7 +6287,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Dodavanje tunera nije uspjelo: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6487,12 +6301,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Dodavanje pružatelja nije uspjelo: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Uklanjanje tunera nije uspjelo: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6500,16 +6314,16 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Poništavanje tunera nije uspjelo: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ova vrsta tunera ne podržava poništavanje.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Uklanjanje pružatelja nije uspjelo: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6528,51 +6342,43 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Put snimanja serije';
 
   @override
-  String get adminMovieRecordingPath => 'Putanja za snimanje filmova';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Broj dana podataka TV vodiča';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatski';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    String _temp0 = intl.Intl.pluralLogic(
-      days,
-      locale: localeName,
-      other: '$days dana',
-      few: '$days dana',
-      one: '$days dan',
-    );
-    return '$_temp0';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Putanja aplikacije za naknadnu obradu';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumenti za naknadnu obradu';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Spremi NFO metapodatke snimke';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Spremi slike snimke';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Vremenske postavke';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Putanje snimanja';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Naknadna obrada';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Podaci TV vodiča: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6580,7 +6386,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Spremanje postavki nije uspjelo: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6597,7 +6403,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Ažuriranje mapiranja nije uspjelo: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6614,15 +6420,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminGuideProviders => 'Pružatelji vodiča';
 
   @override
-  String get adminRefreshGuideData => 'Osvježi podatke TV vodiča';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Osvježavanje podataka TV vodiča je pokrenuto';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Zadatak osvježavanja TV vodiča nije dostupan na ovom poslužitelju.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Dodaj davatelja usluga';
@@ -6632,26 +6437,26 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Putanja snimanja: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Putanja serija: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Dodatak prije: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Dodatak poslije: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Otkrivanje tunera';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Preslikavanja kanala';
@@ -6680,7 +6485,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Vratiti sigurnosnu kopiju $name sada?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6704,7 +6509,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminLiveTvTitle => 'TV administracija uživo';
 
   @override
-  String get adminApply => 'Primijeni';
+  String get adminApply => 'primijeniti';
 
   @override
   String get adminNotSet => 'Nije postavljeno';
@@ -6726,34 +6531,27 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'prije $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'prije $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'prije $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Učitavanje datoteke $fileName nije uspjelo';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count podudaranja',
-      few: '$count podudaranja',
-      one: '$count podudaranje',
-    );
-    return '$_temp0';
+    return '$count matches';
   }
 
   @override
@@ -6763,7 +6561,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Uređivač metapodataka';
 
   @override
-  String get adminMetadataIdentify => 'Identificiraj';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tip';
@@ -6778,7 +6576,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminMetadataImages => 'Slike';
 
   @override
-  String get adminMetadataFieldTitle => 'Naslov';
+  String get adminMetadataFieldTitle => 'Titula';
 
   @override
   String get adminMetadataFieldSortTitle => 'Naslov sortiranja';
@@ -6847,7 +6645,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminMetadataImageBackdrop => 'Pozadina';
 
   @override
-  String get adminMetadataImageLogo => 'Logotip';
+  String get adminMetadataImageLogo => 'Logo';
 
   @override
   String get adminMetadataImageBanner => 'Banner';
@@ -6863,22 +6661,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Slika $imageType je ažurirana';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Slika $imageType je prenesena';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Slika $imageType je izbrisana';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Preuzimanje slike nije uspjelo: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6887,12 +6685,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Prijenos slike nije uspio: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Izbriši sliku $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6901,16 +6699,16 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Brisanje slike nije uspjelo: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Odaberite sliku $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
-  String get adminMetadataUpload => 'Prenesi';
+  String get adminMetadataUpload => 'Upload';
 
   @override
   String get adminMetadataUpdate => 'Ažurirati';
@@ -6939,7 +6737,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Dostupno ažuriranje: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6963,7 +6761,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Instaliraj ažuriranje (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6975,7 +6773,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '„$name” se instalira...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6995,14 +6793,14 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Postavke – $name';
+    return '$name Settings';
   }
 
   @override
   String get adminPluginDetailDetails => 'pojedinosti';
 
   @override
-  String get adminPluginDetailDeveloper => 'Razvojni programer';
+  String get adminPluginDetailDeveloper => 'Developer';
 
   @override
   String get adminPluginDetailRepository => 'Spremište';
@@ -7035,7 +6833,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Učitavanje repozitorija nije uspjelo: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -7043,15 +6841,15 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Jeste li sigurni da želite ukloniti „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Ukloni';
+  String get adminReposRemove => 'Ukloniti';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Spremanje repozitorija nije uspjelo: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7179,20 +6977,19 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Omogući početni zaslon';
 
   @override
-  String get adminBrandingSplashUpload => 'Prenesi sliku';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Uvodni zaslon je ažuriran';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Prijenos uvodnog zaslona nije uspio';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Uvodni zaslon je uklonjen';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Nema prilagođenog uvodnog zaslona';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardversko ubrzanje';
@@ -7208,127 +7005,121 @@ class AppLocalizationsHr extends AppLocalizations {
       'Omogući hardversko dekodiranje za:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV uređaj';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Omogući poboljšani NVDEC dekoder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferiraj izvorni hardverski dekoder sustava';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Dubina boje hardverskog dekodiranja';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bitno HEVC dekodiranje';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bitno VP9 dekodiranje';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bitno dekodiranje';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-bitno dekodiranje';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardversko kodiranje';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Dopusti HEVC kodiranje';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Dopusti AV1 kodiranje';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Omogući Intel H.264 koder niske potrošnje';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Omogući Intel HEVC koder niske potrošnje';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapiranje tonova';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Omogući mapiranje tonova';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Omogući VPP mapiranje tonova';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Omogući VideoToolbox mapiranje tonova';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritam mapiranja tonova';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Način mapiranja tonova';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Raspon mapiranja tonova';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturacija mapiranja tonova';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak =>
-      'Vršna vrijednost mapiranja tonova';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametar mapiranja tonova';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Svjetlina VPP mapiranja tonova';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast VPP mapiranja tonova';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Predlošci i kvaliteta';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Predložak kodera';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF za H.264 kodiranje';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF za H.265 (HEVC) kodiranje';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod =>
-      'Metoda uklanjanja isprepletenosti';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Udvostruči brzinu kadrova pri uklanjanju isprepletenosti';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Zvuk';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Omogući VBR kodiranje zvuka';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Pojačanje downmiksa zvuka';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritam stereo downmiksa';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Najveća veličina reda za muxanje';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automatski';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodiranje';
@@ -7447,10 +7238,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminTaskNeverRun => 'Nikad ne trči';
 
   @override
-  String get adminTaskStop => 'Zaustavi';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Zadaci u tijeku';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Trčanje';
@@ -7472,17 +7263,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Svaki dan u $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Svaki $day u $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Svakih $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7520,9 +7311,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sati',
-      few: '$count sata',
-      one: '$count sat',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7550,17 +7340,17 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'prije $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'prije $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'prije $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7568,22 +7358,22 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month.';
+    return '$month/$day';
   }
 
   @override
@@ -7597,50 +7387,49 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Osnovni URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'npr. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'npr. /želefina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Javni HTTP port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Zahtijevaj HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Preusmjeri sve udaljene zahtjeve na HTTPS. Nema učinka ako poslužitelj nema valjani certifikat.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Lozinka certifikata';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP postavke';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Omogući IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Omogući IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Omogući automatsko mapiranje portova';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN mreže';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Popis IP adresa ili CIDR podmreža koje se smatraju dijelom lokalne mreže, odvojenih zarezom ili novim redom.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Objavljeni URI-ji poslužitelja';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Mapirajte podmrežu ili adresu na objavljeni URL, npr. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Put potvrde';
@@ -7670,11 +7459,11 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Prigušni međuspremnik';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Odgoda ograničavanja (sekunde)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Dopusti izdvajanje titlova u hodu';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimalni postotak životopisa';
@@ -7723,30 +7512,29 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Ažuriranje vrste sadržaja nije uspjelo: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Prag sporog odgovora (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Omogući upozorenja o sporim odgovorima';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Omogući Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Poslužitelj';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metapodaci';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Putanje';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Performanse';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Put predmemorije';
@@ -7758,7 +7546,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminGeneralServerName => 'Naziv poslužitelja';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Željeni jezik prikaza';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Učitavanje postavki nije uspjelo';
@@ -7768,19 +7556,19 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Ažuriranje mapiranja nije uspjelo: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Vremensko ograničenje: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'mape';
 
   @override
-  String get libraries => 'Biblioteke';
+  String get libraries => 'Knjižnice';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7810,9 +7598,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# sudionika',
-      few: '# sudionika',
-      one: '# sudionik',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7856,7 +7643,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Stavka $index';
+    return 'Item $index';
   }
 
   @override
@@ -7904,12 +7691,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName se pridružio/la SyncPlay grupi';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName je napustio/la SyncPlay grupu';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7921,7 +7708,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Sinkronizacija reprodukcije s grupom $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7959,9 +7746,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# redova otkriveno',
-      few: '# reda otkrivena',
-      one: '# red otkriven',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -8002,20 +7788,20 @@ class AppLocalizationsHr extends AppLocalizations {
   String get offlineSavedMedia => 'Spremljeni mediji';
 
   @override
-  String get offlineBannerTitle => 'Izvan mreže ste';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Prikazuju se vaša preuzimanja';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Preuzimanja';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Poslužitelj nije dostupan';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Reprodukcija iz preuzimanja dok se ne vrati';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8027,16 +7813,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get castDlna => 'DLNA';
 
   @override
-  String get castRemotePlayback => 'Udaljena reprodukcija';
+  String get castRemotePlayback => 'Remote Playback';
 
   @override
   String castControlFailed(String error) {
-    return 'Cast kontrola nije uspjela: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Kontrole – $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -8047,7 +7833,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Zaustavi $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -8070,12 +7856,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Unesite $length-znamenkasti PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Unesite svoj $length-znamenkasti PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -8088,41 +7874,41 @@ class AppLocalizationsHr extends AppLocalizations {
   String get pinForgot => 'Zaboravili ste PIN?';
 
   @override
-  String get pinClear => 'Očisti';
+  String get pinClear => 'Jasan';
 
   @override
-  String get pinBackspace => 'Brisanje';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Zahtjev za Quick Connect je odobren.';
+  String get quickConnectAuthorized => 'Zahtjev za brzo povezivanje odobren.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect kôd nije valjan ili je istekao.';
+      'Kôd za brzo povezivanje nije valjan ili je istekao.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect nije podržan na ovom poslužitelju.';
+      'Brzo povezivanje nije podržano na ovom poslužitelju.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Autorizacija Quick Connect koda nije uspjela.';
+      'Autorizacija koda za brzo povezivanje nije uspjela.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect je onemogućen na ovom poslužitelju.';
+      'Brzo povezivanje je onemogućeno na ovom poslužitelju.';
 
   @override
   String get quickConnectForbidden =>
-      'Vaš račun ne može odobriti ovaj Quick Connect zahtjev.';
+      'Vaš račun ne može odobriti ovaj zahtjev za brzo povezivanje.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect kôd nije pronađen. Pokušajte s novim kodom.';
+      'Kôd za brzo povezivanje nije pronađen. Pokušajte s novim kodom.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect nije uspio: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -8133,7 +7919,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Naredba nije uspjela: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8162,7 +7948,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Pokretanje Casta nije uspjelo: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8209,7 +7995,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Preuzimanje: $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8229,7 +8015,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get shuffleSelectGenre => 'Odaberite žanr';
 
   @override
-  String get shuffleLibrary => 'Biblioteka';
+  String get shuffleLibrary => 'Knjižnica';
 
   @override
   String get shuffleGenre => 'Žanr';
@@ -8248,7 +8034,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get posterImageType => 'Vrsta slike';
 
   @override
-  String get imageTypePoster => 'Plakat';
+  String get imageTypePoster => 'Poster';
 
   @override
   String get imageTypeThumbnail => 'Sličica';
@@ -8292,14 +8078,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get stillWatchingContent => 'Reprodukcija je pauzirana. Još gledaš?';
 
   @override
-  String get stillWatchingStop => 'Zaustavi';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Nastaviti';
 
   @override
   String skipSegment(String segment) {
-    return 'Preskoči $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8310,12 +8096,12 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Preuzimanje $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Preuzimanje: $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8331,7 +8117,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get playerTooltipCastControls => 'Kontrole cast';
 
   @override
-  String get playerTooltipPlaybackQuality => 'Brzina prijenosa';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'Otvori cijeli zaslon';
@@ -8377,13 +8163,13 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Sakrij iz odjeljka „Nastavite s gledanjem”';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Sakrij iz odjeljka „Sljedeći”';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Dodaj u kolekciju';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8438,15 +8224,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsAlphabetical => 'Abecedno';
 
   @override
-  String get settingsConnectionSection => 'VEZA';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Dopusti samopotpisane certifikate';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Vjeruj poslužiteljima koji koriste samopotpisane certifikate ili certifikate privatnog CA-a. Omogućite samo za poslužitelje koje kontrolirate. Ovime se onemogućuje provjera certifikata za sve veze.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVATNOST I SIGURNOST';
@@ -8462,11 +8247,11 @@ class AppLocalizationsHr extends AppLocalizations {
       'Tematski naglasci, pozadine, indikatori praćenja i tematska glazba';
 
   @override
-  String get settingsDetailsScreen => 'Zaslon s detaljima';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, zamućenje pozadine i ponašanje kartica';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Početna stranica';
@@ -8504,11 +8289,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Prikaži Seerr gumb u navigacijskoj traci';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Uvijek prikaži tekstualne natpise u gornjoj navigacijskoj traci';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8578,7 +8363,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Počastite razvojnog programera kavom';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'PRAVNO';
@@ -8612,9 +8397,8 @@ class AppLocalizationsHr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licencnih obavijesti',
-      few: '# licencne obavijesti',
-      one: '# licencna obavijest',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8663,16 +8447,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiti Intros i Outros?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Odbrojavanje medijskog segmenta';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Traka napretka';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Odbrojavanje';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ništa';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Brzi korisnik';
@@ -8707,13 +8491,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (preporučeno)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (zastarjelo)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (nasljeđe)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (preporučeno)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Zamjena';
@@ -8783,7 +8567,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Bitstream AC3 na vanjski dekoder';
 
   @override
-  String get settingsCinemaMode => 'Kino način';
+  String get settingsCinemaMode => 'Cinema Mode';
 
   @override
   String get settingsCinemaModeSubtitle =>
@@ -8903,761 +8687,749 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nedavno objavljeno – $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Automatski pusti sljedeću epizodu';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Automatski pusti sljedeću epizodu kada je dostupna.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Preskoči tišinu';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Automatski preskoči tihe dijelove zvuka kada ih stream podržava.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Dopusti vanjske zvučne efekte';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Dopusti aplikacijama za ekvilizaciju i efekte (npr. Wavelet) povezivanje s Media3 sesijama reprodukcije.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Onemogući tuneliranje';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Prisili reprodukciju bez tuneliranja. Korisno na uređajima s prekidima zvuka/videa pri tuneliranju.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Omogući tuneliranje';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Napredno. Usmjerava zvuk i video kroz povezani hardverski put. Zadano isključeno jer na nekim uređajima uzrokuje ispadanje zvuka/videa.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Mapiraj Dolby Vision profil 7 u HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Reproduciraj Dolby Vision profil 7 streamove kao HDR10-kompatibilni HEVC na uređajima bez DV-a.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Koristi ugrađene stilove titlova';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Primijeni boje, fontove i položaj ugrađene u zapis titlova. Isključite kako biste umjesto toga koristili vlastite postavke stila titlova.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Koristi ugrađene veličine fonta titlova';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Primijeni preporuke veličine fonta ugrađene u zapis titlova. Isključite kako biste koristili veličinu titlova iz vlastitih postavki stila.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Prikaži detalje medija';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Prikaži detalje odabrane stavke na vrhu stranica biblioteke.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Sakriti pozadinske slike pri pregledavanju?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Koristi detaljne podnaslove';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Prikaži detaljan ili minimalan podred na stranicama biblioteke.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Izbrisati spremljenu temu?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Ukloniti „$themeName” iz predmemorije ovog uređaja?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Trgovina tema';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Pregledajte i spremite teme zajednice';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Spremite temu kako biste je koristili kao i ostale spremljene teme.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Trenutno nema dostupnih tema.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Učitavanje Trgovine tema nije uspjelo. Provjerite vezu i pokušajte ponovno.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Spremi';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Spremi i primijeni';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Spremljeno';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Ovu temu nije bilo moguće učitati.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Spremljeno: „$themeName”.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '„$themeName” je izbrisana s ovog uređaja.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Nije moguće izbrisati „$themeName”.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Spremljene teme';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Ovo su teme preuzete iz Moonfin dodatka za trenutni poslužitelj. Brisanjem se uklanja samo ova lokalna kopija.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Za ovaj poslužitelj nisu pronađene spremljene teme.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Trenutno aktivna';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Izbriši spremljenu temu';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Upravljajte preuzetim temama dodatka na ovom uređaju';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Uređivač tema';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Otvorite Moonfin Uređivač tema u pregledniku';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Početni zaslon';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Donja traka';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasični';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderni';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Redovi početnog zaslona';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Prikaz redova početnog zaslona';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Odjeljci redova početnog zaslona';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Preklopnici redova početnog zaslona';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Omogućite ili onemogućite kategorije redova početnog zaslona temeljene na biblioteci';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Omogućite sljedeće preklopnike za prikaz redova u odjeljcima početnog zaslona.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasični zadržava vrstu slike po redu i informacijski sloj. Moderni koristi redove od portreta do pozadinske slike.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Prikaži redove favorita';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Prikaži omiljene filmove, serije i ostale redove favorita u odjeljcima početnog zaslona.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortiranje redova favorita';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sortirajte redove favorita prema datumu dodavanja, datumu izlaska, abecedno i više.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Prikaži redove kolekcija';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Prikaži redove kolekcija u odjeljcima početnog zaslona.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortiranje redova kolekcija';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sortirajte redove kolekcija prema datumu dodavanja, datumu izlaska, abecedno i više.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Prikaži redove žanrova';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Prikaži redove žanrova u odjeljcima početnog zaslona.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortiranje redova žanrova';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sortirajte redove žanrova prema datumu dodavanja, datumu izlaska, abecedno i više.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Stavke redova žanrova';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Prikaži filmove, serije ili oboje u redovima žanrova.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Prikaži redove popisa za reprodukciju';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Prikaži redove popisa za reprodukciju u odjeljcima početnog zaslona.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortiranje redova popisa za reprodukciju';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sortirajte redove popisa za reprodukciju prema datumu dodavanja, datumu izlaska, abecedno i više.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Prikaži audioredove';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Prikaži audioredove u odjeljcima početnog zaslona.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortiranje audioredova';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sortirajte audioredove prema datumu dodavanja, datumu izlaska, abecedno i više.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Audiopopisi za reprodukciju';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Izgled';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Raspored';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tipkovnica';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Gumbi';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Prikazivanje';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV konfiguracija';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Vanjska aplikacija za reprodukciju';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Postavite vanjski reproduktor za omogućavanje opcije reprodukcije dugim pritiskom';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Prikaži odabir aplikacije pri pokretanju reprodukcije.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Učitavanje instaliranih reproduktora...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Veza';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Ciljni format transkodiranja zvuka';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Podržano na ovom uređaju';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Nije podržano na ovom uređaju';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Šalji DTS:X (DTS UHD) bitstream vanjskom dekoderu.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD s Atmosom (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Ponašanje medijskog reproduktora';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Poboljšanja reprodukcije';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Uvijek uključeno.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Zamijeni preskakanje odjavne špice prikazom „Sljedeći”';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Prikaži sloj „Sljedeći” umjesto gumba za preskakanje odjavne špice.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Usmjeravanje reproduktora';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Preferiraj softverske dekodere';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Koristi FFmpeg (zvuk) i libgav1 (AV1) prije hardverskih dekodera. Isključite ako HDMI audio passthrough prestane raditi.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Otvori reprodukciju videa u odabranoj vanjskoj aplikaciji na Android TV-u.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatsko dodavanje u red';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferiraj SDH titlove';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Daj prednost SDH/CC zapisima titlova pri automatskom odabiru.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Web dijagnostika';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin web dijagnostika';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Koristite ovu stranicu za dijagnostiku problema s povezivanjem preglednika (CORS, miješani sadržaj i postavke otkrivanja).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Otkriven kvar zbog miješanog sadržaja';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Otkriven kvar CORS-a/preflight zahtjeva';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin je otkrio da HTTPS stranica pokušava pozvati HTTP URL poslužitelja. Preglednici blokiraju taj zahtjev prije nego što dođe do vašeg poslužitelja.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin je otkrio kvar zahtjeva na razini preglednika koji obično uzrokuju nedostajuća CORS ili preflight zaglavlja na medijskom poslužitelju.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Ciljni URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detalji: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Trenutni kontekst izvođenja';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Izvor';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Shema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Način dodatka';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC skeniranje';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Prisilni URL poslužitelja';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Zadani URL poslužitelja';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL proxyja za otkrivanje';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'nije konfigurirano';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Miješani sadržaj';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Ova se stranica učitava putem HTTPS-a, ali je jedan ili više konfiguriranih URL-ova HTTP. Preglednici blokiraju HTTPS stranicama pozivanje HTTP API-ja.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Rješenje: poslužite svoj medijski poslužitelj ili proxy krajnju točku putem HTTPS-a ili učitajte Moonfin putem HTTP-a samo na pouzdanim lokalnim mrežama.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Iz trenutnih postavki izvođenja nije otkrivena očita konfiguracija miješanog sadržaja.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS kontrolni popis';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Dopustite izvor preglednika u Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Uključite Authorization, X-Emby-Authorization i X-Emby-Token u Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Izložite Content-Range i Accept-Ranges za streaming i premotavanje.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Vratite 204 na OPTIONS preflight zahtjeve.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Primjer isječka zaglavlja (nginx stil)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Napomena';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Ova je dijagnostička ruta namijenjena web verzijama. Ako ovo vidite na drugoj platformi, ove se provjere možda ne primjenjuju.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Natrag na odabir poslužitelja';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Odjavi sve korisnike';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Dopuštenje za mikrofon trajno je odbijeno. Omogućite ga u postavkama sustava.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Za glasovno pretraživanje potrebno je dopuštenje za mikrofon.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nismo to uhvatili. Pokušajte ponovno.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Govor nije otkriven.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Greška mikrofona.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Glasovno pretraživanje zahtijeva internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Glasovna usluga je zauzeta. Pokušajte ponovno.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Dopuštenje za mikrofon trajno je odbijeno.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Dopuštenje za mikrofon je odbijeno.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Prepoznavanje govora nije dostupno na ovom uređaju.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Otvori iOS odabir izlaza';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay odabir izlaza nije dostupan na ovom uređaju.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videozapisi';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Emisije';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Pjesme';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Foto albumi';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotografije';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Osobe';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Nedavno objavljene epizode';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Pogledajte ponovno';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Gostujuće uloge';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Pojavljivanja (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Doprinosi ekipe (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Gledaj s grupom';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Greške';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Upozorenja';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Otvori u pregledniku';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Ugrađeni preglednik nije dostupan na ovoj platformi.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Jeste li sigurni da želite ponovno pokrenuti poslužitelj?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Jeste li sigurni da želite isključiti poslužitelj? Morat ćete ga ručno ponovno pokrenuti.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Interno';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Neaktivno';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nema pronađenih korisnika';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Nijedan korisnik ne odgovara pretraživanju';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nema pronađenih uređaja';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Nijedan uređaj ne odgovara trenutnim filtrima';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Lozinka je postavljena';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Lozinka nije konfigurirana';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Udaljeni pristup';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Samo lokalno';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Učitavanje medijske analitike nije uspjelo';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Objedinjena analitika svih medijskih biblioteka.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Najbolji izvođači';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Najbolji autori';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Najveći doprinositelji';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count biblioteka',
-      few: '$count biblioteke',
-      one: '$count biblioteka',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Za ovaj odabir još nisu dostupni ukupni iznosi indeksiranih medija.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Detalji biblioteke';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Raščlamba biblioteke';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Nema dostupnih biblioteka.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administracija poslužitelja';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Podaci';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Predmemorija slika';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Predmemorija';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Zapisnici';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metapodaci';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transkodiranje';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Ovaj poslužitelj nije vratio nijednu putanju.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% iskorišteno';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Aktivnost korisnika';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Događaji sustava';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Zahtijeva pozornost';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Poslužitelj';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Reprodukcija';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Uređaji';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Napredno';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Dodaci';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV uživo';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Kućni videozapisi';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Miješani sadržaj';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Kućni videozapisi i fotografije';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Miješani filmovi i serije';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9669,300 +9441,299 @@ class AppLocalizationsHr extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nema pronađenih snimki';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'U .$extension arhivi nisu pronađene stranice sa slikama.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Ugrađeni prikazivač nije uspio ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB prikazivač nije uspio ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Nedostaje lokalna datoteka za čitač: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status pri otvaranju podataka knjige s $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nema dostupne krajnje točke za čitanje knjige';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Nepodržani format arhive stripa: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Dodatak za izdvajanje CBR-a nije dostupan na ovoj platformi.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Izdvajanje .cbr arhive nije uspjelo.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Izdvajanje CB7-a nije dostupno na ovoj platformi.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Dodatak za izdvajanje CB7-a nije dostupan na ovoj platformi.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Zatvori ploču žanrova';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Učitavanje nasumične reprodukcije...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'NASUMIČNO IZ BIBLIOTEKE';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'NASUMIČNI ODABIR';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'NASUMIČNO PO ŽANROVIMA';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatsko prebacivanje na HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Automatski omogući HDR za reprodukciju HDR videa i vrati način prikaza pri izlasku.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'U cijelom zaslonu';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Promijeni grafiku';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Nedostaje';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Ograničenja transkodiranja';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Očistiti svu grafiku?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Jeste li sigurni da želite očistiti svu preuzetu grafiku?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Potvrdi čišćenje';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Jeste li sigurni da želite očistiti ovo: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Prenijeti?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Razlučivost: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Prikaži samo grafiku na jeziku sučelja';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Potvrdi čišćenje svega';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Slika je uspješno prenesena!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Prijenos slike nije uspio: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Postavljanje slike nije uspjelo: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Brisanje slike nije uspjelo: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Čišćenje sve grafike nije uspjelo: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Da';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Pozadinske slike';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotip';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Minijatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika diska';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Snimka zaslona';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Prednja strana kutije';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Stražnja strana kutije';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika izbornika';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'pozadinska slika';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotip';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'minijatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafika diska';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'snimka zaslona';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'prednja strana kutije';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'stražnja strana kutije';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafika izbornika';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Sve';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Visoka (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Srednja (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Niska (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Izvori';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Poglavlja';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Oznake';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Bilješke';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Red';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Vremenska crta';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Vremenska crta je prazna';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Cijela knjiga';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokusirana vremenska crta';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Izvezi oznake';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Izvezi bilješke';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Izvezi sve';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Izvezeno u $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Izvoz nije uspio: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Tekst';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Dodaj oznaku';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Dodaj bilješku';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Uredi bilješku';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Napišite bilješku za ovaj trenutak';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Mjerač vremena za spavanje';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Isključeno';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Kraj poglavlja';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Prilagođeno';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'još $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9977,51 +9748,51 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Brzina reprodukcije';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Preostalo';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Proteklo';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Natrag $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Naprijed $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Prethodno poglavlje';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Sljedeće poglavlje';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Poglavlje $current od $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Nema poglavlja';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Još nema oznaka';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Još nema bilježaka';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Oznaka dodana na $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Vrati na 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -10029,250 +9800,249 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Spremi';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Odustani';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Izbriši';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Postavke titlova';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Promijenite načine titlova, zadane jezike, izgled i opcije prikaza.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Prikaz titlova';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opcije prikaza';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Datum izlaska (uzlazno)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Datum izlaska (silazno)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupiranje doprinosa';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupiraj više uloga';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Upozorenje o pristupu za pisanje u biblioteku';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kako to riješiti:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Dodijelite dopuštenja za pisanje korisniku Jellyfin usluge (npr. jellyfin ili Docker PUID/PGID) za mape vaše medijske biblioteke na poslužitelju.\n\n2. Ili idite na Jellyfin nadzornu ploču -> Biblioteke, uredite ovu biblioteku i onemogućite „Spremi grafiku u medijske mape” kako bi se grafika pohranila u Jellyfinovu internu bazu podataka.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Odbaci';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Vaša biblioteka „$libraryName” konfigurirana je za spremanje grafike izravno u medijske mape (uključena je opcija „Spremi grafiku u medijske mape”). Međutim, Jellyfin je testirao pristup za pisanje i nema dopuštenje za pisanje datoteka u ovaj direktorij:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Čini se da Jellyfin nije uspio ažurirati grafiku. Vaša je biblioteka konfigurirana za spremanje grafike izravno u medijske mape (uključena je opcija „Spremi grafiku u medijske mape”). Ova se greška obično javlja kada proces Jellyfin poslužitelja nema dopuštenje za pisanje datoteka u vaše medijske direktorije.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Vanjski popisi';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Ponovi';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Podaci o datoteci';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Veličina: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Prikaži sve audiozapise ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Prikaži sve titlove ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Provjera mogućnosti izravne reprodukcije...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Mogućnost izravne reprodukcije: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Prisilni';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Reproduktor ne podržava format kontejnera.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Video kodek nije podržan.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Audiokodek nije podržan.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Format titlova nije podržan (zahtijeva utiskivanje).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Audioprofil nije podržan.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Videoprofil nije podržan.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Video razina nije podržana.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Ovaj uređaj ne podržava razlučivost videa.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Dubina boje videa nije podržana.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Brzina kadrova videa nije podržana.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Brzina prijenosa datoteke premašuje ograničenje streaminga reproduktora.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Brzina prijenosa videa premašuje ograničenje streaminga.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Brzina prijenosa zvuka premašuje ograničenje streaminga.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Broj audiokanala nije podržan.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Abecedno';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Redoslijed izlaska (uzlazno)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Redoslijed izlaska (silazno)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Prilagođeno (povuci i ispusti)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opcije sortiranja popisa za reprodukciju';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Poništi sortiranje';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Ponovno pogledaj S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Ponovno pogledaj popis za reprodukciju';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nisu pronađeni titlovi.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administratorske kontrole';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Mehanizam prikaza (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller je Flutterov moderni GPU prikazivač za glađe animacije i manje zastajkivanja. Na nekim TV uređajima i starijim GPU-ovima može uzrokovati smetnje ili crni video; isključite ga ako to primijetite. Automatski odabire najbolju postavku za vaš uređaj. Ponovno pokrenite Moonfin za primjenu.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatski';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Uključeno';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Isključeno';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Potrebno je ponovno pokretanje';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin se mora ponovno pokrenuti za promjenu mehanizma prikaza. Zatvorite aplikaciju sada, a zatim je ponovno otvorite za primjenu.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Zatvori aplikaciju sada';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Osvježi biblioteku';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Osvježi sve biblioteke';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Datum dodavanja (najstarije prvo)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Datum dodavanja (najnovije prvo)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Abecedno (A – Ž)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Abecedno (Ž – A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Učitavanje analitike poslužitelja... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Kao izvor';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filmova';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 TV serija';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb najpopularniji filmovi';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb najpopularnije TV serije';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb najlošije ocijenjeni filmovi';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb najbolje ocijenjeni engleski filmovi';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -15,7 +15,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get accountPreferences => 'Fiókbeállítások';
 
   @override
-  String get interfaceLanguage => 'Alkalmazás nyelvi beállításainak címkéje';
+  String get interfaceLanguage => 'Felület nyelve';
 
   @override
   String get systemLanguageDefault => 'Alapértelmezett';
@@ -28,7 +28,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String connectingToServer(String serverName) {
-    return 'Kapcsolódás a $serverName szerverhez';
+    return 'Csatlakozás $serverName-hez';
   }
 
   @override
@@ -385,7 +385,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noItemsFound => 'Nem találhatók elemek';
 
   @override
-  String get home => 'Kezdőlap';
+  String get home => 'Kezdőképernyő';
 
   @override
   String get browseAll => 'Összes böngészése';
@@ -1191,7 +1191,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get subtitleTrack => 'Feliratsáv';
 
   @override
-  String get none => 'Nincs';
+  String get none => 'Egyik sem';
 
   @override
   String get downloadSubtitlesLabel => 'Feliratok letöltése...';
@@ -3255,7 +3255,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Ki';
+  String get mediaBarModeOff => 'Kikapcsolva';
 
   @override
   String get enableMediaBar => 'Médiasáv engedélyezése';
@@ -3986,7 +3986,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showMore => 'Továbbiak megjelenítése';
 
   @override
-  String get appearances => 'Szereplések';
+  String get appearances => 'Megjelenések';
 
   @override
   String get crewSection => 'Stáb';
@@ -4561,7 +4561,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get sessionRewind => 'Visszatekerés';
 
   @override
-  String get sessionForward => 'Előretekerés';
+  String get sessionForward => 'Előre';
 
   @override
   String get sessionNext => 'Következő';
@@ -6231,7 +6231,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminEditTuner => 'Tuner szerkesztése';
 
   @override
-  String get adminTunerTypeM3u => 'M3U tuner';
+  String get adminTunerTypeM3u => 'M3U-tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
@@ -6243,17 +6243,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminTunerIpAddress => 'Tuner IP-címe';
 
   @override
-  String get adminTunerFriendlyName => 'Megjelenített név';
+  String get adminTunerFriendlyName => 'Barátságos név';
 
   @override
-  String get adminTunerUserAgent => 'Felhasználói ügynök';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
   String get adminTunerCount => 'Egyidejű kapcsolatok korlátja';
 
   @override
   String get adminTunerCountHelp =>
-      'A tuner által egyszerre engedélyezett adatfolyamok maximális száma. A korlátlanhoz állítsd 0-ra.';
+      'A tuner által egyidejűleg engedélyezett streamek maximális száma. Állítsd 0-ra a korlátlanhoz.';
 
   @override
   String get adminTunerFallbackBitrate =>
@@ -6271,19 +6271,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminTunerAllowFmp4 => 'fMP4 átkódolási konténer engedélyezése';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Adatfolyam megosztásának engedélyezése';
+  String get adminTunerAllowStreamSharing => 'Streammegosztás engedélyezése';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Adatfolyam ismétlésének engedélyezése';
+  String get adminTunerEnableStreamLooping => 'Streamismétlés engedélyezése';
 
   @override
   String get adminTunerIgnoreDts => 'DTS figyelmen kívül hagyása';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Bemenet beolvasása natív képkockasebességgel';
+      'Bemenet olvasása natív képsebességgel';
 
   @override
   String get adminEditProvider => 'Szolgáltató szerkesztése';
@@ -6298,14 +6296,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminXmltvPath => 'Fájl vagy URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmek előtagja';
+  String get adminXmltvMoviePrefix => 'Filmelőtag';
 
   @override
   String get adminXmltvMovieCategories => 'Filmkategóriák';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'A kategóriákat függőleges vonallal válaszd el egymástól.';
+      'Több kategória elválasztásához használj függőleges vonalat.';
 
   @override
   String get adminXmltvKidsCategories => 'Gyerekkategóriák';
@@ -6326,19 +6324,19 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminSdCountry => 'Ország';
 
   @override
-  String get adminSdCountrySelect => 'Válassz egy országot';
+  String get adminSdCountrySelect => 'Válassz országot';
 
   @override
   String get adminSdPostalCode => 'Irányítószám';
 
   @override
-  String get adminSdGetListings => 'Műsorújság lekérése';
+  String get adminSdGetListings => 'Műsorlisták lekérése';
 
   @override
-  String get adminSdListings => 'Műsorújság';
+  String get adminSdListings => 'Műsorlisták';
 
   @override
-  String get adminEnableAllTuners => 'Az összes tuner engedélyezése';
+  String get adminEnableAllTuners => 'Összes tuner engedélyezése';
 
   @override
   String get adminTunerType => 'Tuner típusa';
@@ -7149,11 +7147,11 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP tónusleképezési fényerő';
+      'VPP-tónusleképezés fényereje';
 
   @override
   String get adminPlaybackVppTonemappingContrast =>
-      'VPP tónusleképezési kontraszt';
+      'VPP-tónusleképezés kontrasztja';
 
   @override
   String get adminPlaybackPresetsQuality => 'Előbeállítások és minőség';
@@ -7172,7 +7170,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Képkockasebesség megduplázása váltottsoros bontáskor';
+      'Képsebesség duplázása váltottsorosság megszüntetésekor';
 
   @override
   String get adminPlaybackAudioSection => 'Hang';
@@ -7447,7 +7445,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$month. $day.';
+    return '$month/$day';
   }
 
   @override
@@ -7537,7 +7535,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get adminPlaybackThrottleDelay =>
-      'Korlátozási késleltetés (másodperc)';
+      'Visszafogási késleltetés (másodperc)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -9,7 +9,7 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'sirip bulan';
 
   @override
   String get accountPreferences => 'PREFERENSI AKUN';
@@ -32,7 +32,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Koneksi Cepat';
 
   @override
   String get password => 'Kata Sandi';
@@ -122,7 +122,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get serverAddress => 'Alamat Server';
 
   @override
-  String get serverAddressHint => 'https://your-server.example.com';
+  String get serverAddressHint =>
+      '[https://your-server.example.com](https://your-server.example.com)';
 
   @override
   String get connect => 'Hubungkan';
@@ -141,62 +142,62 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema Aplikasi';
 
   @override
-  String get detailScreenStyle => 'Gaya layar detail';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasik adalah tata letak Moonfin asli yang terpusat. Modern adalah tata letak sinematik yang responsif.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasik';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Tab Diperluas';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Tampilkan konten tab secara otomatis saat menjelajahi tab. Matikan untuk membuka dan menutup setiap tab secara manual.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Tampilkan Detail Teknis?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Tampilkan informasi codec, resolusi, dan stream pada ringkasan banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistem Rekomendasi';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Gunakan algoritme pustaka lokal Moonfin Recommends atau metrik kemiripan TMDb online. Catatan: rekomendasi online memerlukan integrasi Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Kemiripan TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Terapkan Batas Rating Orang Tua?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Batasi saran Moonfin Recommends berdasarkan rating orang tua dari media yang dituju';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Gaya Antarmuka';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Otomatis menyesuaikan dengan perangkat Anda. Pilih Apple atau Material untuk memaksa tampilan tertentu.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Otomatis';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +206,31 @@ class AppLocalizationsId extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kualitas Efek Kaca';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Otomatis memilih efek kaca terbaik untuk perangkat ini. Penuh memaksa blur asli; Ringan menggunakan efek kaca sederhana yang menghemat daya GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Otomatis';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Penuh';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Ringan';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Beralih antara Moonfin dan Neon Pulse tanpa memulai ulang aplikasi';
 
   @override
-  String get customThemeTitle => 'Tema Kustom';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Tema kustom mengubah elemen visual di seluruh Moonfin. Pilih salah satu opsi berikut yang sesuai dengan gaya Anda.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Utamakan keyboard sistem';
@@ -264,7 +265,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Gaya pixel-art retro dengan palet tebal, bingkai kotak, bayangan tajam, dan font piksel';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Masuk dengan akun Emby Connect Anda';
@@ -329,33 +330,32 @@ class AppLocalizationsId extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Dijeda';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Simpan state';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Game';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Muat state';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Percepat';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Pengaturan emulator';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Core ini tidak memiliki opsi yang dapat diatur.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Tahan untuk membuka menu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Bermain game belum didukung di perangkat ini.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Tidak ada baris beranda yang dapat dimuat';
@@ -712,7 +712,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get browseByGenre => 'Telusuri berdasarkan Genre';
 
   @override
-  String get discover => 'Jelajahi';
+  String get discover => 'Discover';
 
   @override
   String get trendingTitlesOpenLibrary =>
@@ -767,43 +767,43 @@ class AppLocalizationsId extends AppLocalizations {
   String get books => 'Buku';
 
   @override
-  String get latestBooks => 'Buku Terbaru';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Audiobook Terbaru';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count buku',
-      one: '1 buku',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Buku';
+  String get bookFormatBook => 'Book';
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% dibaca';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'tersisa $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Baca';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Dengarkan';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Penulis';
@@ -997,35 +997,35 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get items => 'Item';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ekstra';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Di Balik Layar';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Adegan yang Dihapus';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Featurette';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Wawancara';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Adegan';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Film Pendek';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Trailer';
 
   @override
   String timeRemaining(String time) {
-    return 'tersisa $time';
+    return '$time remaining';
   }
 
   @override
@@ -1072,7 +1072,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get version => 'Versi';
 
   @override
-  String get cast => 'Transmisikan';
+  String get cast => 'Pemeran';
 
   @override
   String get trailer => 'Trailer';
@@ -1189,7 +1189,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get subtitleTrack => 'Trek Subtitle';
 
   @override
-  String get none => 'Tidak ada';
+  String get none => 'Tidak Ada';
 
   @override
   String get downloadSubtitlesLabel => 'Unduh subtitle...';
@@ -1273,7 +1273,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get writer => 'PENULIS';
 
   @override
-  String get writers => 'PENULIS';
+  String get writers => 'PARA PENULIS';
 
   @override
   String get studio => 'STUDIO';
@@ -1350,13 +1350,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get shuffle => 'Acak';
 
   @override
-  String get shuffleAllMusic => 'Acak semua musik';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Masuk ke Moonfin di ponsel Anda';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Tidak dapat menjangkau server Anda';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1527,7 +1527,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get subtitleDelay => 'Penundaan Subtitle';
 
   @override
-  String get reset => 'Atur Ulang';
+  String get reset => 'Reset';
 
   @override
   String get unknown => 'Tidak Diketahui';
@@ -1554,7 +1554,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get transcodeReasons => 'Alasan Transcode';
 
   @override
-  String get player => 'Pemutar';
+  String get player => 'Player';
 
   @override
   String get container => 'Kontainer';
@@ -1688,7 +1688,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Atur Ulang Zoom (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1775,7 +1775,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get kids => 'Anak-anak';
 
   @override
-  String get premiere => 'Perdana';
+  String get premiere => 'Premiere';
 
   @override
   String get guideTimeline => 'Linimasa Panduan';
@@ -1793,22 +1793,22 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Berikutnya: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'tersisa ${minutes}m';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'tersisa ${hours}j';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'tersisa ${hours}j ${minutes}m';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -2103,7 +2103,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get images => 'Gambar';
 
   @override
-  String get database => 'Basis Data';
+  String get database => 'Database';
 
   @override
   String ofStorageLimit(String limit) {
@@ -2284,7 +2284,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Halaman detail, baris beranda, dan volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2299,11 +2299,11 @@ class AppLocalizationsId extends AppLocalizations {
       'Putar saat menelusuri layar beranda';
 
   @override
-  String get loopThemeMusic => 'Ulangi Musik Tema';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ulangi trek terus-menerus, bukan memutarnya sekali saja';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Blur Latar Belakang Detail';
@@ -2396,21 +2396,21 @@ class AppLocalizationsId extends AppLocalizations {
   String get defaultAudioLanguage => 'Bahasa Audio Default';
 
   @override
-  String get fallbackAudioLanguage => 'Bahasa Audio Cadangan';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Utamakan Trek Audio Bawaan';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Utamakan trek audio asli daripada sulih suara terlokalisasi.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Utamakan Trek Deskripsi Audio';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Utamakan trek deskripsi audio daripada trek biasa.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
   String get transcodingAudio => 'Transcoding (Audio)';
@@ -2420,7 +2420,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcoding (Bitrate atau Resolusi)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
   String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
@@ -2523,7 +2523,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsAudioFallbackCodecAuto => 'Deteksi Otomatis\n(Disarankan)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Bawaan)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2658,7 +2658,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Headphone';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2837,61 +2837,61 @@ class AppLocalizationsId extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Sesuaikan tampilan subtitle';
 
   @override
-  String get subtitleMode => 'Mode Subtitle';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Ditandai';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Selalu';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Bahasa Asing';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Paksa';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Memutar trek yang ditandai di dalam metadata berkas media sebagai \"default\" atau \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Memuat dan menampilkan subtitle secara otomatis setiap kali video dimulai.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Otomatis menyalakan subtitle jika trek audio bawaan menggunakan bahasa asing.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Hanya memuat subtitle yang secara eksplisit ditandai dengan flag metadata forced.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Menonaktifkan pemuatan subtitle otomatis sepenuhnya.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Bahasa Subtitle Cadangan';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream Subtitle';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
-      'Musang cokelat lincah melompati anjing pemalas';
+      'The quick brown fox jumps over the lazy dog';
 
   @override
   String get verticalOffset => 'Offset Vertikal';
 
   @override
-  String get pgsDirectPlay => 'Direct Play PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Direct play subtitle PGS';
 
   @override
-  String get assSsaDirectPlay => 'Direct Play ASS/SSA';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles => 'Direct play subtitle ASS/SSA';
@@ -3008,7 +3008,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get downloadLocation => 'Lokasi Unduhan';
 
   @override
-  String get defaultLabel => 'Bawaan';
+  String get defaultLabel => 'Default';
 
   @override
   String get saveToDownloadsFolder => 'Simpan ke folder Unduhan';
@@ -3079,7 +3079,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get showLibrariesInToolbar => 'Tampilkan Pustaka di Toolbar';
 
   @override
-  String get navbarAlwaysExpanded => 'Selalu Tampilkan Label Bilah Navigasi';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
   String get showSeerrButton => 'Tampilkan Tombol Seerr';
@@ -3100,7 +3100,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get purple => 'Ungu';
 
   @override
-  String get teal => 'Tosca';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Navy';
@@ -3156,19 +3156,18 @@ class AppLocalizationsId extends AppLocalizations {
   String get showFolderBrowsingOption => 'Tampilkan opsi penelusuran folder';
 
   @override
-  String get groupItemsIntoCollections => 'Kelompokkan Item ke dalam Koleksi';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Sembunyikan item pustaka yang terkait koleksi saat menjelajahi pustaka';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Pemberitahuan Pengelompokan Pustaka';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Untuk menggunakan pengaturan ini, pastikan pengaturan pustaka \"Kelompokkan film ke dalam koleksi\" dan/atau \"Kelompokkan serial ke dalam koleksi\" telah diaktifkan pada pengaturan Tampilan pustaka Anda di server Jellyfin atau Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilitas Pustaka';
@@ -3280,11 +3279,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Putar trailer secara otomatis di bar media setelah 3 detik';
 
   @override
-  String get trailerAudio => 'Audio Trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Aktifkan audio untuk trailer di bilah media';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Pratinjau Episode';
@@ -3658,28 +3656,28 @@ class AppLocalizationsId extends AppLocalizations {
   String get hideAdultContent => 'Sembunyikan konten dewasa dari hasil';
 
   @override
-  String get seerrNotificationsSection => 'Notifikasi';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Notifikasi permintaan baru';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Beri tahu saya saat seseorang mengirim permintaan';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Pembaruan permintaan';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Disetujui, ditolak, dan ditambahkan ke pustaka Anda';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Pembaruan masalah';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Masalah baru, balasan, dan penyelesaian';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3687,15 +3685,15 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Halaman Jelajah Seerr';
+  String get discoverRows => 'Baris Discover';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktifkan baris yang ingin ditampilkan di halaman utama Seerr. Seret untuk mengubah urutan. Urutan kustom disinkronkan dengan Moonbase.';
+      'Seret untuk mengatur ulang urutan. Aktifkan atau nonaktifkan baris. Urutan baris yang diaktifkan akan disinkronkan dengan plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktifkan baris yang ingin ditampilkan di halaman utama Seerr. Seret untuk mengubah urutan. Urutan kustom disinkronkan dengan Moonbase.';
+      'Seret untuk mengatur ulang urutan. Aktifkan atau nonaktifkan baris.';
 
   @override
   String get enabled => 'Diaktifkan';
@@ -3718,7 +3716,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get sourceCode => 'Kode Sumber';
 
   @override
-  String get sourceCodeUrl => 'https://github.com/Moonfin-Client/Moonfin-Core';
+  String get sourceCodeUrl =>
+      '[https://github.com/Moonfin-Client/Moonfin-Core](https://github.com/Moonfin-Client/Moonfin-Core)';
 
   @override
   String get checkForUpdatesNow => 'Periksa Pembaruan Sekarang';
@@ -3848,11 +3847,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Mengunduh · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Mengimpor';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3957,7 +3956,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get showMore => 'Tampilkan Lebih Banyak';
 
   @override
-  String get appearances => 'Filmografi';
+  String get appearances => 'Penampilan';
 
   @override
   String get crewSection => 'Kru';
@@ -3995,102 +3994,102 @@ class AppLocalizationsId extends AppLocalizations {
   String get deletedStatus => 'Dihapus';
 
   @override
-  String get failedStatus => 'Gagal';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Diproses';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Diubah oleh $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Selesai';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Judul ini sudah pernah diminta';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Batas permintaan tercapai';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Judul ini masuk daftar blokir';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Tidak ada musim tersisa untuk diminta';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Anda tidak memiliki izin untuk membuat permintaan ini';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Permintaan';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Masalah';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Terbaru';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Terakhir Diubah';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Tidak ada masalah';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Tersisa $remaining dari $limit permintaan film';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Tersisa $remaining dari $limit permintaan musim';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Bagian dari $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Lihat Koleksi';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Minta Koleksi';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total film · $available tersedia';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Minta $count film';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Meminta $current dari $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count film telah diminta';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok dari $total film telah diminta';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Semua film sudah tersedia atau telah diminta';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Laporkan Masalah';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4099,44 +4098,44 @@ class AppLocalizationsId extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Apa masalahnya?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Semua Episode';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Terbuka';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Selesai';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Selesaikan';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Buka Kembali';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Dilaporkan oleh $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentar';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Tambahkan komentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Hapus masalah ini?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Kirim Laporan';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Skor TMDB';
@@ -4232,7 +4231,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get next => 'Berikutnya';
 
   @override
-  String get path => 'Jalur';
+  String get path => 'Path';
 
   @override
   String get paused => 'Dijeda';
@@ -4253,7 +4252,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get refresh => 'Segarkan';
 
   @override
-  String get remote => 'Jarak jauh';
+  String get remote => 'Jarak Jauh';
 
   @override
   String get rename => 'Ubah Nama';
@@ -4322,7 +4321,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get branding => 'Branding';
 
   @override
-  String get adminDrawerDashboard => 'Dasbor';
+  String get adminDrawerDashboard => 'Dashboard';
 
   @override
   String get adminDrawerAnalytics => 'Analitik';
@@ -4340,13 +4339,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminDrawerLibraries => 'Pustaka';
 
   @override
-  String get adminDrawerDisplay => 'Tampilan';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Pengaturan NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcoding';
@@ -4469,7 +4468,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminServerActions => 'Tindakan Server';
 
   @override
-  String get adminRestartServer => 'Mulai Ulang Server';
+  String get adminRestartServer => 'Restart Server';
 
   @override
   String get adminShutdownServer => 'Matikan Server';
@@ -4528,7 +4527,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get sessionRewind => 'Mundur';
 
   @override
-  String get sessionForward => 'Maju cepat';
+  String get sessionForward => 'Maju';
 
   @override
   String get sessionNext => 'Berikutnya';
@@ -4573,10 +4572,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminClearDates => 'Hapus tanggal';
 
   @override
-  String get adminActivitySeverityAll => 'Semua tingkat keparahan';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Rentang tanggal';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4613,23 +4612,23 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Hapus perangkat \'$name\'? Pengguna harus masuk kembali di perangkat ini.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Hapus semua perangkat';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Hapus $count perangkat? Pengguna yang terdampak harus masuk kembali. Perangkat Anda saat ini tidak terdampak.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Perangkat telah dihapus';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Sebagian perangkat telah dihapus; $count tidak dapat dihapus.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4744,253 +4743,244 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminMetadataCountryHint => 'mis. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Jalur';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opsi';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Pengunduh';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Penyimpan metadata';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Pengunduh subtitle';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Pengunduh lirik';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Pengunduh metadata: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Pengambil gambar: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Server ini tidak menyediakan pengunduh untuk jenis pustaka ini.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Umum';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Info Tertanam';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtitle';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Gambar';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serial';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musik';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Film';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktifkan pemantauan waktu nyata';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Deteksi perubahan berkas dan proses secara otomatis.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Perlakukan arsip sebagai berkas media';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Tampilkan foto';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Simpan artwork ke dalam folder media';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Penyegaran metadata otomatis';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Tidak pernah';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Bawaan';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Tampilan';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Tampilan pustaka';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Tampilkan tampilan folder untuk folder media biasa';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Tampilkan episode spesial di dalam musim saat episode itu ditayangkan';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Kelompokkan film ke dalam koleksi';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Kelompokkan serial ke dalam koleksi';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Tampilkan konten eksternal dalam saran';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Perilaku tanggal ditambahkan';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Gunakan tanggal ditambahkan dari';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Tanggal dipindai ke dalam pustaka';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Tanggal berkas dibuat';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata dan Gambar';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Bahasa metadata pilihan';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Bab';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Durasi bab bawaan (detik)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Durasi bab yang dibuat untuk media yang tidak memilikinya. Setel ke 0 untuk menonaktifkan.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Resolusi gambar bab';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Pengaturan NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadata NFO kompatibel dengan Kodi dan klien serupa. Pengaturan berlaku untuk semua pustaka yang menyimpan metadata NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Pengguna yang data tontonannya disimpan dalam berkas NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Simpan jalur gambar di dalam berkas NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktifkan substitusi jalur untuk jalur gambar NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Salin gambar extrafanart ke dalam folder extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Tidak ada';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days hari';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Gunakan judul tertanam';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Gunakan judul tertanam untuk ekstra';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Gunakan informasi episode tertanam';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Izinkan subtitle tertanam';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Izinkan semua';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Hanya teks';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Hanya gambar';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Tidak ada';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Lewati unduhan jika sudah ada subtitle tertanam';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Lewati unduhan jika trek audio sesuai dengan bahasa unduhan';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Wajibkan kecocokan subtitle yang sempurna';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Simpan subtitle ke dalam folder media';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Ekstrak gambar bab';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Ekstrak gambar bab saat pemindaian pustaka';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktifkan ekstraksi gambar Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Ekstrak gambar Trickplay saat pemindaian pustaka';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Simpan gambar Trickplay ke dalam folder media';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Gabungkan otomatis serial yang tersebar di beberapa folder';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nama tampilan musim nol';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Aktifkan pemindaian LUFS untuk normalisasi audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Utamakan tag artis non-standar';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Tambahkan film ke koleksi secara otomatis';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Nama pustaka wajib diisi';
@@ -5227,145 +5217,143 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktifkan akses ke semua kanal';
 
   @override
-  String get adminParentalControl => 'Kontrol Orang Tua';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Rating orang tua maksimum yang diizinkan';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Konten dengan rating lebih tinggi akan disembunyikan dari pengguna ini.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Tidak ada';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokir item tanpa informasi rating atau dengan rating yang tidak dikenali';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Buku';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanal';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV Langsung';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Film';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musik';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailer';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serial';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Jadwal Akses';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Izinkan akses hanya pada waktu terjadwal di bawah ini. Akses diizinkan sepanjang hari jika tidak ada jadwal yang disetel.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Tambah Jadwal';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Hari';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Mulai';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Selesai';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Setiap hari';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Hari kerja';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Akhir pekan';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Minggu';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Senin';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Selasa';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Rabu';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Kamis';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Jumat';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sabtu';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tag yang diizinkan';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Hanya konten dengan tag ini yang ditampilkan. Kosongkan untuk mengizinkan semua.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Tag yang diblokir';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Konten dengan tag ini disembunyikan dari pengguna ini.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Tambah tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Perangkat yang diaktifkan';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Kanal yang diaktifkan';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Penyedia autentikasi';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Penyedia reset kata sandi';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Jumlah maksimum percobaan masuk yang gagal sebelum penguncian';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Setel ke 0 untuk nilai bawaan, atau -1 untuk menonaktifkan penguncian.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Akses SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Izinkan membuat dan bergabung ke grup';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Izinkan bergabung ke grup';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Tanpa akses';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Izinkan penghapusan konten dari';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5453,26 +5441,25 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Buat Cadangan';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Pilih apa saja yang disertakan dalam cadangan.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Basis Data';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Selalu disertakan';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtitle';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Gambar Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Membuat cadangan...';
@@ -6179,58 +6166,57 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Berkas atau URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Alamat IP tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nama ramah';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Batas koneksi bersamaan';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Jumlah maksimum stream yang diizinkan tuner secara bersamaan. Setel ke 0 untuk tanpa batas.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Bitrate streaming maksimum cadangan';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Impor hanya kanal favorit';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Izinkan transcoding perangkat keras';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Izinkan kontainer transcoding fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Izinkan berbagi stream';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Aktifkan pengulangan stream';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Abaikan DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Baca masukan pada frame rate asli';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Edit Penyedia';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6239,50 +6225,50 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Berkas atau URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefiks film';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategori film';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Pisahkan beberapa kategori dengan garis vertikal.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategori anak';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategori berita';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategori olahraga';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nama pengguna';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Kata sandi';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Negara';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Pilih negara';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Kode pos';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Ambil daftar acara';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Daftar acara';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktifkan semua tuner';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipe Tuner';
@@ -6324,7 +6310,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Jenis tuner ini tidak mendukung pengaturan ulang.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6347,43 +6333,43 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Path rekaman serial';
 
   @override
-  String get adminMovieRecordingPath => 'Jalur rekaman film';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Jumlah hari data panduan';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Otomatis';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days hari';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Jalur aplikasi pascaproses';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumen pascaproses';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Simpan metadata NFO rekaman';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Simpan gambar rekaman';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Waktu';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Jalur rekaman';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Pascaproses';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Data panduan: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6424,14 +6410,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminGuideProviders => 'Penyedia Panduan';
 
   @override
-  String get adminRefreshGuideData => 'Segarkan Data Panduan';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Penyegaran data panduan dimulai';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Tugas penyegaran panduan tidak tersedia di server ini.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Tambah Penyedia';
@@ -6520,7 +6506,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminNotSet => 'Tidak diatur';
 
   @override
-  String get adminReset => 'Atur Ulang';
+  String get adminReset => 'Reset';
 
   @override
   String get adminLogsTitle => 'Log Server';
@@ -6566,7 +6552,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor Metadata';
 
   @override
-  String get adminMetadataIdentify => 'Identifikasi';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipe';
@@ -6981,19 +6967,19 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktifkan splash screen';
 
   @override
-  String get adminBrandingSplashUpload => 'Unggah gambar';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Splashscreen diperbarui';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'Gagal mengunggah splashscreen';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Splashscreen dihapus';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Tidak ada splashscreen kustom';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Akselerasi Perangkat Keras';
@@ -7010,123 +6996,121 @@ class AppLocalizationsId extends AppLocalizations {
       'Aktifkan decoding perangkat keras untuk:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Perangkat QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Aktifkan dekoder NVDEC yang disempurnakan';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Utamakan dekoder perangkat keras asli sistem';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Kedalaman warna dekoding perangkat keras';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Dekoding HEVC 10-bit';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Dekoding VP9 10-bit';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'Dekoding HEVC RExt 8/10-bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'Dekoding HEVC RExt 12-bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Encoding perangkat keras';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Izinkan encoding HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Izinkan encoding AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktifkan encoder Intel H.264 berdaya rendah';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktifkan encoder Intel HEVC berdaya rendah';
+      'Enable Intel low-power HEVC encoder';
 
   @override
   String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktifkan tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Aktifkan tone mapping VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktifkan tone mapping VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritme tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Mode tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Rentang tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturasi tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Puncak tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Kecerahan tone mapping VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'Kontras tone mapping VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Preset & Kualitas';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Preset encoder';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF encoding H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF encoding H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metode deinterlace';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Gandakan frame rate saat deinterlace';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktifkan encoding audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Penguatan downmix audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritme downmix stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Ukuran maksimum antrean muxing';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Otomatis';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Encoding';
@@ -7197,7 +7181,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminTrickplayPriorityBelowNormal => 'Di Bawah Normal';
 
   @override
-  String get adminTrickplayPriorityIdle => 'Saat menganggur';
+  String get adminTrickplayPriorityIdle => 'Idle';
 
   @override
   String get adminTrickplayImageSettings => 'Pengaturan Gambar';
@@ -7249,7 +7233,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminTaskStop => 'Hentikan';
 
   @override
-  String get adminRunningTasks => 'Tugas Berjalan';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Jalankan';
@@ -7381,7 +7365,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7401,43 +7385,43 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Port HTTP publik';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Wajibkan HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Alihkan semua permintaan jarak jauh ke HTTPS. Tidak berpengaruh jika server tidak memiliki sertifikat yang valid.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Kata sandi sertifikat';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Pengaturan IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktifkan IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktifkan IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'Aktifkan pemetaan port otomatis';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Jaringan LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Daftar alamat IP atau subnet CIDR yang dianggap berada di jaringan lokal, dipisahkan dengan koma atau baris baru.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI server yang dipublikasikan';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Petakan subnet atau alamat ke URL yang dipublikasikan, mis. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Path sertifikat';
@@ -7467,11 +7451,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Batasi buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Jeda pembatasan (detik)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Izinkan ekstraksi subtitle secara langsung';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Persentase minimum resume';
@@ -7513,7 +7497,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminTrickplayWidthResolutions => 'Resolusi lebar';
 
   @override
-  String get adminMetadataDefault => 'Bawaan';
+  String get adminMetadataDefault => 'Default';
 
   @override
   String get adminMetadataContentTypeUpdated => 'Tipe konten diperbarui';
@@ -7527,11 +7511,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Ambang respons lambat (md)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktifkan peringatan respons lambat';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktifkan Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7540,10 +7523,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Jalur';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Performa';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Path cache';
@@ -7555,7 +7538,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminGeneralServerName => 'Nama server';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Bahasa tampilan pilihan';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Gagal memuat pengaturan';
@@ -7797,21 +7780,20 @@ class AppLocalizationsId extends AppLocalizations {
   String get offlineSavedMedia => 'Media Tersimpan';
 
   @override
-  String get offlineBannerTitle => 'Anda sedang offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Menampilkan unduhan Anda';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Unduhan';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Tidak dapat menjangkau server Anda';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Memutar dari unduhan hingga server kembali tersedia';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8171,13 +8153,13 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Sembunyikan dari Lanjut Menonton';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Sembunyikan dari Berikutnya';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Tambahkan ke Koleksi';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8231,15 +8213,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetis';
 
   @override
-  String get settingsConnectionSection => 'KONEKSI';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Izinkan sertifikat yang ditandatangani sendiri';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Percayai server yang menggunakan sertifikat TLS yang ditandatangani sendiri atau dari CA privat. Aktifkan hanya untuk server yang Anda kendalikan. Opsi ini menonaktifkan validasi sertifikat untuk semua koneksi.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVASI & KEAMANAN';
@@ -8255,11 +8236,11 @@ class AppLocalizationsId extends AppLocalizations {
       'Aksen tema, backdrop, indikator tontonan, dan musik tema';
 
   @override
-  String get settingsDetailsScreen => 'Layar Detail';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Gaya, blur latar belakang, dan perilaku tab';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Halaman Beranda';
@@ -8301,7 +8282,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Selalu tampilkan label teks di bilah navigasi atas';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8454,10 +8435,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsProgressBar => 'Bilah Progres';
 
   @override
-  String get settingsTimer => 'Pengatur Waktu';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Tidak ada';
+  String get settingsNone => 'Tidak Ada';
 
   @override
   String get settingsPromptUser => 'Minta Pengguna';
@@ -8492,10 +8473,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Media3 (direkomendasikan)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (lawas)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
-  String get settingsPlaybackEngineMpvLegacy => 'mpv (lawas)';
+  String get settingsPlaybackEngineMpvLegacy => 'mpv (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvRecommended => 'mpv (direkomendasikan)';
@@ -8595,7 +8576,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get settingsLiveTvDirect => 'TV Langsung Direct';
+  String get settingsLiveTvDirect => 'Live TV Direct';
 
   @override
   String get settingsLiveTvDirectSubtitle =>
@@ -8686,7 +8667,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName yang Baru Rilis';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8754,8 +8735,7 @@ class AppLocalizationsId extends AppLocalizations {
       'Tampilkan detail item yang dipilih di bagian atas halaman Pustaka.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Sembunyikan Backdrop saat Menjelajah?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Gunakan Subjudul Terperinci';
@@ -8968,22 +8948,22 @@ class AppLocalizationsId extends AppLocalizations {
   String get appearance => 'Tampilan';
 
   @override
-  String get layout => 'Tata Letak';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Papan Ketik';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Tombol';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfigurasi MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Ukuran Tampilan Kartu Baris Beranda';
@@ -9136,7 +9116,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get notConfigured => 'tidak dikonfigurasi';
 
   @override
-  String get webDiagnosticsMixedContent => 'Konten Campuran';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
@@ -9258,7 +9238,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get appearancesSeerr => 'Penampilan (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Kontribusi Kru (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Tonton bersama grup';
@@ -9603,7 +9583,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Gambar Cakram';
+  String get discArtCategory => 'Disc Art';
 
   @override
   String get screenshotCategory => 'Tangkapan Layar';
@@ -9615,7 +9595,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get boxRearCoverCategory => 'Sampul Belakang Kotak';
 
   @override
-  String get menuArtCategory => 'Gambar Menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
@@ -9636,7 +9616,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'gambar cakram';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
   String get confirmItemScreenshot => 'tangkapan layar';
@@ -9648,7 +9628,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get confirmItemBoxRearCover => 'sampul belakang kotak';
 
   @override
-  String get confirmItemMenuArt => 'gambar menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
   String get resolutionAll => 'Semua';
@@ -9666,78 +9646,78 @@ class AppLocalizationsId extends AppLocalizations {
   String get sources => 'Sumber';
 
   @override
-  String get audiobookChapters => 'Bab';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Markah';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Catatan';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Antrean';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Lini Masa';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Lini masa kosong';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Seluruh Buku';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Lini Masa Terfokus';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Ekspor Markah';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Ekspor Catatan';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Ekspor Semua';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Diekspor ke $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Ekspor gagal: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Lirik';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Tambah markah';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Tambah catatan';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Edit catatan';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Tulis catatan untuk momen ini';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Pengatur waktu tidur';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Nonaktif';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Akhir bab';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Kustom';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'tersisa $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9745,58 +9725,58 @@ class AppLocalizationsId extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count mnt',
-      one: '1 mnt',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Kecepatan pemutaran';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Tersisa';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Berlalu';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Mundur ${seconds}d';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Maju ${seconds}d';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Bab sebelumnya';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Bab berikutnya';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Bab $current dari $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Tidak ada bab';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Belum ada markah';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Belum ada catatan';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Markah ditambahkan pada $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Atur ulang ke 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9804,251 +9784,249 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Simpan';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Batal';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Hapus';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferensi Subtitle';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Ubah mode subtitle, bahasa bawaan, tampilan, dan opsi rendering.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Rendering Subtitle';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opsi Tampilan';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Tanggal Rilis (Menaik)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Tanggal Rilis (Menurun)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Kelompokkan Kontribusi';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Kelompokkan beberapa peran';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'Peringatan Akses Tulis Pustaka';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Cara memperbaikinya:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Berikan izin tulis kepada pengguna layanan Jellyfin (mis. jellyfin atau PUID/PGID Docker) untuk folder pustaka media Anda di server.\n\n2. Atau, buka Dasbor Jellyfin -> Pustaka, edit pustaka ini, lalu nonaktifkan \'Simpan artwork ke dalam folder media\' agar artwork disimpan di basis data internal Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Tutup';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Pustaka \'$libraryName\' Anda dikonfigurasi untuk menyimpan artwork langsung ke dalam folder media (opsi \'Simpan artwork ke dalam folder media\' aktif). Namun, Jellyfin telah menguji akses tulis dan tidak memiliki izin untuk menulis berkas ke direktori ini:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Sepertinya Jellyfin gagal memperbarui artwork. Pustaka Anda dikonfigurasi untuk menyimpan artwork langsung ke dalam folder media (opsi \'Simpan artwork ke dalam folder media\' aktif). Kesalahan ini biasanya terjadi ketika proses server Jellyfin tidak memiliki izin untuk menulis berkas ke direktori media Anda.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Daftar Eksternal';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Putar Ulang';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informasi Berkas';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Ukuran: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Tampilkan Semua ($count) Trek Audio';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Tampilkan Semua ($count) Trek Subtitle';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Memeriksa kemampuan Direct Play...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Kemampuan Direct Play: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Dipaksa';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Format kontainer tidak didukung oleh pemutar.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Codec video tidak didukung.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Codec audio tidak didukung.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Format subtitle tidak didukung (perlu dibakar ke gambar).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Profil audio tidak didukung.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Profil video tidak didukung.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Level video tidak didukung.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Resolusi video tidak didukung oleh perangkat ini.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Kedalaman bit video tidak didukung.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Frame rate video tidak didukung.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Bitrate berkas melebihi batas streaming pemutar.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Bitrate video melebihi batas streaming.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Bitrate audio melebihi batas streaming.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Jumlah kanal audio tidak didukung.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetis';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Urutan Rilis (Menaik)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Urutan Rilis (Menurun)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Kustom (Seret dan Lepas)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opsi Urutan Playlist';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Atur Ulang Urutan';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Tonton Ulang S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Tonton Ulang Playlist';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Subtitle tidak ditemukan.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Kontrol Admin';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Mesin rendering (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller adalah perender GPU modern dari Flutter untuk animasi yang lebih mulus dan minim patah-patah. Pada sebagian TV box dan GPU lama, Impeller dapat menyebabkan gangguan tampilan atau video hitam; matikan jika Anda mengalaminya. Otomatis memilih nilai bawaan terbaik untuk perangkat Anda. Mulai ulang Moonfin untuk menerapkannya.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Otomatis';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Aktif';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Nonaktif';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Perlu dimulai ulang';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin perlu dimulai ulang untuk mengubah mesin rendering. Tutup aplikasi sekarang, lalu buka kembali untuk menerapkannya.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Tutup aplikasi sekarang';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Segarkan Pustaka';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Segarkan Semua Pustaka';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Tanggal Ditambahkan (Terlama Dulu)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Tanggal Ditambahkan (Terbaru Dulu)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetis (A ke Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetis (Z ke A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Memuat Analitik Server... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Samakan dengan sumber';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 Film';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 Serial TV';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Film Terpopuler IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Serial TV Terpopuler IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Film dengan Rating Terendah IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Film Berbahasa Inggris dengan Rating Tertinggi IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -28,11 +28,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String connectingToServer(String serverName) {
-    return 'Connessione a $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Connessione Rapida';
 
   @override
   String get password => 'Password';
@@ -61,12 +61,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect non disponibile: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect non disponibile ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Versione Moonfin $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Rimuovere \"$serverName\" dai tuoi server?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -154,18 +154,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get detailScreenStyleModern => 'Moderna';
 
   @override
-  String get expandedTabs => 'Schede Espanse';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Mostra automaticamente il contenuto delle schede durante la navigazione. Disattiva per aprire e chiudere ogni scheda manualmente.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Mostrare i Dettagli Tecnici?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Mostra informazioni su codec, risoluzione e stream nel riepilogo del banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
   String get recommendationSystem => 'Sistema di raccomandazione';
@@ -336,7 +336,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gameSaveState => 'Salva stato';
 
   @override
-  String get games => 'Giochi';
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Carica stato';
@@ -384,7 +384,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noItemsFound => 'Nessun elemento trovato';
 
   @override
-  String get home => 'Home';
+  String get home => 'Casa';
 
   @override
   String get browseAll => 'Sfoglia Tutto';
@@ -429,7 +429,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Impossibile caricare la cartella: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -437,7 +437,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count elementi';
+    return '$count items';
   }
 
   @override
@@ -454,7 +454,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Elementi';
+    return '$count Items';
   }
 
   @override
@@ -495,7 +495,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Generi';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +533,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count min fa';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count h fa';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count g fa';
+    return '${count}d ago';
   }
 
   @override
@@ -578,7 +578,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count titoli';
+    return '$count titles';
   }
 
   @override
@@ -666,17 +666,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count autori';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count generi';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% completato';
+    return '$percent% completed';
   }
 
   @override
@@ -693,7 +693,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titoli organizzati per una navigazione all\'insegna della lettura.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -730,7 +730,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Nessun $label trovato';
+    return 'No $label found';
   }
 
   @override
@@ -767,43 +767,43 @@ class AppLocalizationsIt extends AppLocalizations {
   String get books => 'Libri';
 
   @override
-  String get latestBooks => 'Ultimi Libri';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Ultimi Audiolibri';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count libri',
-      one: '1 libro',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Libro';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiolibro';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% letto';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time rimanenti';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Leggi';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Ascolta';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autore';
@@ -841,12 +841,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count sezioni';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Prima pubblicazione $year';
+    return 'First published $year';
   }
 
   @override
@@ -861,7 +861,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count libri';
+    return '$count books';
   }
 
   @override
@@ -873,7 +873,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Autori';
+    return '$count Authors';
   }
 
   @override
@@ -881,8 +881,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiolibri',
-      one: '1 audiolibro',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -930,7 +930,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get movies => 'Film';
 
   @override
-  String get musicVideos => 'Video Musicali';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Altro';
@@ -949,7 +949,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disco $number';
+    return 'Disc $number';
   }
 
   @override
@@ -986,8 +986,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Stagioni',
-      one: '1 Stagione',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -1223,7 +1223,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Versione $number';
+    return 'Version $number';
   }
 
   @override
@@ -1347,20 +1347,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get readMore => 'Leggi Tutto';
 
   @override
-  String get shuffle => 'Casuale';
+  String get shuffle => 'Riproduzione Casuale';
 
   @override
-  String get shuffleAllMusic => 'Riproduci tutta la musica in ordine casuale';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Accedi a Moonfin dal tuo telefono';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Impossibile raggiungere il tuo server';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count download';
+    return '$count downloads';
   }
 
   @override
@@ -1463,7 +1463,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Interrompi $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1495,7 +1495,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get longPressToUnlock => 'Premi a lungo per sbloccare';
 
   @override
-  String get off => 'Disattivati';
+  String get off => 'Spento';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1603,12 +1603,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Errore sessione $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Impossibile caricare i dettagli del libro: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1617,7 +1617,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Questo formato (.$extension) non può ancora essere visualizzato nell\'app.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1630,17 +1630,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Impossibile aprire il lettore integrato: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Segnalibro già salvato a $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Segnalibro aggiunto: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1652,7 +1652,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Pagina $number';
+    return 'Page $number';
   }
 
   @override
@@ -1663,12 +1663,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Formato: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% letto';
+    return '$percent% read';
   }
 
   @override
@@ -1692,7 +1692,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Reimposta Zoom (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1715,7 +1715,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Impossibile aggiornare lo stato di lettura: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -2026,7 +2026,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Episodio $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2198,7 +2198,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count opzioni';
+    return '$count options';
   }
 
   @override
@@ -2293,7 +2293,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Pagine di dettaglio, righe home e volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2308,11 +2308,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Riproduci durante la navigazione della schermata home';
 
   @override
-  String get loopThemeMusic => 'Ripeti Musica Tema';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ripeti la traccia invece di riprodurla una sola volta';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Sfocatura Sfondo Dettagli';
@@ -2366,7 +2366,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get refreshRateSwitching => 'Cambio Frequenza Aggiornamento';
 
   @override
-  String get disabled => 'Disattivato';
+  String get disabled => 'Disabilitato';
 
   @override
   String get scaleOnTv => 'Scala su TV';
@@ -2427,17 +2427,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get transcodingAudio => 'Transcodifica (audio)';
 
   @override
-  String get directStreamRemux => 'Stream Diretto (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodifica (Bitrate o Risoluzione)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodifica (Video e Audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodifica (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatico (Predefinito Server)';
@@ -2514,14 +2514,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Abilita audio TrueHD (potrebbe non funzionare su tutte le piattaforme)';
 
   @override
-  String get settingsAudioOutputMode => 'Modalità Uscita Audio';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
       'Scegli come viene decodificato l\'audio. AVR Passthrough invia i flussi Dolby/DTS originali al ricevitore; Auto o Downmix esegue la decodifica localmente.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Passthrough AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
   String get settingsAudioFallbackCodec => 'Codec audio alternativo';
@@ -2576,7 +2576,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrifonico';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2591,67 +2591,67 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (Avanzate)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough Codec';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Abilita solo i formati supportati dal tuo AVR o dispositivo HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Invia in bitstream Dolby Digital Plus (EAC3) al decoder esterno.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Invia in bitstream Dolby Atmos su EAC3 (JOC) al decoder esterno.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Invia in bitstream DTS-HD MA (include DTS core) al decoder esterno.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Invia in bitstream Dolby TrueHD con metadati Atmos al decoder esterno.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Capacità Audio Rilevate';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Nessuna istantanea delle capacità di runtime ancora disponibile.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Percorso';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Decodifica';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Percorso audio HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2666,10 +2666,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Altoparlante';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Cuffie';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2677,40 +2677,39 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostica';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Livello Video';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Gamma Video';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Codec Sottotitoli';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Codec Audio Consentiti';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Codec Audio HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Codec Audio HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'passthrough audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Percorso Audio Attivo';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Supporto Audio HD del Percorso';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Modalità Notturna';
@@ -2774,7 +2773,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Dopo $episodes episodi / ${hours}h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2851,45 +2850,45 @@ class AppLocalizationsIt extends AppLocalizations {
       'Personalizza l\'aspetto dei sottotitoli';
 
   @override
-  String get subtitleMode => 'Modalità Sottotitoli';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Contrassegnati';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Sempre';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Stranieri';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Forzati';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Riproduce le tracce contrassegnate come \"default\" o \"forced\" nei metadati del file media.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Carica e mostra automaticamente i sottotitoli ogni volta che inizia un video.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Attiva automaticamente i sottotitoli se la traccia audio predefinita è in una lingua straniera.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Carica solo i sottotitoli contrassegnati esplicitamente con il flag di metadati forced.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Disabilita completamente il caricamento automatico dei sottotitoli.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Lingua Sottotitoli di Riserva';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream Sottotitoli';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2949,17 +2948,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Impostazioni del profilo $profile caricate.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Impossibile caricare le impostazioni del profilo $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Impostazioni locali sincronizzate con il profilo $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3095,11 +3094,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Mostra Librerie nella Barra Strumenti';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Espandi Sempre le Etichette della Barra di Navigazione';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Mostra Pulsante Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacità Barra Navigazione';
@@ -3175,19 +3173,18 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra opzione di navigazione cartelle';
 
   @override
-  String get groupItemsIntoCollections => 'Raggruppa Elementi in Collezioni';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Nascondi gli elementi della libreria associati a una collezione durante la navigazione';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Avviso sul Raggruppamento della Libreria';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Per usare questa impostazione, assicurati che le impostazioni della libreria \"Raggruppa i film in collezioni\" e/o \"Raggruppa le serie in collezioni\" siano abilitate nelle impostazioni di Visualizzazione della tua libreria sul server Jellyfin o Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilità Libreria';
@@ -3216,7 +3213,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count selezionati';
+    return '$count selected';
   }
 
   @override
@@ -3299,11 +3296,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Riproduci automaticamente i trailer nella barra media dopo 3 secondi';
 
   @override
-  String get trailerAudio => 'Audio Trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Abilita l\'audio dei trailer nella barra media';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Anteprima Episodio';
@@ -3381,11 +3377,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Combina entrambe le righe in un\'unica sezione home';
 
   @override
-  String get fullScreenRows => 'Righe Home Espanse';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limita le righe home a 1 per schermata';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Tipo Immagine per Riga';
@@ -3400,7 +3395,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lastUser => 'Ultimo Utente';
 
   @override
-  String get currentUser => 'Utente Attuale';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentica Sempre';
@@ -3507,10 +3502,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra l\'orologio durante lo screensaver';
 
   @override
-  String get clockModeStatic => 'Statico';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Rimbalzante';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Critici)';
@@ -3582,7 +3577,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Abilita e riordina le fonti di valutazione mostrate nell\'app';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Collegare';
 
   @override
   String get pluginDetected => 'Plugin Rilevato';
@@ -3600,7 +3595,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersione: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3654,7 +3649,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get networks => 'Reti';
 
   @override
-  String get seerrDiscoveryRows => 'Righe Scoperta Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Ripristina righe predefinite';
@@ -3677,47 +3672,47 @@ class AppLocalizationsIt extends AppLocalizations {
   String get hideAdultContent => 'Nascondi contenuti per adulti nei risultati';
 
   @override
-  String get seerrNotificationsSection => 'Notifiche';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Notifiche nuove richieste';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Avvisami quando qualcuno invia una richiesta';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Aggiornamenti richieste';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Approvate, rifiutate e aggiunte alla tua libreria';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Aggiornamenti segnalazioni';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nuove segnalazioni, risposte e risoluzioni';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Accesso effettuato come: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Pagina Discovery di Seerr';
+  String get discoverRows => 'Righe Scoperta';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Abilita le righe da mostrare nella pagina principale di Seerr. Trascina per riordinare. L\'ordine personalizzato si sincronizza con Moonbase.';
+      'Trascina per riordinare. Abilita o disabilita le righe. L\'ordine delle righe abilitate si sincronizza con il plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Abilita le righe da mostrare nella pagina principale di Seerr. Trascina per riordinare. L\'ordine personalizzato si sincronizza con Moonbase.';
+      'Trascina per riordinare. Abilita o disabilita le righe.';
 
   @override
-  String get enabled => 'Attivato';
+  String get enabled => 'Abilitato';
 
   @override
   String get hidden => 'Nascosto';
@@ -3727,7 +3722,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Versione $version';
+    return 'Version $version';
   }
 
   @override
@@ -3778,7 +3773,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Aggiornamento disponibile: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3790,7 +3785,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version Disponibile';
+    return 'v$version Available';
   }
 
   @override
@@ -3869,15 +3864,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Scaricamento · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importazione';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count Elementi';
+    return '$count Items';
   }
 
   @override
@@ -3897,7 +3892,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Richiesto da $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3914,12 +3909,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Annullare la richiesta per \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Annullare $count richieste per \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3939,7 +3934,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String revenueAmount(String amount) {
-    return 'Incassi: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3949,7 +3944,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Richiedi $type';
+    return 'Request $type';
   }
 
   @override
@@ -3978,14 +3973,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showMore => 'Mostra Altro';
 
   @override
-  String get appearances => 'Filmografia';
+  String get appearances => 'Apparizioni';
 
   @override
   String get crewSection => 'Troupe';
 
   @override
   String ageValue(int age) {
-    return '$age anni';
+    return 'age $age';
   }
 
   @override
@@ -4016,102 +4011,102 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deletedStatus => 'Eliminato';
 
   @override
-  String get failedStatus => 'Non riuscita';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'In elaborazione';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificato da $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Completata';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Questo titolo è già stato richiesto';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Limite di richieste raggiunto';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Questo titolo è nella lista bloccati';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Nessuna stagione rimasta da richiedere';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Non hai il permesso di effettuare questa richiesta';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Richieste';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Segnalazioni';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Più recenti';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Ultima modifica';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Nessuna segnalazione';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining di $limit richieste di film rimanenti';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining di $limit richieste di stagioni rimanenti';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Parte di $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vedi Collezione';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Richiedi Collezione';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total film · $available disponibili';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Richiedi $count film';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Richiesta $current di $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Richiesti $count film';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Richiesti $ok di $total film';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Tutti i film sono già disponibili o richiesti';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Segnala Problema';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4120,44 +4115,44 @@ class AppLocalizationsIt extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Qual è il problema?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Tutti gli Episodi';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episodio';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Aperta';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Risolta';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Risolvi';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Riapri';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Segnalato da $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count commenti';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Aggiungi un commento';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Eliminare questa segnalazione?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Invia Segnalazione';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Punteggio TMDB';
@@ -4310,7 +4305,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get status => 'Stato';
 
   @override
-  String get stop => 'Interrompi';
+  String get stop => 'Ferma';
 
   @override
   String get streaming => 'Streaming';
@@ -4319,7 +4314,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get time => 'Ora';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trucchi';
 
   @override
   String get uninstall => 'Disinstalla';
@@ -4361,25 +4356,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminDrawerLibraries => 'Librerie';
 
   @override
-  String get adminDrawerDisplay => 'Visualizzazione';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadati';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Impostazioni NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodifica';
 
   @override
-  String get adminDrawerResume => 'Riprendi';
+  String get adminDrawerResume => 'Ripresa';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trucchi';
 
   @override
   String get adminDrawerDevices => 'Dispositivi';
@@ -4430,22 +4425,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Aggiornamenti plugin disponibili: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Plugin che richiedono il riavvio: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Attività pianificate non riuscite: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Voci recenti di avviso/errore: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4504,7 +4499,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Errore: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4531,7 +4526,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Comando non riuscito: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4550,7 +4545,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sessionRewind => 'Riavvolgi';
 
   @override
-  String get sessionForward => 'Avanti veloce';
+  String get sessionForward => 'Avanti';
 
   @override
   String get sessionNext => 'Successivo';
@@ -4595,14 +4590,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminClearDates => 'Cancella date';
 
   @override
-  String get adminActivitySeverityAll => 'Tutte le gravità';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Intervallo di date';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Impossibile caricare il registro attività: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4619,7 +4614,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Impossibile aggiornare il dispositivo: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4630,28 +4625,28 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Impossibile eliminare il dispositivo: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Rimuovere il dispositivo \'$name\'? L\'utente dovrà accedere di nuovo su questo dispositivo.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Elimina tutti i dispositivi';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Rimuovere $count dispositivi? Gli utenti interessati dovranno accedere di nuovo. Il tuo dispositivo attuale non è interessato.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Dispositivi rimossi';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Alcuni dispositivi rimossi; $count non è stato possibile rimuoverli.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4680,7 +4675,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Impossibile avviare la scansione: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4691,12 +4686,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Libreria rinominata in \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Impossibile rinominare: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4704,17 +4699,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Libreria \"$name\" eliminata';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Impossibile eliminare la libreria: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Impossibile aggiungere il percorso: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4722,12 +4717,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Rimuovere \"$path\" da questa libreria?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Impossibile rimuovere il percorso: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4735,7 +4730,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Impossibile salvare le opzioni: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4766,257 +4761,244 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminMetadataCountryHint => 'es. IT, US, DE';
 
   @override
-  String get adminLibraryTabPaths => 'Percorsi';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opzioni';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Downloader';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Salvataggio metadati';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Downloader sottotitoli';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Downloader testi';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Downloader metadati: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Fonti immagini: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Questo server non espone downloader per questo tipo di libreria.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Generale';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadati';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Info Incorporate';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Sottotitoli';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Immagini';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serie';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musica';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Film';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'Abilita il monitoraggio in tempo reale';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Rileva le modifiche ai file e le elabora automaticamente.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratta gli archivi come file multimediali';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Mostra le foto';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Salva le immagini nelle cartelle dei media';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Aggiornamento automatico dei metadati';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Mai';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Predefinito';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visualizzazione';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Visualizzazione libreria';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Mostra una vista cartelle per le cartelle multimediali semplici';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Mostra gli speciali nelle stagioni in cui sono andati in onda';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Raggruppa i film in collezioni';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Raggruppa le serie in collezioni';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Mostra contenuti esterni nei suggerimenti';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportamento data di aggiunta';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Usa la data di aggiunta da';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data di scansione nella libreria';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data di creazione del file';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadati e Immagini';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Lingua preferita dei metadati';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capitoli';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Durata capitoli fittizi (secondi)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Durata dei capitoli generati per i media che non ne hanno. Imposta 0 per disabilitare.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Risoluzione immagini capitoli';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Impostazioni NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'I metadati NFO sono compatibili con Kodi e client simili. Le impostazioni si applicano a tutte le librerie che salvano metadati NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Utente per cui memorizzare i dati di visione nei file NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Salva i percorsi delle immagini nei file NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Abilita la sostituzione dei percorsi per le immagini NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copia le immagini extrafanart in una cartella extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Nessuno';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days giorni';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Usa i titoli incorporati';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usa i titoli incorporati per gli extra';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usa le informazioni episodio incorporate';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Consenti i sottotitoli incorporati';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Consenti tutti';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Solo testo';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Solo immagine';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Nessuno';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Salta il download se sono presenti sottotitoli incorporati';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Salta il download se la traccia audio corrisponde alla lingua di download';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Richiedi una corrispondenza perfetta dei sottotitoli';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Salva i sottotitoli nelle cartelle dei media';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Estrai le immagini dei capitoli';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Estrai le immagini dei capitoli durante la scansione della libreria';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Abilita l\'estrazione delle immagini trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Estrai le immagini trickplay durante la scansione della libreria';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Salva le immagini trickplay nelle cartelle dei media';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Unisci automaticamente le serie distribuite su più cartelle';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nome visualizzato della stagione zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Abilita la scansione LUFS per la normalizzazione audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferisci il tag artists non standard';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Aggiungi automaticamente i film alle collezioni';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired =>
@@ -5024,7 +5006,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Impossibile creare la libreria: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5051,27 +5033,27 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Disabilitare $name? Non potrà più accedere.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Abilitare $name? Potrà accedere di nuovo.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Utente \"$name\" disabilitato';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Utente \"$name\" abilitato';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Impossibile aggiornare la policy utente: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5088,7 +5070,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Impossibile creare l\'utente: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5108,7 +5090,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Impossibile salvare: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5119,7 +5101,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Non riuscito: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5256,147 +5238,143 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminEnableAllChannels => 'Abilita l\'accesso a tutti i canali';
 
   @override
-  String get adminParentalControl => 'Controllo Parentale';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Classificazione parentale massima consentita';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'I contenuti con una classificazione superiore saranno nascosti a questo utente.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Nessuna';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blocca gli elementi senza classificazione o con classificazione non riconosciuta';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Libri';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canali';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV Live';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Film';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musica';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailer';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serie';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Orari di Accesso';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Consenti l\'accesso solo durante gli orari pianificati qui sotto. Se non è impostato alcun orario, l\'accesso è consentito tutto il giorno.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Aggiungi Orario';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Giorno';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Inizio';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fine';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Ogni giorno';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Giorni feriali';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Fine settimana';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Domenica';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Lunedì';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Martedì';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Mercoledì';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Giovedì';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Venerdì';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sabato';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tag consentiti';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Vengono mostrati solo i contenuti con questi tag. Lascia vuoto per consentire tutto.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Tag bloccati';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'I contenuti con questi tag sono nascosti a questo utente.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Aggiungi tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispositivi abilitati';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canali abilitati';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Provider di autenticazione';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Provider di reimpostazione password';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Numero massimo di tentativi di accesso falliti prima del blocco';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Imposta 0 per il valore predefinito, o -1 per disabilitare il blocco.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Accesso SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Consenti di creare gruppi e di unirsi';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Consenti di unirsi ai gruppi';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Nessun accesso';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Consenti l\'eliminazione dei contenuti da';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5404,22 +5382,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Il server ha restituito HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Sei sicuro di voler eliminare $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Utente \"$name\" eliminato';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Impossibile eliminare l\'utente: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5440,7 +5418,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Impossibile creare la chiave: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5452,7 +5430,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Revocare la chiave per $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5460,7 +5438,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Impossibile revocare la chiave: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5480,29 +5458,29 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nCreato: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Crea Backup';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Scegli cosa includere nel backup.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
   String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Sempre incluso';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadati';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Sottotitoli';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Immagini trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Creazione backup...';
@@ -5512,7 +5490,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Impossibile creare il backup: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5526,7 +5504,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Impossibile caricare il manifest: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5537,7 +5515,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Impossibile ripristinare il backup: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5569,17 +5547,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Salvato in $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Impossibile salvare il file: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Impossibile caricare $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5590,7 +5568,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Impossibile caricare le attività: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5602,17 +5580,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Impossibile avviare l\'attività: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Impossibile fermare l\'attività: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Impossibile caricare l\'attività: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5620,12 +5598,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Impossibile rimuovere il trigger: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Impossibile aggiungere il trigger: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5651,7 +5629,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ora/e';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5662,7 +5640,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Impossibile attivare/disattivare il plugin: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5670,27 +5648,27 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Sei sicuro di voler disinstallare \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Impossibile disinstallare il plugin: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Impossibile installare il pacchetto: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Impossibile installare l\'aggiornamento: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Impossibile caricare i plugin: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5702,12 +5680,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Installa aggiornamento (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Impossibile caricare il catalogo: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5729,17 +5707,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" verrà rimosso dopo il riavvio del server';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Impossibile disinstallare: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Aggiornamento di \"$name\" alla v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5748,7 +5726,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Impossibile caricare il plugin: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5756,7 +5734,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versione $version';
+    return 'Version $version';
   }
 
   @override
@@ -5776,17 +5754,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Sei sicuro di voler rimuovere \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Impossibile salvare i repository: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Impossibile caricare i repository: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5803,12 +5781,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Impossibile caricare le impostazioni del plugin: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Impossibile aprire $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6089,12 +6067,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Impossibile caricare i metadati: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Impossibile salvare i metadati: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6115,7 +6093,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Impossibile aggiornare i metadati: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6129,7 +6107,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Ricerca remota non riuscita: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6143,7 +6121,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Impossibile aggiornare il tipo di contenuto: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6158,12 +6136,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Immagine $imageType aggiornata';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Impossibile scaricare l\'immagine: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6175,27 +6153,27 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Immagine $imageType caricata';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Impossibile caricare l\'immagine: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Elimina immagine $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Immagine $imageType eliminata';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Impossibile eliminare l\'immagine: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6206,71 +6184,67 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Rilevamento tuner non riuscito: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Aggiungi Tuner';
 
   @override
-  String get adminEditTuner => 'Modifica Tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'File o URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Indirizzo IP del tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nome descrittivo';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limite di connessioni simultanee';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Il numero massimo di stream consentiti contemporaneamente dal tuner. Imposta 0 per illimitati.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Bitrate massimo di streaming di riserva';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importa solo i canali preferiti';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Consenti la transcodifica hardware';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Consenti il contenitore di transcodifica fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Consenti la condivisione dello stream';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Abilita il looping dello stream';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignora DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Leggi l\'input al frame rate nativo';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Modifica Provider';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6279,50 +6253,50 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'File o URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefisso film';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorie film';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separa più categorie con una barra verticale.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorie per bambini';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorie notizie';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorie sport';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nome utente';
+  String get adminSdUsername => 'Username';
 
   @override
   String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Paese';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Seleziona un paese';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Codice postale';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Ottieni palinsesti';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Palinsesti';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Abilita tutti i tuner';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipo Tuner';
@@ -6332,7 +6306,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Impossibile aggiungere il tuner: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6346,12 +6320,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Impossibile aggiungere il provider: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Impossibile rimuovere il tuner: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6359,16 +6333,16 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Impossibile reimpostare il tuner: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Questo tipo di tuner non supporta il reset.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Impossibile rimuovere il provider: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6387,46 +6361,43 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Percorso registrazione serie';
 
   @override
-  String get adminMovieRecordingPath => 'Percorso registrazione film';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Giorni di dati della guida';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatico';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days giorni';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Percorso applicazione di post-elaborazione';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argomenti del post-processore';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Salva i metadati NFO delle registrazioni';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages =>
-      'Salva le immagini delle registrazioni';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tempistiche';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Percorsi di registrazione';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Post-elaborazione';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Dati della guida: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6435,7 +6406,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Impossibile salvare le impostazioni: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6452,7 +6423,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Impossibile aggiornare le mappature: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6469,15 +6440,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminGuideProviders => 'Provider Guida';
 
   @override
-  String get adminRefreshGuideData => 'Aggiorna Dati Guida';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Aggiornamento dei dati della guida avviato';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'L\'attività di aggiornamento della guida non è disponibile su questo server.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Aggiungi Provider';
@@ -6488,22 +6458,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Percorso registrazione: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Percorso serie: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Margine iniziale: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Margine finale: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6536,7 +6506,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Ripristinare ora il backup $name?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6582,27 +6552,27 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes min fa';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours h fa';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days g fa';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Impossibile caricare $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count corrispondenze';
+    return '$count matches';
   }
 
   @override
@@ -6612,7 +6582,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor Metadati';
 
   @override
-  String get adminMetadataIdentify => 'Identifica';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -6713,22 +6683,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Immagine $imageType aggiornata';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Immagine $imageType caricata';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Immagine $imageType eliminata';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Impossibile scaricare l\'immagine: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6737,12 +6707,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Impossibile caricare l\'immagine: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Elimina immagine $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6751,12 +6721,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Impossibile eliminare l\'immagine: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Scegli immagine $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6789,7 +6759,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Aggiornamento disponibile: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6813,7 +6783,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Installa aggiornamento (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6825,7 +6795,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" è in fase di installazione...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6845,7 +6815,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Impostazioni $name';
+    return '$name Settings';
   }
 
   @override
@@ -6885,7 +6855,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Impossibile caricare i repository: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6893,7 +6863,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Sei sicuro di voler rimuovere \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6901,7 +6871,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Impossibile salvare i repository: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7028,20 +6998,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Abilita schermata di avvio';
 
   @override
-  String get adminBrandingSplashUpload => 'Carica immagine';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Splashscreen aggiornata';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Impossibile caricare la splashscreen';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Splashscreen rimossa';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Nessuna splashscreen personalizzata';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Accelerazione Hardware';
@@ -7057,123 +7026,118 @@ class AppLocalizationsIt extends AppLocalizations {
       'Abilita decodifica hardware per:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Abilita il decoder NVDEC avanzato';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferisci il decoder hardware nativo di sistema';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profondità colore della decodifica hardware';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodifica HEVC a 10 bit';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodifica VP9 a 10 bit';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodifica HEVC RExt a 8/10 bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodifica HEVC RExt a 12 bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codifica hardware';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Consenti la codifica HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Consenti la codifica AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Abilita il codificatore Intel H.264 a basso consumo';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Abilita il codificatore Intel HEVC a basso consumo';
+      'Enable Intel low-power HEVC encoder';
 
   @override
   String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Abilita il tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Abilita il tone mapping VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Abilita il tone mapping VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritmo di tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modalità di tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Intervallo di tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturazione del tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Picco del tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametro del tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Luminosità del tone mapping VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contrasto del tone mapping VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Preset e Qualità';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Preset del codificatore';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF di codifica H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF di codifica H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metodo di deinterlacciamento';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Raddoppia il frame rate durante il deinterlacciamento';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Abilita la codifica audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Guadagno del downmix audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo di downmix stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Dimensione massima della coda di muxing';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7296,10 +7260,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminTaskNeverRun => 'Mai eseguita';
 
   @override
-  String get adminTaskStop => 'Interrompi';
+  String get adminTaskStop => 'Ferma';
 
   @override
-  String get adminRunningTasks => 'Attività in Esecuzione';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Esegui';
@@ -7321,17 +7285,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Ogni giorno alle $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Ogni $day alle $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Ogni $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7369,8 +7333,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ore',
-      one: '1 ora',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7398,17 +7362,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days g fa';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours h fa';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes min fa';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7416,22 +7380,22 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days g';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7451,44 +7415,43 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Porta HTTP pubblica';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Richiedi HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Reindirizza tutte le richieste remote a HTTPS. Non ha effetto se il server non ha un certificato valido.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Password del certificato';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Impostazioni IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Abilita IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Abilita IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Abilita la mappatura automatica delle porte';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Reti LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Elenco di indirizzi IP o subnet CIDR, separati da virgole o a capo, da considerare come rete locale.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI del server pubblicati';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Associa una subnet o un indirizzo a un URL pubblicato, es. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Percorso certificato';
@@ -7519,11 +7482,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Limitazione buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Ritardo di throttling (secondi)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Consenti l\'estrazione dei sottotitoli al volo';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Percentuale minima di ripresa';
@@ -7572,30 +7535,29 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Impossibile aggiornare il tipo di contenuto: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Soglia risposta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Abilita gli avvisi di risposta lenta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Abilita Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadati';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Percorsi';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Prestazioni';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Percorso cache';
@@ -7607,8 +7569,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminGeneralServerName => 'Nome server';
 
   @override
-  String get adminGeneralDisplayLanguage =>
-      'Lingua di visualizzazione preferita';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Impossibile caricare le impostazioni';
@@ -7618,12 +7579,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Impossibile aggiornare le mappature: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Limite di tempo: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7660,8 +7621,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# partecipanti',
-      one: '# partecipante',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7705,7 +7666,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Elemento $index';
+    return 'Item $index';
   }
 
   @override
@@ -7753,12 +7714,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName si è unito al gruppo SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName ha lasciato il gruppo SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7770,7 +7731,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Sincronizzazione della riproduzione con $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7808,8 +7769,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# righe rilevate',
-      one: '# riga rilevata',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7850,21 +7811,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get offlineSavedMedia => 'Media Salvati';
 
   @override
-  String get offlineBannerTitle => 'Sei offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Vengono mostrati i tuoi download';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Download';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Impossibile raggiungere il tuo server';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Riproduzione dai download finché non torna disponibile';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7880,12 +7840,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Controllo Cast non riuscito: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Controlli di $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7896,7 +7856,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Interrompi $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7919,12 +7879,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Inserisci un PIN di $length cifre';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Inserisci il tuo PIN di $length cifre';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7943,35 +7903,36 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pinBackspace => 'Cancella';
 
   @override
-  String get quickConnectAuthorized => 'Richiesta Quick Connect autorizzata.';
+  String get quickConnectAuthorized =>
+      'Richiesta Connessione Rapida autorizzata.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Il codice Quick Connect non è valido o è scaduto.';
+      'Il codice Connessione Rapida non è valido o è scaduto.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect non è supportato su questo server.';
+      'La Connessione Rapida non è supportata su questo server.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Impossibile autorizzare il codice Quick Connect.';
+      'Impossibile autorizzare il codice Connessione Rapida.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect è disabilitato su questo server.';
+      'La Connessione Rapida è disabilitata su questo server.';
 
   @override
   String get quickConnectForbidden =>
-      'Il tuo account non può autorizzare questa richiesta Quick Connect.';
+      'Il tuo account non può autorizzare questa richiesta di Connessione Rapida.';
 
   @override
   String get quickConnectNotFound =>
-      'Codice Quick Connect non trovato. Prova un nuovo codice.';
+      'Codice Connessione Rapida non trovato. Prova un nuovo codice.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect non riuscito: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7982,7 +7943,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Comando non riuscito: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8013,7 +7974,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Impossibile avviare la trasmissione: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8059,7 +8020,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Download di $name in corso...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8141,14 +8102,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'La riproduzione è stata messa in pausa. Stai ancora guardando?';
 
   @override
-  String get stillWatchingStop => 'Interrompi';
+  String get stillWatchingStop => 'Ferma';
 
   @override
   String get stillWatchingContinue => 'Continua';
 
   @override
   String skipSegment(String segment) {
-    return 'Salta $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8159,12 +8120,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Download $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Download di $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8226,13 +8187,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Nascondi da Continua a Guardare';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Nascondi da Prossimo';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Aggiungi alla Collezione';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8290,11 +8251,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsConnectionSection => 'CONNESSIONE';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Consenti certificati autofirmati';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Considera attendibili i server che usano certificati TLS autofirmati o con CA privata. Abilita solo per i server che controlli. Questo disattiva la convalida dei certificati per tutte le connessioni.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACY E SICUREZZA';
@@ -8310,11 +8271,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Accenti del tema, sfondi, indicatori osservati e musica a tema';
 
   @override
-  String get settingsDetailsScreen => 'Schermata Dettagli';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stile, sfocatura dello sfondo e comportamento delle schede';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Pagina iniziale';
@@ -8352,11 +8313,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Mostra il pulsante Seerr nella barra di navigazione';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Mostra sempre le etichette di testo nella barra di navigazione superiore';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8426,7 +8387,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Offri un caffè allo sviluppatore';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'LEGALE';
@@ -8460,8 +8421,8 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# avvisi di licenza',
-      one: '# avviso di licenza',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8511,17 +8472,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Saltare intro e outro?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Conto alla Rovescia Segmenti Media';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Barra di Avanzamento';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Nessuno';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Richiedi all\'utente';
@@ -8562,10 +8522,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsPlaybackEngineMpvLegacy => 'mpv (precedente)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (consigliato)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
-  String get settingsDolbyVisionFallback => 'Fallback Dolby Vision';
+  String get settingsDolbyVisionFallback => 'Dolby Vision Fallback';
 
   @override
   String get settingsDolbyVisionFallbackDescription =>
@@ -8752,762 +8712,749 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName - Usciti di Recente';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode =>
-      'Riproduci Automaticamente l\'Episodio Successivo';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Riproduci automaticamente l\'episodio successivo quando disponibile.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Salta i silenzi';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Salta automaticamente i segmenti audio silenziosi quando lo stream lo supporta.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Consenti effetti audio esterni';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Consenti alle app di equalizzazione ed effetti (es. Wavelet) di collegarsi alle sessioni di riproduzione Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Disabilita il tunneling';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Forza la riproduzione senza tunneling. Utile sui dispositivi con discontinuità audio/video dovute al tunneling.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Abilita il tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avanzato. Instrada audio e video attraverso un percorso hardware accoppiato. Disattivato per impostazione predefinita perché causa interruzioni audio/video su alcuni dispositivi.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Converti il profilo Dolby Vision 7 in HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Riproduci gli stream Dolby Vision profilo 7 come HEVC compatibile con HDR10 sui dispositivi senza Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Usa gli stili incorporati dei sottotitoli';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Applica colori, caratteri e posizionamento incorporati nella traccia dei sottotitoli. Disattiva per usare invece le tue preferenze di stile.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Usa le dimensioni del carattere incorporate nei sottotitoli';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Applica le indicazioni di dimensione del carattere incorporate nella traccia dei sottotitoli. Disattiva per usare la dimensione definita nelle tue preferenze di stile.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostra Dettagli Media';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostra i dettagli dell\'elemento selezionato in cima alle pagine della Libreria.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Nascondere gli Sfondi durante la Navigazione?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Usa Sottotitoli Dettagliati';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Mostra una sottoriga dettagliata o minimale nelle pagine della Libreria.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Eliminare il tema salvato?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Rimuovere \"$themeName\" dalla cache di questo dispositivo?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Store dei Temi';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Sfoglia e salva i temi della community';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Salva un tema per usarlo come gli altri temi salvati.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Al momento non è disponibile alcun tema.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Impossibile caricare lo Store dei Temi. Controlla la connessione e riprova.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Salva';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Salva e applica';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Salvato';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Impossibile caricare questo tema.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" salvato.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" eliminato da questo dispositivo.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Impossibile eliminare \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Temi salvati';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Questi sono i temi scaricati dal plugin Moonfin per il server attuale. L\'eliminazione rimuove solo questa copia locale.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Nessun tema salvato trovato per questo server.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Attualmente attivo';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Elimina tema salvato';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Gestisci i temi del plugin scaricati su questo dispositivo';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Editor Temi';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Apri l\'Editor Temi di Moonfin nel browser';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Schermata Home';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Barra Inferiore';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Classico';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderno';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Righe Home';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Visualizzazione Righe Home';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sezioni Righe Home';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Interruttori Righe Home';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Abilita o disabilita le categorie di righe home basate sulle librerie';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Abilita i seguenti interruttori per mostrare le righe nelle Sezioni Home.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Classico mantiene il tipo di immagine per riga e l\'overlay informativo. Moderno usa righe da verticale a sfondo.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Mostra Righe Preferiti';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Mostra Film Preferiti, Serie e altre righe di preferiti nelle Sezioni Home.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Ordinamento Righe Preferiti';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Ordina le righe Preferiti per data di aggiunta, data di uscita, alfabeticamente e altro.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Mostra Righe Collezioni';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Mostra le righe Collezioni nelle Sezioni Home.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Ordinamento Righe Collezioni';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Ordina le righe Collezioni per data di aggiunta, data di uscita, alfabeticamente e altro.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Mostra Righe Generi';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Mostra le righe Generi nelle Sezioni Home.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Ordinamento Righe Generi';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Ordina le righe Generi per data di aggiunta, data di uscita, alfabeticamente e altro.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementi Righe Generi';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Mostra Film, Serie o entrambi nelle righe Generi.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Mostra Righe Playlist';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Mostra le righe Playlist nelle Sezioni Home.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Ordinamento Righe Playlist';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordina le righe Playlist per data di aggiunta, data di uscita, alfabeticamente e altro.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Mostra Righe Audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Mostra le righe Audio nelle Sezioni Home.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ordinamento righe Audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordina le righe Audio per data di aggiunta, data di uscita, alfabeticamente e altro.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Playlist Audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Aspetto';
+  String get appearance => 'Appearance';
 
   @override
   String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastiera';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Pulsanti';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configurazione MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'App lettore esterno';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Imposta un lettore esterno per abilitare la riproduzione con pressione prolungata';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Mostra il selettore di app all\'avvio della riproduzione.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Caricamento dei lettori installati...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Connessione';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Destinazione Transcodifica Audio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Supportato su questo dispositivo';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Non supportato su questo dispositivo';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Invia in bitstream DTS:X (DTS UHD) al decoder esterno.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD con Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Comportamento del Lettore Media';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Miglioramenti della Riproduzione';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Sempre attivo.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Sostituisci Salta Finale con la Schermata Prossimo';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Mostra l\'overlay Prossimo invece del pulsante Salta Finale.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Instradamento del Lettore';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Preferisci i decoder software';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Usa FFmpeg (audio) e libgav1 (AV1) prima dei decoder hardware. Disattiva se il passthrough audio HDMI non funziona.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Apri la riproduzione video nell\'app esterna selezionata su Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Accodamento Automatico';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferisci i sottotitoli SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Dai priorità alle tracce di sottotitoli SDH/CC nella selezione automatica.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnostica web';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnostica Web di Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Usa questa pagina per diagnosticare i problemi di connettività del browser (CORS, contenuti misti e impostazioni di rilevamento).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Rilevato Errore di Contenuto Misto';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Rilevato Errore CORS/Preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin ha rilevato una pagina HTTPS che tenta di chiamare un URL server HTTP. I browser bloccano questa richiesta prima che raggiunga il tuo server.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin ha rilevato un errore di richiesta a livello di browser, comunemente causato da intestazioni CORS o preflight mancanti sul media server.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL di destinazione: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Dettaglio: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Contesto di Runtime Attuale';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Origine';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Modalità Plugin';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Scansione WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL Server Forzato';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL Server Predefinito';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL Proxy di Rilevamento';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'non configurato';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Contenuto Misto';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Questa pagina è caricata via HTTPS, ma uno o più URL configurati sono HTTP. I browser impediscono alle pagine HTTPS di chiamare API HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Soluzione: pubblica il tuo media server o l\'endpoint proxy via HTTPS, oppure carica Moonfin via HTTP solo su reti locali attendibili.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Nessuna configurazione evidente di contenuto misto rilevata dalle impostazioni di runtime attuali.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Checklist CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Consenti l\'origine del browser in Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Includi Authorization, X-Emby-Authorization e X-Emby-Token in Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Esponi Content-Range e Accept-Ranges per lo streaming e la ricerca.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Rispondi con 204 alle richieste preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Esempio di Intestazioni (stile nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Nota';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Questa pagina di diagnostica è pensata per le build web. Se la stai vedendo su un\'altra piattaforma, questi controlli potrebbero non essere pertinenti.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Torna alla Selezione Server';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Disconnetti Tutti gli Utenti';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'L\'autorizzazione al microfono è stata negata definitivamente. Abilitala nelle impostazioni di sistema.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'L\'autorizzazione al microfono è necessaria per la ricerca vocale.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Non ho capito. Riprova.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nessuna voce rilevata.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Errore del microfono.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'La ricerca vocale richiede una connessione a Internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Il servizio vocale è occupato. Riprova.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'L\'autorizzazione al microfono è stata negata definitivamente.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'L\'autorizzazione al microfono è stata negata.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Il riconoscimento vocale non è disponibile su questo dispositivo.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Apri il selettore di uscita iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Il selettore AirPlay non è disponibile su questo dispositivo.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Video';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programmi';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Brani';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Album Fotografici';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Foto';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Persone';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Episodi Usciti di Recente';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Guarda di Nuovo';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Partecipazioni Speciali';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Apparizioni (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Contributi Troupe (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Guarda con il gruppo';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Errori';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Avvisi';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Disco';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Apri nel Browser';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Il browser integrato non è disponibile su questa piattaforma.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Sei sicuro di voler riavviare il server?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Sei sicuro di voler spegnere il server? Dovrai riavviarlo manualmente.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Interno';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inattivo';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nessun utente trovato';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Nessun utente corrisponde alla ricerca';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nessun dispositivo trovato';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Nessun dispositivo corrisponde ai filtri attuali';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Password impostata';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nessuna password configurata';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Accesso Remoto';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Solo Locale';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Impossibile caricare le statistiche dei media';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Statistiche combinate di tutte le librerie multimediali.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Artisti Principali';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Autori Principali';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Collaboratori Principali';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Librerie',
-      one: '1 Libreria',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Nessun totale di media indicizzati disponibile per questa selezione.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Dettagli Libreria';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Ripartizione per Libreria';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Nessuna libreria disponibile.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Amministrazione Server';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Dati';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Cache Immagini';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Registri';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadati';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcodifica';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Nessun percorso restituito da questo server.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% usato';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Attività Utente';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Eventi di Sistema';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Richiede Attenzione';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Riproduzione';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Dispositivi';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avanzate';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Plugin';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV Live';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Video Personali';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Contenuti Misti';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Video Personali e Foto';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Film e Serie Misti';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9519,151 +9466,150 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nessuna registrazione trovata';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Nessuna pagina immagine trovata nell\'archivio .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Renderer integrato non riuscito ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Renderer EPUB non riuscito ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'File locale mancante per il lettore: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status durante l\'apertura dei dati del libro da $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nessun endpoint di lettura disponibile per il libro';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Formato di archivio fumetti non supportato: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Il plugin di estrazione CBR non è disponibile su questa piattaforma.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Impossibile estrarre l\'archivio .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'L\'estrazione CB7 non è disponibile su questa piattaforma.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Il plugin di estrazione CB7 non è disponibile su questa piattaforma.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Chiudi il pannello dei generi';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Caricamento riproduzione casuale...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'CASUALE DALLA LIBRERIA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'CASUALE';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'CASUALE PER GENERE';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Cambio HDR Automatico';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Attiva automaticamente l\'HDR per la riproduzione di video HDR e ripristina la modalità di visualizzazione all\'uscita.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'A schermo intero';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Cambia Immagine';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Mancante';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Limiti di Transcodifica';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Cancellare tutte le immagini?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Sei sicuro di voler cancellare tutte le immagini scaricate?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Conferma Cancellazione';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Sei sicuro di voler cancellare questo $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Caricare?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Risoluzione: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Mostra solo le immagini nella lingua dell\'interfaccia';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Conferma Cancella Tutto';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Immagine caricata con successo!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Impossibile caricare l\'immagine: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Impossibile impostare l\'immagine: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Impossibile eliminare l\'immagine: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Impossibile cancellare tutte le immagini: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Sì';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Sfondi';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9672,31 +9618,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Illustrazione';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Immagine Disco';
+  String get discArtCategory => 'Disc Art';
 
   @override
   String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Copertina';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Retro Copertina';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Immagine Menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'sfondo';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9705,114 +9651,114 @@ class AppLocalizationsIt extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'illustrazione';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'immagine disco';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
   String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'copertina';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'retro copertina';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'immagine menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Tutte';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Media (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Bassa (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fonti';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capitoli';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Segnalibri';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Note';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Coda';
+  String get audiobookQueue => 'Queue';
 
   @override
   String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'La timeline è vuota';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Tutto il Libro';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Timeline Focalizzata';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Esporta Segnalibri';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Esporta Note';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Esporta Tutto';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Esportato in $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Esportazione non riuscita: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Testi';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Aggiungi segnalibro';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Aggiungi nota';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Modifica nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Scrivi una nota per questo momento';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Timer di spegnimento';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Disattivato';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fine del capitolo';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalizzato';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining rimanenti';
+    return '$remaining left';
   }
 
   @override
@@ -9827,51 +9773,51 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Velocità di riproduzione';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Rimanente';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Trascorso';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Indietro ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Avanti ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capitolo precedente';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Capitolo successivo';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capitolo $current di $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Nessun capitolo';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Nessun segnalibro';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Nessuna nota';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Segnalibro aggiunto a $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Reimposta a 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9879,256 +9825,249 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Salva';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Annulla';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Elimina';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferenze Sottotitoli';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Modifica le modalità dei sottotitoli, le lingue predefinite, l\'aspetto e le opzioni di rendering.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Rendering Sottotitoli';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opzioni di Visualizzazione';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data di Uscita (Crescente)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data di Uscita (Decrescente)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Raggruppa Contributi';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Raggruppa più ruoli';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Avviso di Accesso in Scrittura alla Libreria';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Come risolvere:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Concedi i permessi di scrittura all\'utente del servizio Jellyfin (es. jellyfin o PUID/PGID di Docker) sulle cartelle della tua libreria multimediale sul server.\n\n2. Oppure, vai nella Dashboard di Jellyfin -> Librerie, modifica questa libreria e disattiva \'Salva le immagini nelle cartelle dei media\' per archiviare le immagini nel database interno di Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Ignora';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'La tua libreria \'$libraryName\' è configurata per salvare le immagini direttamente nelle cartelle dei media (\'Salva le immagini nelle cartelle dei media\' è attivo). Tuttavia, Jellyfin ha verificato l\'accesso in scrittura e non ha il permesso di scrivere file in questa directory:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Sembra che Jellyfin non sia riuscito ad aggiornare l\'immagine. La tua libreria è configurata per salvare le immagini direttamente nelle cartelle dei media (\'Salva le immagini nelle cartelle dei media\' è attivo). Questo errore si verifica in genere quando il processo del server Jellyfin non ha il permesso di scrivere file nelle tue directory multimediali.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Liste Esterne';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Riproduci di Nuovo';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informazioni File';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Dimensione: $size  •  Formato: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Mostra Tutte le ($count) Tracce Audio';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Mostra Tutte le ($count) Tracce Sottotitoli';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Verifica della capacità di Riproduzione Diretta...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Capacità di Riproduzione Diretta: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Forzato';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Il formato del contenitore non è supportato dal lettore.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Il codec video non è supportato.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Il codec audio non è supportato.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Il formato dei sottotitoli non è supportato (richiede l\'incisione).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Il profilo audio non è supportato.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Il profilo video non è supportato.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Il livello video non è supportato.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'La risoluzione video non è supportata da questo dispositivo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'La profondità di bit del video non è supportata.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Il frame rate del video non è supportato.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Il bitrate del file supera il limite di streaming del lettore.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Il bitrate video supera il limite di streaming.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Il bitrate audio supera il limite di streaming.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Il numero di canali audio non è supportato.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetico';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ordine di Uscita (Crescente)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Ordine di Uscita (Decrescente)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personalizzato (Trascina e Rilascia)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opzioni Ordinamento Playlist';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Ripristina Ordinamento';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Rivedi S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Rivedi Playlist';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nessun sottotitolo trovato.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Controlli Amministratore';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motore di rendering (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller è il moderno renderer GPU di Flutter, per animazioni più fluide e meno scatti. Su alcuni TV box e GPU datate può causare glitch o video nero; in tal caso disattivalo. Automatico sceglie l\'impostazione migliore per il tuo dispositivo. Riavvia Moonfin per applicare la modifica.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatico';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Attivo';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Disattivo';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Riavvio necessario';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin deve riavviarsi per cambiare il motore di rendering. Chiudi l\'app ora, poi riaprila per applicare la modifica.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Chiudi l\'app ora';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Aggiorna Libreria';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Aggiorna Tutte le Librerie';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Data di Aggiunta (Prima i Meno Recenti)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Data di Aggiunta (Prima i Più Recenti)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetico (dalla A alla Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetico (dalla Z alla A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Caricamento delle statistiche del server... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Come la sorgente';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 Film';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 Serie TV';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Film Più Popolari su IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Serie TV Più Popolari su IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Film con Voto Più Basso su IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Migliori Film in Inglese su IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12,27 +12,27 @@ class AppLocalizationsJa extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'アカウント設定';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => '表示言語';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'システムのデフォルト';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'サインイン';
 
   @override
-  String get empty => '空';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName に接続しています';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'クイックコネクト';
 
   @override
   String get password => 'パスワード';
@@ -60,12 +60,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect を利用できません: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect を利用できません ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -79,7 +79,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin バージョン $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -105,14 +105,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '「$serverName」をサーバー一覧から削除しますか?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'キャンセル';
 
   @override
-  String get remove => '削除';
+  String get remove => '取り除く';
 
   @override
   String get connectToServer => 'サーバーに接続する';
@@ -140,59 +140,62 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsAppearanceTheme => 'アプリのテーマ';
 
   @override
-  String get detailScreenStyle => '詳細画面のスタイル';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'クラシックは従来の Moonfin の中央寄せレイアウトです。モダンはレスポンシブなシネマティックレイアウトです。';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'クラシック';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'モダン';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'タブの自動展開';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
-  String get expandedTabsSubtitle => 'タブを移動すると内容を自動的に表示します。オフにすると各タブを手動で開閉します。';
+  String get expandedTabsSubtitle =>
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => '技術情報を表示しますか?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
-  String get showTechnicalDetailsSubtitle => 'バナーの概要にコーデック、解像度、ストリーム情報を表示します';
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'おすすめシステム';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends のローカルライブラリ用アルゴリズム、またはオンラインの TMDb 類似度指標を使用します。注: オンラインのおすすめには Seerr 連携が必要です。';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb 類似度';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
-  String get recommendationsApplyParentalRatingCap => '視聴年齢制限の上限を適用しますか?';
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Moonfin Recommends のおすすめを対象作品の視聴年齢制限で絞り込みます';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'インターフェーススタイル';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '自動はお使いのデバイスに合わせます。Apple または Material を選ぶと外観を固定できます。';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => '自動';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -201,37 +204,38 @@ class AppLocalizationsJa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'グラスの品質';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '自動はこのデバイスに最適なグラス効果を選びます。フルは本物のぼかしを使用し、軽量は GPU 負荷を抑えた軽いグラスを使用します。';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => '自動';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'フル';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => '軽量';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'アプリを再起動せずに Moonfin と Neon Pulse を切り替える';
 
   @override
-  String get customThemeTitle => 'カスタムテーマ';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'カスタムテーマは Moonfin 全体の見た目を変更します。好みに合わせて選択してください。';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'システムのキーボードを優先';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
-  String get keyboardPreferSystemImeDescription => '文字入力に標準でデバイスの入力方式を使用します';
+  String get keyboardPreferSystemImeDescription =>
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -251,14 +255,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      '流れるグラデーション背景、すりガラスの表面、Apple ブルーのアクセントを備えたリキッドグラス風スタイル';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      '太めのパレット、角張った枠線、くっきりしたドロップシャドウ、ピクセルフォントによるレトロなドット絵風スタイル';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Emby Connect アカウントでサインインする';
@@ -303,7 +307,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target に接続できません';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -316,34 +320,35 @@ class AppLocalizationsJa extends AppLocalizations {
   String get exit => '出口';
 
   @override
-  String get gameMenu => 'メニュー';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => '一時停止中';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'ステートセーブ';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ゲーム';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'ステートロード';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => '早送り';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'エミュレーター設定';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'このコアには調整できる設定がありません。';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => '長押しでメニューを開く';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
-  String get gamePlaybackUnsupported => 'このデバイスではまだゲームを実行できません。';
+  String get gamePlaybackUnsupported =>
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ホーム行をロードできませんでした';
@@ -358,7 +363,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get guide => 'ガイド';
 
   @override
-  String get recordings => '録画';
+  String get recordings => '録音';
 
   @override
   String get schedule => 'スケジュール';
@@ -370,7 +375,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noItemsFound => '項目が見つかりませんでした';
 
   @override
-  String get home => 'ホーム';
+  String get home => '家';
 
   @override
   String get browseAll => 'すべて参照';
@@ -400,7 +405,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noLibrariesFound => 'ライブラリが見つかりませんでした';
 
   @override
-  String get library => 'ライブラリ';
+  String get library => '図書館';
 
   @override
   String get displaySettings => '表示設定';
@@ -413,7 +418,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'フォルダーの読み込みに失敗しました: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -421,7 +426,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count 件';
+    return '$count items';
   }
 
   @override
@@ -438,7 +443,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count 件';
+    return '$count Items';
   }
 
   @override
@@ -479,7 +484,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ジャンル';
+    return '$name — Genres';
   }
 
   @override
@@ -517,17 +522,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count 分前';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count 時間前';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count 日前';
+    return '${count}d ago';
   }
 
   @override
@@ -537,7 +542,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get pickDiscoverySubjects => 'Discover に表示する件名フィードを選択します。';
 
   @override
-  String get apply => '適用';
+  String get apply => '適用する';
 
   @override
   String get openLink => 'リンクを開く';
@@ -559,7 +564,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count 作品';
+    return '$count titles';
   }
 
   @override
@@ -584,7 +589,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get listen => '聞く';
 
   @override
-  String get resume => '再開';
+  String get resume => '再開する';
 
   @override
   String get failedToLoadLibrary => 'ライブラリのロードに失敗しました';
@@ -639,17 +644,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count 人の著者';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count ジャンル';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% 完了';
+    return '$percent% completed';
   }
 
   @override
@@ -666,7 +671,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '読書優先で並べた $count 作品。';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -702,7 +707,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$labelが見つかりません';
+    return 'No $label found';
   }
 
   @override
@@ -721,7 +726,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get readStatus => '読む';
 
   @override
-  String get watched => '視聴済み';
+  String get watched => '見た';
 
   @override
   String get unread => '未読';
@@ -739,43 +744,43 @@ class AppLocalizationsJa extends AppLocalizations {
   String get books => '本';
 
   @override
-  String get latestBooks => '最新の書籍';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => '最新のオーディオブック';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 冊',
-      one: '1 冊',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => '書籍';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'オーディオブック';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% 読了';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '残り $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => '読む';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => '聴く';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => '著者';
@@ -812,12 +817,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count セクション';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return '初版 $year 年';
+    return 'First published $year';
   }
 
   @override
@@ -831,7 +836,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count 冊';
+    return '$count books';
   }
 
   @override
@@ -842,7 +847,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count 人の著者';
+    return '$count Authors';
   }
 
   @override
@@ -850,8 +855,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 冊のオーディオブック',
-      one: '1 冊のオーディオブック',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -866,7 +871,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get failedToLoad => 'ロードに失敗しました';
 
   @override
-  String get delete => '削除';
+  String get delete => '消去';
 
   @override
   String get save => '保存';
@@ -887,7 +892,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get nextUp => '次は次へ';
 
   @override
-  String get seasons => 'シーズン';
+  String get seasons => '季節';
 
   @override
   String get chapters => '章';
@@ -899,7 +904,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get movies => '映画';
 
   @override
-  String get musicVideos => 'ミュージックビデオ';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => '他の';
@@ -918,7 +923,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'ディスク $number';
+    return 'Disc $number';
   }
 
   @override
@@ -941,7 +946,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String published(int year) {
-    return '$year 年発行';
+    return 'Published $year';
   }
 
   @override
@@ -952,52 +957,52 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count シーズン',
-      one: '1 シーズン',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time に終了';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'アイテム';
+  String get items => 'Items';
 
   @override
-  String get extras => '特典';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'メイキング';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => '未公開シーン';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'フィーチャレット';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'インタビュー';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'シーン';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => '短編';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => '予告編';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '残り $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time 後に終了';
+    return 'Ends in $time';
   }
 
   @override
@@ -1011,11 +1016,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position から再開';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => '再生';
+  String get play => '遊ぶ';
 
   @override
   String get startOver => '最初からやり直す';
@@ -1042,7 +1047,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get cast => 'キャスト';
 
   @override
-  String get trailer => '予告編';
+  String get trailer => 'トレーラー';
 
   @override
   String get finished => '終了した';
@@ -1109,7 +1114,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '「$title」のダウンロード済みトラックを削除しますか?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1123,17 +1128,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabelが読み込まれていません';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title をダウンロードしています ($count 件)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '「$name」をサーバーから削除してもよろしいですか? この操作は取り消せません。';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1144,7 +1149,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return '対応していない書籍形式です: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1170,7 +1175,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return '字幕をダウンロードして選択しました: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1179,7 +1184,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language のリモート字幕が見つかりませんでした。';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1187,7 +1192,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'バージョン $number';
+    return 'Version $number';
   }
 
   @override
@@ -1207,7 +1212,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name ($quality) をダウンロードしています...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1215,7 +1220,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabelのローカルファイルを削除しますか?\n\nストレージの空き容量が増えます。あとで再ダウンロードできます。';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1231,25 +1236,25 @@ class AppLocalizationsJa extends AppLocalizations {
   String get director => '監督';
 
   @override
-  String get directors => '監督';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => '脚本';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => '脚本家';
+  String get writers => 'ライター';
 
   @override
   String get studio => 'スタジオ';
 
   @override
   String studioMoreCount(int count) {
-    return '他 $count 件';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count エピソード';
+    return '$count Episodes';
   }
 
   @override
@@ -1259,12 +1264,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'エピソード $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'チャプター $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1272,8 +1277,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count トラック',
-      one: '1 トラック',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1283,25 +1288,25 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count チャプター',
-      one: '1 チャプター',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return '生誕 $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return '没年 $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return '$age 歳';
+    return 'Age $age';
   }
 
   @override
@@ -1314,17 +1319,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shuffle => 'シャッフル';
 
   @override
-  String get shuffleAllMusic => 'すべての音楽をシャッフル';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'スマートフォンで Moonfin にサインインしてください';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'サーバーに接続できません';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count ダウンロード';
+    return '$count downloads';
   }
 
   @override
@@ -1336,39 +1341,39 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get mono => 'モノラル';
+  String get mono => '単核症';
 
   @override
   String get stereo => 'ステレオ';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'リモート字幕の$actionには、このユーザーに Jellyfin の字幕管理権限が必要です。';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'リモート字幕の$actionを行うアイテムがサーバー上で見つかりませんでした。';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'リモート字幕の$actionに失敗しました: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'リモート字幕の$actionに失敗しました (HTTP $status)。';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'リモート字幕の$actionに失敗しました。';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '「$name」のダウンロード済みエピソードすべて';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1396,17 +1401,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label の操作に失敗しました: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'キャストの音量を変更できませんでした: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label のコントロール';
+    return '$label Controls';
   }
 
   @override
@@ -1423,7 +1428,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$label を停止';
+    return 'Stop $label';
   }
 
   @override
@@ -1431,7 +1436,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'トラック $number';
+    return 'Track $number';
   }
 
   @override
@@ -1448,7 +1453,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds 秒';
+    return '$seconds seconds';
   }
 
   @override
@@ -1541,7 +1546,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoBitrate => 'ビデオビットレート';
 
   @override
-  String get track => 'トラック';
+  String get track => '追跡';
 
   @override
   String get channels => 'チャンネル';
@@ -1563,12 +1568,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol セッションエラー';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return '書籍の詳細の読み込みに失敗しました: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1577,7 +1582,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'この形式 (.$extension) はまだアプリ内で表示できません。';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1589,17 +1594,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'アプリ内リーダーを開けませんでした: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label にはすでにブックマークがあります。';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'ブックマークを追加しました: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1611,7 +1616,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '$number ページ';
+    return 'Page $number';
   }
 
   @override
@@ -1622,12 +1627,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return '形式: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% 読了';
+    return '$percent% read';
   }
 
   @override
@@ -1650,7 +1655,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'ズームをリセット (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1673,7 +1678,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return '既読状態を更新できませんでした: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1705,7 +1710,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'このプラットフォームでは $extension ファイル用の組み込みドキュメントエンジンを利用できません。';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1744,7 +1749,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return '番組表の読み込みに失敗しました: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1755,22 +1760,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return '次: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '残り $minutes 分';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '残り $hours 時間';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '残り $hours 時間 $minutes 分';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1792,29 +1797,29 @@ class AppLocalizationsJa extends AppLocalizations {
   String get favoriteChannel => 'お気に入りのチャンネル';
 
   @override
-  String get record => '録画予約';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => '録画をキャンセル';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => '番組の録画を予約しました';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => '録画をキャンセルしました';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => '録画を作成できません';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => '視聴';
+  String get watch => '時計';
 
   @override
-  String get close => '閉じる';
+  String get close => '近い';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name を再生できませんでした';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1840,7 +1845,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '「$name」の録画予約をキャンセルしますか?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1866,7 +1871,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '「$name」の録画を停止しますか?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1880,19 +1885,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '「$query」に一致する結果はありません';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return '検索に失敗しました: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr アカウントの種類';
+  String get seerrAccountType => 'シーアアカウントの種類';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1926,12 +1931,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '「$name」とそのファイルを削除しますか?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count トラック';
+    return '$count tracks';
   }
 
   @override
@@ -1942,16 +1947,16 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'アルバムの読み込みに失敗しました: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name のダウンロード済みトラックはありません。';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'シーズン';
+  String get season => '季節';
 
   @override
   String get errorLoadingEpisodes => 'エピソードの読み込みエラー';
@@ -1964,12 +1969,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '「$name」を削除しますか?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes 分';
+    return '$minutes min';
   }
 
   @override
@@ -1979,7 +1984,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'エピソード $number';
+    return 'Episode $number';
   }
 
   @override
@@ -1993,7 +1998,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'シーズン $number';
+    return 'Season $number';
   }
 
   @override
@@ -2009,7 +2014,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season のダウンロード済みエピソードをすべて削除しますか?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2017,8 +2022,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count エピソード',
-      one: '1 エピソード',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2053,7 +2058,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'ダウンロード済みの $count 件を削除しますか?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2067,7 +2072,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '/ 上限 $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2148,7 +2153,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count 項目';
+    return '$count options';
   }
 
   @override
@@ -2237,7 +2242,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get themeMusicVolume => 'テーマ曲の音量';
 
   @override
-  String get themeMusicSettingsSubtitle => '詳細ページ、ホーム行、音量';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2251,10 +2257,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'ホーム画面閲覧時に再生';
 
   @override
-  String get loopThemeMusic => 'テーマ音楽をループ再生';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => '1 回だけ再生せずにトラックを繰り返します';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => '詳細背景ぼかし';
@@ -2277,23 +2284,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get playerZoomMode => 'プレーヤーズームモード';
 
   @override
-  String get settingsScrollWheelAction => 'マウスホイール';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      '再生中に映像の上でマウスホイールを回したときの動作を選択します。';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'オフ';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'シーク (前後移動)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => '音量';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => '音量';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'フィット';
@@ -2344,35 +2351,37 @@ class AppLocalizationsJa extends AppLocalizations {
   String get defaultAudioLanguage => 'デフォルトの音声言語';
 
   @override
-  String get fallbackAudioLanguage => '代替オーディオ言語';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => '既定のオーディオトラックを優先';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      '吹き替えよりもオリジナルのオーディオトラックを優先します。';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => '音声解説トラックを優先';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
-  String get preferAudioDescriptionDescription => '通常のトラックよりも音声解説トラックを優先します。';
+  String get preferAudioDescriptionDescription =>
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'トランスコード (オーディオ)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'ダイレクトストリーム (リマックス)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
-  String get transcodingBitrateOrResolution => 'トランスコード (ビットレートまたは解像度)';
+  String get transcodingBitrateOrResolution =>
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'トランスコード (映像とオーディオ)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'トランスコード (映像)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => '自動 (サーバーのデフォルト)';
@@ -2449,27 +2458,27 @@ class AppLocalizationsJa extends AppLocalizations {
       'TrueHD オーディオを有効にする (プラットフォームによっては機能しない場合があります)';
 
   @override
-  String get settingsAudioOutputMode => 'オーディオ出力モード';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'オーディオのデコード方法を選択します。AVR パススルーは Dolby / DTS のストリームをそのままレシーバーに送信し、自動またはダウンミックスは本体でデコードします。';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR パススルー';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => '代替オーディオコーデック';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      '元のストリームをダイレクト再生もパススルーもできない場合に、マルチチャンネルオーディオを変換する形式を選択します。';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => '自動検出\n(推奨)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(既定)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2478,113 +2487,113 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ロスレス)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ステレオのみ)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(高効率)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ロスレス)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => '最大オーディオチャンネル数';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'お使いのオーディオ環境の最大チャンネル数を設定します。この上限を超えるマルチチャンネルストリームはダウンミックスまたはトランスコードされます。';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => '自動検出\n(ハードウェアの既定)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 モノラル';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ステレオ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 サラウンド';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 クアドラフォニック';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 サラウンド';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 サラウンド';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 サラウンド';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 サラウンド';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'パススルー (詳細設定)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'コーデックパススルー';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'お使いの AVR または HDMI 出力先が対応している形式のみを有効にしてください。';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 パススルー';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) パススルー';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS コアパススルー';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA パススルー';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD パススルー';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos パススルー';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) を外部デコーダーにビットストリーム出力します。';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) の Dolby Atmos を外部デコーダーにビットストリーム出力します。';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS コアを含む) を外部デコーダーにビットストリーム出力します。';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos メタデータ付きの Dolby TrueHD を外部デコーダーにビットストリーム出力します。';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => '検出されたオーディオ機能';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      '実行時の機能情報はまだ取得されていません。';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => '出力経路';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'デコード';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'パススルー';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD オーディオ対応の経路';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2599,10 +2608,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'スピーカー';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'ヘッドホン';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2610,37 +2619,39 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => '診断情報';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'ビデオレベル';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'ビデオレンジ';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => '字幕コーデック';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => '許可するオーディオコーデック';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS オーディオコーデック';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 オーディオコーデック';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif パススルー';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => '現在のオーディオ出力経路';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
-  String get settingsAudioDiagnosticsRouteHdAudioSupport => '経路の HD オーディオ対応状況';
+  String get settingsAudioDiagnosticsRouteHdAudioSupport =>
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'ナイトモード';
@@ -2688,7 +2699,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value秒';
+    return '${value}s';
   }
 
   @override
@@ -2702,7 +2713,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes エピソード / $hours 時間ごと';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2777,42 +2788,45 @@ class AppLocalizationsJa extends AppLocalizations {
   String get subtitleCustomizationDescription => '字幕の外観をカスタマイズする';
 
   @override
-  String get subtitleMode => '字幕モード';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'フラグ付き';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => '常に表示';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => '外国語';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => '強制';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'メディアファイルのメタデータで「デフォルト」または「強制」とフラグが付いたトラックを再生します。';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
-  String get subtitleModeAlwaysDescription => '動画の再生開始時に、常に字幕を読み込んで表示します。';
+  String get subtitleModeAlwaysDescription =>
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      '既定のオーディオトラックが外国語の場合に、自動的に字幕をオンにします。';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
-  String get subtitleModeForcedDescription => '強制フラグが明示的に付いた字幕のみを読み込みます。';
+  String get subtitleModeForcedDescription =>
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
-  String get subtitleModeNoneDescription => '字幕の自動読み込みを完全に無効にします。';
+  String get subtitleModeNoneDescription =>
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => '代替字幕言語';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => '字幕ストリーム';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => '素早い茶色のキツネが怠惰な犬を飛び越える';
@@ -2870,17 +2884,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile プロファイルの設定を読み込みました。';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile プロファイルの設定を読み込めませんでした。';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'ローカル設定を $profile プロファイルに同期しました。';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3014,10 +3028,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showLibrariesInToolbar => 'ツールバーにライブラリを表示';
 
   @override
-  String get navbarAlwaysExpanded => 'ナビゲーションバーのラベルを常に表示';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr ボタンを表示';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'ナビゲーションバーの不透明度';
@@ -3089,18 +3103,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showFolderBrowsingOption => 'フォルダー参照オプションを表示する';
 
   @override
-  String get groupItemsIntoCollections => 'アイテムをコレクションにまとめる';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ライブラリの閲覧時にコレクションに含まれるアイテムを非表示にします';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'ライブラリのグループ化について';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'この設定を使用するには、Jellyfin または Emby サーバーのライブラリの表示設定で「映画をコレクションにまとめる」または「番組をコレクションにまとめる」が有効になっていることを確認してください。';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'ライブラリの可視性';
@@ -3129,7 +3143,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count 件を選択中';
+    return '$count selected';
   }
 
   @override
@@ -3209,10 +3223,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoPlayTrailers => '3 秒後にメディア バーでトレーラーを自動再生します';
 
   @override
-  String get trailerAudio => '予告編のオーディオ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'メディアバーの予告編でオーディオを有効にします';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'エピソードのプレビュー';
@@ -3286,10 +3300,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get combineBothRows => '両方の行を 1 つのホーム セクションに結合します';
 
   @override
-  String get fullScreenRows => 'ホーム行を拡大表示';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => '1 画面に表示するホーム行を 1 行に制限します';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => '行ごとの画像タイプ';
@@ -3304,7 +3318,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lastUser => '最後のユーザー';
 
   @override
-  String get currentUser => '現在のユーザー';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '常に認証する';
@@ -3374,7 +3388,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes 分';
+    return '$minutes min';
   }
 
   @override
@@ -3404,10 +3418,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get displayClockDuringScreensaver => 'スクリーンセーバー中に時計を表示する';
 
   @override
-  String get clockModeStatic => '固定';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'バウンド';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'ロッテン・トマト (批評家)';
@@ -3428,7 +3442,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get metacriticUser => 'Metacritic (ユーザー)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'トラクト';
 
   @override
   String get letterboxd => 'レターボックスd';
@@ -3476,7 +3490,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get ratingSourcesDescription => 'アプリ全体に表示される評価ソースを有効にして並べ替える';
 
   @override
-  String get pluginLabel => 'Moonbase プラグイン';
+  String get pluginLabel => 'プラグイン';
 
   @override
   String get pluginDetected => 'プラグインが検出されました';
@@ -3494,7 +3508,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nバージョン: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3547,13 +3561,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get networks => 'ネットワーク';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr のディスカバリー行';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => '行をデフォルトにリセットする';
 
   @override
-  String get enableSeerr => 'Seerr を有効にする';
+  String get enableSeerr => 'Seer を有効にする';
 
   @override
   String get showSeerrInNavigation => 'ナビゲーションに Seerr を表示 (サーバープラグインが必要)';
@@ -3568,41 +3582,43 @@ class AppLocalizationsJa extends AppLocalizations {
   String get hideAdultContent => '結果内のアダルト コンテンツを非表示にする';
 
   @override
-  String get seerrNotificationsSection => '通知';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => '新規リクエストの通知';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => '誰かがリクエストを送信したときに通知します';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'リクエストの更新';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
-  String get seerrNotifyLibraryAddedSubtitle => '承認、却下、ライブラリへの追加';
+  String get seerrNotifyLibraryAddedSubtitle =>
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => '問題の更新';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => '新しい問題、返信、解決';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'ログイン中: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr ディスカバリーページ';
+  String get discoverRows => '行の発見';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr のメインページに表示する行を有効にします。ドラッグして並べ替えられます。カスタムの並び順は Moonbase と同期されます。';
+      'ドラッグして並べ替えます。行を有効または無効にします。 Moonfin プラグインとの行順序の同期が有効になりました。';
 
   @override
-  String get discoverRowsDescription =>
-      'Seerr のメインページに表示する行を有効にします。ドラッグして並べ替えられます。カスタムの並び順は Moonbase と同期されます。';
+  String get discoverRowsDescription => 'ドラッグして並べ替えます。行を有効または無効にします。';
 
   @override
   String get enabled => '有効';
@@ -3615,7 +3631,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'バージョン $version';
+    return 'Version $version';
   }
 
   @override
@@ -3659,7 +3675,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'アップデートがあります: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3670,7 +3686,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version が利用可能です';
+    return 'v$version Available';
   }
 
   @override
@@ -3745,19 +3761,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'ダウンロード中 · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => '取り込み中';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count 件';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr 設定';
+  String get seerrSettings => 'シーラー設定';
 
   @override
   String get requestMore => 'さらにリクエスト';
@@ -3773,7 +3789,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name がリクエスト';
+    return 'Requested by $name';
   }
 
   @override
@@ -3790,12 +3806,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '「$title」のリクエストをキャンセルしますか?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '「$title」の $count 件のリクエストをキャンセルしますか?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3809,12 +3825,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return '製作費: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return '興行収入: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3824,7 +3840,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$typeをリクエスト';
+    return 'Request $type';
   }
 
   @override
@@ -3852,14 +3868,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showMore => 'もっと見る';
 
   @override
-  String get appearances => '出演作品';
+  String get appearances => '出演';
 
   @override
   String get crewSection => 'クルー';
 
   @override
   String ageValue(int age) {
-    return '$age 歳';
+    return 'age $age';
   }
 
   @override
@@ -3890,146 +3906,148 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deletedStatus => '削除されました';
 
   @override
-  String get failedStatus => '失敗';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => '処理中';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name が更新';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => '完了';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'このタイトルはすでにリクエスト済みです';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'リクエストの上限に達しました';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'このタイトルはブロックリストに登録されています';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'リクエストできるシーズンがありません';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'このリクエストを行う権限がありません';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'リクエスト';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => '問題';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => '新着順';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => '更新順';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => '問題はありません';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '映画のリクエスト残り $remaining / $limit 件';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'シーズンのリクエスト残り $remaining / $limit 件';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name の一部';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'コレクションを表示';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'コレクションをリクエスト';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total 本の映画 · $available 本が視聴可能';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count 本の映画をリクエスト';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'リクエスト中 $current / $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count 本の映画をリクエストしました';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total 本中 $ok 本の映画をリクエストしました';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'すべての映画は視聴可能かリクエスト済みです';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => '問題を報告';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => '映像';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'オーディオ';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'どのような問題ですか?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => '全エピソード';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'エピソード';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => '未解決';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => '解決済み';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => '解決にする';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => '再開する';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name が報告';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count 件のコメント';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'コメントを追加';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'この問題を削除しますか?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => '報告を送信';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDBスコア';
@@ -4053,7 +4071,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get originalLanguageLabel => '元の言語';
 
   @override
-  String get seasonsLabel => 'シーズン';
+  String get seasonsLabel => '季節';
 
   @override
   String get episodesLabel => 'エピソード';
@@ -4086,7 +4104,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get disable => '無効にする';
 
   @override
-  String get done => '完了';
+  String get done => '終わり';
 
   @override
   String get edit => '編集';
@@ -4098,10 +4116,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get error => 'エラー';
 
   @override
-  String get forward => '進む';
+  String get forward => 'フォワード';
 
   @override
-  String get general => '一般';
+  String get general => '一般的な';
 
   @override
   String get go => '行く';
@@ -4122,7 +4140,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get networking => 'ネットワーキング';
 
   @override
-  String get next => '次へ';
+  String get next => '次';
 
   @override
   String get path => 'パス';
@@ -4191,7 +4209,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get time => '時間';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'トリックプレイ';
 
   @override
   String get uninstall => 'アンインストール';
@@ -4230,28 +4248,28 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminDrawerUsers => 'ユーザー';
 
   @override
-  String get adminDrawerLibraries => 'ライブラリ';
+  String get adminDrawerLibraries => '図書館';
 
   @override
-  String get adminDrawerDisplay => '表示';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'メタデータ';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO 設定';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'トランスコーディング';
 
   @override
-  String get adminDrawerResume => '再開';
+  String get adminDrawerResume => '再開する';
 
   @override
   String get adminDrawerStreaming => 'ストリーミング';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'トリックプレイ';
 
   @override
   String get adminDrawerDevices => 'デバイス';
@@ -4301,22 +4319,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return '更新可能なプラグイン: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return '再起動が必要なプラグイン: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return '失敗したスケジュールタスク: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return '最近の警告/エラー件数: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4375,7 +4393,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'エラー: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4401,7 +4419,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'コマンドに失敗しました: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4420,13 +4438,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sessionRewind => '巻き戻し';
 
   @override
-  String get sessionForward => '早送り';
+  String get sessionForward => 'フォワード';
 
   @override
-  String get sessionNext => '次へ';
+  String get sessionNext => '次';
 
   @override
-  String get sessionVolumeDown => '音量 –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
   String get sessionVolumeUp => '巻+';
@@ -4465,14 +4483,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminClearDates => '日付を明確にする';
 
   @override
-  String get adminActivitySeverityAll => 'すべての重要度';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => '期間';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'アクティビティログの読み込みに失敗しました: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4489,7 +4507,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'デバイスを更新できませんでした: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4500,28 +4518,28 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'デバイスを削除できませんでした: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'デバイス「$name」を削除しますか? このデバイスでは再度サインインが必要になります。';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'すべてのデバイスを削除';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count 台のデバイスを削除しますか? 対象のユーザーは再度サインインが必要になります。現在お使いのデバイスは影響を受けません。';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'デバイスを削除しました';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return '一部のデバイスを削除しました。$count 台は削除できませんでした。';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4550,7 +4568,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'スキャンを開始できませんでした: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4561,12 +4579,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'ライブラリの名前を「$name」に変更しました';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return '名前を変更できませんでした: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4574,17 +4592,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'ライブラリ「$name」を削除しました';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'ライブラリを削除できませんでした: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'パスを追加できませんでした: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4592,12 +4610,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'このライブラリから「$path」を削除しますか?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'パスを削除できませんでした: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4605,7 +4623,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return '設定を保存できませんでした: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4636,236 +4654,251 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminMetadataCountryHint => '例えば米国、ドイツ、フランス';
 
   @override
-  String get adminLibraryTabPaths => 'パス';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'オプション';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ダウンローダー';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'メタデータの保存先';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => '字幕ダウンローダー';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => '歌詞ダウンローダー';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'メタデータダウンローダー: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return '画像取得元: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
-  String get adminLibNoDownloaders => 'このサーバーには、このライブラリ種別で利用できるダウンローダーがありません。';
+  String get adminLibNoDownloaders =>
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => '一般';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'メタデータ';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => '埋め込み情報';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => '字幕';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => '画像';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'シリーズ';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => '音楽';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => '映画';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'リアルタイム監視を有効にする';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
-  String get adminLibRealtimeMonitorHint => 'ファイルの変更を検出して自動的に処理します。';
+  String get adminLibRealtimeMonitorHint =>
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'アーカイブをメディアファイルとして扱う';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => '写真を表示する';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'アートワークをメディアフォルダーに保存する';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'メタデータの自動更新';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'しない';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'デフォルト';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => '表示';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'ライブラリの表示';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
-  String get adminLibFolderView => '通常のメディアフォルダーを表示するフォルダービューを表示する';
+  String get adminLibFolderView =>
+      'Display a folder view to show plain media folders';
 
   @override
-  String get adminLibSpecialsInSeasons => '特別編を放送されたシーズン内に表示する';
+  String get adminLibSpecialsInSeasons =>
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => '映画をコレクションにまとめる';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => '番組をコレクションにまとめる';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'おすすめに外部コンテンツを表示する';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => '追加日の扱い';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => '追加日として使用する日付';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'ライブラリにスキャンされた日付';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ファイルが作成された日付';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'メタデータと画像';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => '優先するメタデータの言語';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'チャプター';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ダミーチャプターの長さ (秒)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'チャプターがないメディア用に生成するチャプターの長さ。0 にすると無効になります。';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'チャプター画像の解像度';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO 設定';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO メタデータは Kodi などのクライアントと互換性があります。設定は NFO メタデータを保存するすべてのライブラリに適用されます。';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'NFO ファイルに視聴データを保存するユーザー';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO ファイルに画像のパスを保存する';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
-  String get adminLibPathSubstitution => 'NFO の画像パスでパス置換を有効にする';
+  String get adminLibPathSubstitution =>
+      'Enable path substitution for NFO image paths';
 
   @override
-  String get adminLibExtraThumbs => 'extrafanart の画像を extrathumbs フォルダーにコピーする';
+  String get adminLibExtraThumbs =>
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'なし';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days 日';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => '埋め込みタイトルを使用する';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => '特典に埋め込みタイトルを使用する';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => '埋め込みのエピソード情報を使用する';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => '埋め込み字幕を許可する';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'すべて許可';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'テキストのみ';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => '画像のみ';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'なし';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
-  String get adminLibSkipIfEmbeddedSubs => '埋め込み字幕がある場合はダウンロードをスキップする';
+  String get adminLibSkipIfEmbeddedSubs =>
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'オーディオトラックがダウンロード言語と一致する場合はダウンロードをスキップする';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => '字幕の完全一致を必須にする';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => '字幕をメディアフォルダーに保存する';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'チャプター画像を抽出する';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
-  String get adminLibChapterImagesDuringScan => 'ライブラリのスキャン中にチャプター画像を抽出する';
+  String get adminLibChapterImagesDuringScan =>
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Trickplay画像の抽出を有効にする';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
-  String get adminLibTrickplayDuringScan => 'ライブラリのスキャン中にTrickplay画像を抽出する';
+  String get adminLibTrickplayDuringScan =>
+      'Extract trickplay images during the library scan';
 
   @override
-  String get adminLibSaveTrickplayWithMedia => 'Trickplay画像をメディアフォルダーに保存する';
+  String get adminLibSaveTrickplayWithMedia =>
+      'Save trickplay images into media folders';
 
   @override
-  String get adminLibAutomaticSeriesGrouping => '複数のフォルダーに分かれたシリーズを自動的に統合する';
+  String get adminLibAutomaticSeriesGrouping =>
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'シーズン 0 の表示名';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => '音量正規化のための LUFS スキャンを有効にする';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
-  String get adminLibPreferNonstandardArtist => '非標準のアーティストタグを優先する';
+  String get adminLibPreferNonstandardArtist =>
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => '映画を自動的にコレクションに追加する';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'ライブラリ名は必須です';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'ライブラリを作成できませんでした: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4891,27 +4924,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name を無効にしますか? サインインできなくなります。';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name を有効にしますか? 再びサインインできるようになります。';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'ユーザー「$name」を無効にしました';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'ユーザー「$name」を有効にしました';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'ユーザーポリシーを更新できませんでした: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -4928,7 +4961,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'ユーザーを作成できませんでした: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -4948,7 +4981,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return '保存できませんでした: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -4959,7 +4992,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return '失敗しました: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5089,138 +5122,143 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminEnableAllChannels => 'すべてのチャンネルへのアクセスを有効にする';
 
   @override
-  String get adminParentalControl => 'ペアレンタルコントロール';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => '許可する視聴年齢制限の上限';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'これより高いレーティングのコンテンツは、このユーザーには表示されません。';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'なし';
+  String get adminParentalRatingNone => 'None';
 
   @override
-  String get adminBlockUnratedItems => 'レーティング情報がない、または認識できないアイテムをブロックする';
+  String get adminBlockUnratedItems =>
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => '書籍';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'チャンネル';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ライブ TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => '映画';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => '音楽';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => '予告編';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => '番組';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'アクセススケジュール';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      '以下のスケジュールの時間帯のみアクセスを許可します。スケジュールを設定しない場合は終日アクセスできます。';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'スケジュールを追加';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => '曜日';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => '開始';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => '終了';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => '毎日';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => '平日';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => '週末';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => '日曜日';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => '月曜日';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => '火曜日';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => '水曜日';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => '木曜日';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => '金曜日';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => '土曜日';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => '許可するタグ';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
-  String get adminAllowedTagsHint => 'これらのタグが付いたコンテンツのみを表示します。空欄にするとすべて許可されます。';
+  String get adminAllowedTagsHint =>
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'ブロックするタグ';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
-  String get adminBlockedTagsHint => 'これらのタグが付いたコンテンツは、このユーザーには表示されません。';
+  String get adminBlockedTagsHint =>
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'タグを追加';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => '有効なデバイス';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => '有効なチャンネル';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => '認証プロバイダー';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'パスワードリセットプロバイダー';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
-  String get adminLoginAttemptsBeforeLockout => 'ロックアウトまでのログイン失敗回数の上限';
+  String get adminLoginAttemptsBeforeLockout =>
+      'Maximum failed login attempts before lockout';
 
   @override
-  String get adminLoginAttemptsHint => '0 で既定値、-1 でロックアウトを無効にします。';
+  String get adminLoginAttemptsHint =>
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay のアクセス権';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'グループの作成と参加を許可する';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'グループへの参加を許可する';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'アクセスなし';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'コンテンツの削除を許可する場所';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5228,22 +5266,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'サーバーが HTTP $status を返しました';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name を削除してもよろしいですか?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'ユーザー「$name」を削除しました';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'ユーザーを削除できませんでした: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5264,7 +5302,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'キーを作成できませんでした: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5275,7 +5313,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name のキーを無効化しますか?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5283,7 +5321,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'キーを無効化できませんでした: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5303,29 +5341,29 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'トークン: $token\\n作成日時: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'バックアップを作成';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'バックアップに含める項目を選択してください。';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'データベース';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => '常に含まれます';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'メタデータ';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => '字幕';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay画像';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'バックアップを作成しています...';
@@ -5335,7 +5373,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'バックアップを作成できませんでした: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5343,12 +5381,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'マニフェスト: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'マニフェストを読み込めませんでした: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5359,7 +5397,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'バックアップを復元できませんでした: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5391,17 +5429,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path に保存しました';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ファイルを保存できませんでした: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName を読み込めませんでした';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5412,7 +5450,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'タスクの読み込みに失敗しました: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5423,17 +5461,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'タスクを開始できませんでした: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'タスクを停止できませんでした: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'タスクの読み込みに失敗しました: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5441,12 +5479,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'トリガーを削除できませんでした: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'トリガーを追加できませんでした: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5472,7 +5510,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours 時間';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5483,7 +5521,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'プラグインを切り替えられませんでした: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5491,27 +5529,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '「$name」をアンインストールしてもよろしいですか?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'プラグインをアンインストールできませんでした: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'パッケージをインストールできませんでした: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'アップデートをインストールできませんでした: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'プラグインの読み込みに失敗しました: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5522,12 +5560,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'アップデートをインストール (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'カタログの読み込みに失敗しました: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5548,17 +5586,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '「$name」はサーバーの再起動後に削除されます';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'アンインストールできませんでした: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '「$name」を v$version に更新しています...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5566,7 +5604,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'プラグインの読み込みに失敗しました: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5574,7 +5612,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'バージョン $version';
+    return 'Version $version';
   }
 
   @override
@@ -5594,17 +5632,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '「$name」を削除してもよろしいですか?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'リポジトリを保存できませんでした: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'リポジトリの読み込みに失敗しました: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5621,12 +5659,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'プラグイン設定を読み込めません: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri を開けませんでした';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5742,10 +5780,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminThrottleBuffering => 'スロットルバッファリング';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay 設定が保存されました';
+  String get adminTrickplaySaved => 'トリックプレイ設定が保存されました';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay 設定の読み込みに失敗しました';
+  String get adminTrickplayLoadFailed => 'トリックプレイ設定のロードに失敗しました';
 
   @override
   String get adminEnableHardwareAcceleration => 'ハードウェアアクセラレーションを有効にする';
@@ -5847,7 +5885,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminBaseUrl => 'ベース URL';
 
   @override
-  String get adminBaseUrlHint => '例: /jellyfin';
+  String get adminBaseUrlHint => '例えば/ジェリーフィン';
 
   @override
   String get https => 'HTTPS';
@@ -5887,12 +5925,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'メタデータの読み込みに失敗しました: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'メタデータを保存できませんでした: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -5912,7 +5950,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'メタデータを更新できませんでした: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -5926,7 +5964,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'リモート検索に失敗しました: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -5940,7 +5978,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'コンテンツ種別を更新できませんでした: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -5954,12 +5992,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType 画像を更新しました';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return '画像をダウンロードできませんでした: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -5970,27 +6008,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType 画像をアップロードしました';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return '画像をアップロードできませんでした: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType 画像を削除';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType 画像を削除しました';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return '画像を削除できませんでした: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6001,65 +6039,67 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'チューナーの検出に失敗しました: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'チューナーの追加';
 
   @override
-  String get adminEditTuner => 'チューナーを編集';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U チューナー';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ファイルまたは URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'チューナーの IP アドレス';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => '表示名';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'ユーザーエージェント';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => '同時接続数の上限';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
-  String get adminTunerCountHelp => 'チューナーが同時に許可するストリームの最大数です。0 にすると無制限になります。';
+  String get adminTunerCountHelp =>
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => '代替の最大ストリーミングビットレート';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'お気に入りチャンネルのみを取り込む';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'ハードウェアトランスコードを許可する';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 トランスコードコンテナーを許可する';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ストリームの共有を許可する';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ストリームのループを有効にする';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS を無視する';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
-  String get adminTunerReadAtNativeFramerate => '入力をネイティブのフレームレートで読み込む';
+  String get adminTunerReadAtNativeFramerate =>
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'プロバイダーを編集';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6068,49 +6108,50 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ファイルまたは URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => '映画の接頭辞';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => '映画のカテゴリー';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => '複数のカテゴリーは縦棒 (|) で区切ってください。';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'キッズのカテゴリー';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'ニュースのカテゴリー';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'スポーツのカテゴリー';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ユーザー名';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'パスワード';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => '国';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => '国を選択';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => '郵便番号';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => '番組リストを取得';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => '番組リスト';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'すべてのチューナーを有効にする';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'チューナーの種類';
@@ -6120,7 +6161,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'チューナーを追加できませんでした: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6134,12 +6175,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'プロバイダーを追加できませんでした: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'チューナーを削除できませんでした: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6147,15 +6188,16 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'チューナーをリセットできませんでした: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported => 'この種類のチューナーはリセットに対応していません。';
+  String get adminTunerResetNotSupported =>
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'プロバイダーを削除できませんでした: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6174,43 +6216,43 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'シリーズ録画パス';
 
   @override
-  String get adminMovieRecordingPath => '映画の録画先パス';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => '番組表データの日数';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => '自動';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days 日';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => '後処理アプリケーションのパス';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => '後処理の引数';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => '録画の NFO メタデータを保存する';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => '録画の画像を保存する';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'タイミング';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => '録画先パス';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => '後処理';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return '番組表データ: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6218,7 +6260,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return '設定を保存できませんでした: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6235,7 +6277,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'マッピングを更新できませんでした: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6251,13 +6293,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminGuideProviders => 'ガイドプロバイダー';
 
   @override
-  String get adminRefreshGuideData => '番組表データを更新';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => '番組表データの更新を開始しました';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
-  String get adminGuideRefreshUnavailable => 'このサーバーでは番組表の更新タスクを利用できません。';
+  String get adminGuideRefreshUnavailable =>
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'プロバイダーの追加';
@@ -6267,22 +6310,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return '録画先パス: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'シリーズのパス: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return '前の余裕時間: $minutes 分';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return '後の余裕時間: $minutes 分';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6312,7 +6355,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'バックアップ $name を今すぐ復元しますか?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6335,7 +6378,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminLiveTvTitle => 'ライブ TV 管理';
 
   @override
-  String get adminApply => '適用';
+  String get adminApply => '適用する';
 
   @override
   String get adminNotSet => '未設定';
@@ -6357,27 +6400,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes 分前';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours 時間前';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days 日前';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName を読み込めませんでした';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count 件一致';
+    return '$count matches';
   }
 
   @override
@@ -6387,7 +6430,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminMetadataEditorTitle => 'メタデータエディター';
 
   @override
-  String get adminMetadataIdentify => '識別';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'タイプ';
@@ -6487,22 +6530,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType 画像を更新しました';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType 画像をアップロードしました';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType 画像を削除しました';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return '画像をダウンロードできませんでした: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6510,12 +6553,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return '画像をアップロードできませんでした: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType 画像を削除';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6523,12 +6566,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return '画像を削除できませんでした: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType 画像を選択';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6560,7 +6603,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'アップデートがあります: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6583,7 +6626,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'アップデートをインストール (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6594,7 +6637,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '「$name」をインストールしています...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6614,7 +6657,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name の設定';
+    return '$name Settings';
   }
 
   @override
@@ -6652,7 +6695,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'リポジトリの読み込みに失敗しました: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6660,15 +6703,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '「$name」を削除してもよろしいですか?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => '削除';
+  String get adminReposRemove => '取り除く';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'リポジトリを保存できませんでした: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6790,19 +6833,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'スプラッシュスクリーンを有効にする';
 
   @override
-  String get adminBrandingSplashUpload => '画像をアップロード';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'スプラッシュ画面を更新しました';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'スプラッシュ画面をアップロードできませんでした';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'スプラッシュ画面を削除しました';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'カスタムスプラッシュ画面はありません';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'ハードウェアアクセラレーション';
@@ -6817,115 +6860,121 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => '以下のハードウェア デコードを有効にします。';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV デバイス';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => '拡張 NVDEC デコーダーを有効にする';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
-  String get adminPlaybackPreferNativeDecoder => 'システム標準のハードウェアデコーダーを優先する';
+  String get adminPlaybackPreferNativeDecoder =>
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'ハードウェアデコードの色深度';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10 ビット HEVC デコード';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10 ビット VP9 デコード';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10 ビットデコード';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12 ビットデコード';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'ハードウェアエンコード';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC エンコードを許可する';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 エンコードを許可する';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
-  String get adminPlaybackIntelLowPowerH264 => 'Intel 低消費電力 H.264 エンコーダーを有効にする';
+  String get adminPlaybackIntelLowPowerH264 =>
+      'Enable Intel low-power H.264 encoder';
 
   @override
-  String get adminPlaybackIntelLowPowerHevc => 'Intel 低消費電力 HEVC エンコーダーを有効にする';
+  String get adminPlaybackIntelLowPowerHevc =>
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'トーンマッピング';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'トーンマッピングを有効にする';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP トーンマッピングを有効にする';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
-  String get adminPlaybackEnableVtTonemapping => 'VideoToolbox トーンマッピングを有効にする';
+  String get adminPlaybackEnableVtTonemapping =>
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'トーンマッピングのアルゴリズム';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'トーンマッピングのモード';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'トーンマッピングのレンジ';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'トーンマッピングの彩度低下';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'トーンマッピングのピーク';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'トーンマッピングのパラメーター';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'VPP トーンマッピングの明るさ';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP トーンマッピングのコントラスト';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'プリセットと画質';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'エンコーダープリセット';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 エンコードの CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) エンコードの CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'インターレース解除の方式';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
-  String get adminPlaybackDeinterlaceDoubleRate => 'インターレース解除時にフレームレートを 2 倍にする';
+  String get adminPlaybackDeinterlaceDoubleRate =>
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'オーディオ';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'オーディオの VBR エンコードを有効にする';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'オーディオダウンミックスのブースト';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ステレオダウンミックスのアルゴリズム';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => '多重化キューの最大サイズ';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => '自動';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'エンコーディング';
@@ -7039,7 +7088,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminTaskStop => '停止';
 
   @override
-  String get adminRunningTasks => '実行中のタスク';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => '走る';
@@ -7061,17 +7110,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return '毎日 $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return '毎週$day $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return '$durationごと';
+    return 'Every $duration';
   }
 
   @override
@@ -7109,8 +7158,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 時間',
-      one: '1 時間',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7138,17 +7187,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days 日前';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours 時間前';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes 分前';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7156,17 +7205,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes 分';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours 時間';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days 日';
+    return '${days}d';
   }
 
   @override
@@ -7175,8 +7224,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get adminTrickplayDescription =>
-      'シークプレビューのサムネイル用に Trickplay 画像の生成を設定します。';
+  String get adminTrickplayDescription => 'シークプレビューサムネイル用のトリックプレイ画像生成を設定します。';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'パブリックHTTPSポート';
@@ -7185,49 +7233,49 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'ベース URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => '例: /jellyfin';
+  String get adminNetworkingBaseUrlHint => '例えば/ジェリーフィン';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => '公開 HTTP ポート';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS を必須にする';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'リモートからのリクエストをすべて HTTPS にリダイレクトします。サーバーに有効な証明書がない場合は効果がありません。';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => '証明書のパスワード';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP 設定';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 を有効にする';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 を有効にする';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'ポートの自動マッピングを有効にする';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN ネットワーク';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'ローカルネットワークとして扱う IP アドレスまたは CIDR サブネットを、カンマまたは改行で区切って入力します。';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => '公開サーバー URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'サブネットまたはアドレスを公開 URL に対応付けます (例: all=https://example.com)';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => '証明書のパス';
@@ -7257,10 +7305,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'スロットルバッファリング';
 
   @override
-  String get adminPlaybackThrottleDelay => 'スロットリングの遅延 (秒)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
-  String get adminPlaybackEnableSubtitleExtraction => '字幕のオンザフライ抽出を許可する';
+  String get adminPlaybackEnableSubtitleExtraction =>
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => '最低履歴書の割合';
@@ -7307,29 +7356,29 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'コンテンツ種別を更新できませんでした: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => '低速応答しきい値 (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => '応答遅延の警告を有効にする';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect を有効にする';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'サーバー';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'メタデータ';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'パス';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'パフォーマンス';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'キャッシュパス';
@@ -7341,7 +7390,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminGeneralServerName => 'サーバー名';
 
   @override
-  String get adminGeneralDisplayLanguage => '優先する表示言語';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => '設定の読み込みに失敗しました';
@@ -7351,19 +7400,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'マッピングを更新できませんでした: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return '制限時間: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'フォルダー';
 
   @override
-  String get libraries => 'ライブラリ';
+  String get libraries => '図書館';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7392,8 +7441,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 人が参加中',
-      one: '# 人が参加中',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7433,7 +7482,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'アイテム $index';
+    return 'Item $index';
   }
 
   @override
@@ -7481,12 +7530,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName が SyncPlay グループに参加しました';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName が SyncPlay グループから退出しました';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7498,7 +7547,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName と再生を同期しています';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7535,8 +7584,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 行を検出',
-      one: '# 行を検出',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7575,19 +7624,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get offlineSavedMedia => '保存されたメディア';
 
   @override
-  String get offlineBannerTitle => 'オフラインです';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'ダウンロード済みの項目を表示しています';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ダウンロード';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'サーバーに接続できません';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
-  String get serverUnreachableBannerSubtitle => '復旧するまでダウンロード済みの項目を再生します';
+  String get serverUnreachableBannerSubtitle =>
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7603,12 +7653,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'キャストの操作に失敗しました: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind のコントロール';
+    return '$kind Controls';
   }
 
   @override
@@ -7619,7 +7669,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind を停止';
+    return 'Stop $kind';
   }
 
   @override
@@ -7642,12 +7692,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length 桁の PIN を入力してください';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '$length 桁の PIN を入力してください';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7666,31 +7716,29 @@ class AppLocalizationsJa extends AppLocalizations {
   String get pinBackspace => 'バックスペース';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect のリクエストが承認されました。';
+  String get quickConnectAuthorized => 'クイック接続リクエストが承認されました。';
 
   @override
-  String get quickConnectInvalidOrExpired => 'Quick Connect のコードが無効か期限切れです。';
+  String get quickConnectInvalidOrExpired => 'クイック接続コードが無効か期限切れです。';
 
   @override
-  String get quickConnectNotSupported => 'このサーバーでは Quick Connect がサポートされていません。';
+  String get quickConnectNotSupported => 'このサーバーではクイック接続がサポートされていません。';
 
   @override
-  String get quickConnectAuthorizeFailed => 'Quick Connect のコードを承認できませんでした。';
+  String get quickConnectAuthorizeFailed => 'クイック接続コードを認証できませんでした。';
 
   @override
-  String get quickConnectDisabled => 'このサーバーでは Quick Connect が無効になっています。';
+  String get quickConnectDisabled => 'このサーバーではクイック接続が無効になっています。';
 
   @override
-  String get quickConnectForbidden =>
-      'お使いのアカウントではこの Quick Connect リクエストを承認できません。';
+  String get quickConnectForbidden => 'お使いのアカウントはこのクイック接続リクエストを承認できません。';
 
   @override
-  String get quickConnectNotFound =>
-      'Quick Connect のコードが見つかりませんでした。新しいコードをお試しください。';
+  String get quickConnectNotFound => 'クイック接続コードが見つかりませんでした。新しいコードを試してください。';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect に失敗しました: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7701,7 +7749,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'コマンドに失敗しました: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7730,7 +7778,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'キャストを開始できませんでした: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7775,7 +7823,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name をダウンロードしています...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -7794,7 +7842,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shuffleSelectGenre => 'ジャンルを選択';
 
   @override
-  String get shuffleLibrary => 'ライブラリ';
+  String get shuffleLibrary => '図書館';
 
   @override
   String get shuffleGenre => 'ジャンル';
@@ -7861,7 +7909,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return '$segmentをスキップ';
+    return 'Skip $segment';
   }
 
   @override
@@ -7872,12 +7920,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'ダウンロード中 $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName をダウンロードしています';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -7914,7 +7962,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get playerTooltipUnlockOrientation => '回転を許可する';
 
   @override
-  String get playerTooltipPrevious => '前へ';
+  String get playerTooltipPrevious => '前の';
 
   @override
   String get playerTooltipSeekBack => 'シークバック';
@@ -7938,13 +7986,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get contextMenuGoToSeries => 'シリーズへ';
 
   @override
-  String get contextMenuHideFromContinueWatching => '「視聴を続ける」から削除';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => '「次のエピソード」から削除';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'コレクションに追加';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'サーバー管理パネルにアクセスします';
@@ -7993,14 +8042,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsAlphabetical => 'アルファベット順';
 
   @override
-  String get settingsConnectionSection => '接続';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => '自己署名証明書を許可する';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      '自己署名またはプライベート CA の TLS 証明書を使うサーバーを信頼します。ご自身が管理するサーバーでのみ有効にしてください。この設定はすべての接続で証明書の検証を無効にします。';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'プライバシーと安全性';
@@ -8015,10 +8064,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsGeneralStyleSubtitle => 'テーマのアクセント、背景、注目のインジケーター、テーマ音楽';
 
   @override
-  String get settingsDetailsScreen => '詳細画面';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
-  String get settingsDetailsScreenSubtitle => 'スタイル、背景のぼかし、タブの動作';
+  String get settingsDetailsScreenSubtitle =>
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'ホームページ';
@@ -8052,10 +8102,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'ナビゲーションバーに Seerr ボタンを表示します';
+      'Show the Seerr button in the navigation bar';
 
   @override
-  String get settingsAlwaysExpandNavbarLabels => '上部ナビゲーションバーに文字ラベルを常に表示します';
+  String get settingsAlwaysExpandNavbarLabels =>
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8120,7 +8171,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSupportMoonfin => 'Moonfin をサポート';
 
   @override
-  String get settingsSupportMoonfinSubtitle => '開発者にコーヒーを 1 杯おごる';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => '法律上の';
@@ -8151,8 +8203,8 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 件のライセンス表記',
-      one: '# 件のライセンス表記',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8196,16 +8248,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'イントロとアウトロをスキップしますか?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'メディアセグメントのカウントダウン';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => '進行状況バー';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'タイマー';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'なし';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ユーザーにプロンプ​​トを表示';
@@ -8238,13 +8290,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (推奨)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (旧方式)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (レガシー)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (推奨)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision フォールバック';
@@ -8419,719 +8471,749 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '最近公開された$libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => '次のエピソードを自動再生';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
-  String get autoplayNextEpisodeSubtitle => '次のエピソードがある場合は自動的に再生します。';
+  String get autoplayNextEpisodeSubtitle =>
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => '無音部分をスキップ';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
-  String get skipSilenceSubtitle => 'ストリームが対応している場合、無音部分を自動的にスキップします。';
+  String get skipSilenceSubtitle =>
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => '外部の音響エフェクトを許可';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'イコライザーやエフェクトのアプリ (Wavelet など) が Media3 の再生セッションに接続できるようにします。';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'トンネリングを無効にする';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'トンネリングを使わない再生を強制します。トンネリング時に音声と映像が途切れるデバイスで有効です。';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'トンネリングを有効にする';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      '上級者向け。音声と映像を連携したハードウェア経路で処理します。一部のデバイスで音声や映像が途切れるため、既定ではオフです。';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Dolby Vision プロファイル 7 を HEVC にマッピング';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Dolby Vision 非対応のデバイスで、プロファイル 7 のストリームを HDR10 互換の HEVC として再生します。';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => '字幕に埋め込まれたスタイルを使用';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      '字幕トラックに埋め込まれた色、フォント、表示位置を適用します。オフにすると、ご自身の字幕スタイル設定が使用されます。';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
-  String get subtitlesUseEmbeddedFontSizes => '字幕に埋め込まれた文字サイズを使用';
+  String get subtitlesUseEmbeddedFontSizes =>
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      '字幕トラックに埋め込まれた文字サイズの指定を適用します。オフにすると、スタイル設定の字幕サイズが使用されます。';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'メディアの詳細を表示';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'ライブラリページの上部に、選択中のアイテムの詳細を表示します。';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => '閲覧中は背景画像を非表示にしますか?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => '詳細な小見出しを使用';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'ライブラリページで詳細な小見出しを表示するか、簡易表示にするかを選びます。';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => '保存したテーマを削除しますか?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '「$themeName」をこのデバイスのキャッシュから削除しますか?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'テーマストア';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'コミュニティのテーマを探して保存できます';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
-  String get themeStoreDescription => 'テーマを保存すると、他の保存済みテーマと同じように使用できます。';
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => '現在利用できるテーマはありません。';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
-  String get themeStoreLoadFailed => 'テーマストアを読み込めませんでした。接続を確認してもう一度お試しください。';
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => '保存';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => '保存して適用';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => '保存済み';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'このテーマを読み込めませんでした。';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '「$themeName」を保存しました。';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '「$themeName」をこのデバイスから削除しました。';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '「$themeName」を削除できませんでした。';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => '保存したテーマ';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      '現在のサーバーの Moonfin プラグインからダウンロードしたテーマです。削除してもこのデバイス上のコピーが消えるだけです。';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'このサーバーの保存済みテーマは見つかりませんでした。';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • 現在使用中';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => '保存したテーマを削除';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
-  String get savedThemesManageSubtitle => 'このデバイスにダウンロードしたプラグインのテーマを管理します';
+  String get savedThemesManageSubtitle =>
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'テーマエディター';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'ブラウザーで Moonfin テーマエディターを開きます';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'ホーム画面';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => '下部バー';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'クラシック';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'モダン';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'ホーム行';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'ホーム行の表示';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'ホーム行のセクション';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'ホーム行の切り替え';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
-  String get homeRowTogglesSubtitle => 'ライブラリごとのホーム行カテゴリーを有効または無効にします';
+  String get homeRowTogglesSubtitle =>
+      'Enable or disable library-based home row categories';
 
   @override
-  String get homeRowTogglesDescription => '以下をオンにすると、ホームセクションに対応する行が表示されます。';
+  String get homeRowTogglesDescription =>
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'クラシックは行ごとの画像タイプと情報オーバーレイを維持します。モダンは縦長から横長へ変化する行を使用します。';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'お気に入りの行を表示';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'お気に入りの映画やシリーズなどの行をホームセクションに表示します。';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'お気に入りの行の並び順';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
-  String get favoritesRowSortingDescription => 'お気に入りの行を追加日、公開日、名前順などで並べ替えます。';
+  String get favoritesRowSortingDescription =>
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'コレクションの行を表示';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
-  String get displayCollectionsRowsSubtitle => 'コレクションの行をホームセクションに表示します。';
+  String get displayCollectionsRowsSubtitle =>
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'コレクションの行の並び順';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'コレクションの行を追加日、公開日、名前順などで並べ替えます。';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'ジャンルの行を表示';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'ジャンルの行をホームセクションに表示します。';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'ジャンルの行の並び順';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
-  String get genresRowSortingDescription => 'ジャンルの行を追加日、公開日、名前順などで並べ替えます。';
+  String get genresRowSortingDescription =>
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'ジャンルの行のアイテム';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
-  String get genresRowItemsDescription => 'ジャンルの行に映画、シリーズ、またはその両方を表示します。';
+  String get genresRowItemsDescription =>
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'プレイリストの行を表示';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
-  String get displayPlaylistsRowsSubtitle => 'プレイリストの行をホームセクションに表示します。';
+  String get displayPlaylistsRowsSubtitle =>
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'プレイリストの行の並び順';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
-  String get playlistsRowSortingDescription => 'プレイリストの行を追加日、公開日、名前順などで並べ替えます。';
+  String get playlistsRowSortingDescription =>
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'オーディオの行を表示';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'オーディオの行をホームセクションに表示します。';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'オーディオの行の並び順';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
-  String get audioRowsSortingDescription => 'オーディオの行を追加日、公開日、名前順などで並べ替えます。';
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'オーディオのプレイリスト';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => '外観';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'レイアウト';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'テーマ';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'キーボード';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'ボタン';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'レンダリング';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV の設定';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => '外部プレイヤーアプリ';
+  String get externalPlayerApp => 'External player app';
 
   @override
-  String get externalPlayerAppDescription => '外部プレイヤーを設定すると、長押しで再生する項目が有効になります';
+  String get externalPlayerAppDescription =>
+      'Set external player to enable long-press play option';
 
   @override
-  String get externalPlayerAskEachTimeSubtitle => '再生開始時にアプリの選択画面を表示します。';
+  String get externalPlayerAskEachTimeSubtitle =>
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'インストール済みのプレイヤーを読み込んでいます...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => '接続';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'オーディオの変換先形式';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'パススルー';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'このデバイスで対応しています';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'このデバイスでは対応していません';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) パススルー';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) を外部デコーダーにビットストリーム出力します。';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD with Atmos (JOC) パススルー';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'メディアプレイヤーの動作';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => '再生の拡張機能';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => '常にオンです。';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      '「エンディングをスキップ」を「次のエピソード」表示に置き換える';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '「エンディングをスキップ」ボタンの代わりに「次のエピソード」のオーバーレイを表示します。';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'プレイヤーの振り分け';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'ソフトウェアデコーダーを優先';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'ハードウェアデコーダーより先に FFmpeg (オーディオ) と libgav1 (AV1) を使用します。HDMI のオーディオパススルーが機能しない場合はオフにしてください。';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
-  String get useExternalPlayerSubtitle => 'Android TV で、選択した外部アプリを使って動画を再生します。';
+  String get useExternalPlayerSubtitle =>
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => '自動キュー追加';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH 字幕を優先';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
-  String get preferSdhSubtitlesSubtitle => '自動選択時に SDH / CC の字幕トラックを優先します。';
+  String get preferSdhSubtitlesSubtitle =>
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Web 診断';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin Web 診断';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'このページでは、ブラウザーの接続に関する問題 (CORS、混在コンテンツ、検出設定) を診断できます。';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      '混在コンテンツによるエラーを検出しました';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS / プリフライトのエラーを検出しました';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin は、HTTPS のページから HTTP のサーバー URL を呼び出そうとしているのを検出しました。ブラウザーはこのリクエストをサーバーに届く前にブロックします。';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin はブラウザーレベルのリクエスト失敗を検出しました。多くの場合、メディアサーバー側で CORS やプリフライトのヘッダーが不足していることが原因です。';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return '対象 URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return '詳細: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => '現在の実行環境';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'オリジン';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'スキーム';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'プラグインモード';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC スキャン';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => '強制サーバー URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => '既定のサーバー URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => '検出プロキシの URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => '未設定';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => '混在コンテンツ';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'このページは HTTPS で読み込まれていますが、設定された URL に HTTP のものが含まれています。ブラウザーは HTTPS のページから HTTP の API を呼び出すことをブロックします。';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      '対処法: メディアサーバーまたはプロキシのエンドポイントを HTTPS で公開するか、信頼できるローカルネットワークでのみ Moonfin を HTTP で読み込んでください。';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      '現在の実行時設定からは、明らかな混在コンテンツの構成は検出されませんでした。';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS チェックリスト';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin でブラウザーのオリジンを許可する。';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers に Authorization、X-Emby-Authorization、X-Emby-Token を含める。';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ストリーミングとシークのために Content-Range と Accept-Ranges を公開する。';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS のプリフライトリクエストに 204 を返す。';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
-  String get webDiagnosticsHeaderSnippetTitle => 'ヘッダーの記述例 (nginx 形式)';
+  String get webDiagnosticsHeaderSnippetTitle =>
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => '注意';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'この診断ページは Web 版向けです。他のプラットフォームで表示されている場合、これらのチェックは当てはまらないことがあります。';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'サーバー選択に戻る';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'すべてのユーザーをサインアウト';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'マイクの使用が完全に拒否されています。システム設定で許可してください。';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
-  String get voiceSearchPermissionRequired => '音声検索にはマイクの使用許可が必要です。';
+  String get voiceSearchPermissionRequired =>
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => '聞き取れませんでした。もう一度お試しください。';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => '音声を検出できませんでした。';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'マイクのエラーです。';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => '音声検索にはインターネット接続が必要です。';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => '音声サービスが混雑しています。もう一度お試しください。';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
-  String get microphonePermissionPermanentlyDenied => 'マイクの使用が完全に拒否されています。';
+  String get microphonePermissionPermanentlyDenied =>
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'マイクの使用が拒否されています。';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
-  String get speechRecognitionUnavailable => 'このデバイスでは音声認識を利用できません。';
+  String get speechRecognitionUnavailable =>
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS の出力先選択を開く';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'このデバイスでは AirPlay の出力先選択を利用できません。';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => '動画';
+  String get videos => 'Videos';
 
   @override
-  String get programs => '番組';
+  String get programs => 'Programs';
 
   @override
-  String get songs => '曲';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'フォトアルバム';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => '写真';
+  String get photos => 'Photos';
 
   @override
-  String get people => '人物';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => '最近公開されたエピソード';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'もう一度見る';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'ゲスト出演';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => '出演 (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'スタッフとしての参加 (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'グループで視聴';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'エラー';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => '警告';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'ディスク';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'ブラウザーで開く';
+  String get openInBrowser => 'Open in Browser';
 
   @override
-  String get embeddedBrowserNotAvailable => 'このプラットフォームでは組み込みブラウザーを利用できません。';
+  String get embeddedBrowserNotAvailable =>
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get adminRestartServerConfirmation => 'サーバーを再起動してもよろしいですか?';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'サーバーをシャットダウンしてもよろしいですか? 再起動は手動で行う必要があります。';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => '内部';
+  String get internal => 'Internal';
 
   @override
-  String get idle => '待機中';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'ユーザーが見つかりません';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => '検索条件に一致するユーザーはありません';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'デバイスが見つかりません';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
-  String get adminNoDevicesMatchCurrentFilters => '現在のフィルターに一致するデバイスはありません';
+  String get adminNoDevicesMatchCurrentFilters =>
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'パスワード設定済み';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'パスワードが設定されていません';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'リモートアクセス';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'ローカルのみ';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => 'メディア統計の読み込みに失敗しました';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
-  String get analyticsCombinedAcrossLibraries => 'すべてのメディアライブラリを合計した統計です。';
+  String get analyticsCombinedAcrossLibraries =>
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => '人気のアーティスト';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => '人気の著者';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => '主な貢献者';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ライブラリ',
-      one: '1 ライブラリ',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
-  String get analyticsNoIndexedMediaTotals => 'この選択に対する索引済みメディアの集計はまだありません。';
+  String get analyticsNoIndexedMediaTotals =>
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'ライブラリの詳細';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'ライブラリの内訳';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => '利用できるライブラリがありません。';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'サーバー管理';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'データ';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => '画像キャッシュ';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'キャッシュ';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'ログ';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'メタデータ';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'トランスコード';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'このサーバーからサーバーパスが返されませんでした。';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% 使用中';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'ユーザーのアクティビティ';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'システムイベント';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => '要確認';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'サーバー';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => '再生';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'デバイス';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => '詳細設定';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'プラグイン';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'ライブ TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'ホームビデオ';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => '混合コンテンツ';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'ホームビデオと写真';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => '映画と番組の混合';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9143,295 +9225,299 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => '録画が見つかりません';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension アーカイブ内に画像ページが見つかりませんでした。';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return '組み込みレンダラーでエラーが発生しました ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB レンダラーでエラーが発生しました ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'リーダー用のローカルファイルが見つかりません: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri から書籍データを開く際に HTTP $status が返されました';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => '読み込み可能な書籍のエンドポイントがありません';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return '対応していないコミックアーカイブ形式です: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'このプラットフォームでは CBR 展開プラグインを利用できません。';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '.cbr アーカイブを展開できませんでした。';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => 'このプラットフォームでは CB7 の展開を利用できません。';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'このプラットフォームでは CB7 展開プラグインを利用できません。';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'ジャンルパネルを閉じる';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'シャッフルを準備しています...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ライブラリシャッフル';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ランダムシャッフル';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ジャンルシャッフル';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'HDR の自動切り替え';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR 動画の再生時に自動的に HDR を有効にし、終了時に表示モードを元に戻します。';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => '全画面表示のとき';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'アートワークを変更';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'なし';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'トランスコードの制限';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'すべてのアートワークを消去しますか?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
-  String get clearAllArtworkWarning => 'ダウンロード済みのアートワークをすべて消去してもよろしいですか?';
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => '消去の確認';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'この$itemTypeを消去してもよろしいですか?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'アップロードしますか?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => '解像度: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => '表示言語のアートワークのみを表示';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'すべて消去の確認';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => '画像をアップロードしました!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return '画像をアップロードできませんでした: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return '画像を設定できませんでした: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return '画像を削除できませんでした: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'すべてのアートワークを消去できませんでした: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'はい';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'ポスター';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => '背景画像';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'バナー';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'ロゴ';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'サムネイル';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'アート';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ディスクアート';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'スクリーンショット';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'ボックスカバー';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'ボックス裏面カバー';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'メニューアート';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'ポスター';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => '背景画像';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'バナー';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'ロゴ';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'サムネイル';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'アート';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ディスクアート';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'スクリーンショット';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'ボックスカバー';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'ボックス裏面カバー';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'メニューアート';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'すべて';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => '高 (1080p 以上)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => '中 (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => '低 (720p 未満)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => '提供元';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'チャプター';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'ブックマーク';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'メモ';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'キュー';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'タイムライン';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'タイムラインは空です';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => '本全体';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => '注目のタイムライン';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ブックマークを書き出す';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'メモを書き出す';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'すべて書き出す';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path に書き出しました';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return '書き出しに失敗しました: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => '歌詞';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'ブックマークを追加';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'メモを追加';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'メモを編集';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'この場面のメモを書く';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'スリープタイマー';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'オフ';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'チャプターの終わり';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'カスタム';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '残り $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9439,58 +9525,58 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 分',
-      one: '1 分',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => '再生速度';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => '残り';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => '経過';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds 秒戻る';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds 秒進む';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => '前のチャプター';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => '次のチャプター';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'チャプター $current / $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'チャプターはありません';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'まだブックマークはありません';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'まだメモはありません';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position にブックマークを追加しました';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x に戻す';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9498,241 +9584,249 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => '保存';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'キャンセル';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => '削除';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => '字幕の設定';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
-  String get subtitlePreferencesDescription => '字幕モード、既定の言語、外観、描画方法を変更します。';
+  String get subtitlePreferencesDescription =>
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => '字幕の描画';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => '表示オプション';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => '公開日 (古い順)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => '公開日 (新しい順)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => '参加作品のグループ化';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => '複数の役割をまとめる';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'ライブラリの書き込み権限に関する警告';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => '対処方法:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. サーバー上のメディアライブラリフォルダーに対して、Jellyfin のサービスユーザー (jellyfin や Docker の PUID/PGID など) に書き込み権限を付与してください。\n\n2. または、Jellyfin のダッシュボード -> ライブラリ でこのライブラリを編集し、「アートワークをメディアフォルダーに保存する」を無効にして、アートワークを Jellyfin の内部データベースに保存してください。';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => '閉じる';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '「$libraryName」ライブラリは、アートワークをメディアフォルダーに直接保存する設定になっています (「アートワークをメディアフォルダーに保存する」が有効です)。しかし Jellyfin が書き込みを確認したところ、次のディレクトリにファイルを書き込む権限がありませんでした:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin がアートワークを更新できなかったようです。このライブラリは、アートワークをメディアフォルダーに直接保存する設定になっています (「アートワークをメディアフォルダーに保存する」が有効です)。このエラーは通常、Jellyfin サーバーのプロセスにメディアディレクトリへの書き込み権限がない場合に発生します。';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => '外部リスト';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'もう一度再生';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ファイル情報';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'サイズ: $size  •  形式: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'すべてのオーディオトラック ($count) を表示';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'すべての字幕トラック ($count) を表示';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'ダイレクト再生に対応しているか確認しています...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'ダイレクト再生の可否: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => '強制';
+  String get forced => 'Forced';
 
   @override
-  String get transcodeContainerNotSupported => 'コンテナー形式にプレイヤーが対応していません。';
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => '映像コーデックに対応していません。';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'オーディオコーデックに対応していません。';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
-  String get transcodeSubtitleCodecNotSupported => '字幕形式に対応していません (焼き付けが必要です)。';
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'オーディオのプロファイルに対応していません。';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => '映像のプロファイルに対応していません。';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => '映像のレベルに対応していません。';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'このデバイスは、この映像の解像度に対応していません。';
+      'Video resolution is not supported by this device.';
 
   @override
-  String get transcodeVideoBitDepthNotSupported => '映像のビット深度に対応していません。';
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
 
   @override
-  String get transcodeVideoFramerateNotSupported => '映像のフレームレートに対応していません。';
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ファイルのビットレートがプレイヤーのストリーミング上限を超えています。';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      '映像のビットレートがストリーミングの上限を超えています。';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'オーディオのビットレートがストリーミングの上限を超えています。';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioChannelsNotSupported => 'このオーディオのチャンネル数に対応していません。';
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => '名前順';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => '公開順 (古い順)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => '公開順 (新しい順)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'カスタム (ドラッグ＆ドロップ)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'プレイリストの並べ替え';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => '並び順をリセット';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode をもう一度見る';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'プレイリストをもう一度見る';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => '字幕が見つかりません。';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => '管理者向け操作';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'レンダリングエンジン (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller は Flutter の新しい GPU レンダラーで、アニメーションが滑らかになり、カクつきが減ります。一部の TV ボックスや古い GPU では表示の乱れや映像が黒くなることがあり、その場合はオフにしてください。自動はお使いのデバイスに最適な設定を選びます。適用するには Moonfin を再起動してください。';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => '自動';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'オン';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'オフ';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => '再起動が必要です';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'レンダリングエンジンを変更するには Moonfin の再起動が必要です。アプリをいったん終了し、開き直すと適用されます。';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => '今すぐアプリを終了';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'ライブラリを更新';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'すべてのライブラリを更新';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => '追加日 (古い順)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => '追加日 (新しい順)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => '名前順 (A → Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => '名前順 (Z → A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'サーバー統計を読み込んでいます... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'ソースに合わせる';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 映画トップ 250';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb TV 番組トップ 250';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb 人気の映画';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb 人気の TV 番組';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb 低評価の映画';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb 高評価の英語映画';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -9,30 +9,30 @@ class AppLocalizationsKk extends AppLocalizations {
   AppLocalizationsKk([String locale = 'kk']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Ай жүзі';
 
   @override
-  String get accountPreferences => 'ТІРКЕЛГІ ПАРАМЕТРЛЕРІ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Интерфейс тілі';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Жүйе бойынша';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Кіру';
 
   @override
-  String get empty => 'Бос';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName серверіне қосылуда';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Жылдам қосылу';
 
   @override
   String get password => 'Құпия сөз';
@@ -61,12 +61,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect қолжетімсіз: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect қолжетімсіз ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin нұсқасы $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '«$serverName» серверлер тізімінен жойылсын ба?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'Болдырмау';
 
   @override
-  String get remove => 'Алып тастау';
+  String get remove => 'Жою';
 
   @override
   String get connectToServer => 'Серверге қосылу';
@@ -141,62 +141,62 @@ class AppLocalizationsKk extends AppLocalizations {
   String get settingsAppearanceTheme => 'Қолданба тақырыбы';
 
   @override
-  String get detailScreenStyle => 'Мәліметтер экранының стилі';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '«Классикалық» — Moonfin бағдарламасының бастапқы, ортаға тураланған қалыбы. «Заманауи» — бейімделгіш кинематографиялық қалып.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Классикалық';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Заманауи';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Жайылған қойындылар';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Қойындыларды шолу кезінде олардың мазмұнын автоматты түрде көрсету. Әр қойындыны қолмен ашып-жабу үшін өшіріңіз.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Техникалық мәліметтер көрсетілсін бе?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Баннер түйіндемесінде кодек, ажыратымдылық және ағын туралы мәліметтерді көрсету';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Ұсыныс жүйесі';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin ұсынады жергілікті кітапхана алгоритмін немесе TMDb ұсынатын желілік ұқсастық метрикаларын пайдаланыңыз. Ескертпе: желілік ұсыныстар Seerr интеграциясын талап етеді.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin ұсынады';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb ұқсастығы';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Жас шектеуі бойынша шек қойылсын ба?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Moonfin ұсынады тізіміндегі ұсыныстарды таңдалған медиафайлдың жас шектеуі бойынша шектеу';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Интерфейс стилі';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '«Автоматты» құрылғыңызға сәйкес келеді. Белгілі бір көріністі мәжбүрлеп орнату үшін Apple немесе Material таңдаңыз.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автоматты';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsKk extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Шыны сапасы';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '«Авто» осы құрылғыға ең қолайлы шыны әсерін таңдайды. «Толық» нақты бұлдырлатуды қосады, «Азайтылған» GPU қуатын үнемдейтін жеңіл шыныны пайдаланады.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Авто';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Толық';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Азайтылған';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Қолданбаны қайта іске қоспай, Moonfin және Neon Pulse арасында ауысыңыз';
 
   @override
-  String get customThemeTitle => 'Жеке тақырып';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Жеке тақырыптар Moonfin бойынша визуалды элементтерді өзгертеді. Өз стиліңізге сай нұсқаны таңдаңыз.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Жүйелік пернетақтаны таңдау';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Мәтін енгізу үшін әдепкіде құрылғыңыздың енгізу әдісін пайдалану';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Ай жүзі';
 
   @override
   String get themeMoonfinSubtitle => 'Ағымдағы Moonfin келбеті бәріңізге ұнады';
@@ -252,18 +252,18 @@ class AppLocalizationsKk extends AppLocalizations {
       'Күлгін түсті жарқыл, көгілдір мәтін және күшті хром контрастымен Synthwave стилі';
 
   @override
-  String get themeGlass => 'Шыны';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Сұйық шыны стилі: жылжымалы градиент фоны, күңгірт беттер және Apple көк екпіні';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-биттік батыр';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретро пиксель-арт стилі: ірі палитра, блокты жиектер, қатты көлеңкелер және пиксельдік қаріп';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +313,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target серверіне қосылу мүмкін болмады';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -326,35 +326,35 @@ class AppLocalizationsKk extends AppLocalizations {
   String get exit => 'Шығу';
 
   @override
-  String get gameMenu => 'Мәзір';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Кідіртілді';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Күйді сақтау';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Ойындар';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Күйді жүктеу';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Жылдам алға';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Эмулятор параметрлері';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Бұл ядроның реттелетін параметрлері жоқ.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Мәзірді ашу үшін басып тұрыңыз';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Ойындар бұл құрылғыда әзірге қолдау таппайды.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Ешбір негізгі жолдарды жүктеу мүмкін болмады';
@@ -376,13 +376,13 @@ class AppLocalizationsKk extends AppLocalizations {
   String get schedule => 'Кесте';
 
   @override
-  String get series => 'Сериалдар';
+  String get series => 'Сериялар';
 
   @override
   String get noItemsFound => 'Ешбір элемент табылмады';
 
   @override
-  String get home => 'Басты бет';
+  String get home => 'Үй';
 
   @override
   String get browseAll => 'Барлығын шолу';
@@ -415,7 +415,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get noLibrariesFound => 'Ешқандай кітапхана табылмады';
 
   @override
-  String get library => 'Медиатека';
+  String get library => 'Кітапхана';
 
   @override
   String get displaySettings => 'Дисплей параметрлері';
@@ -428,7 +428,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Қалтаны жүктеу мүмкін болмады: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +436,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count элемент';
+    return '$count items';
   }
 
   @override
@@ -453,7 +453,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Элемент';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +494,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Жанрлар';
+    return '$name — Genres';
   }
 
   @override
@@ -507,7 +507,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get albumArtists => 'Альбом әртістері';
 
   @override
-  String get artists => 'Орындаушылар';
+  String get artists => 'Суретшілер';
 
   @override
   String get bookmarks => 'Бетбелгілер';
@@ -533,17 +533,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count мин бұрын';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count сағ бұрын';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count күн бұрын';
+    return '${count}d ago';
   }
 
   @override
@@ -578,7 +578,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count атау';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +603,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get listen => 'Тыңда';
 
   @override
-  String get resume => 'Жалғастыру';
+  String get resume => 'Резюме';
 
   @override
   String get failedToLoadLibrary => 'Кітапхана жүктелмеді';
@@ -664,17 +664,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count автор';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count жанр';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% аяқталды';
+    return '$percent% completed';
   }
 
   @override
@@ -691,7 +691,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'Оқуға бағытталған шолу үшін $count атау реттелген.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -728,7 +728,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label табылмады';
+    return 'No $label found';
   }
 
   @override
@@ -765,43 +765,43 @@ class AppLocalizationsKk extends AppLocalizations {
   String get books => 'Кітаптар';
 
   @override
-  String get latestBooks => 'Соңғы кітаптар';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Соңғы аудиокітаптар';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count кітап',
-      one: '$count кітап',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Кітап';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудиокітап';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% оқылды';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time қалды';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Оқу';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Тыңдау';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Автор';
@@ -839,12 +839,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count бөлім';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Алғаш $year жылы жарық көрген';
+    return 'First published $year';
   }
 
   @override
@@ -859,7 +859,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count кітап';
+    return '$count books';
   }
 
   @override
@@ -871,7 +871,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Автор';
+    return '$count Authors';
   }
 
   @override
@@ -879,8 +879,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудиокітап',
-      one: '$count аудиокітап',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -916,7 +916,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get nextUp => 'Келесі';
 
   @override
-  String get seasons => 'Маусымдар';
+  String get seasons => 'Жыл мезгілдері';
 
   @override
   String get chapters => 'тараулар';
@@ -928,7 +928,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get movies => 'Фильмдер';
 
   @override
-  String get musicVideos => 'Музыкалық бейнелер';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Басқа';
@@ -947,7 +947,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return '$number-диск';
+    return 'Disc $number';
   }
 
   @override
@@ -971,7 +971,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String published(int year) {
-    return '$year жылы жарық көрген';
+    return 'Published $year';
   }
 
   @override
@@ -982,52 +982,52 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Маусым',
-      one: '$count Маусым',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time аяқталады';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Элементтер';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Қосымшалар';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Сахна артында';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Жойылған көріністер';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Қысқа сюжеттер';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Сұхбаттар';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Көріністер';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Қысқаметражды фильмдер';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Трейлерлер';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time қалды';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time кейін аяқталады';
+    return 'Ends in $time';
   }
 
   @override
@@ -1041,11 +1041,11 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position орнынан жалғастыру';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Ойнату';
+  String get play => 'Ойнау';
 
   @override
   String get startOver => 'Қайтадан бастау';
@@ -1069,7 +1069,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get version => 'Нұсқа';
 
   @override
-  String get cast => 'Трансляциялау';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Трейлер';
@@ -1140,7 +1140,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '«$title» үшін жүктелген тректер жойылсын ба?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1155,17 +1155,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel жүктелмеген';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title жүктелуде ($count элемент)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '«$name» серверден жойылсын ба? Бұл әрекетті қайтару мүмкін емес.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1176,7 +1176,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Қолдау көрсетілмейтін кітап пішімі: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1203,7 +1203,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Субтитр жүктелді және таңдалды: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1212,7 +1212,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language тілі үшін қашықтағы субтитрлер табылмады.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1220,7 +1220,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return '$number-нұсқа';
+    return 'Version $number';
   }
 
   @override
@@ -1240,7 +1240,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name жүктелуде ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1248,7 +1248,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel үшін жергілікті файлдар жойылсын ба?\n\nБұл жад орнын босатады. Кейінірек қайта жүктей аласыз.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1264,25 +1264,25 @@ class AppLocalizationsKk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕЖИССЁРЛЕР';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТЕР';
+  String get writers => 'ЖАЗУШЫЛАР';
 
   @override
   String get studio => 'СТУДИЯ';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count тағы';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count Эпизод';
+    return '$count Episodes';
   }
 
   @override
@@ -1292,12 +1292,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return '$number-эпизод';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '$number-тарау';
+    return 'Chapter $number';
   }
 
   @override
@@ -1305,8 +1305,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count трек',
-      one: '$count трек',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1316,25 +1316,25 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count тарау',
-      one: '$count тарау',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Туған күні: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Қайтыс болған күні: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Жасы: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1347,17 +1347,17 @@ class AppLocalizationsKk extends AppLocalizations {
   String get shuffle => 'Араластыру';
 
   @override
-  String get shuffleAllMusic => 'Барлық музыканы араластыру';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Телефоныңызда Moonfin-ге кіріңіз';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Серверге қосылу мүмкін емес';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count жүктеу';
+    return '$count downloads';
   }
 
   @override
@@ -1365,7 +1365,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count арна';
+    return '${count}ch';
   }
 
   @override
@@ -1376,32 +1376,32 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Қашықтағы субтитрді $action үшін бұл пайдаланушыға Jellyfin субтитрлерін басқару рұқсаты қажет.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Қашықтағы субтитрді $action үшін бұл элемент серверде табылмады.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Қашықтағы субтитрді $action орындалмады: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Қашықтағы субтитрді $action орындалмады (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Қашықтағы субтитрлерді $action мүмкін болмады.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '«$name» үшін жүктелген барлық эпизодтар';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1432,17 +1432,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label әрекеті орындалмады: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Cast дыбыс деңгейін орнату мүмкін болмады: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label басқару элементтері';
+    return '$label Controls';
   }
 
   @override
@@ -1459,7 +1459,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$label тоқтату';
+    return 'Stop $label';
   }
 
   @override
@@ -1467,7 +1467,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '$number-трек';
+    return 'Track $number';
   }
 
   @override
@@ -1484,7 +1484,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds секунд';
+    return '$seconds seconds';
   }
 
   @override
@@ -1514,12 +1514,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value мс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value мс';
+    return '+${value}ms';
   }
 
   @override
@@ -1553,7 +1553,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get transcodeReasons => 'Транскодтың себептері';
 
   @override
-  String get player => 'Ойнатқыш';
+  String get player => 'Ойыншы';
 
   @override
   String get container => 'Контейнер';
@@ -1571,7 +1571,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'Кодек';
+  String get codec => 'Codec';
 
   @override
   String get videoBitrate => 'Бейне бит жылдамдығы';
@@ -1599,12 +1599,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol сеансының қатесі';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Кітап мәліметтерін жүктеу мүмкін болмады: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1613,7 +1613,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Бұл пішім (.$extension) қолданбада әзірге көрсетілмейді.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1626,17 +1626,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Кірістірілген оқу құралын ашу мүмкін болмады: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label орнында бетбелгі бұрыннан сақталған.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Бетбелгі қосылды: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1648,7 +1648,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '$number-бет';
+    return 'Page $number';
   }
 
   @override
@@ -1659,12 +1659,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Пішім: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% оқылды';
+    return '$percent% read';
   }
 
   @override
@@ -1687,7 +1687,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Масштабты ысыру (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1710,7 +1710,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Оқылу күйін жаңарту мүмкін болмады: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1744,7 +1744,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Бұл платформа $extension файлдары үшін кірістірілген құжат жүйесін іске қоса алмайды.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1783,7 +1783,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Бағдарламаны жүктеу мүмкін болмады: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1794,22 +1794,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Келесі: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes мин қалды';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours сағ қалды';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours сағ $minutes мин қалды';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1832,19 +1832,19 @@ class AppLocalizationsKk extends AppLocalizations {
   String get favoriteChannel => 'Сүйікті арна';
 
   @override
-  String get record => 'Жазу';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Жазуды болдырмау';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Бағдарлама жазуға қойылды';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Жазу болдырылмады';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Жазу жасау мүмкін болмады';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Қарау';
@@ -1854,7 +1854,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name ойнату мүмкін болмады';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1880,7 +1880,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '«$name» жоспарланған жазуы болдырылмасын ба?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1907,7 +1907,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '«$name» жазуы тоқтатылсын ба?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1922,12 +1922,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '«$query» бойынша нәтиже жоқ';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Іздеу орындалмады: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1968,12 +1968,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '«$name» және оның файлдары жойылсын ба?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count трек';
+    return '$count tracks';
   }
 
   @override
@@ -1984,12 +1984,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Альбомды жүктеу мүмкін болмады: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name үшін жүктелген тректер табылмады.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2006,22 +2006,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '«$name» жойылсын ба?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'М$season Э$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return '$number-эпизод';
+    return 'Episode $number';
   }
 
   @override
@@ -2035,12 +2035,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return '$number-маусым';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'М$number';
+    return 'S$number';
   }
 
   @override
@@ -2051,7 +2051,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season ішіндегі барлық жүктелген эпизодтар жойылсын ба?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2059,8 +2059,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count эпизод',
-      one: '$count эпизод',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2095,7 +2095,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '$count жүктелген элемент жойылсын ба?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2109,7 +2109,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit шегінен';
+    return 'of $limit limit';
   }
 
   @override
@@ -2194,7 +2194,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count параметр';
+    return '$count options';
   }
 
   @override
@@ -2289,7 +2289,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Мәліметтер беттері, негізгі бет жолдары және дыбыс деңгейі';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2304,18 +2304,18 @@ class AppLocalizationsKk extends AppLocalizations {
       'Негізгі экранды шолу кезінде ойнату';
 
   @override
-  String get loopThemeMusic => 'Тақырыптық музыканы қайталау';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Тректі бір рет ойнатудың орнына циклмен қайталау';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Мәліметтер Фонды бұлыңғырлау';
 
   @override
   String pixelValue(int value) {
-    return '$value пикс';
+    return '${value}px';
   }
 
   @override
@@ -2331,23 +2331,23 @@ class AppLocalizationsKk extends AppLocalizations {
   String get playerZoomMode => 'Ойыншының масштабтау режимі';
 
   @override
-  String get settingsScrollWheelAction => 'Тінтуір дөңгелегі';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Ойнату кезінде бейне үстінде тінтуір дөңгелегін айналдыру не істейтінін таңдаңыз.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Өшірулі';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Айналдыру (алға / артқа)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Дыбыс деңгейі';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Дыбыс деңгейі';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Сәйкес';
@@ -2401,37 +2401,37 @@ class AppLocalizationsKk extends AppLocalizations {
   String get defaultAudioLanguage => 'Әдепкі аудио тілі';
 
   @override
-  String get fallbackAudioLanguage => 'Резервтік аудио тілі';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Әдепкі аудиотрек таңдалсын';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Локализацияланған дубляждың орнына түпнұсқа аудиотректі таңдау.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Аудиосипаттама тректері таңдалсын';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Қарапайым тректердің орнына аудиосипаттама тректерін таңдау.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскодтау (аудио)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Тікелей ағын (ремукс)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскодтау (битрейт немесе ажыратымдылық)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскодтау (бейне және аудио)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскодтау (бейне)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Авто (Сервердің әдепкі)';
@@ -2508,27 +2508,27 @@ class AppLocalizationsKk extends AppLocalizations {
       'TrueHD дыбысын қосу (барлық платформаларда жұмыс істемеуі мүмкін)';
 
   @override
-  String get settingsAudioOutputMode => 'Аудио шығысының режимі';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Аудионың қалай декодталатынын таңдаңыз. AVR Passthrough өңделмеген Dolby/DTS ағындарын ресиверіңізге жібереді, ал «Авто» мен «Араластыру» жергілікті түрде декодтайды.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Резервтік аудиокодек';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Бастапқы ағынды тікелей ойнату немесе транзитпен жіберу мүмкін болмағанда, көпарналы аудионы транскодтайтын мақсатты пішімді таңдаңыз.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Автоанықтау\n(ұсынылады)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(әдепкі)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2537,114 +2537,113 @@ class AppLocalizationsKk extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(шығынсыз)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(тек стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(үнемді)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(шығынсыз)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Ең көп аудиоарна';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Аудиожүйеңіздің ең көп арна санын реттеңіз. Осы шектен асатын көпарналы ағындар араластырылады немесе транскодталады.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'Автоанықтау\n(жабдық әдепкісі)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Көлемді дыбыс';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Квадрофониялық';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Көлемді дыбыс';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Көлемді дыбыс';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Көлемді дыбыс';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Көлемді дыбыс';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Транзит (кеңейтілген)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Кодек транзиті';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Тек AVR немесе HDMI қабылдағышыңыз қолдайтын пішімдерді қосыңыз.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 транзиті';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) транзиті';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core транзиті';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA транзиті';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD транзиті';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos транзиті';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) битағынын сыртқы декодерге жіберу.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) арқылы Dolby Atmos битағынын сыртқы декодерге жіберу.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS Core қоса) битағынын сыртқы декодерге жіберу.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos метадеректері бар Dolby TrueHD битағынын сыртқы декодерге жіберу.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Анықталған аудио мүмкіндіктері';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Орындалу кезіндегі мүмкіндіктер туралы дерек әзірге жоқ.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Бағыт';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Декодтау';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Транзит';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD аудио бағыты';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2659,51 +2658,50 @@ class AppLocalizationsKk extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Динамик';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Құлаққап';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count арна PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Диагностика';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Бейне деңгейі';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Бейне ауқымы';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Субтитр кодегі';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Рұқсат етілген аудиокодектер';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS аудиокодектері';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 аудиокодектері';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif транзиті';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Белсенді аудио бағыты';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Бағыттың HD аудио қолдауы';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Түнгі режим';
@@ -2752,7 +2750,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value с';
+    return '${value}s';
   }
 
   @override
@@ -2767,7 +2765,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes эпизодтан / $hours сағаттан кейін';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2843,45 +2841,45 @@ class AppLocalizationsKk extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Субтитр көрінісін реттеңіз';
 
   @override
-  String get subtitleMode => 'Субтитр режимі';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Белгіленген';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Әрқашан';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Шет тіліндегі';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Мәжбүрлі';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Медиафайл метадеректерінде «default» немесе «forced» деп белгіленген тректерді ойнатады.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Бейне басталған сайын субтитрлерді автоматты түрде жүктеп көрсетеді.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Әдепкі аудиотрек шет тілінде болса, субтитрлерді автоматты түрде қосады.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Тек метадеректерде forced деп белгіленген субтитрлерді жүктейді.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Субтитрлерді автоматты жүктеуді толығымен өшіреді.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Резервтік субтитр тілі';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Субтитр ағыны';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2940,17 +2938,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile профилінің параметрлері жүктелді.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile профилінің параметрлерін жүктеу мүмкін болмады.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Жергілікті параметрлер $profile профиліне синхрондалды.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3088,11 +3086,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Құралдар тақтасында кітапханаларды көрсету';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Навигация жолағының белгілері әрқашан жайылсын';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr түймесін көрсету';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Шарлау тақтасының мөлдірлігі';
@@ -3167,19 +3164,18 @@ class AppLocalizationsKk extends AppLocalizations {
   String get showFolderBrowsingOption => 'Қалтаны шолу опциясын көрсету';
 
   @override
-  String get groupItemsIntoCollections => 'Элементтерді жинақтарға топтау';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Кітапханаларды шолу кезінде жинаққа байланысты элементтерді жасыру';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Кітапхананы топтау туралы ескертпе';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Бұл параметрді пайдалану үшін Jellyfin немесе Emby серверіңіздегі кітапхананың «Көрсету» параметрлерінде «Фильмдерді жинақтарға топтау» және/немесе «Сериалдарды жинақтарға топтау» параметрлерінің қосулы екеніне көз жеткізіңіз.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Кітапхананың көрінуі';
@@ -3208,7 +3204,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count таңдалды';
+    return '$count selected';
   }
 
   @override
@@ -3238,7 +3234,7 @@ class AppLocalizationsKk extends AppLocalizations {
       'Түрлі медиа жолақ мәнерлерінің бірін таңдаңыз немесе медиа жолағын өшіріңіз';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Ай жүзі';
 
   @override
   String get mediaBarModeMakd => 'МакД';
@@ -3291,11 +3287,10 @@ class AppLocalizationsKk extends AppLocalizations {
       '3 секундтан кейін медиа жолағында трейлерлерді автоматты түрде ойнату';
 
   @override
-  String get trailerAudio => 'Трейлер дыбысы';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Медиажолақтағы трейлерлер үшін дыбысты қосу';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Эпизодты алдын ала қарау';
@@ -3372,11 +3367,10 @@ class AppLocalizationsKk extends AppLocalizations {
   String get combineBothRows => 'Екі жолды бір үй бөліміне біріктіріңіз';
 
   @override
-  String get fullScreenRows => 'Жайылған негізгі бет жолдары';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Негізгі бет жолдарын әр экранға бір жолмен шектеу';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Әр жолдағы кескін түрі';
@@ -3391,7 +3385,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get lastUser => 'Соңғы пайдаланушы';
 
   @override
-  String get currentUser => 'Ағымдағы пайдаланушы';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Әрқашан аутентификация';
@@ -3446,7 +3440,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get screensaver => 'Скринсейвер';
 
   @override
-  String get inAppScreensaver => 'Қолданба ішіндегі скринсейвер';
+  String get inAppScreensaver => 'In-App Screensaver';
 
   @override
   String get enableBuiltInScreensaver =>
@@ -3469,7 +3463,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
@@ -3500,10 +3494,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Скринсейвер кезінде сағатты көрсету';
 
   @override
-  String get clockModeStatic => 'Тұрақты';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Секіретін';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (сыншылар)';
@@ -3524,7 +3518,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get metacriticUser => 'Metacritic (пайдаланушы)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'Letterboxd';
@@ -3577,7 +3571,7 @@ class AppLocalizationsKk extends AppLocalizations {
       'Қолданбада көрсетілген бағалау көздерін қосыңыз және қайта реттеңіз';
 
   @override
-  String get pluginLabel => 'Moonbase плагині';
+  String get pluginLabel => 'Плагин';
 
   @override
   String get pluginDetected => 'Плагин анықталды';
@@ -3595,7 +3589,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nНұсқасы: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3649,7 +3643,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get networks => 'Желілер';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr ашу жолдары';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Жолдарды әдепкі мәндерге қайтарыңыз';
@@ -3673,44 +3667,44 @@ class AppLocalizationsKk extends AppLocalizations {
       'Нәтижелерде ересектерге арналған мазмұнды жасыру';
 
   @override
-  String get seerrNotificationsSection => 'Хабарландырулар';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Жаңа сұраныс хабарландырулары';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Біреу сұраныс жібергенде маған хабарлау';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Сұраныс жаңартулары';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Мақұлданды, қабылданбады және кітапханаңызға қосылды';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Мәселе жаңартулары';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Жаңа мәселелер, жауаптар және шешімдер';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Кірген пайдаланушы: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr ашу беті';
+  String get discoverRows => 'Жолдарды табу';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr негізгі бетінде көрсетілетін жолдарды қосыңыз. Ретін өзгерту үшін сүйреңіз. Жеке рет Moonbase-пен синхрондалады.';
+      'Қайта реттеу үшін сүйреңіз. Жолдарды қосу немесе өшіру. Қосылған жол тәртібі Moonfin плагинімен синхрондалады.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr негізгі бетінде көрсетілетін жолдарды қосыңыз. Ретін өзгерту үшін сүйреңіз. Жеке рет Moonbase-пен синхрондалады.';
+      'Қайта реттеу үшін сүйреңіз. Жолдарды қосу немесе өшіру.';
 
   @override
   String get enabled => 'Қосылған';
@@ -3723,7 +3717,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return '$version нұсқасы';
+    return 'Version $version';
   }
 
   @override
@@ -3772,7 +3766,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Жаңарту қолжетімді: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3784,7 +3778,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version қолжетімді';
+    return 'v$version Available';
   }
 
   @override
@@ -3829,7 +3823,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value ГБ';
+    return '$value GB';
   }
 
   @override
@@ -3847,7 +3841,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get imageCacheCleared => 'Кескін кэші тазаланды';
 
   @override
-  String get clear => 'Тазалау';
+  String get clear => 'Таза';
 
   @override
   String get browse => 'Шолу';
@@ -3863,15 +3857,15 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Жүктелуде · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Импортталуда';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count Элемент';
+    return '$count Items';
   }
 
   @override
@@ -3891,7 +3885,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Сұраған: $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3908,12 +3902,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '«$title» сұранысы болдырылмасын ба?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '«$title» үшін $count сұраныс болдырылмасын ба?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3928,12 +3922,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Бюджеті: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Табысы: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3943,7 +3937,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type сұрау';
+    return 'Request $type';
   }
 
   @override
@@ -3972,14 +3966,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get showMore => 'Көбірек көрсету';
 
   @override
-  String get appearances => 'Фильмография';
+  String get appearances => 'Сыртқы көріністер';
 
   @override
   String get crewSection => 'Экипаж';
 
   @override
   String ageValue(int age) {
-    return 'жасы $age';
+    return 'age $age';
   }
 
   @override
@@ -4010,147 +4004,148 @@ class AppLocalizationsKk extends AppLocalizations {
   String get deletedStatus => 'Жойылды';
 
   @override
-  String get failedStatus => 'Сәтсіз';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Өңделуде';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Өзгерткен: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Аяқталды';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Бұл атау бұрын сұралған';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Сұраныс шегіне жетті';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Бұл атау бұғаттау тізімінде';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Сұрауға маусым қалмады';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Бұл сұранысты жасауға рұқсатыңыз жоқ';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Сұраныстар';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Мәселелер';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Ең жаңа';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Соңғы өзгертілген';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Мәселе жоқ';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit фильм сұранысының $remaining қалды';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit маусым сұранысының $remaining қалды';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name құрамында';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Жинақты ашу';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Жинақты сұрау';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total фильм · $available қолжетімді';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count фильм сұрау';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total ішінен $current сұралуда...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count фильм сұралды';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total фильмнің $ok сұралды';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Барлық фильмдер қолжетімді немесе сұралып қойған';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Мәселе туралы хабарлау';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Бейне';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Аудио';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Не дұрыс емес?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Барлық эпизодтар';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Эпизод';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Ашық';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Шешілді';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Шешу';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Қайта ашу';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Хабарлаған: $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count пікір';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Пікір қосу';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Бұл мәселе жойылсын ба?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Хабарламаны жіберу';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB ұпайы';
@@ -4174,7 +4169,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get originalLanguageLabel => 'Түпнұсқа тілі';
 
   @override
-  String get seasonsLabel => 'Маусымдар';
+  String get seasonsLabel => 'Жыл мезгілдері';
 
   @override
   String get episodesLabel => 'Эпизодтар';
@@ -4183,7 +4178,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get access => 'Қол жеткізу';
 
   @override
-  String get add => 'Қосу';
+  String get add => 'қосу';
 
   @override
   String get address => 'Мекенжай';
@@ -4267,7 +4262,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get refresh => 'Жаңарту';
 
   @override
-  String get remote => 'Қашықтағы';
+  String get remote => 'Қашықтан';
 
   @override
   String get rename => 'Атын өзгерту';
@@ -4303,7 +4298,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get status => 'Күй';
 
   @override
-  String get stop => 'Тоқтату';
+  String get stop => 'Тоқта';
 
   @override
   String get streaming => 'Ағын';
@@ -4312,7 +4307,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get time => 'Уақыт';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Трикплей';
 
   @override
   String get uninstall => 'Жою';
@@ -4351,28 +4346,28 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminDrawerUsers => 'Пайдаланушылар';
 
   @override
-  String get adminDrawerLibraries => 'Медиатекалар';
+  String get adminDrawerLibraries => 'Кітапханалар';
 
   @override
-  String get adminDrawerDisplay => 'Көрсету';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метадеректер';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO параметрлері';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Транскодтау';
 
   @override
-  String get adminDrawerResume => 'Жалғастыру';
+  String get adminDrawerResume => 'Резюме';
 
   @override
   String get adminDrawerStreaming => 'Ағын';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Трикплей';
 
   @override
   String get adminDrawerDevices => 'Құрылғылар';
@@ -4423,22 +4418,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Қолжетімді плагин жаңартулары: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Қайта іске қосуды қажет ететін плагиндер: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Орындалмаған жоспарлы тапсырмалар: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Соңғы ескерту/қате жазбалары: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4497,7 +4492,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Қате: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4524,7 +4519,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Пәрмен орындалмады: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4543,7 +4538,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get sessionRewind => 'Артқа айналдыру';
 
   @override
-  String get sessionForward => 'Алға айналдыру';
+  String get sessionForward => 'Алға';
 
   @override
   String get sessionNext => 'Келесі';
@@ -4561,7 +4556,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get nowPlaying => 'Қазір ойнатылады';
 
   @override
-  String get volume => 'Дыбыс деңгейі';
+  String get volume => 'Көлемі';
 
   @override
   String get actions => 'Әрекеттер';
@@ -4573,7 +4568,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audioCodec => 'Аудио кодек';
 
   @override
-  String get hwAccel => 'Аппараттық үдету';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Аяқтау';
@@ -4588,14 +4583,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminClearDates => 'Күндерді тазалау';
 
   @override
-  String get adminActivitySeverityAll => 'Барлық деңгейлер';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Күн ауқымы';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Әрекеттер журналын жүктеу мүмкін болмады: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4612,7 +4607,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Құрылғыны жаңарту мүмкін болмады: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4623,28 +4618,28 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Құрылғыны жою мүмкін болмады: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '«$name» құрылғысы жойылсын ба? Пайдаланушыға осы құрылғыда қайта кіру қажет болады.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Барлық құрылғыны жою';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count құрылғы жойылсын ба? Тиісті пайдаланушыларға қайта кіру қажет болады. Ағымдағы құрылғыңызға әсер етпейді.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Құрылғылар жойылды';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Кейбір құрылғылар жойылды; $count құрылғыны жою мүмкін болмады.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4673,7 +4668,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Сканерлеуді бастау мүмкін болмады: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4684,12 +4679,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Кітапхана «$name» деп өзгертілді';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Атын өзгерту мүмкін болмады: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4697,17 +4692,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '«$name» кітапханасы жойылды';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Кітапхананы жою мүмкін болмады: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Жолды қосу мүмкін болмады: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4715,12 +4710,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '«$path» осы кітапханадан жойылсын ба?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Жолды жою мүмкін болмады: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4728,7 +4723,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Параметрлерді сақтау мүмкін болмады: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4759,261 +4754,251 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminMetadataCountryHint => 'мысалы АҚШ, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Жолдар';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Параметрлер';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Жүктеушілер';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Метадеректерді сақтаушылар';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Субтитр жүктеушілері';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Ән мәтінін жүктеушілер';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Метадеректерді жүктеушілер: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Кескін көздері: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Бұл сервер кітапхананың осы түрі үшін жүктеушілер ұсынбайды.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Жалпы';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метадеректер';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Кірістірілген мәліметтер';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Субтитрлер';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Кескіндер';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Сериалдар';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музыка';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Фильмдер';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Нақты уақыттағы бақылауды қосу';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Файл өзгерістерін анықтап, оларды автоматты түрде өңдеу.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Архивтерді медиафайл ретінде қарастыру';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Фотосуреттерді көрсету';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Мұқабаларды медиақалталарға сақтау';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Метадеректерді автоматты жаңарту';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Ешқашан';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Әдепкі';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Көрсету';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Кітапхананы көрсету';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Қарапайым медиақалталарды көрсету үшін қалталар көрінісін пайдалану';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Арнайы шығарылымдарды шыққан маусымдарында көрсету';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Фильмдерді жинақтарға топтау';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Сериалдарды жинақтарға топтау';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Ұсыныстарда сыртқы мазмұнды көрсету';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Қосылған күн әрекеті';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Қосылған күнді мына көзден алу';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Кітапханаға сканерленген күн';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Файл жасалған күн';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метадеректер және кескіндер';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Қалаулы метадерек тілі';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Тараулар';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Жасанды тараудың ұзақтығы (секунд)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Тараулары жоқ медиа үшін жасалатын тараулардың ұзақтығы. Өшіру үшін 0 мәнін қойыңыз.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Тарау кескінінің ажыратымдылығы';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO параметрлері';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO метадеректері Kodi және ұқсас клиенттермен үйлесімді. Параметрлер NFO метадеректерін сақтайтын барлық кітапханаға қолданылады.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO файлдарында көру деректері сақталатын пайдаланушы';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Кескін жолдарын NFO файлдарында сақтау';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO кескін жолдары үшін жолды алмастыруды қосу';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart кескіндерін extrathumbs қалтасына көшіру';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Жоқ';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days күн';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Кірістірілген атауларды пайдалану';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Қосымшалар үшін кірістірілген атауларды пайдалану';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Кірістірілген эпизод мәліметтерін пайдалану';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Кірістірілген субтитрлерге рұқсат ету';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Барлығына рұқсат ету';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Тек мәтіндік';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Тек кескіндік';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Жоқ';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Кірістірілген субтитрлер болса, жүктеуді өткізіп жіберу';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Аудиотрек жүктеу тіліне сәйкес келсе, жүктеуді өткізіп жіберу';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Субтитрлердің дәл сәйкестігін талап ету';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Субтитрлерді медиақалталарға сақтау';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Тарау кескіндерін шығарып алу';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Кітапхананы сканерлеу кезінде тарау кескіндерін шығарып алу';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'trickplay кескіндерін шығарып алуды қосу';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Кітапхананы сканерлеу кезінде trickplay кескіндерін шығарып алу';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'trickplay кескіндерін медиақалталарға сақтау';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Бірнеше қалтаға таралған сериалдарды автоматты түрде біріктіру';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Нөлінші маусымның көрсетілетін атауы';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Дыбысты қалыпқа келтіру үшін LUFS сканерлеуін қосу';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Стандартты емес орындаушылар тегін таңдау';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Фильмдерді жинақтарға автоматты түрде қосу';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Кітапхана атауы қажет';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Кітапхана жасау мүмкін болмады: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5039,27 +5024,27 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name өшірілсін бе? Ол кіре алмайтын болады.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name қосылсын ба? Ол қайта кіре алатын болады.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '«$name» пайдаланушысы өшірілді';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '«$name» пайдаланушысы қосылды';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Пайдаланушы саясатын жаңарту мүмкін болмады: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5076,7 +5061,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Пайдаланушы жасау мүмкін болмады: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5096,7 +5081,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Сақтау мүмкін болмады: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5107,7 +5092,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Сәтсіз: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5250,144 +5235,143 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminEnableAllChannels => 'Барлық арналарға кіруді қосыңыз';
 
   @override
-  String get adminParentalControl => 'Ата-ана бақылауы';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Рұқсат етілген ең жоғары жас шектеуі';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Одан жоғары шектеуі бар мазмұн бұл пайдаланушыдан жасырылады.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Жоқ';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Шектеу туралы мәліметі жоқ немесе танылмаған элементтерді бұғаттау';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Кітаптар';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Арналар';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Тікелей теледидар';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Фильмдер';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музыка';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трейлерлер';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Сериалдар';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Қатынау кестелері';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Қатынауға тек төмендегі кесте бойынша рұқсат ету. Кесте орнатылмаса, қатынауға күні бойы рұқсат етіледі.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Кесте қосу';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Күн';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Басталуы';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Аяқталуы';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Күн сайын';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Жұмыс күні';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Демалыс күні';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Жексенбі';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Дүйсенбі';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Сейсенбі';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Сәрсенбі';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Бейсенбі';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Жұма';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Сенбі';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Рұқсат етілген тегтер';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Тек осы тегтері бар мазмұн көрсетіледі. Барлығына рұқсат ету үшін бос қалдырыңыз.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Бұғатталған тегтер';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Осы тегтері бар мазмұн бұл пайдаланушыдан жасырылады.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Тег қосу';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Қосылған құрылғылар';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Қосылған арналар';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Аутентификация провайдері';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Құпия сөзді ысыру провайдері';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Бұғаттауға дейінгі сәтсіз кіру әрекеттерінің ең көп саны';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Әдепкі мән үшін 0, бұғаттауды өшіру үшін -1 қойыңыз.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay қатынауы';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Топтар жасауға және оларға қосылуға рұқсат ету';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Топтарға қосылуға рұқсат ету';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Қатынау жоқ';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Мазмұнды жоюға рұқсат ету көзі';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5395,22 +5379,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Сервер HTTP $status қайтарды';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name жойылсын ба?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '«$name» пайдаланушысы жойылды';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Пайдаланушыны жою мүмкін болмады: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5431,7 +5415,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Кілт жасау мүмкін болмады: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5442,7 +5426,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name үшін кілт кері қайтарылсын ба?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5450,7 +5434,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Кілтті кері қайтару мүмкін болмады: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5470,29 +5454,29 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Токен: $token\\nЖасалды: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Сақтық көшірме жасау';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Сақтық көшірмеге не кіретінін таңдаңыз.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Дерекқор';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Әрқашан қосылады';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метадеректер';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Субтитрлер';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay кескіндері';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Сақтық көшірме жасалуда...';
@@ -5502,7 +5486,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Сақтық көшірме жасау мүмкін болмады: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5511,12 +5495,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Манифест: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Манифестті жүктеу мүмкін болмады: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5527,7 +5511,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Сақтық көшірмеден қалпына келтіру мүмкін болмады: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5559,17 +5543,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path орнына сақталды';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Файлды сақтау мүмкін болмады: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName жүктеу мүмкін болмады';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5580,7 +5564,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Тапсырмаларды жүктеу мүмкін болмады: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5592,17 +5576,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Тапсырманы бастау мүмкін болмады: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Тапсырманы тоқтату мүмкін болмады: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Тапсырманы жүктеу мүмкін болмады: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5610,12 +5594,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Триггерді жою мүмкін болмады: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Триггер қосу мүмкін болмады: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5641,7 +5625,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours сағат';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5652,7 +5636,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Плагинді ауыстыру мүмкін болмады: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5660,27 +5644,27 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '«$name» жойылсын ба?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Плагинді жою мүмкін болмады: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Пакетті орнату мүмкін болмады: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Жаңартуды орнату мүмкін болмады: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Плагиндерді жүктеу мүмкін болмады: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5692,12 +5676,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Жаңартуды орнату (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Каталогты жүктеу мүмкін болмады: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5718,17 +5702,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '«$name» сервер қайта іске қосылғаннан кейін жойылады';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Жою мүмкін болмады: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '«$name» v$version нұсқасына жаңартылуда...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5737,7 +5721,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Плагинді жүктеу мүмкін болмады: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5745,7 +5729,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return '$version нұсқасы';
+    return 'Version $version';
   }
 
   @override
@@ -5765,17 +5749,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '«$name» жойылсын ба?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Репозиторийлерді сақтау мүмкін болмады: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Репозиторийлерді жүктеу мүмкін болмады: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5792,12 +5776,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Плагин параметрлерін жүктеу мүмкін емес: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri ашу мүмкін болмады';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5925,7 +5909,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Trickplay параметрлерін жүктеу мүмкін болмады';
+      'Трик-плей параметрлерін жүктеу мүмкін болмады';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6039,7 +6023,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminBaseUrl => 'Негізгі URL';
 
   @override
-  String get adminBaseUrlHint => 'мыс. /jellyfin';
+  String get adminBaseUrlHint => 'мысалы /желлифин';
 
   @override
   String get https => 'HTTPS';
@@ -6079,12 +6063,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Метадеректерді жүктеу мүмкін болмады: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Метадеректерді сақтау мүмкін болмады: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6104,7 +6088,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Метадеректерді жаңарту мүмкін болмады: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6118,7 +6102,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Қашықтан іздеу орындалмады: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6132,7 +6116,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Мазмұн түрін жаңарту мүмкін болмады: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6147,12 +6131,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType кескіні жаңартылды';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Кескінді жүктеу мүмкін болмады: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6164,27 +6148,27 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType кескіні жүктеп салынды';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Кескінді жүктеп салу мүмкін болмады: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType кескінін жою';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType кескіні жойылды';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Кескінді жою мүмкін болмады: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6195,70 +6179,67 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Тюнерді табу мүмкін болмады: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Тюнер қосыңыз';
 
   @override
-  String get adminEditTuner => 'Тюнерді өңдеу';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U тюнері';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл немесе URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Тюнердің IP мекенжайы';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Ыңғайлы атауы';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Бір мезгілдегі қосылым шегі';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Тюнер бір мезгілде рұқсат ететін ағындардың ең көп саны. Шектеусіз ету үшін 0 қойыңыз.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Резервтік ең жоғары ағын битрейті';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Тек таңдаулы арналарды импорттау';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Аппараттық транскодтауға рұқсат ету';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 транскодтау контейнеріне рұқсат ету';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Ағынды бірлесіп пайдалануға рұқсат ету';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Ағынды циклмен қайталауды қосу';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS елемеу';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Кірісті бастапқы кадр жиілігімен оқу';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Провайдерді өңдеу';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6267,50 +6248,50 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл немесе URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Фильм префиксі';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Фильм санаттары';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Бірнеше санатты тік сызықпен бөліңіз.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Балалар санаттары';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Жаңалықтар санаттары';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Спорт санаттары';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Пайдаланушы аты';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Құпия сөз';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Ел';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Елді таңдаңыз';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Пошта индексі';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Бағдарламаны алу';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Бағдарлама';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Барлық тюнерді қосу';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тюнер түрі';
@@ -6320,7 +6301,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Тюнер қосу мүмкін болмады: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6334,12 +6315,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Провайдер қосу мүмкін болмады: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Тюнерді жою мүмкін болмады: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6347,16 +6328,16 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Тюнерді ысыру мүмкін болмады: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Тюнердің бұл түрі ысыруды қолдамайды.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Провайдерді жою мүмкін болмады: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6375,43 +6356,43 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Сериялық жазу жолы';
 
   @override
-  String get adminMovieRecordingPath => 'Фильм жазбасының жолы';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Бағдарлама деректерінің күндері';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автоматты';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days күн';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Кейінгі өңдеу қолданбасының жолы';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Кейінгі өңдеу аргументтері';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Жазбаның NFO метадеректерін сақтау';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Жазба кескіндерін сақтау';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Уақыт';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Жазба жолдары';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Кейінгі өңдеу';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Бағдарлама деректері: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6419,7 +6400,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Параметрлерді сақтау мүмкін болмады: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6437,7 +6418,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Салыстыруларды жаңарту мүмкін болмады: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6453,15 +6434,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminGuideProviders => 'Гид провайдерлері';
 
   @override
-  String get adminRefreshGuideData => 'Бағдарлама деректерін жаңарту';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Бағдарлама деректерін жаңарту басталды';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Бағдарламаны жаңарту тапсырмасы бұл серверде қолжетімсіз.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Провайдерді қосу';
@@ -6472,22 +6452,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Жазба жолы: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Сериал жолы: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Алдыңғы қор: $minutes мин';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Соңғы қор: $minutes мин';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6520,7 +6500,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name сақтық көшірмесі қазір қалпына келтірілсін бе?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6566,27 +6546,27 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes мин бұрын';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours сағ бұрын';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days күн бұрын';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName жүктеу мүмкін болмады';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count сәйкестік';
+    return '$count matches';
   }
 
   @override
@@ -6596,7 +6576,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Метадеректер редакторы';
 
   @override
-  String get adminMetadataIdentify => 'Анықтау';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Түр';
@@ -6611,7 +6591,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminMetadataImages => 'Суреттер';
 
   @override
-  String get adminMetadataFieldTitle => 'Атауы';
+  String get adminMetadataFieldTitle => 'Тақырып';
 
   @override
   String get adminMetadataFieldSortTitle => 'Тақырыпты сұрыптау';
@@ -6696,22 +6676,22 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType кескіні жаңартылды';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType кескіні жүктеп салынды';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType кескіні жойылды';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Кескінді жүктеу мүмкін болмады: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6720,12 +6700,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Кескінді жүктеп салу мүмкін болмады: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType кескінін жою';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6734,12 +6714,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Кескінді жою мүмкін болмады: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType кескінін таңдау';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6772,7 +6752,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Жаңарту қолжетімді: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6797,7 +6777,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Жаңартуды орнату (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6809,7 +6789,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '«$name» орнатылуда...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6829,7 +6809,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name параметрлері';
+    return '$name Settings';
   }
 
   @override
@@ -6869,7 +6849,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Репозиторийлерді жүктеу мүмкін болмады: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6877,15 +6857,15 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '«$name» жойылсын ба?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Алып тастау';
+  String get adminReposRemove => 'Жою';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Репозиторийлерді сақтау мүмкін болмады: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7011,20 +6991,19 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Экранды қосу';
 
   @override
-  String get adminBrandingSplashUpload => 'Кескінді жүктеп салу';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Бастау экраны жаңартылды';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Бастау экранын жүктеп салу мүмкін болмады';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Бастау экраны жойылды';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Жеке бастау экраны жоқ';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Аппараттық жеделдету';
@@ -7040,126 +7019,121 @@ class AppLocalizationsKk extends AppLocalizations {
       'Аппараттық құралдардың декодтауын қосыңыз:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV құрылғысы';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Кеңейтілген NVDEC декодерін қосу';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Жүйенің өз аппараттық декодерін таңдау';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Аппараттық декодтаудың түс тереңдігі';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10 биттік HEVC декодтауы';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10 биттік VP9 декодтауы';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10 биттік декодтауы';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12 биттік декодтауы';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Аппараттық кодтау';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC кодтауына рұқсат ету';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 кодтауына рұқсат ету';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel аз қуатты H.264 кодерін қосу';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel аз қуатты HEVC кодерін қосу';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тон салыстыру';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Тон салыстыруды қосу';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP тон салыстыруын қосу';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox тон салыстыруын қосу';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Тон салыстыру алгоритмі';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Тон салыстыру режимі';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Тон салыстыру ауқымы';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Тон салыстыру десатурациясы';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Тон салыстыру шыңы';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Тон салыстыру параметрі';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP тон салыстыруының жарықтығы';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP тон салыстыруының контрасты';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Дайын баптаулар және сапа';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Кодер баптауы';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 кодтауының CRF мәні';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) кодтауының CRF мәні';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Деинтерлейс әдісі';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Деинтерлейс кезінде кадр жиілігін екі есе арттыру';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Аудио';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'VBR аудиокодтауын қосу';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost =>
-      'Аудионы араластыру кезіндегі күшейту';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Стереоға араластыру алгоритмі';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Мультиплекстеу кезегінің ең үлкен өлшемі';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Авто';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодтау';
@@ -7280,10 +7254,10 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminTaskNeverRun => 'Ешқашан жүгірме';
 
   @override
-  String get adminTaskStop => 'Тоқтату';
+  String get adminTaskStop => 'Тоқта';
 
   @override
-  String get adminRunningTasks => 'Орындалып жатқан тапсырмалар';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Жүгіру';
@@ -7305,17 +7279,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Күн сайын $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Әр $day сайын $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Әр $duration сайын';
+    return 'Every $duration';
   }
 
   @override
@@ -7353,8 +7327,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count сағат',
-      one: '$count сағат',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7382,17 +7356,17 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days күн бұрын';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours сағ бұрын';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes мин бұрын';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7400,27 +7374,27 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes мин';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours сағ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days күн';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Айналдыру кезіндегі алдын ала қарау нобайлары үшін trickplay кескіндерін жасауды реттеңіз.';
+      'Алдын ала қарау нобайларын іздеу үшін трик-плей кескінін жасауды конфигурациялаңыз.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Қоғамдық HTTPS порты';
@@ -7429,51 +7403,49 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Негізгі URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'мыс. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'мысалы /желлифин';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Ашық HTTP порты';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS талап ету';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Барлық қашықтағы сұраныстарды HTTPS-ке бағыттау. Серверде жарамды сертификат болмаса, әсер етпейді.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Сертификат құпия сөзі';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP параметрлері';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 қосу';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 қосу';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Порттарды автоматты салыстыруды қосу';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN желілері';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Жергілікті желіде деп саналатын IP мекенжайлардың немесе CIDR ішкі желілерінің үтірмен не жол бойынша бөлінген тізімі.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris =>
-      'Жарияланған сервер URI мекенжайлары';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Ішкі желіні немесе мекенжайды жарияланған URL-ге салыстырыңыз, мыс. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Сертификат жолы';
@@ -7503,11 +7475,11 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Дроссельді буферлеу';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Ағынды шектеу кідірісі (секунд)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Субтитрлерді жүріп жатқанда шығарып алуға рұқсат ету';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Резюменің минималды пайызы';
@@ -7556,30 +7528,29 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Мазмұн түрін жаңарту мүмкін болмады: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Баяу жауап шегі (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Баяу жауап туралы ескертулерді қосу';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect қосу';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метадеректер';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Жолдар';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Өнімділік';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Кэш жолы';
@@ -7591,7 +7562,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminGeneralServerName => 'Сервер атауы';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Қалаулы көрсету тілі';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Параметрлерді жүктеу сәтсіз аяқталды';
@@ -7601,19 +7572,19 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Салыстыруларды жаңарту мүмкін болмады: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Уақыт шегі: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'Қалталар';
 
   @override
-  String get libraries => 'Медиатекалар';
+  String get libraries => 'Кітапханалар';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7643,8 +7614,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# қатысушы',
-      one: '# қатысушы',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7687,7 +7658,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return '$index-элемент';
+    return 'Item $index';
   }
 
   @override
@@ -7735,12 +7706,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay тобына қосылды';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay тобынан шықты';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7752,7 +7723,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Ойнату $groupName тобымен синхрондалуда';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7791,8 +7762,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# жол табылды',
-      one: '# жол табылды',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7833,20 +7804,20 @@ class AppLocalizationsKk extends AppLocalizations {
   String get offlineSavedMedia => 'Сақталған медиа';
 
   @override
-  String get offlineBannerTitle => 'Желіден тыссыз';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Жүктеулеріңіз көрсетілуде';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Жүктеулер';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Серверге қосылу мүмкін емес';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Ол қайта қосылғанша жүктеулерден ойнатылуда';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7862,12 +7833,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Cast басқаруы орындалмады: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind басқару элементтері';
+    return '$kind Controls';
   }
 
   @override
@@ -7878,7 +7849,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind тоқтату';
+    return 'Stop $kind';
   }
 
   @override
@@ -7901,12 +7872,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length таңбалы PIN енгізіңіз';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '$length таңбалы PIN кодыңызды енгізіңіз';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7919,17 +7890,17 @@ class AppLocalizationsKk extends AppLocalizations {
   String get pinForgot => 'PIN кодын ұмыттыңыз ба?';
 
   @override
-  String get pinClear => 'Тазалау';
+  String get pinClear => 'Таза';
 
   @override
-  String get pinBackspace => 'Жою';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect сұранысы расталды.';
+  String get quickConnectAuthorized => 'Жылдам қосылу сұрауы рұқсат етілген.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect коды жарамсыз немесе мерзімі өткен.';
+      'Жылдам қосылу коды жарамсыз немесе мерзімі өтіп кеткен.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7937,7 +7908,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect кодын растау мүмкін болмады.';
+      'Жылдам қосылу кодын авторизациялау мүмкін болмады.';
 
   @override
   String get quickConnectDisabled => 'Бұл серверде Quick Connect өшірілген.';
@@ -7948,11 +7919,11 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect коды табылмады. Жаңа кодты байқап көріңіз.';
+      'Жылдам қосылу коды табылмады. Жаңа кодты қолданып көріңіз.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect қатесі: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7963,7 +7934,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Пәрмен орындалмады: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7992,7 +7963,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Тасымалдауды бастау мүмкін болмады: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8037,7 +8008,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name жүктелуде...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8057,7 +8028,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get shuffleSelectGenre => 'Жанр таңдаңыз';
 
   @override
-  String get shuffleLibrary => 'Медиатека';
+  String get shuffleLibrary => 'Кітапхана';
 
   @override
   String get shuffleGenre => 'Жанр';
@@ -8118,14 +8089,14 @@ class AppLocalizationsKk extends AppLocalizations {
       'Ойнату кідіртілді. Сіз әлі қарап отырсыз ба?';
 
   @override
-  String get stillWatchingStop => 'Тоқтату';
+  String get stillWatchingStop => 'Тоқта';
 
   @override
   String get stillWatchingContinue => 'Жалғастыру';
 
   @override
   String skipSegment(String segment) {
-    return '$segment өткізіп жіберу';
+    return 'Skip $segment';
   }
 
   @override
@@ -8136,12 +8107,12 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$total ішінен $current жүктелуде — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName жүктелуде';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8203,13 +8174,13 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      '«Көруді жалғастыру» бөлімінен жасыру';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => '«Келесі» бөлімінен жасыру';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Жинаққа қосу';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8264,15 +8235,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get settingsAlphabetical => 'Алфавиттік';
 
   @override
-  String get settingsConnectionSection => 'ҚОСЫЛЫМ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Өздігінен қол қойылған сертификаттарға рұқсат ету';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Өздігінен қол қойылған немесе жеке ЦС берген TLS сертификаттарын пайдаланатын серверлерге сену. Тек өзіңіз басқаратын серверлер үшін қосыңыз. Бұл барлық қосылым үшін сертификатты тексеруді өшіреді.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ҚҰПИЯЛЫҚ ЖӘНЕ ҚАУІПСІЗДІК';
@@ -8288,11 +8258,11 @@ class AppLocalizationsKk extends AppLocalizations {
       'Тақырып екпіні, фон, қаралған индикаторлар және тақырыптық музыка';
 
   @override
-  String get settingsDetailsScreen => 'Мәліметтер экраны';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стиль, фонды бұлдырлату және қойынды әрекеті';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Негізгі бет';
@@ -8330,11 +8300,11 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Навигация жолағында Seerr түймесін көрсету';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Жоғарғы навигация жолағында мәтіндік белгілерді әрқашан көрсету';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8404,7 +8374,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Әзірлеушіге бір кесе кофеге қайыр беру';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ЗАҢДЫ';
@@ -8438,8 +8408,8 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лицензиялық ескертпе',
-      one: '# лицензиялық ескертпе',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8489,16 +8459,16 @@ class AppLocalizationsKk extends AppLocalizations {
       'Кіріспелер мен шығыстарды өткізіп жіберу керек пе?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Медиасегмент кері санағы';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Прогресс жолағы';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Жоқ';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Шұғыл пайдаланушы';
@@ -8533,13 +8503,13 @@ class AppLocalizationsKk extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (ұсынылады)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (ескі)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (мұра)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (ұсынылады)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Қайта';
@@ -8632,7 +8602,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8728,756 +8698,749 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Жақында шыққан: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Келесі эпизодты автоойнату';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Қолжетімді болғанда келесі эпизодты автоматты түрде ойнату.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Үнсіздікті өткізіп жіберу';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Ағын қолдаса, үнсіз аудиосегменттерді автоматты түрде өткізіп жіберу.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Сыртқы аудиоәсерлерге рұқсат ету';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Эквалайзер мен әсер қолданбаларына (мыс. Wavelet) Media3 ойнату сеанстарына қосылуға рұқсат ету.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Туннельдеуді өшіру';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Туннельсіз ойнатуды мәжбүрлеу. Туннельдеу кезінде аудио/бейне үзілістері бар құрылғыларда пайдалы.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Туннельдеуді қосу';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Кеңейтілген. Аудио мен бейнені байланысқан аппараттық жол арқылы бағыттайды. Кейбір құрылғыларда аудио/бейне үзілістерін тудыратындықтан әдепкіде өшірулі.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision 7-профилін HEVC-ке салыстыру';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'DV емес құрылғыларда Dolby Vision 7-профиль ағындарын HDR10-үйлесімді HEVC ретінде ойнату.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Кірістірілген субтитр стильдерін пайдалану';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Субтитр трегіне кірістірілген түстерді, қаріптерді және орналасуды қолдану. Оның орнына өз субтитр стилі параметрлеріңізді пайдалану үшін өшіріңіз.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Кірістірілген субтитр қаріп өлшемдерін пайдалану';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Субтитр трегіне кірістірілген қаріп өлшемі кеңестерін қолдану. Стиль параметрлеріңіздегі субтитр өлшемін пайдалану үшін өшіріңіз.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Медиа мәліметтерін көрсету';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Таңдалған элементтің мәліметтерін кітапхана беттерінің жоғарғы жағында көрсету.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Шолу кезінде фондық кескіндерді жасыру керек пе?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Толық ішкі тақырыптарды пайдалану';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Кітапхана беттерінде толық немесе қысқа ішкі жолды көрсету.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Сақталған тақырып жойылсын ба?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '«$themeName» осы құрылғының кэшінен жойылсын ба?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Тақырыптар дүкені';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Қауымдастық тақырыптарын шолу және сақтау';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Тақырыпты басқа сақталған тақырыптарыңыздай пайдалану үшін оны сақтаңыз.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Қазір қолжетімді тақырыптар жоқ.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Тақырыптар дүкенін жүктеу мүмкін болмады. Қосылымыңызды тексеріп, қайталап көріңіз.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Сақтау';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Сақтап, қолдану';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Сақталды';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Бұл тақырыпты жүктеу мүмкін болмады.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '«$themeName» сақталды.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '«$themeName» осы құрылғыдан жойылды.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '«$themeName» жою мүмкін болмады.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Сақталған тақырыптар';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Бұл — ағымдағы сервер үшін Moonfin плагинінен жүктелген тақырыптар. Жою тек осы жергілікті көшірмені өшіреді.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Бұл сервер үшін сақталған тақырыптар табылмады.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Қазір белсенді';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Сақталған тақырыпты жою';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Осы құрылғыда жүктелген плагин тақырыптарын басқару';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Тақырып өңдегіші';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'Браузерде Moonfin тақырып өңдегішін ашу';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Негізгі экран';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Төменгі жолақ';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Классикалық';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Заманауи';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Негізгі бет жолдары';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Негізгі бет жолын көрсету';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Негізгі бет жолы бөлімдері';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Негізгі бет жолы қосқыштары';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Кітапханаға негізделген негізгі бет жолы санаттарын қосу немесе өшіру';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Негізгі бет бөлімдерінде жолдарды көрсету үшін мына қосқыштарды қосыңыз.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      '«Классикалық» әр жолдың кескін түрі мен ақпарат қабатын сақтайды. «Заманауи» тік бағыттан фондық кескінге өтетін жолдарды пайдаланады.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Таңдаулылар жолдарын көрсету';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Негізгі бет бөлімдерінде таңдаулы фильмдер, сериалдар және басқа таңдаулы жолдарды көрсету.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Таңдаулылар жолын сұрыптау';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Таңдаулылар жолдарын қосылған күні, шығу күні, әліпби бойынша және басқаша сұрыптаңыз.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Жинақтар жолдарын көрсету';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Негізгі бет бөлімдерінде жинақтар жолдарын көрсету.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Жинақтар жолын сұрыптау';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Жинақтар жолдарын қосылған күні, шығу күні, әліпби бойынша және басқаша сұрыптаңыз.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Жанрлар жолдарын көрсету';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Негізгі бет бөлімдерінде жанрлар жолдарын көрсету.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Жанрлар жолын сұрыптау';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Жанрлар жолдарын қосылған күні, шығу күні, әліпби бойынша және басқаша сұрыптаңыз.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Жанрлар жолының элементтері';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Жанрлар жолдарында фильмдерді, сериалдарды немесе екеуін де көрсету.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Ойнату тізімі жолдарын көрсету';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Негізгі бет бөлімдерінде ойнату тізімі жолдарын көрсету.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Ойнату тізімі жолын сұрыптау';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ойнату тізімі жолдарын қосылған күні, шығу күні, әліпби бойынша және басқаша сұрыптаңыз.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Аудио жолдарын көрсету';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Негізгі бет бөлімдерінде аудио жолдарын көрсету.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Аудио жолдарын сұрыптау';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Аудио жолдарын қосылған күні, шығу күні, әліпби бойынша және басқаша сұрыптаңыз.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудио ойнату тізімдері';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Сыртқы түрі';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Қалып';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тақырып';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Пернетақта';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Түймелер';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Рендеринг';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV конфигурациясы';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Сыртқы ойнатқыш қолданбасы';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Ұзақ басу арқылы ойнату опциясын қосу үшін сыртқы ойнатқышты орнатыңыз';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Ойнату басталғанда қолданба таңдағышын көрсету.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Орнатылған ойнатқыштар жүктелуде...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Қосылым';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Аудио транскодтау мақсаты';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'Транзит';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Бұл құрылғыда қолдау көрсетіледі';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Бұл құрылғыда қолдау көрсетілмейді';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) транзиті';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) битағынын сыртқы декодерге жіберу.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
-  String get settingsAudioTrueHdJocPassthrough => 'TrueHD Atmos (JOC) транзиті';
+  String get settingsAudioTrueHdJocPassthrough =>
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Медиаойнатқыш әрекеті';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Ойнату жақсартулары';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Әрқашан қосулы.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      '«Титрді өткізу» орнына «Келесі» көрінісін қолдану';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '«Титрді өткізу» түймесінің орнына «Келесі» қабатын көрсету.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Ойнатқыш бағыттауы';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Бағдарламалық декодерлерді таңдау';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Аппараттық декодерлерден бұрын FFmpeg (аудио) және libgav1 (AV1) пайдалану. HDMI аудио транзиті бұзылса, өшіріңіз.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV-де бейнені таңдалған сыртқы қолданбада ойнату.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Автоматты кезекке қою';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH субтитрлерін таңдау';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Автоматты таңдау кезінде SDH/CC субтитр тректеріне басымдық беру.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Веб-диагностика';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin веб-диагностикасы';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Браузердің қосылым мәселелерін (CORS, аралас мазмұн және табу параметрлері) диагностикалау үшін осы бетті пайдаланыңыз.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Аралас мазмұн қатесі анықталды';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight қатесі анықталды';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin HTTPS бетінің HTTP сервер URL-іне қоңырау шалу әрекетін анықтады. Браузерлер бұл сұранысты серверіңізге жетпей тұрып бұғаттайды.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin браузер деңгейіндегі сұраныс қатесін анықтады, ол әдетте медиасервердегі CORS немесе preflight тақырыптарының болмауынан туындайды.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Мақсатты URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Мәлімет: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Ағымдағы орындалу контексті';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Бастапқы көзі';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Схема';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Плагин режимі';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC сканерлеуі';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Мәжбүрлі сервер URL-і';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Әдепкі сервер URL-і';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'Табу прокси URL-і';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'конфигурацияланбаған';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Аралас мазмұн';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Бұл бет HTTPS арқылы жүктелген, бірақ бір немесе бірнеше конфигурацияланған URL — HTTP. Браузерлер HTTPS беттеріне HTTP API-ге қоңырау шалуды бұғаттайды.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Түзету: медиасерверіңізді немесе прокси нүктеңізді HTTPS арқылы ұсыныңыз, немесе Moonfin-ді HTTP арқылы тек сенімді жергілікті желілерде жүктеңіз.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Ағымдағы орындалу параметрлерінен айқын аралас мазмұн конфигурациясы анықталмады.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS тексеру тізімі';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Браузердің бастапқы көзіне Access-Control-Allow-Origin ішінде рұқсат етіңіз.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers ішіне Authorization, X-Emby-Authorization және X-Emby-Token қосыңыз.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Ағын мен айналдыру әрекеті үшін Content-Range және Accept-Ranges ашыңыз.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight сұраныстарына 204 қайтарыңыз.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Тақырып үзіндісінің мысалы (nginx стилінде)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Ескертпе';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Бұл диагностика бағыты веб-құрастырылымдарға арналған. Мұны басқа платформада көріп тұрсаңыз, бұл тексерулер қолданылмауы мүмкін.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Сервер таңдауға оралу';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Барлық пайдаланушыны шығару';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Микрофон рұқсаты біржола қабылданбады. Оны жүйе параметрлерінде қосыңыз.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Дауыстық іздеу үшін микрофон рұқсаты қажет.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Түсінбедім. Қайталап көріңіз.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Сөйлеу анықталмады.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Микрофон қатесі.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Дауыстық іздеу үшін интернет қажет.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Дауыстық қызмет бос емес. Қайталап көріңіз.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Микрофон рұқсаты біржола қабылданбады.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Микрофон рұқсаты қабылданбады.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Сөйлеуді тану бұл құрылғыда қолжетімсіз.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS бағыт таңдағышын ашу';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay бағыт таңдағышы бұл құрылғыда қолжетімсіз.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Бейнелер';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Бағдарламалар';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Әндер';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Фотоальбомдар';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Фотосуреттер';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Адамдар';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Жақында шыққан эпизодтар';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Қайта көру';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Қонақ ретінде қатысу';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Қатысуы (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Түсіру тобының үлесі (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Топпен бірге көру';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Қателер';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Ескертулер';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Диск';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Браузерде ашу';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Кірістірілген браузер бұл платформада қолжетімсіз.';
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get adminRestartServerConfirmation => 'Сервер қайта іске қосылсын ба?';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Сервер өшірілсін бе? Оны қолмен қайта іске қосу қажет болады.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Ішкі';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Бос';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Пайдаланушылар табылмады';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Іздеуіңізге сәйкес пайдаланушы жоқ';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Құрылғылар табылмады';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Ағымдағы сүзгілерге сәйкес құрылғы жоқ';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Құпия сөз орнатылған';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Құпия сөз конфигурацияланбаған';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Қашықтан қатынау';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Тек жергілікті';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Медиа аналитикасын жүктеу мүмкін болмады';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Барлық медиакітапхана бойынша біріктірілген аналитика.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Үздік орындаушылар';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Үздік авторлар';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Үздік үлес қосушылар';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Кітапхана',
-      one: '$count Кітапхана',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Бұл таңдау үшін индекстелген медиа қосындылары әзірге қолжетімсіз.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Кітапхана мәліметтері';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Кітапхана бөлінісі';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Қолжетімді кітапханалар жоқ.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Сервер әкімшілігі';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Деректер';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Кескін кэші';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Кэш';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Журналдар';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Метадеректер';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Транскодтау';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Бұл сервер сервер жолдарын қайтармады.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% пайдаланылды';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Пайдаланушы әрекеті';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Жүйелік оқиғалар';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Назар аудару қажет';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Сервер';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Ойнату';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Құрылғылар';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Кеңейтілген';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Плагиндер';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Тікелей теледидар';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Үй бейнелері';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Аралас мазмұн';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Үй бейнелері мен фотосуреттер';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Аралас фильмдер мен сериалдар';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9489,300 +9452,299 @@ class AppLocalizationsKk extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Жазбалар табылмады';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension архивінің ішінен кескін беттері табылмады.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Кірістірілген рендерер сәтсіз болды ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB рендерері сәтсіз болды ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Оқу құралы үшін жергілікті файл жоқ: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri көзінен кітап деректерін ашу кезінде HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Оқуға болатын кітап нүктесі қолжетімсіз';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Қолдау көрсетілмейтін комикс архивінің пішімі: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'CBR шығарып алу плагині бұл платформада қолжетімсіз.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr архивін шығарып алу мүмкін болмады.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7 шығарып алу бұл платформада қолжетімсіз.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'CB7 шығарып алу плагині бұл платформада қолжетімсіз.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Жанр панелін жабу';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Араластыру жүктелуде...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'КІТАПХАНАНЫ АРАЛАСТЫРУ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'КЕЗДЕЙСОҚ АРАЛАСТЫРУ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ЖАНРЛАРДЫ АРАЛАСТЫРУ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Автоматты HDR ауыстыру';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR бейнесін ойнату үшін HDR-ды автоматты түрде қосу және шыққанда дисплей режимін қалпына келтіру.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Толық экран кезінде';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Мұқабаны өзгерту';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Жоқ';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Транскодтау шектеулері';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Барлық мұқаба тазалансын ба?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Барлық жүктелген мұқабаны тазалағыңыз келе ме?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Тазалауды растау';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Осы «$itemType» тазалағыңыз келе ме?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Жүктеп салу керек пе?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Ажыратымдылық: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Мұқабаларды тек интерфейс тілінде көрсету';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Барлығын тазалауды растау';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Кескін сәтті жүктеп салынды!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Кескінді жүктеп салу мүмкін болмады: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Кескінді орнату мүмкін болмады: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Кескінді жою мүмкін болмады: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Барлық мұқабаны тазалау мүмкін болмады: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Иә';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Фондық кескіндер';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Баннер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Логотип';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Нобай';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Мұқаба';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Диск мұқабасы';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Скриншот';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Қорап мұқабасы';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Қораптың артқы мұқабасы';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Мәзір мұқабасы';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'фондық кескін';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'баннер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'логотип';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'нобай';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'мұқаба';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'диск мұқабасы';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'скриншот';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'қорап мұқабасы';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'қораптың артқы мұқабасы';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'мәзір мұқабасы';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Барлығы';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Жоғары (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Орташа (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Төмен (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Көздер';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Тараулар';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Бетбелгілер';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Ескертпелер';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Кезек';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Уақыт шкаласы';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Уақыт шкаласы бос';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Бүкіл кітап';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Фокустелген шкала';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Бетбелгілерді экспорттау';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Ескертпелерді экспорттау';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Барлығын экспорттау';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path орнына экспортталды';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Экспорттау мүмкін болмады: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Мәтін';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Бетбелгі қосу';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Ескертпе қосу';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Ескертпені өңдеу';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Осы сәт үшін ескертпе жазыңыз';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Ұйқы таймері';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Өшірулі';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Тарау соңы';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Реттелетін';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining қалды';
+    return '$remaining left';
   }
 
   @override
@@ -9790,58 +9752,58 @@ class AppLocalizationsKk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Ойнату жылдамдығы';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Қалды';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Өтті';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Артқа $seconds с';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Алға $seconds с';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Алдыңғы тарау';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Келесі тарау';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total ішінен $current-тарау';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Тараулар жоқ';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Әзірге бетбелгілер жоқ';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Әзірге ескертпелер жоқ';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position орнына бетбелгі қосылды';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x-ке ысыру';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9849,252 +9811,249 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Сақтау';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Болдырмау';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Жою';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Субтитр параметрлері';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Субтитр режимдерін, әдепкі тілдерді, сыртқы түрін және көрсету параметрлерін өзгертіңіз.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Субтитрлерді көрсету';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Көрсету параметрлері';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Шығу күні (өсу ретімен)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Шығу күні (кему ретімен)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Үлесті топтау';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Бірнеше рөлді топтау';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Кітапханаға жазу рұқсаты туралы ескерту';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Мұны қалай түзетуге болады:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Серверіңіздегі медиакітапхана қалталары үшін Jellyfin қызметінің пайдаланушысына (мыс. jellyfin немесе Docker PUID/PGID) жазу рұқсатын беріңіз.\n\n2. Немесе Jellyfin басқару тақтасы -> Кітапханалар бөліміне өтіп, осы кітапхананы өңдеп, мұқабаны Jellyfin ішкі дерекқорында сақтау үшін «Мұқабаларды медиақалталарға сақтау» параметрін өшіріңіз.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Жабу';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '«$libraryName» кітапханаңыз мұқабаларды тікелей медиақалталарға сақтауға конфигурацияланған («Мұқабаларды медиақалталарға сақтау» қосулы). Алайда Jellyfin жазу рұқсатын тексерді және осы каталогқа файлдар жазуға рұқсаты жоқ:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin мұқабаны жаңарта алмаған сияқты. Кітапханаңыз мұқабаларды тікелей медиақалталарға сақтауға конфигурацияланған («Мұқабаларды медиақалталарға сақтау» қосулы). Бұл қате әдетте Jellyfin сервер процесінің медиакаталогтарыңызға файлдар жазуға рұқсаты болмағанда орын алады.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Сыртқы тізімдер';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Қайта ойнату';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Файл туралы мәлімет';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Өлшемі: $size  •  Пішімі: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Барлық ($count) аудиотректі көрсету';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Барлық ($count) субтитр трегін көрсету';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Тікелей ойнату мүмкіндігі тексерілуде...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Тікелей ойнату мүмкіндігі: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Мәжбүрлі';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Контейнер пішімі ойнатқышта қолдау таппайды.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видеокодек қолдау таппайды.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудиокодек қолдау таппайды.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Субтитр пішімі қолдау таппайды (қаттауды қажет етеді).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Аудиопрофиль қолдау таппайды.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Видеопрофиль қолдау таппайды.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Бейне деңгейі қолдау таппайды.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Бейне ажыратымдылығы бұл құрылғыда қолдау таппайды.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Бейне түс тереңдігі қолдау таппайды.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Бейне кадр жиілігі қолдау таппайды.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Файл битрейті ойнатқыштың ағын шегінен асады.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Бейне битрейті ағын шегінен асады.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Аудио битрейті ағын шегінен асады.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Аудиоарналар саны қолдау таппайды.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Әліпби бойынша';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Шығу реті (өсу ретімен)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Шығу реті (кему ретімен)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Реттелетін (сүйреп апару)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Ойнату тізімін сұрыптау параметрлері';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Сұрыптауды ысыру';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'М$season:Э$episode қайта көру';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Ойнату тізімін қайта көру';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Субтитрлер табылмады.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Әкімші басқаруы';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Рендеринг қозғалтқышы (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller — плавнырақ анимациялар мен азырақ кідірістер үшін Flutter-дің заманауи GPU рендерері. Кейбір ТД-приставкаларда және ескі GPU-ларда ол ақаулар немесе қара бейне тудыруы мүмкін; мұны көрсеңіз, өшіріңіз. «Автоматты» құрылғыңызға ең қолайлы әдепкіні таңдайды. Қолдану үшін Moonfin-ді қайта іске қосыңыз.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автоматты';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Қосулы';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Өшірулі';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Қайта іске қосу қажет';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Рендеринг қозғалтқышын өзгерту үшін Moonfin-ді қайта іске қосу қажет. Қолдану үшін қолданбаны қазір жауып, содан кейін қайта ашыңыз.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Қолданбаны қазір жабу';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Кітапхананы жаңарту';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Барлық кітапхананы жаңарту';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Қосылған күні (алдымен ескілері)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Қосылған күні (алдымен жаңалары)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Әліпби бойынша (А-дан Я-ға)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Әліпби бойынша (Я-дан А-ға)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Сервер аналитикасы жүктелуде... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Көзге сәйкес';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb үздік 250 фильм';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb үздік 250 сериал';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb ең танымал фильмдер';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb ең танымал сериалдар';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb ең төмен бағаланған фильмдер';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb ең жоғары бағаланған ағылшын фильмдері';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -9,30 +9,30 @@ class AppLocalizationsKn extends AppLocalizations {
   AppLocalizationsKn([String locale = 'kn']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'ಮೂನ್ಫಿನ್';
 
   @override
-  String get accountPreferences => 'ಖಾತೆ ಆದ್ಯತೆಗಳು';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ಇಂಟರ್‌ಫೇಸ್ ಭಾಷೆ';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'ಸಿಸ್ಟಂ ಡೀಫಾಲ್ಟ್';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'ಸೈನ್ ಇನ್ ಮಾಡಿ';
 
   @override
-  String get empty => 'ಖಾಲಿ';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName ಗೆ ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'ತ್ವರಿತ ಸಂಪರ್ಕ';
 
   @override
   String get password => 'ಪಾಸ್ವರ್ಡ್';
@@ -61,12 +61,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ಲಭ್ಯವಿಲ್ಲ: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ಲಭ್ಯವಿಲ್ಲ ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin ಆವೃತ್ತಿ $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'ನಿಮ್ಮ ಸರ್ವರ್‌ಗಳಿಂದ \"$serverName\" ಅನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsKn extends AppLocalizations {
   String get settingsAppearanceTheme => 'ಅಪ್ಲಿಕೇಶನ್ ಥೀಮ್';
 
   @override
-  String get detailScreenStyle => 'ವಿವರ ಪರದೆಯ ಶೈಲಿ';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'ಕ್ಲಾಸಿಕ್ ಎಂಬುದು ಮೂಲ ಕೇಂದ್ರೀಕೃತ Moonfin ವಿನ್ಯಾಸ. ಮಾಡರ್ನ್ ಎಂಬುದು ಸ್ಪಂದನಶೀಲ ಸಿನಿಮ್ಯಾಟಿಕ್ ವಿನ್ಯಾಸ.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'ಕ್ಲಾಸಿಕ್';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'ಮಾಡರ್ನ್';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'ವಿಸ್ತರಿಸಿದ ಟ್ಯಾಬ್‌ಗಳು';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಟ್ಯಾಬ್ ವಿಷಯವನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ತೋರಿಸಿ. ಪ್ರತಿ ಟ್ಯಾಬ್ ಅನ್ನು ಹಸ್ತಚಾಲಿತವಾಗಿ ತೆರೆಯಲು ಮತ್ತು ಮುಚ್ಚಲು ಆಫ್ ಮಾಡಿ.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'ತಾಂತ್ರಿಕ ವಿವರಗಳನ್ನು ತೋರಿಸುವುದೇ?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'ಬ್ಯಾನರ್ ಸಾರಾಂಶದಲ್ಲಿ ಕೊಡೆಕ್, ರೆಸಲ್ಯೂಶನ್ ಮತ್ತು ಸ್ಟ್ರೀಮ್ ಮಾಹಿತಿಯನ್ನು ತೋರಿಸಿ';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'ಶಿಫಾರಸು ವ್ಯವಸ್ಥೆ';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends ಸ್ಥಳೀಯ-ಲೈಬ್ರರಿ ಅಲ್ಗಾರಿದಮ್ ಅಥವಾ ಆನ್‌ಲೈನ್ TMDb ಸಾಮ್ಯತೆ ಮಾಪನಗಳನ್ನು ಬಳಸಿ. ಗಮನಿಸಿ: ಆನ್‌ಲೈನ್ ಶಿಫಾರಸುಗಳಿಗೆ Seerr ಸಂಯೋಜನೆ ಅಗತ್ಯವಿದೆ.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb ಸಾಮ್ಯತೆ';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'ಪೋಷಕರ ರೇಟಿಂಗ್ ಮಿತಿಯನ್ನು ಅನ್ವಯಿಸುವುದೇ?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'ಗುರಿ ಮಾಧ್ಯಮದ ಪೋಷಕರ ರೇಟಿಂಗ್ ಪ್ರಕಾರ Moonfin Recommends ಸಲಹೆಗಳನ್ನು ಮಿತಿಗೊಳಿಸಿ';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'ಇಂಟರ್‌ಫೇಸ್ ಶೈಲಿ';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ಸ್ವಯಂಚಾಲಿತವು ನಿಮ್ಮ ಸಾಧನಕ್ಕೆ ಹೊಂದಿಕೊಳ್ಳುತ್ತದೆ. ನಿರ್ದಿಷ್ಟ ನೋಟವನ್ನು ಒತ್ತಾಯಿಸಲು Apple ಅಥವಾ Material ಆಯ್ಕೆಮಾಡಿ.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ಸ್ವಯಂಚಾಲಿತ';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsKn extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'ಗ್ಲಾಸ್ ಗುಣಮಟ್ಟ';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ಆಟೋ ಈ ಸಾಧನಕ್ಕೆ ಅತ್ಯುತ್ತಮ ಗ್ಲಾಸ್ ಪರಿಣಾಮವನ್ನು ಆಯ್ಕೆಮಾಡುತ್ತದೆ. ಫುಲ್ ನಿಜವಾದ ಬ್ಲರ್ ಅನ್ನು ಒತ್ತಾಯಿಸುತ್ತದೆ; ರಿಡ್ಯೂಸ್ಡ್ GPU ಶಕ್ತಿಯನ್ನು ಉಳಿಸುವ ಹಗುರವಾದ ಗ್ಲಾಸ್ ಅನ್ನು ಬಳಸುತ್ತದೆ.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ಆಟೋ';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'ಫುಲ್';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'ರಿಡ್ಯೂಸ್ಡ್';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'ಅಪ್ಲಿಕೇಶನ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸದೆಯೇ Moonfin ಮತ್ತು Neon Pulse ನಡುವೆ ಬದಲಿಸಿ';
 
   @override
-  String get customThemeTitle => 'ಕಸ್ಟಮ್ ಥೀಮ್';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ಕಸ್ಟಮ್ ಥೀಮ್‌ಗಳು Moonfin ನಾದ್ಯಂತ ದೃಶ್ಯ ಅಂಶಗಳನ್ನು ಬದಲಾಯಿಸುತ್ತವೆ. ನಿಮ್ಮ ಶೈಲಿಗೆ ಸರಿಹೊಂದುವ ಒಂದನ್ನು ಆಯ್ಕೆಮಾಡಿ.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'ಸಿಸ್ಟಂ ಕೀಬೋರ್ಡ್‌ಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'ಪಠ್ಯ ನಮೂದಿಗೆ ಪೂರ್ವನಿಯೋಜಿತವಾಗಿ ನಿಮ್ಮ ಸಾಧನದ ಇನ್‌ಪುಟ್ ವಿಧಾನವನ್ನು ಬಳಸಿ';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'ಮೂನ್ಫಿನ್';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಮೆಜೆಂಟಾ ಗ್ಲೋ, ಸಯಾನ್ ಪಠ್ಯ ಮತ್ತು ಬಲವಾದ ಕ್ರೋಮ್ ಕಾಂಟ್ರಾಸ್ಟ್‌ನೊಂದಿಗೆ ಸಿಂಥ್ವೇವ್ ಸ್ಟೈಲಿಂಗ್';
 
   @override
-  String get themeGlass => 'ಗ್ಲಾಸ್';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'ತೇಲುವ ಗ್ರೇಡಿಯಂಟ್ ಹಿನ್ನೆಲೆ, ಮಂಜುಗಟ್ಟಿದ ಮೇಲ್ಮೈಗಳು ಮತ್ತು Apple-ನೀಲಿ ಆಕ್ಸೆಂಟ್‌ನೊಂದಿಗೆ ಲಿಕ್ವಿಡ್-ಗ್ಲಾಸ್ ಶೈಲಿ';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit ಹೀರೋ';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'ದಪ್ಪ ಬಣ್ಣದ ಪ್ಯಾಲೆಟ್, ಬ್ಲಾಕಿ ಅಂಚುಗಳು, ಗಟ್ಟಿಯಾದ ಡ್ರಾಪ್-ಶ್ಯಾಡೋಗಳು ಮತ್ತು ಪಿಕ್ಸೆಲ್ ಫಾಂಟ್‌ನೊಂದಿಗೆ ರೆಟ್ರೊ ಪಿಕ್ಸೆಲ್-ಆರ್ಟ್ ಶೈಲಿ';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,35 +327,35 @@ class AppLocalizationsKn extends AppLocalizations {
   String get exit => 'ನಿರ್ಗಮಿಸಿ';
 
   @override
-  String get gameMenu => 'ಮೆನು';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'ವಿರಾಮಗೊಂಡಿದೆ';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'ಸ್ಥಿತಿಯನ್ನು ಉಳಿಸಿ';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ಆಟಗಳು';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'ಸ್ಥಿತಿಯನ್ನು ಲೋಡ್ ಮಾಡಿ';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'ಫಾಸ್ಟ್-ಫಾರ್ವರ್ಡ್';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'ಎಮ್ಯುಲೇಟರ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'ಈ ಕೋರ್‌ಗೆ ಹೊಂದಿಸಬಹುದಾದ ಆಯ್ಕೆಗಳಿಲ್ಲ.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'ಮೆನು ತೆರೆಯಲು ಒತ್ತಿ ಹಿಡಿಯಿರಿ';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'ಈ ಸಾಧನದಲ್ಲಿ ಆಟ ಆಡುವುದನ್ನು ಇನ್ನೂ ಬೆಂಬಲಿಸಲಾಗಿಲ್ಲ.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ಯಾವುದೇ ಹೋಮ್ ಸಾಲುಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುವುದಿಲ್ಲ';
@@ -377,13 +377,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get schedule => 'ವೇಳಾಪಟ್ಟಿ';
 
   @override
-  String get series => 'ಸರಣಿಗಳು';
+  String get series => 'ಸರಣಿ';
 
   @override
   String get noItemsFound => 'ಯಾವುದೇ ಐಟಂಗಳು ಕಂಡುಬಂದಿಲ್ಲ';
 
   @override
-  String get home => 'ಮುಖಪುಟ';
+  String get home => 'ಮನೆ';
 
   @override
   String get browseAll => 'ಎಲ್ಲವನ್ನೂ ಬ್ರೌಸ್ ಮಾಡಿ';
@@ -414,7 +414,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get noLibrariesFound => 'ಯಾವುದೇ ಗ್ರಂಥಾಲಯಗಳು ಕಂಡುಬಂದಿಲ್ಲ';
 
   @override
-  String get library => 'ಲೈಬ್ರರಿ';
+  String get library => 'ಗ್ರಂಥಾಲಯ';
 
   @override
   String get displaySettings => 'ಪ್ರದರ್ಶನ ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
@@ -427,7 +427,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'ಫೋಲ್ಡರ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -435,7 +435,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count ಐಟಂಗಳು';
+    return '$count items';
   }
 
   @override
@@ -452,7 +452,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count ಐಟಂಗಳು';
+    return '$count Items';
   }
 
   @override
@@ -493,7 +493,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ಪ್ರಕಾರಗಳು';
+    return '$name — Genres';
   }
 
   @override
@@ -532,17 +532,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$countನಿ ಹಿಂದೆ';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$countಗಂ ಹಿಂದೆ';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$countದಿ ಹಿಂದೆ';
+    return '${count}d ago';
   }
 
   @override
@@ -553,7 +553,7 @@ class AppLocalizationsKn extends AppLocalizations {
       'Discover ನಲ್ಲಿ ತೋರಿಸಲು ಯಾವ ವಿಷಯದ ಫೀಡ್‌ಗಳನ್ನು ಆರಿಸಿ.';
 
   @override
-  String get apply => 'ಅನ್ವಯಿಸಿ';
+  String get apply => 'ಅನ್ವಯಿಸು';
 
   @override
   String get openLink => 'ಲಿಂಕ್ ತೆರೆಯಿರಿ';
@@ -577,7 +577,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count ಶೀರ್ಷಿಕೆಗಳು';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +603,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get listen => 'ಕೇಳು';
 
   @override
-  String get resume => 'ಮುಂದುವರಿಸಿ';
+  String get resume => 'ಪುನರಾರಂಭಿಸಿ';
 
   @override
   String get failedToLoadLibrary => 'ಲೈಬ್ರರಿಯನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
@@ -665,17 +665,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count ಲೇಖಕರು';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count ಪ್ರಕಾರಗಳು';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% ಪೂರ್ಣಗೊಂಡಿದೆ';
+    return '$percent% completed';
   }
 
   @override
@@ -692,7 +692,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'ಓದುವಿಕೆಗೆ ಆದ್ಯತೆ ನೀಡುವ ಬ್ರೌಸಿಂಗ್‌ಗಾಗಿ ಜೋಡಿಸಲಾದ $count ಶೀರ್ಷಿಕೆಗಳು.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -729,7 +729,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'ಯಾವುದೇ $label ಕಂಡುಬಂದಿಲ್ಲ';
+    return 'No $label found';
   }
 
   @override
@@ -748,7 +748,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get readStatus => 'ಓದು';
 
   @override
-  String get watched => 'ವೀಕ್ಷಿಸಲಾಗಿದೆ';
+  String get watched => 'ವೀಕ್ಷಿಸಿದರು';
 
   @override
   String get unread => 'ಓದಿಲ್ಲ';
@@ -766,43 +766,43 @@ class AppLocalizationsKn extends AppLocalizations {
   String get books => 'ಪುಸ್ತಕಗಳು';
 
   @override
-  String get latestBooks => 'ಇತ್ತೀಚಿನ ಪುಸ್ತಕಗಳು';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'ಇತ್ತೀಚಿನ ಆಡಿಯೋಬುಕ್‌ಗಳು';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಪುಸ್ತಕಗಳು',
-      one: '1 ಪುಸ್ತಕ',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'ಪುಸ್ತಕ';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ಆಡಿಯೋಬುಕ್';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% ಓದಲಾಗಿದೆ';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time ಬಾಕಿ';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'ಓದಿ';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'ಕೇಳಿ';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'ಲೇಖಕ';
@@ -840,12 +840,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count ವಿಭಾಗಗಳು';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'ಮೊದಲ ಪ್ರಕಟಣೆ $year';
+    return 'First published $year';
   }
 
   @override
@@ -860,7 +860,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count ಪುಸ್ತಕಗಳು';
+    return '$count books';
   }
 
   @override
@@ -872,7 +872,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count ಲೇಖಕರು';
+    return '$count Authors';
   }
 
   @override
@@ -880,8 +880,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಆಡಿಯೋಬುಕ್‌ಗಳು',
-      one: '1 ಆಡಿಯೋಬುಕ್',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -917,7 +917,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get nextUp => 'ಮುಂದೆ';
 
   @override
-  String get seasons => 'ಸೀಸನ್‌ಗಳು';
+  String get seasons => 'ಋತುಗಳು';
 
   @override
   String get chapters => 'ಅಧ್ಯಾಯಗಳು';
@@ -929,7 +929,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get movies => 'ಚಲನಚಿತ್ರಗಳು';
 
   @override
-  String get musicVideos => 'ಸಂಗೀತ ವಿಡಿಯೋಗಳು';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'ಇತರೆ';
@@ -948,7 +948,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'ಡಿಸ್ಕ್ $number';
+    return 'Disc $number';
   }
 
   @override
@@ -973,7 +973,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'ಪ್ರಕಟಣೆ $year';
+    return 'Published $year';
   }
 
   @override
@@ -984,52 +984,52 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಸೀಸನ್‌ಗಳು',
-      one: '1 ಸೀಸನ್',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time ಕ್ಕೆ ಮುಗಿಯುತ್ತದೆ';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'ಐಟಂಗಳು';
+  String get items => 'Items';
 
   @override
-  String get extras => 'ಹೆಚ್ಚುವರಿಗಳು';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'ತೆರೆಯ ಹಿಂದೆ';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ಅಳಿಸಿದ ದೃಶ್ಯಗಳು';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ಫೀಚರೆಟ್‌ಗಳು';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'ಸಂದರ್ಶನಗಳು';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'ದೃಶ್ಯಗಳು';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'ಕಿರುಚಿತ್ರಗಳು';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ಟ್ರೇಲರ್‌ಗಳು';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time ಉಳಿದಿದೆ';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time ನಲ್ಲಿ ಮುಗಿಯುತ್ತದೆ';
+    return 'Ends in $time';
   }
 
   @override
@@ -1043,7 +1043,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position ರಿಂದ ಪುನರಾರಂಭಿಸಿ';
+    return 'Resume from $position';
   }
 
   @override
@@ -1071,10 +1071,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get version => 'ಆವೃತ್ತಿ';
 
   @override
-  String get cast => 'ಬಿತ್ತರಿಸಿ';
+  String get cast => 'ಎರಕಹೊಯ್ದ';
 
   @override
-  String get trailer => 'ಟ್ರೇಲರ್';
+  String get trailer => 'ಟ್ರೈಲರ್';
 
   @override
   String get finished => 'ಮುಗಿದಿದೆ';
@@ -1141,7 +1141,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" ಗಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಟ್ರ್ಯಾಕ್‌ಗಳನ್ನು ಅಳಿಸುವುದೇ?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1157,17 +1157,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'ಯಾವುದೇ $itemLabel ಲೋಡ್ ಆಗಿಲ್ಲ';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ ($count ಐಟಂಗಳು)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'ಸರ್ವರ್‌ನಿಂದ \"$name\" ಅನ್ನು ಅಳಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ? ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1178,7 +1178,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'ಬೆಂಬಲಿಸದ ಪುಸ್ತಕ ಸ್ವರೂಪ: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1204,7 +1204,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'ಉಪಶೀರ್ಷಿಕೆ ಡೌನ್‌ಲೋಡ್ ಆಗಿ ಆಯ್ಕೆಯಾಗಿದೆ: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1213,7 +1213,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language ಗಾಗಿ ಯಾವುದೇ ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1221,7 +1221,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'ಆವೃತ್ತಿ $number';
+    return 'Version $number';
   }
 
   @override
@@ -1241,7 +1241,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1249,7 +1249,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel ಗಾಗಿ ಸ್ಥಳೀಯ ಫೈಲ್‌ಗಳನ್ನು ಅಳಿಸುವುದೇ?\n\nಇದು ಸಂಗ್ರಹಣಾ ಸ್ಥಳವನ್ನು ಮುಕ್ತಗೊಳಿಸುತ್ತದೆ. ನೀವು ನಂತರ ಮತ್ತೆ ಡೌನ್‌ಲೋಡ್ ಮಾಡಬಹುದು.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1265,10 +1265,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get director => 'ನಿರ್ದೇಶಕ';
 
   @override
-  String get directors => 'ನಿರ್ದೇಶಕರು';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ಬರಹಗಾರ';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'ಬರಹಗಾರರು';
@@ -1278,12 +1278,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    return '+$count ಇನ್ನಷ್ಟು';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count ಸಂಚಿಕೆಗಳು';
+    return '$count Episodes';
   }
 
   @override
@@ -1293,12 +1293,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'ಸಂಚಿಕೆ $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'ಅಧ್ಯಾಯ $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1306,8 +1306,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಟ್ರ್ಯಾಕ್‌ಗಳು',
-      one: '1 ಟ್ರ್ಯಾಕ್',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1317,25 +1317,25 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಅಧ್ಯಾಯಗಳು',
-      one: '1 ಅಧ್ಯಾಯ',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'ಜನನ $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'ಮರಣ $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'ವಯಸ್ಸು $age';
+    return 'Age $age';
   }
 
   @override
@@ -1348,18 +1348,17 @@ class AppLocalizationsKn extends AppLocalizations {
   String get shuffle => 'ಷಫಲ್';
 
   @override
-  String get shuffleAllMusic => 'ಎಲ್ಲಾ ಸಂಗೀತವನ್ನು ಷಫಲ್ ಮಾಡಿ';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'ನಿಮ್ಮ ಫೋನ್‌ನಲ್ಲಿ Moonfin ಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable =>
-      'ನಿಮ್ಮ ಸರ್ವರ್ ಅನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count ಡೌನ್‌ಲೋಡ್‌ಗಳು';
+    return '$count downloads';
   }
 
   @override
@@ -1378,32 +1377,32 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆ $action ಗೆ ಈ ಬಳಕೆದಾರರಿಗೆ Jellyfin ಉಪಶೀರ್ಷಿಕೆ ನಿರ್ವಹಣೆ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆ $action ಗಾಗಿ ಈ ಐಟಂ ಸರ್ವರ್‌ನಲ್ಲಿ ಕಂಡುಬಂದಿಲ್ಲ.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆ $action ವಿಫಲವಾಗಿದೆ: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆ $action ವಿಫಲವಾಗಿದೆ (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'ರಿಮೋಟ್ ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು $action ಮಾಡಲು ವಿಫಲವಾಗಿದೆ.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" ಗಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಎಲ್ಲಾ ಸಂಚಿಕೆಗಳು';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1435,17 +1434,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label ಕ್ರಿಯೆ ವಿಫಲವಾಗಿದೆ: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'ಕಾಸ್ಟ್ ವಾಲ್ಯೂಮ್ ಹೊಂದಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label ನಿಯಂತ್ರಣಗಳು';
+    return '$label Controls';
   }
 
   @override
@@ -1462,7 +1461,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$label ನಿಲ್ಲಿಸಿ';
+    return 'Stop $label';
   }
 
   @override
@@ -1470,7 +1469,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ಟ್ರ್ಯಾಕ್ $number';
+    return 'Track $number';
   }
 
   @override
@@ -1487,7 +1486,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds ಸೆಕೆಂಡುಗಳು';
+    return '$seconds seconds';
   }
 
   @override
@@ -1556,7 +1555,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get transcodeReasons => 'ಟ್ರಾನ್ಸ್ಕೋಡ್ ಕಾರಣಗಳು';
 
   @override
-  String get player => 'ಪ್ಲೇಯರ್';
+  String get player => 'ಆಟಗಾರ';
 
   @override
   String get container => 'ಕಂಟೈನರ್';
@@ -1580,7 +1579,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get videoBitrate => 'ವೀಡಿಯೊ ಬಿಟ್ರೇಟ್';
 
   @override
-  String get track => 'ಟ್ರ್ಯಾಕ್';
+  String get track => 'ಟ್ರ್ಯಾಕ್ ಮಾಡಿ';
 
   @override
   String get channels => 'ಚಾನೆಲ್‌ಗಳು';
@@ -1602,12 +1601,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol ಸೆಷನ್ ದೋಷ';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'ಪುಸ್ತಕದ ವಿವರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1616,7 +1615,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'ಈ ಸ್ವರೂಪವನ್ನು (.$extension) ಇನ್ನೂ ಆ್ಯಪ್‌ನಲ್ಲಿ ತೋರಿಸಲಾಗುವುದಿಲ್ಲ.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1629,17 +1628,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'ಆ್ಯಪ್‌ನಲ್ಲಿನ ರೀಡರ್ ತೆರೆಯಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label ನಲ್ಲಿ ಬುಕ್‌ಮಾರ್ಕ್ ಈಗಾಗಲೇ ಉಳಿಸಲಾಗಿದೆ.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'ಬುಕ್‌ಮಾರ್ಕ್ ಸೇರಿಸಲಾಗಿದೆ: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1651,7 +1650,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'ಪುಟ $number';
+    return 'Page $number';
   }
 
   @override
@@ -1662,12 +1661,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'ಸ್ವರೂಪ: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% ಓದಲಾಗಿದೆ';
+    return '$percent% read';
   }
 
   @override
@@ -1691,7 +1690,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'ಝೂಮ್ ಮರುಹೊಂದಿಸಿ (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1714,7 +1713,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'ಓದಿದ ಸ್ಥಿತಿಯನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1747,7 +1746,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್ $extension ಫೈಲ್‌ಗಳಿಗಾಗಿ ಎಂಬೆಡೆಡ್ ಡಾಕ್ಯುಮೆಂಟ್ ಎಂಜಿನ್ ಅನ್ನು ಹೋಸ್ಟ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1786,7 +1785,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'ಗೈಡ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1797,22 +1796,22 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'ಮುಂದೆ: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesನಿ ಬಾಕಿ';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursಗಂ ಬಾಕಿ';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursಗಂ $minutesನಿ ಬಾಕಿ';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1836,19 +1835,19 @@ class AppLocalizationsKn extends AppLocalizations {
   String get favoriteChannel => 'ಮೆಚ್ಚಿನ ಚಾನಲ್';
 
   @override
-  String get record => 'ರೆಕಾರ್ಡ್ ಮಾಡಿ';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'ರೆಕಾರ್ಡಿಂಗ್ ರದ್ದುಮಾಡಿ';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'ಪ್ರೋಗ್ರಾಂ ರೆಕಾರ್ಡ್ ಮಾಡಲು ಹೊಂದಿಸಲಾಗಿದೆ';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'ರೆಕಾರ್ಡಿಂಗ್ ರದ್ದಾಗಿದೆ';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'ರೆಕಾರ್ಡಿಂಗ್ ರಚಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'ವೀಕ್ಷಿಸಿ';
@@ -1858,7 +1857,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name ಪ್ಲೇ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1885,11 +1884,11 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" ನ ನಿಗದಿತ ರೆಕಾರ್ಡಿಂಗ್ ಅನ್ನು ರದ್ದುಮಾಡುವುದೇ?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'ಇಲ್ಲ';
+  String get no => 'ಸಂ';
 
   @override
   String get yesCancel => 'ಹೌದು, ರದ್ದುಮಾಡಿ';
@@ -1913,7 +1912,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" ರೆಕಾರ್ಡಿಂಗ್ ನಿಲ್ಲಿಸುವುದೇ?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1928,19 +1927,19 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" ಗಾಗಿ ಯಾವುದೇ ಫಲಿತಾಂಶಗಳಿಲ್ಲ';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'ಹುಡುಕಾಟ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr ಖಾತೆ ಪ್ರಕಾರ';
+  String get seerrAccountType => 'ಸೀರ್ ಖಾತೆಯ ಪ್ರಕಾರ';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1975,12 +1974,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" ಮತ್ತು ಅದರ ಫೈಲ್‌ಗಳನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ಟ್ರ್ಯಾಕ್‌ಗಳು';
+    return '$count tracks';
   }
 
   @override
@@ -1991,12 +1990,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ಆಲ್ಬಮ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name ಗಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಯಾವುದೇ ಟ್ರ್ಯಾಕ್‌ಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2013,12 +2012,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" ಅನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes ನಿಮಿ';
+    return '$minutes min';
   }
 
   @override
@@ -2028,7 +2027,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'ಸಂಚಿಕೆ $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2042,7 +2041,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'ಸೀಸನ್ $number';
+    return 'Season $number';
   }
 
   @override
@@ -2058,7 +2057,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season ನಲ್ಲಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಎಲ್ಲಾ ಸಂಚಿಕೆಗಳನ್ನು ಅಳಿಸುವುದೇ?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2066,8 +2065,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಸಂಚಿಕೆಗಳು',
-      one: '1 ಸಂಚಿಕೆ',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2102,7 +2101,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ $count ಐಟಂಗಳನ್ನು ಅಳಿಸುವುದೇ?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2116,7 +2115,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit ಮಿತಿಯಲ್ಲಿ';
+    return 'of $limit limit';
   }
 
   @override
@@ -2198,7 +2197,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count ಆಯ್ಕೆಗಳು';
+    return '$count options';
   }
 
   @override
@@ -2293,7 +2292,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'ವಿವರ ಪುಟಗಳು, ಹೋಮ್ ಸಾಲುಗಳು ಮತ್ತು ವಾಲ್ಯೂಮ್';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2308,11 +2307,11 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಹೋಮ್ ಸ್ಕ್ರೀನ್ ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಪ್ಲೇ ಮಾಡಿ';
 
   @override
-  String get loopThemeMusic => 'ಥೀಮ್ ಸಂಗೀತವನ್ನು ಲೂಪ್ ಮಾಡಿ';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'ಟ್ರ್ಯಾಕ್ ಅನ್ನು ಒಮ್ಮೆ ಪ್ಲೇ ಮಾಡುವ ಬದಲು ಪುನರಾವರ್ತಿಸಿ';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'ವಿವರಗಳ ಹಿನ್ನೆಲೆ ಮಸುಕು';
@@ -2335,23 +2334,23 @@ class AppLocalizationsKn extends AppLocalizations {
   String get playerZoomMode => 'ಪ್ಲೇಯರ್ ಜೂಮ್ ಮೋಡ್';
 
   @override
-  String get settingsScrollWheelAction => 'ಮೌಸ್ ಸ್ಕ್ರಾಲ್ ವೀಲ್';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'ಪ್ಲೇಬ್ಯಾಕ್ ಸಮಯದಲ್ಲಿ ವಿಡಿಯೋ ಮೇಲೆ ಮೌಸ್ ವೀಲ್ ಸ್ಕ್ರಾಲ್ ಮಾಡಿದಾಗ ಏನಾಗಬೇಕು ಎಂಬುದನ್ನು ಆಯ್ಕೆಮಾಡಿ.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ಆಫ್';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'ಸೀಕ್ (ಮುಂದೆ / ಹಿಂದೆ)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ವಾಲ್ಯೂಮ್';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ವಾಲ್ಯೂಮ್';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'ಫಿಟ್';
@@ -2405,40 +2404,37 @@ class AppLocalizationsKn extends AppLocalizations {
   String get defaultAudioLanguage => 'ಡೀಫಾಲ್ಟ್ ಆಡಿಯೊ ಭಾಷೆ';
 
   @override
-  String get fallbackAudioLanguage => 'ಪರ್ಯಾಯ ಆಡಿಯೋ ಭಾಷೆ';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'ಡೀಫಾಲ್ಟ್ ಆಡಿಯೋ ಟ್ರ್ಯಾಕ್‌ಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'ಸ್ಥಳೀಯ ಡಬ್‌ಗಿಂತ ಮೂಲ ಆಡಿಯೋ ಟ್ರ್ಯಾಕ್‌ಗೆ ಆದ್ಯತೆ ನೀಡಿ.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'ಆಡಿಯೋ ವಿವರಣೆ ಟ್ರ್ಯಾಕ್‌ಗಳಿಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'ಸಾಮಾನ್ಯ ಟ್ರ್ಯಾಕ್‌ಗಳಿಗಿಂತ ಆಡಿಯೋ ವಿವರಣೆ ಟ್ರ್ಯಾಕ್‌ಗಳಿಗೆ ಆದ್ಯತೆ ನೀಡಿ.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ (ಆಡಿಯೋ)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'ಡೈರೆಕ್ಟ್ ಸ್ಟ್ರೀಮ್ (ರೀಮಕ್ಸ್)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ (ಬಿಟ್‌ರೇಟ್ ಅಥವಾ ರೆಸಲ್ಯೂಶನ್)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio =>
-      'ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ (ವಿಡಿಯೋ ಮತ್ತು ಆಡಿಯೋ)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ (ವಿಡಿಯೋ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ಸ್ವಯಂ (ಸರ್ವರ್ ಡೀಫಾಲ್ಟ್)';
@@ -2515,28 +2511,27 @@ class AppLocalizationsKn extends AppLocalizations {
       'TrueHD ಆಡಿಯೊವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ (ಎಲ್ಲಾ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ಗಳಲ್ಲಿ ಕೆಲಸ ಮಾಡದಿರಬಹುದು)';
 
   @override
-  String get settingsAudioOutputMode => 'ಆಡಿಯೋ ಔಟ್‌ಪುಟ್ ಮೋಡ್';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ಆಡಿಯೋವನ್ನು ಹೇಗೆ ಡಿಕೋಡ್ ಮಾಡಬೇಕು ಎಂಬುದನ್ನು ಆಯ್ಕೆಮಾಡಿ. AVR ಪಾಸ್‌ಥ್ರೂ ಕಚ್ಚಾ Dolby/DTS ಸ್ಟ್ರೀಮ್‌ಗಳನ್ನು ನಿಮ್ಮ ರಿಸೀವರ್‌ಗೆ ಕಳುಹಿಸುತ್ತದೆ; ಆಟೋ ಅಥವಾ ಡೌನ್‌ಮಿಕ್ಸ್ ಸ್ಥಳೀಯವಾಗಿ ಡಿಕೋಡ್ ಮಾಡುತ್ತದೆ.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'ಆಡಿಯೋ ಪರ್ಯಾಯ ಕೊಡೆಕ್';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'ಮೂಲ ಸ್ಟ್ರೀಮ್ ಅನ್ನು ನೇರವಾಗಿ ಪ್ಲೇ ಮಾಡಲು ಅಥವಾ ಪಾಸ್‌ಥ್ರೂ ಮಾಡಲು ಸಾಧ್ಯವಾಗದಿದ್ದಾಗ ಬಹು-ಚಾನೆಲ್ ಆಡಿಯೋವನ್ನು ಟ್ರಾನ್ಸ್‌ಕೋಡ್ ಮಾಡಲು ಗುರಿ ಸ್ವರೂಪವನ್ನು ಆಯ್ಕೆಮಾಡಿ.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'ಸ್ವಯಂ ಪತ್ತೆ\n(ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ಡೀಫಾಲ್ಟ್)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2545,114 +2540,113 @@ class AppLocalizationsKn extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ನಷ್ಟರಹಿತ)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ಸ್ಟೀರಿಯೋ ಮಾತ್ರ)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ದಕ್ಷ)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ನಷ್ಟರಹಿತ)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'ಗರಿಷ್ಠ ಆಡಿಯೋ ಚಾನೆಲ್‌ಗಳು';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'ನಿಮ್ಮ ಆಡಿಯೋ ಸೆಟಪ್‌ನ ಗರಿಷ್ಠ ಚಾನೆಲ್‌ಗಳನ್ನು ಕಾನ್ಫಿಗರ್ ಮಾಡಿ. ಈ ಮಿತಿಯನ್ನು ಮೀರಿದ ಬಹು-ಚಾನೆಲ್ ಸ್ಟ್ರೀಮ್‌ಗಳು ಡೌನ್‌ಮಿಕ್ಸ್ ಅಥವಾ ಟ್ರಾನ್ಸ್‌ಕೋಡ್ ಆಗುತ್ತವೆ.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ಸ್ವಯಂ ಪತ್ತೆ\n(ಹಾರ್ಡ್‌ವೇರ್ ಡೀಫಾಲ್ಟ್)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 ಮೊನೊ';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ಸ್ಟೀರಿಯೋ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 ಸರೌಂಡ್';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 ಕ್ವಾಡ್ರಾಫೋನಿಕ್';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 ಸರೌಂಡ್';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 ಸರೌಂಡ್';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 ಸರೌಂಡ್';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 ಸರೌಂಡ್';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'ಪಾಸ್‌ಥ್ರೂ (ಸುಧಾರಿತ)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'ಕೊಡೆಕ್ ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'ನಿಮ್ಮ AVR ಅಥವಾ HDMI ಸಿಂಕ್ ಬೆಂಬಲಿಸುವ ಸ್ವರೂಪಗಳನ್ನು ಮಾತ್ರ ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS ಕೋರ್ ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) ಅನ್ನು ಬಾಹ್ಯ ಡಿಕೋಡರ್‌ಗೆ ಬಿಟ್‌ಸ್ಟ್ರೀಮ್ ಮಾಡಿ.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) ಮೂಲಕ Dolby Atmos ಅನ್ನು ಬಾಹ್ಯ ಡಿಕೋಡರ್‌ಗೆ ಬಿಟ್‌ಸ್ಟ್ರೀಮ್ ಮಾಡಿ.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS ಕೋರ್ ಸೇರಿದಂತೆ) ಅನ್ನು ಬಾಹ್ಯ ಡಿಕೋಡರ್‌ಗೆ ಬಿಟ್‌ಸ್ಟ್ರೀಮ್ ಮಾಡಿ.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos ಮೆಟಾಡೇಟಾದೊಂದಿಗೆ Dolby TrueHD ಅನ್ನು ಬಾಹ್ಯ ಡಿಕೋಡರ್‌ಗೆ ಬಿಟ್‌ಸ್ಟ್ರೀಮ್ ಮಾಡಿ.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'ಪತ್ತೆಯಾದ ಆಡಿಯೋ ಸಾಮರ್ಥ್ಯಗಳು';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'ಇನ್ನೂ ಯಾವುದೇ ರನ್‌ಟೈಮ್ ಸಾಮರ್ಥ್ಯ ಸ್ನ್ಯಾಪ್‌ಶಾಟ್ ಲಭ್ಯವಿಲ್ಲ.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'ಮಾರ್ಗ';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'ಡಿಕೋಡ್';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ಆಡಿಯೋ ಮಾರ್ಗ';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2667,10 +2661,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'ಸ್ಪೀಕರ್';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'ಹೆಡ್‌ಫೋನ್‌ಗಳು';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2678,39 +2672,39 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'ಡಯಾಗ್ನೋಸ್ಟಿಕ್ಸ್';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'ವಿಡಿಯೋ ಲೆವೆಲ್';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'ವಿಡಿಯೋ ರೇಂಜ್';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'ಉಪಶೀರ್ಷಿಕೆ ಕೊಡೆಕ್';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'ಅನುಮತಿಸಲಾದ ಆಡಿಯೋ ಕೊಡೆಕ್‌ಗಳು';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ಆಡಿಯೋ ಕೊಡೆಕ್‌ಗಳು';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ಆಡಿಯೋ ಕೊಡೆಕ್‌ಗಳು';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif ಪಾಸ್‌ಥ್ರೂ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'ಸಕ್ರಿಯ ಆಡಿಯೋ ಮಾರ್ಗ';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'ಮಾರ್ಗದ HD ಆಡಿಯೋ ಬೆಂಬಲ';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'ರಾತ್ರಿ ಮೋಡ್';
@@ -2759,7 +2753,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueಸೆ';
+    return '${value}s';
   }
 
   @override
@@ -2773,7 +2767,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes ಸಂಚಿಕೆಗಳ ನಂತರ / $hoursಗಂ';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2850,45 +2844,45 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಉಪಶೀರ್ಷಿಕೆ ನೋಟವನ್ನು ಕಸ್ಟಮೈಸ್ ಮಾಡಿ';
 
   @override
-  String get subtitleMode => 'ಉಪಶೀರ್ಷಿಕೆ ಮೋಡ್';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ಫ್ಲ್ಯಾಗ್ ಮಾಡಲಾದ';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'ಯಾವಾಗಲೂ';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'ವಿದೇಶಿ';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'ಫೋರ್ಸ್ಡ್';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'ಮಾಧ್ಯಮ ಫೈಲ್‌ನ ಮೆಟಾಡೇಟಾದಲ್ಲಿ \"default\" ಅಥವಾ \"forced\" ಎಂದು ಆಂತರಿಕವಾಗಿ ಫ್ಲ್ಯಾಗ್ ಮಾಡಲಾದ ಟ್ರ್ಯಾಕ್‌ಗಳನ್ನು ಪ್ಲೇ ಮಾಡುತ್ತದೆ.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'ವಿಡಿಯೋ ಪ್ರಾರಂಭವಾದಾಗಲೆಲ್ಲಾ ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಲೋಡ್ ಮಾಡಿ ತೋರಿಸುತ್ತದೆ.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'ಡೀಫಾಲ್ಟ್ ಆಡಿಯೋ ಟ್ರ್ಯಾಕ್ ವಿದೇಶಿ ಭಾಷೆಯಲ್ಲಿದ್ದರೆ ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆನ್ ಮಾಡುತ್ತದೆ.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'ಫೋರ್ಸ್ಡ್ ಮೆಟಾಡೇಟಾ ಫ್ಲ್ಯಾಗ್‌ನೊಂದಿಗೆ ಸ್ಪಷ್ಟವಾಗಿ ಟ್ಯಾಗ್ ಮಾಡಲಾದ ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಮಾತ್ರ ಲೋಡ್ ಮಾಡುತ್ತದೆ.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'ಸ್ವಯಂಚಾಲಿತ ಉಪಶೀರ್ಷಿಕೆ ಲೋಡಿಂಗ್ ಅನ್ನು ಸಂಪೂರ್ಣವಾಗಿ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುತ್ತದೆ.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ಪರ್ಯಾಯ ಉಪಶೀರ್ಷಿಕೆ ಭಾಷೆ';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'ಉಪಶೀರ್ಷಿಕೆ ಸ್ಟ್ರೀಮ್';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2948,17 +2942,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile ಪ್ರೊಫೈಲ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಿದೆ.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile ಪ್ರೊಫೈಲ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'ಸ್ಥಳೀಯ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು $profile ಪ್ರೊಫೈಲ್‌ಗೆ ಸಿಂಕ್ ಮಾಡಲಾಗಿದೆ.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3094,11 +3088,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showLibrariesInToolbar => 'ಟೂಲ್‌ಬಾರ್‌ನಲ್ಲಿ ಲೈಬ್ರರಿಗಳನ್ನು ತೋರಿಸಿ';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'ನ್ಯಾವ್‌ಬಾರ್ ಲೇಬಲ್‌ಗಳನ್ನು ಯಾವಾಗಲೂ ವಿಸ್ತರಿಸಿ';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr ಬಟನ್ ತೋರಿಸಿ';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'ನವಬಾರ್ ಅಪಾರದರ್ಶಕತೆ';
@@ -3173,19 +3166,18 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showFolderBrowsingOption => 'ಫೋಲ್ಡರ್ ಬ್ರೌಸಿಂಗ್ ಆಯ್ಕೆಯನ್ನು ತೋರಿಸಿ';
 
   @override
-  String get groupItemsIntoCollections => 'ಐಟಂಗಳನ್ನು ಸಂಗ್ರಹಣೆಗಳಾಗಿ ಗುಂಪು ಮಾಡಿ';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ಲೈಬ್ರರಿಗಳನ್ನು ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಸಂಗ್ರಹಣೆಗೆ ಸಂಬಂಧಿಸಿದ ಲೈಬ್ರರಿ ಐಟಂಗಳನ್ನು ಮರೆಮಾಡಿ';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'ಲೈಬ್ರರಿ ಗುಂಪುಗೊಳಿಸುವಿಕೆ ಸೂಚನೆ';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಬಳಸಲು, ನಿಮ್ಮ Jellyfin ಅಥವಾ Emby ಸರ್ವರ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಲೈಬ್ರರಿಯ ಪ್ರದರ್ಶನ ಸೆಟ್ಟಿಂಗ್‌ಗಳ ಅಡಿಯಲ್ಲಿ \"Group movies into collections\" ಮತ್ತು/ಅಥವಾ \"Group shows into collections\" ಲೈಬ್ರರಿ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಸಕ್ರಿಯಗೊಂಡಿವೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'ಲೈಬ್ರರಿ ಗೋಚರತೆ';
@@ -3214,7 +3206,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ';
+    return '$count selected';
   }
 
   @override
@@ -3244,7 +3236,7 @@ class AppLocalizationsKn extends AppLocalizations {
       'Moonfin, MakD ನಡುವೆ ಆಯ್ಕೆಮಾಡಿ ಅಥವಾ ಮಾಧ್ಯಮ ಬಾರ್ ಅನ್ನು ಆಫ್ ಮಾಡಿ';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'ಮೂನ್ಫಿನ್';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3297,11 +3289,10 @@ class AppLocalizationsKn extends AppLocalizations {
       '3 ಸೆಕೆಂಡುಗಳ ನಂತರ ಮೀಡಿಯಾ ಬಾರ್‌ನಲ್ಲಿ ಸ್ವಯಂ-ಪ್ಲೇ ಟ್ರೇಲರ್‌ಗಳು';
 
   @override
-  String get trailerAudio => 'ಟ್ರೇಲರ್ ಆಡಿಯೋ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'ಮೀಡಿಯಾ ಬಾರ್‌ನಲ್ಲಿ ಟ್ರೇಲರ್‌ಗಳಿಗೆ ಆಡಿಯೋ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'ಸಂಚಿಕೆ ಮುನ್ನೋಟ';
@@ -3378,11 +3369,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get combineBothRows => 'ಎರಡೂ ಸಾಲುಗಳನ್ನು ಒಂದೇ ಹೋಮ್ ವಿಭಾಗಕ್ಕೆ ಸೇರಿಸಿ';
 
   @override
-  String get fullScreenRows => 'ವಿಸ್ತರಿಸಿದ ಹೋಮ್ ಸಾಲುಗಳು';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'ಹೋಮ್ ಸಾಲುಗಳನ್ನು ಪ್ರತಿ ಪರದೆಗೆ 1 ಸಾಲಿಗೆ ಮಿತಿಗೊಳಿಸಿ';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ಪ್ರತಿ ಸಾಲಿನ ಚಿತ್ರ ಪ್ರಕಾರ';
@@ -3397,7 +3387,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get lastUser => 'ಕೊನೆಯ ಬಳಕೆದಾರ';
 
   @override
-  String get currentUser => 'ಪ್ರಸ್ತುತ ಬಳಕೆದಾರ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ಯಾವಾಗಲೂ ಪ್ರಮಾಣೀಕರಿಸಿ';
@@ -3474,7 +3464,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes ನಿಮಿ';
+    return '$minutes min';
   }
 
   @override
@@ -3505,10 +3495,10 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಸ್ಕ್ರೀನ್ ಸೇವರ್ ಸಮಯದಲ್ಲಿ ಗಡಿಯಾರವನ್ನು ಪ್ರದರ್ಶಿಸಿ';
 
   @override
-  String get clockModeStatic => 'ಸ್ಥಿರ';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'ಪುಟಿಯುವ';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'ರಾಟನ್ ಟೊಮ್ಯಾಟೋಸ್ (ವಿಮರ್ಶಕರು)';
@@ -3529,7 +3519,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get metacriticUser => 'ಮೆಟಾಕ್ರಿಟಿಕ್ (ಬಳಕೆದಾರ)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ಟ್ರ್ಯಾಕ್ಟ್';
 
   @override
   String get letterboxd => 'ಲೆಟರ್ ಬಾಕ್ಸ್';
@@ -3582,7 +3572,7 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಅಪ್ಲಿಕೇಶನ್‌ನಾದ್ಯಂತ ತೋರಿಸಲಾದ ರೇಟಿಂಗ್ ಮೂಲಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತು ಮರುಕ್ರಮಗೊಳಿಸಿ';
 
   @override
-  String get pluginLabel => 'Moonbase ಪ್ಲಗಿನ್';
+  String get pluginLabel => 'ಪ್ಲಗಿನ್';
 
   @override
   String get pluginDetected => 'ಪ್ಲಗಿನ್ ಪತ್ತೆಯಾಗಿದೆ';
@@ -3600,7 +3590,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nಆವೃತ್ತಿ: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3654,21 +3644,21 @@ class AppLocalizationsKn extends AppLocalizations {
   String get networks => 'ಜಾಲಗಳು';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr ಡಿಸ್ಕವರಿ ಸಾಲುಗಳು';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'ಸಾಲುಗಳನ್ನು ಡೀಫಾಲ್ಟ್‌ಗೆ ಮರುಹೊಂದಿಸಿ';
 
   @override
-  String get enableSeerr => 'Seerr ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get enableSeerr => 'ಸೀರ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
   String get showSeerrInNavigation =>
-      'ನ್ಯಾವಿಗೇಶನ್‌ನಲ್ಲಿ Seerr ತೋರಿಸಿ (ಸರ್ವರ್ ಪ್ಲಗಿನ್ ಅಗತ್ಯವಿದೆ)';
+      'ನ್ಯಾವಿಗೇಶನ್‌ನಲ್ಲಿ ಸೀರ್ ಅನ್ನು ತೋರಿಸಿ (ಸರ್ವರ್ ಪ್ಲಗಿನ್ ಅಗತ್ಯವಿದೆ)';
 
   @override
   String get seerrUnavailable =>
-      'ಸರ್ವರ್ ಪ್ಲಗಿನ್‌ನ Seerr ಬೆಂಬಲ ನಿಷ್ಕ್ರಿಯಗೊಂಡಿರುವುದರಿಂದ ಲಭ್ಯವಿಲ್ಲ.';
+      'ಸರ್ವರ್ ಪ್ಲಗಿನ್ ಸೀರ್ ಬೆಂಬಲವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿರುವುದರಿಂದ ಲಭ್ಯವಿಲ್ಲ.';
 
   @override
   String get nsfwFilter => 'NSFW ಫಿಲ್ಟರ್';
@@ -3677,44 +3667,44 @@ class AppLocalizationsKn extends AppLocalizations {
   String get hideAdultContent => 'ಫಲಿತಾಂಶಗಳಲ್ಲಿ ವಯಸ್ಕ ವಿಷಯವನ್ನು ಮರೆಮಾಡಿ';
 
   @override
-  String get seerrNotificationsSection => 'ಅಧಿಸೂಚನೆಗಳು';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'ಹೊಸ ವಿನಂತಿ ಅಧಿಸೂಚನೆಗಳು';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'ಯಾರಾದರೂ ವಿನಂತಿ ಸಲ್ಲಿಸಿದಾಗ ನನಗೆ ತಿಳಿಸಿ';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'ವಿನಂತಿ ನವೀಕರಣಗಳು';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'ಅನುಮೋದಿಸಲಾಗಿದೆ, ತಿರಸ್ಕರಿಸಲಾಗಿದೆ ಮತ್ತು ನಿಮ್ಮ ಲೈಬ್ರರಿಗೆ ಸೇರಿಸಲಾಗಿದೆ';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'ಸಮಸ್ಯೆ ನವೀಕರಣಗಳು';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'ಹೊಸ ಸಮಸ್ಯೆಗಳು, ಪ್ರತ್ಯುತ್ತರಗಳು ಮತ್ತು ಪರಿಹಾರಗಳು';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'ಇವರಾಗಿ ಲಾಗಿನ್ ಆಗಿದ್ದೀರಿ: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr ಡಿಸ್ಕವರಿ ಪುಟ';
+  String get discoverRows => 'ಸಾಲುಗಳನ್ನು ಅನ್ವೇಷಿಸಿ';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr ಮುಖಪುಟದಲ್ಲಿ ನೋಡಲು ಸಾಲುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ. ಮರುಕ್ರಮಗೊಳಿಸಲು ಎಳೆಯಿರಿ. ಕಸ್ಟಮ್ ಕ್ರಮವು Moonbase ನೊಂದಿಗೆ ಸಿಂಕ್ ಆಗುತ್ತದೆ.';
+      'ಮರುಕ್ರಮಗೊಳಿಸಲು ಎಳೆಯಿರಿ. ಸಾಲುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಥವಾ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ. Moonfin ಪ್ಲಗ್‌ಇನ್‌ನೊಂದಿಗೆ ಸಾಲಿನ ಆರ್ಡರ್ ಸಿಂಕ್‌ಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr ಮುಖಪುಟದಲ್ಲಿ ನೋಡಲು ಸಾಲುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ. ಮರುಕ್ರಮಗೊಳಿಸಲು ಎಳೆಯಿರಿ. ಕಸ್ಟಮ್ ಕ್ರಮವು Moonbase ನೊಂದಿಗೆ ಸಿಂಕ್ ಆಗುತ್ತದೆ.';
+      'ಮರುಕ್ರಮಗೊಳಿಸಲು ಎಳೆಯಿರಿ. ಸಾಲುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಥವಾ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ.';
 
   @override
   String get enabled => 'ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ';
@@ -3727,7 +3717,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'ಆವೃತ್ತಿ $version';
+    return 'Version $version';
   }
 
   @override
@@ -3777,7 +3767,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'ನವೀಕರಣ ಲಭ್ಯವಿದೆ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3788,7 +3778,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version ಲಭ್ಯವಿದೆ';
+    return 'v$version Available';
   }
 
   @override
@@ -3869,19 +3859,19 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ಆಮದು ಮಾಡಲಾಗುತ್ತಿದೆ';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count ಐಟಂಗಳು';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+  String get seerrSettings => 'ಸೀರ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
 
   @override
   String get requestMore => 'ಇನ್ನಷ್ಟು ವಿನಂತಿಸಿ';
@@ -3897,7 +3887,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name ವಿನಂತಿಸಿದ್ದಾರೆ';
+    return 'Requested by $name';
   }
 
   @override
@@ -3914,12 +3904,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" ಗಾಗಿ ವಿನಂತಿಯನ್ನು ರದ್ದುಮಾಡುವುದೇ?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" ಗಾಗಿ $count ವಿನಂತಿಗಳನ್ನು ರದ್ದುಮಾಡುವುದೇ?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3934,12 +3924,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'ಬಜೆಟ್: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'ಆದಾಯ: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3949,7 +3939,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type ವಿನಂತಿಸಿ';
+    return 'Request $type';
   }
 
   @override
@@ -3978,14 +3968,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showMore => 'ಇನ್ನಷ್ಟು ತೋರಿಸು';
 
   @override
-  String get appearances => 'ಕಾಣಿಸಿಕೊಂಡ ಕೃತಿಗಳು';
+  String get appearances => 'ಗೋಚರತೆಗಳು';
 
   @override
   String get crewSection => 'ಸಿಬ್ಬಂದಿ';
 
   @override
   String ageValue(int age) {
-    return 'ವಯಸ್ಸು $age';
+    return 'age $age';
   }
 
   @override
@@ -4016,147 +4006,148 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deletedStatus => 'ಅಳಿಸಲಾಗಿದೆ';
 
   @override
-  String get failedStatus => 'ವಿಫಲವಾಗಿದೆ';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'ಪ್ರಕ್ರಿಯೆಗೊಳ್ಳುತ್ತಿದೆ';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name ಮಾರ್ಪಡಿಸಿದ್ದಾರೆ';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'ಪೂರ್ಣಗೊಂಡಿದೆ';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'ಈ ಶೀರ್ಷಿಕೆಯನ್ನು ಈಗಾಗಲೇ ವಿನಂತಿಸಲಾಗಿದೆ';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'ವಿನಂತಿ ಮಿತಿ ತಲುಪಿದೆ';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'ಈ ಶೀರ್ಷಿಕೆ ನಿರ್ಬಂಧಿತ ಪಟ್ಟಿಯಲ್ಲಿದೆ';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'ವಿನಂತಿಸಲು ಯಾವುದೇ ಸೀಸನ್‌ಗಳು ಉಳಿದಿಲ್ಲ';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'ಈ ವಿನಂತಿಯನ್ನು ಮಾಡಲು ನಿಮಗೆ ಅನುಮತಿ ಇಲ್ಲ';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'ವಿನಂತಿಗಳು';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'ಸಮಸ್ಯೆಗಳು';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'ಹೊಸದು';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'ಕೊನೆಯದಾಗಿ ಮಾರ್ಪಡಿಸಿದ್ದು';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'ಯಾವುದೇ ಸಮಸ್ಯೆಗಳಿಲ್ಲ';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit ಚಲನಚಿತ್ರ ವಿನಂತಿಗಳಲ್ಲಿ $remaining ಬಾಕಿ ಉಳಿದಿವೆ';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit ಸೀಸನ್ ವಿನಂತಿಗಳಲ್ಲಿ $remaining ಬಾಕಿ ಉಳಿದಿವೆ';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name ನ ಭಾಗ';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'ಸಂಗ್ರಹಣೆಯನ್ನು ವೀಕ್ಷಿಸಿ';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'ಸಂಗ್ರಹಣೆಯನ್ನು ವಿನಂತಿಸಿ';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total ಚಲನಚಿತ್ರಗಳು · $available ಲಭ್ಯವಿದೆ';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count ಚಲನಚಿತ್ರಗಳನ್ನು ವಿನಂತಿಸಿ';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total ರಲ್ಲಿ $current ವಿನಂತಿಸಲಾಗುತ್ತಿದೆ...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count ಚಲನಚಿತ್ರಗಳನ್ನು ವಿನಂತಿಸಲಾಗಿದೆ';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total ಚಲನಚಿತ್ರಗಳಲ್ಲಿ $ok ಅನ್ನು ವಿನಂತಿಸಲಾಗಿದೆ';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'ಎಲ್ಲಾ ಚಲನಚಿತ್ರಗಳು ಈಗಾಗಲೇ ಲಭ್ಯವಿವೆ ಅಥವಾ ವಿನಂತಿಸಲಾಗಿದೆ';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'ಸಮಸ್ಯೆಯನ್ನು ವರದಿ ಮಾಡಿ';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'ವಿಡಿಯೋ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ಆಡಿಯೋ';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'ಏನು ತಪ್ಪಾಗಿದೆ?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'ಎಲ್ಲಾ ಸಂಚಿಕೆಗಳು';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'ಸಂಚಿಕೆ';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'ತೆರೆದಿದೆ';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'ಪರಿಹರಿಸಲಾಗಿದೆ';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'ಪರಿಹರಿಸಿ';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'ಮತ್ತೆ ತೆರೆಯಿರಿ';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name ವರದಿ ಮಾಡಿದ್ದಾರೆ';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count ಕಾಮೆಂಟ್‌ಗಳು';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'ಕಾಮೆಂಟ್ ಸೇರಿಸಿ';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'ಈ ಸಮಸ್ಯೆಯನ್ನು ಅಳಿಸುವುದೇ?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'ವರದಿಯನ್ನು ಸಲ್ಲಿಸಿ';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB ಸ್ಕೋರ್';
@@ -4180,7 +4171,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get originalLanguageLabel => 'ಮೂಲ ಭಾಷೆ';
 
   @override
-  String get seasonsLabel => 'ಸೀಸನ್‌ಗಳು';
+  String get seasonsLabel => 'ಋತುಗಳು';
 
   @override
   String get episodesLabel => 'ಸಂಚಿಕೆಗಳು';
@@ -4216,7 +4207,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get done => 'ಮುಗಿದಿದೆ';
 
   @override
-  String get edit => 'ಸಂಪಾದಿಸಿ';
+  String get edit => 'ಸಂಪಾದಿಸು';
 
   @override
   String get encoding => 'ಎನ್ಕೋಡಿಂಗ್';
@@ -4291,7 +4282,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get run => 'ಓಡು';
 
   @override
-  String get search => 'ಹುಡುಕಿ';
+  String get search => 'ಹುಡುಕು';
 
   @override
   String get select => 'ಆಯ್ಕೆ ಮಾಡಿ';
@@ -4309,7 +4300,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get status => 'ಸ್ಥಿತಿ';
 
   @override
-  String get stop => 'ನಿಲ್ಲಿಸಿ';
+  String get stop => 'ನಿಲ್ಲಿಸು';
 
   @override
   String get streaming => 'ಸ್ಟ್ರೀಮಿಂಗ್';
@@ -4318,7 +4309,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get time => 'ಸಮಯ';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ಟ್ರಿಕ್ಪ್ಲೇ';
 
   @override
   String get uninstall => 'ಅನ್‌ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ';
@@ -4357,28 +4348,28 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminDrawerUsers => 'ಬಳಕೆದಾರರು';
 
   @override
-  String get adminDrawerLibraries => 'ಲೈಬ್ರರಿಗಳು';
+  String get adminDrawerLibraries => 'ಗ್ರಂಥಾಲಯಗಳು';
 
   @override
-  String get adminDrawerDisplay => 'ಪ್ರದರ್ಶನ';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'ಮೆಟಾಡೇಟಾ';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ಟ್ರಾನ್ಸ್ಕೋಡಿಂಗ್';
 
   @override
-  String get adminDrawerResume => 'ಮುಂದುವರಿಸಿ';
+  String get adminDrawerResume => 'ಪುನರಾರಂಭಿಸಿ';
 
   @override
   String get adminDrawerStreaming => 'ಸ್ಟ್ರೀಮಿಂಗ್';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ಟ್ರಿಕ್ಪ್ಲೇ';
 
   @override
   String get adminDrawerDevices => 'ಸಾಧನಗಳು';
@@ -4429,22 +4420,22 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'ಪ್ಲಗಿನ್ ನವೀಕರಣಗಳು ಲಭ್ಯವಿವೆ: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'ಮರುಪ್ರಾರಂಭ ಅಗತ್ಯವಿರುವ ಪ್ಲಗಿನ್‌ಗಳು: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'ವಿಫಲವಾದ ನಿಗದಿತ ಕಾರ್ಯಗಳು: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'ಇತ್ತೀಚಿನ ಎಚ್ಚರಿಕೆ/ದೋಷ ನಮೂದುಗಳು: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4503,7 +4494,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'ದೋಷ: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4530,7 +4521,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'ಆದೇಶ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4567,7 +4558,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get nowPlaying => 'ಈಗ ಪ್ಲೇ ಆಗುತ್ತಿದೆ';
 
   @override
-  String get volume => 'ವಾಲ್ಯೂಮ್';
+  String get volume => 'ಸಂಪುಟ';
 
   @override
   String get actions => 'ಕ್ರಿಯೆಗಳು';
@@ -4579,7 +4570,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audioCodec => 'ಆಡಿಯೋ ಕೋಡೆಕ್';
 
   @override
-  String get hwAccel => 'HW ವೇಗವರ್ಧನೆ';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'ಪೂರ್ಣಗೊಳಿಸುವಿಕೆ';
@@ -4594,14 +4585,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminClearDates => 'ದಿನಾಂಕಗಳನ್ನು ತೆರವುಗೊಳಿಸಿ';
 
   @override
-  String get adminActivitySeverityAll => 'ಎಲ್ಲಾ ತೀವ್ರತೆಗಳು';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'ದಿನಾಂಕ ವ್ಯಾಪ್ತಿ';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'ಚಟುವಟಿಕೆ ಲಾಗ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4618,7 +4609,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'ಸಾಧನವನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4629,28 +4620,28 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'ಸಾಧನವನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕುವುದೇ? ಬಳಕೆದಾರರು ಈ ಸಾಧನದಲ್ಲಿ ಮತ್ತೆ ಸೈನ್ ಇನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'ಎಲ್ಲಾ ಸಾಧನಗಳನ್ನು ಅಳಿಸಿ';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count ಸಾಧನಗಳನ್ನು ತೆಗೆದುಹಾಕುವುದೇ? ಪ್ರಭಾವಿತ ಬಳಕೆದಾರರು ಮತ್ತೆ ಸೈನ್ ಇನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಸಾಧನಕ್ಕೆ ಇದು ಪರಿಣಾಮ ಬೀರುವುದಿಲ್ಲ.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'ಸಾಧನಗಳನ್ನು ತೆಗೆದುಹಾಕಲಾಗಿದೆ';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'ಕೆಲವು ಸಾಧನಗಳನ್ನು ತೆಗೆದುಹಾಕಲಾಗಿದೆ; $count ಅನ್ನು ತೆಗೆದುಹಾಕಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4679,7 +4670,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'ಸ್ಕ್ಯಾನ್ ಪ್ರಾರಂಭಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4690,12 +4681,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'ಲೈಬ್ರರಿಯನ್ನು \"$name\" ಎಂದು ಮರುಹೆಸರಿಸಲಾಗಿದೆ';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'ಮರುಹೆಸರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4703,17 +4694,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" ಲೈಬ್ರರಿಯನ್ನು ಅಳಿಸಲಾಗಿದೆ';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'ಲೈಬ್ರರಿಯನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'ಪಥವನ್ನು ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4721,12 +4712,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'ಈ ಲೈಬ್ರರಿಯಿಂದ \"$path\" ಅನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'ಪಥವನ್ನು ತೆಗೆದುಹಾಕಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4734,7 +4725,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'ಆಯ್ಕೆಗಳನ್ನು ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4766,259 +4757,251 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminMetadataCountryHint => 'ಉದಾ. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'ಪಥಗಳು';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'ಆಯ್ಕೆಗಳು';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ಡೌನ್‌ಲೋಡರ್‌ಗಳು';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'ಮೆಟಾಡೇಟಾ ಸೇವರ್‌ಗಳು';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'ಉಪಶೀರ್ಷಿಕೆ ಡೌನ್‌ಲೋಡರ್‌ಗಳು';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'ಸಾಹಿತ್ಯ ಡೌನ್‌ಲೋಡರ್‌ಗಳು';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'ಮೆಟಾಡೇಟಾ ಡೌನ್‌ಲೋಡರ್‌ಗಳು: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ಚಿತ್ರ ಫೆಚರ್‌ಗಳು: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'ಈ ಸರ್ವರ್ ಈ ಲೈಬ್ರರಿ ಪ್ರಕಾರಕ್ಕೆ ಯಾವುದೇ ಡೌನ್‌ಲೋಡರ್‌ಗಳನ್ನು ಒದಗಿಸುವುದಿಲ್ಲ.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'ಸಾಮಾನ್ಯ';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'ಮೆಟಾಡೇಟಾ';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'ಎಂಬೆಡೆಡ್ ಮಾಹಿತಿ';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'ಉಪಶೀರ್ಷಿಕೆಗಳು';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'ಚಿತ್ರಗಳು';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'ಸರಣಿಗಳು';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'ಸಂಗೀತ';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'ಚಲನಚಿತ್ರಗಳು';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'ನೈಜ-ಸಮಯದ ಮೇಲ್ವಿಚಾರಣೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ಫೈಲ್ ಬದಲಾವಣೆಗಳನ್ನು ಪತ್ತೆ ಮಾಡಿ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ರಕ್ರಿಯೆಗೊಳಿಸಿ.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'ಆರ್ಕೈವ್‌ಗಳನ್ನು ಮಾಧ್ಯಮ ಫೈಲ್‌ಗಳಾಗಿ ಪರಿಗಣಿಸಿ';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ಫೋಟೋಗಳನ್ನು ಪ್ರದರ್ಶಿಸಿ';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'ಕಲಾಕೃತಿಯನ್ನು ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಉಳಿಸಿ';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'ಸ್ವಯಂಚಾಲಿತ ಮೆಟಾಡೇಟಾ ರಿಫ್ರೆಶ್';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ಎಂದಿಗೂ ಇಲ್ಲ';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ಡೀಫಾಲ್ಟ್';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'ಪ್ರದರ್ಶನ';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'ಲೈಬ್ರರಿ ಪ್ರದರ್ಶನ';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'ಸರಳ ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳನ್ನು ತೋರಿಸಲು ಫೋಲ್ಡರ್ ವೀಕ್ಷಣೆಯನ್ನು ಪ್ರದರ್ಶಿಸಿ';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'ವಿಶೇಷ ಸಂಚಿಕೆಗಳನ್ನು ಅವು ಪ್ರಸಾರವಾದ ಸೀಸನ್‌ಗಳಲ್ಲಿ ಪ್ರದರ್ಶಿಸಿ';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'ಚಲನಚಿತ್ರಗಳನ್ನು ಸಂಗ್ರಹಣೆಗಳಾಗಿ ಗುಂಪು ಮಾಡಿ';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'ಶೋಗಳನ್ನು ಸಂಗ್ರಹಣೆಗಳಾಗಿ ಗುಂಪು ಮಾಡಿ';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'ಸಲಹೆಗಳಲ್ಲಿ ಬಾಹ್ಯ ವಿಷಯವನ್ನು ತೋರಿಸಿ';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'ಸೇರಿಸಿದ ದಿನಾಂಕದ ವರ್ತನೆ';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'ಸೇರಿಸಿದ ದಿನಾಂಕವನ್ನು ಇಲ್ಲಿಂದ ಬಳಸಿ';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'ಲೈಬ್ರರಿಗೆ ಸ್ಕ್ಯಾನ್ ಮಾಡಿದ ದಿನಾಂಕ';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ಫೈಲ್ ರಚಿಸಲಾದ ದಿನಾಂಕ';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'ಮೆಟಾಡೇಟಾ ಮತ್ತು ಚಿತ್ರಗಳು';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ಆದ್ಯತೆಯ ಮೆಟಾಡೇಟಾ ಭಾಷೆ';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'ಅಧ್ಯಾಯಗಳು';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ಡಮ್ಮಿ ಅಧ್ಯಾಯದ ಅವಧಿ (ಸೆಕೆಂಡುಗಳು)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'ಅಧ್ಯಾಯಗಳಿಲ್ಲದ ಮಾಧ್ಯಮಕ್ಕಾಗಿ ರಚಿಸಲಾದ ಅಧ್ಯಾಯಗಳ ಉದ್ದ. ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು 0 ಗೆ ಹೊಂದಿಸಿ.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'ಅಧ್ಯಾಯ ಚಿತ್ರದ ರೆಸಲ್ಯೂಶನ್';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO ಮೆಟಾಡೇಟಾ Kodi ಮತ್ತು ಅಂತಹುದೇ ಕ್ಲೈಂಟ್‌ಗಳೊಂದಿಗೆ ಹೊಂದಿಕೊಳ್ಳುತ್ತದೆ. ಈ ಸೆಟ್ಟಿಂಗ್‌ಗಳು NFO ಮೆಟಾಡೇಟಾವನ್ನು ಉಳಿಸುವ ಎಲ್ಲಾ ಲೈಬ್ರರಿಗಳಿಗೆ ಅನ್ವಯಿಸುತ್ತವೆ.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ಫೈಲ್‌ಗಳಲ್ಲಿ ವೀಕ್ಷಣಾ ಡೇಟಾವನ್ನು ಸಂಗ್ರಹಿಸಬೇಕಾದ ಬಳಕೆದಾರ';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO ಫೈಲ್‌ಗಳಲ್ಲಿ ಚಿತ್ರ ಪಥಗಳನ್ನು ಉಳಿಸಿ';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO ಚಿತ್ರ ಪಥಗಳಿಗೆ ಪಥ ಬದಲಿಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart ಚಿತ್ರಗಳನ್ನು extrathumbs ಫೋಲ್ಡರ್‌ಗೆ ನಕಲಿಸಿ';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ಯಾವುದೂ ಇಲ್ಲ';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ದಿನಗಳು';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'ಎಂಬೆಡೆಡ್ ಶೀರ್ಷಿಕೆಗಳನ್ನು ಬಳಸಿ';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'ಹೆಚ್ಚುವರಿಗಳಿಗೆ ಎಂಬೆಡೆಡ್ ಶೀರ್ಷಿಕೆಗಳನ್ನು ಬಳಸಿ';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'ಎಂಬೆಡೆಡ್ ಸಂಚಿಕೆ ಮಾಹಿತಿಯನ್ನು ಬಳಸಿ';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'ಎಂಬೆಡೆಡ್ ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಅನುಮತಿಸಿ';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'ಎಲ್ಲವನ್ನೂ ಅನುಮತಿಸಿ';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'ಪಠ್ಯ ಮಾತ್ರ';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'ಚಿತ್ರ ಮಾತ್ರ';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ಯಾವುದೂ ಇಲ್ಲ';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'ಎಂಬೆಡೆಡ್ ಉಪಶೀರ್ಷಿಕೆಗಳಿದ್ದರೆ ಡೌನ್‌ಲೋಡ್ ಬಿಟ್ಟುಬಿಡಿ';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ಆಡಿಯೋ ಟ್ರ್ಯಾಕ್ ಡೌನ್‌ಲೋಡ್ ಭಾಷೆಗೆ ಹೊಂದಿಕೆಯಾದರೆ ಡೌನ್‌ಲೋಡ್ ಬಿಟ್ಟುಬಿಡಿ';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'ನಿಖರವಾದ ಉಪಶೀರ್ಷಿಕೆ ಹೊಂದಾಣಿಕೆ ಅಗತ್ಯವಿದೆ';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಉಳಿಸಿ';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'ಅಧ್ಯಾಯ ಚಿತ್ರಗಳನ್ನು ಹೊರತೆಗೆಯಿರಿ';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'ಲೈಬ್ರರಿ ಸ್ಕ್ಯಾನ್ ಸಮಯದಲ್ಲಿ ಅಧ್ಯಾಯ ಚಿತ್ರಗಳನ್ನು ಹೊರತೆಗೆಯಿರಿ';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'trickplay ಚಿತ್ರ ಹೊರತೆಗೆಯುವಿಕೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'ಲೈಬ್ರರಿ ಸ್ಕ್ಯಾನ್ ಸಮಯದಲ್ಲಿ trickplay ಚಿತ್ರಗಳನ್ನು ಹೊರತೆಗೆಯಿರಿ';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'trickplay ಚಿತ್ರಗಳನ್ನು ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಉಳಿಸಿ';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'ಬಹು ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಹರಡಿರುವ ಸರಣಿಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ವಿಲೀನಗೊಳಿಸಿ';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'ಸೀಸನ್ ಶೂನ್ಯದ ಪ್ರದರ್ಶನ ಹೆಸರು';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'ಆಡಿಯೋ ನಾರ್ಮಲೈಸೇಶನ್‌ಗಾಗಿ LUFS ಸ್ಕ್ಯಾನ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'ಪ್ರಮಾಣಿತವಲ್ಲದ ಕಲಾವಿದರ ಟ್ಯಾಗ್‌ಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'ಚಲನಚಿತ್ರಗಳನ್ನು ಸಂಗ್ರಹಣೆಗಳಿಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೇರಿಸಿ';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'ಗ್ರಂಥಾಲಯದ ಹೆಸರು ಅಗತ್ಯವಿದೆ';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'ಲೈಬ್ರರಿ ರಚಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5045,27 +5028,27 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name ಅವರನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುವುದೇ? ಅವರಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗುವುದಿಲ್ಲ.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name ಅವರನ್ನು ಸಕ್ರಿಯಗೊಳಿಸುವುದೇ? ಅವರು ಮತ್ತೆ ಸೈನ್ ಇನ್ ಮಾಡಬಹುದು.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" ಬಳಕೆದಾರರನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" ಬಳಕೆದಾರರನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'ಬಳಕೆದಾರ ನೀತಿಯನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5082,7 +5065,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'ಬಳಕೆದಾರರನ್ನು ರಚಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5102,7 +5085,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5113,7 +5096,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5254,145 +5237,143 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಎಲ್ಲಾ ಚಾನಲ್‌ಗಳಿಗೆ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
-  String get adminParentalControl => 'ಪೋಷಕರ ನಿಯಂತ್ರಣ';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'ಗರಿಷ್ಠ ಅನುಮತಿಸಲಾದ ಪೋಷಕರ ರೇಟಿಂಗ್';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'ಹೆಚ್ಚಿನ ರೇಟಿಂಗ್ ಇರುವ ವಿಷಯವನ್ನು ಈ ಬಳಕೆದಾರರಿಂದ ಮರೆಮಾಡಲಾಗುತ್ತದೆ.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ಯಾವುದೂ ಇಲ್ಲ';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'ರೇಟಿಂಗ್ ಮಾಹಿತಿ ಇಲ್ಲದ ಅಥವಾ ಗುರುತಿಸಲಾಗದ ಐಟಂಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'ಪುಸ್ತಕಗಳು';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ಚಾನೆಲ್‌ಗಳು';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ಲೈವ್ ಟಿವಿ';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'ಚಲನಚಿತ್ರಗಳು';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'ಸಂಗೀತ';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ಟ್ರೇಲರ್‌ಗಳು';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'ಶೋಗಳು';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'ಪ್ರವೇಶ ವೇಳಾಪಟ್ಟಿಗಳು';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'ಕೆಳಗಿನ ನಿಗದಿತ ಸಮಯದಲ್ಲಿ ಮಾತ್ರ ಪ್ರವೇಶವನ್ನು ಅನುಮತಿಸಿ. ಯಾವುದೇ ವೇಳಾಪಟ್ಟಿ ಹೊಂದಿಸದಿದ್ದಾಗ ಇಡೀ ದಿನ ಪ್ರವೇಶವನ್ನು ಅನುಮತಿಸಲಾಗುತ್ತದೆ.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'ವೇಳಾಪಟ್ಟಿ ಸೇರಿಸಿ';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'ದಿನ';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'ಪ್ರಾರಂಭ';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'ಅಂತ್ಯ';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'ಪ್ರತಿದಿನ';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'ವಾರದ ದಿನ';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'ವಾರಾಂತ್ಯ';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ಭಾನುವಾರ';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'ಸೋಮವಾರ';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'ಮಂಗಳವಾರ';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'ಬುಧವಾರ';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'ಗುರುವಾರ';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'ಶುಕ್ರವಾರ';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'ಶನಿವಾರ';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'ಅನುಮತಿಸಲಾದ ಟ್ಯಾಗ್‌ಗಳು';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'ಈ ಟ್ಯಾಗ್‌ಗಳಿರುವ ವಿಷಯವನ್ನು ಮಾತ್ರ ತೋರಿಸಲಾಗುತ್ತದೆ. ಎಲ್ಲವನ್ನೂ ಅನುಮತಿಸಲು ಖಾಲಿ ಬಿಡಿ.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'ನಿರ್ಬಂಧಿಸಿದ ಟ್ಯಾಗ್‌ಗಳು';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'ಈ ಟ್ಯಾಗ್‌ಗಳಿರುವ ವಿಷಯವನ್ನು ಈ ಬಳಕೆದಾರರಿಂದ ಮರೆಮಾಡಲಾಗುತ್ತದೆ.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ಟ್ಯಾಗ್ ಸೇರಿಸಿ';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'ಸಕ್ರಿಯಗೊಳಿಸಿದ ಸಾಧನಗಳು';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'ಸಕ್ರಿಯಗೊಳಿಸಿದ ಚಾನೆಲ್‌ಗಳು';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ದೃಢೀಕರಣ ಪೂರೈಕೆದಾರ';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'ಪಾಸ್‌ವರ್ಡ್ ಮರುಹೊಂದಿಸುವ ಪೂರೈಕೆದಾರ';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'ಲಾಕ್‌ಔಟ್‌ಗೂ ಮೊದಲು ಗರಿಷ್ಠ ವಿಫಲ ಲಾಗಿನ್ ಪ್ರಯತ್ನಗಳು';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'ಡೀಫಾಲ್ಟ್‌ಗಾಗಿ 0 ಗೆ ಹೊಂದಿಸಿ, ಅಥವಾ ಲಾಕ್‌ಔಟ್ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು -1 ಗೆ ಹೊಂದಿಸಿ.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay ಪ್ರವೇಶ';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'ಗುಂಪುಗಳನ್ನು ರಚಿಸಲು ಮತ್ತು ಸೇರಲು ಅನುಮತಿಸಿ';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'ಗುಂಪುಗಳಿಗೆ ಸೇರಲು ಅನುಮತಿಸಿ';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'ಪ್ರವೇಶವಿಲ್ಲ';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'ಇಲ್ಲಿಂದ ವಿಷಯ ಅಳಿಸುವಿಕೆಯನ್ನು ಅನುಮತಿಸಿ';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5400,22 +5381,22 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'ಸರ್ವರ್ HTTP $status ಅನ್ನು ಹಿಂತಿರುಗಿಸಿದೆ';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name ಅವರನ್ನು ಅಳಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" ಬಳಕೆದಾರರನ್ನು ಅಳಿಸಲಾಗಿದೆ';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'ಬಳಕೆದಾರರನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5436,7 +5417,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'ಕೀ ರಚಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5448,7 +5429,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name ಗಾಗಿ ಕೀಯನ್ನು ರದ್ದುಗೊಳಿಸುವುದೇ?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5456,7 +5437,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'ಕೀಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5476,30 +5457,29 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'ಟೋಕನ್: $token\\nರಚಿಸಲಾಗಿದೆ: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'ಬ್ಯಾಕಪ್ ರಚಿಸಿ';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'ಬ್ಯಾಕಪ್‌ನಲ್ಲಿ ಏನನ್ನು ಸೇರಿಸಬೇಕು ಎಂಬುದನ್ನು ಆಯ್ಕೆಮಾಡಿ.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ಡೇಟಾಬೇಸ್';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'ಯಾವಾಗಲೂ ಸೇರಿಸಲಾಗಿದೆ';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'ಮೆಟಾಡೇಟಾ';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'ಉಪಶೀರ್ಷಿಕೆಗಳು';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay ಚಿತ್ರಗಳು';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'ಬ್ಯಾಕಪ್ ರಚಿಸಲಾಗುತ್ತಿದೆ...';
@@ -5509,7 +5489,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'ಬ್ಯಾಕಪ್ ರಚಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5518,12 +5498,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'ಮ್ಯಾನಿಫೆಸ್ಟ್: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'ಮ್ಯಾನಿಫೆಸ್ಟ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5534,7 +5514,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'ಬ್ಯಾಕಪ್ ಮರುಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5566,17 +5546,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path ಗೆ ಉಳಿಸಲಾಗಿದೆ';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ಫೈಲ್ ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5587,7 +5567,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'ಕಾರ್ಯಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5599,17 +5579,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'ಕಾರ್ಯವನ್ನು ಪ್ರಾರಂಭಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'ಕಾರ್ಯವನ್ನು ನಿಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'ಕಾರ್ಯವನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5617,12 +5597,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'ಟ್ರಿಗರ್ ತೆಗೆದುಹಾಕಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'ಟ್ರಿಗರ್ ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5648,7 +5628,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ಗಂಟೆ(ಗಳು)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5659,7 +5639,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'ಪ್ಲಗಿನ್ ಟಾಗಲ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5667,27 +5647,27 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '\"$name\" ಅನ್ನು ಅಸ್ಥಾಪಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'ಪ್ಲಗಿನ್ ಅಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'ಪ್ಯಾಕೇಜ್ ಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'ನವೀಕರಣವನ್ನು ಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'ಪ್ಲಗಿನ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5699,12 +5679,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'ನವೀಕರಣವನ್ನು ಸ್ಥಾಪಿಸಿ (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'ಕ್ಯಾಟಲಾಗ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5726,17 +5706,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'ಸರ್ವರ್ ಮರುಪ್ರಾರಂಭದ ನಂತರ \"$name\" ಅನ್ನು ತೆಗೆದುಹಾಕಲಾಗುತ್ತದೆ';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'ಅಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" ಅನ್ನು v$version ಗೆ ನವೀಕರಿಸಲಾಗುತ್ತಿದೆ...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5745,7 +5725,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'ಪ್ಲಗಿನ್ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5753,7 +5733,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'ಆವೃತ್ತಿ $version';
+    return 'Version $version';
   }
 
   @override
@@ -5773,17 +5753,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '\"$name\" ಅನ್ನು ತೆಗೆದುಹಾಕಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'ರೆಪೊಸಿಟರಿಗಳನ್ನು ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'ರೆಪೊಸಿಟರಿಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5800,12 +5780,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'ಪ್ಲಗಿನ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri ಅನ್ನು ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5930,11 +5910,11 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminThrottleBuffering => 'ಥ್ರೊಟಲ್ ಬಫರಿಂಗ್';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಉಳಿಸಲಾಗಿದೆ';
+  String get adminTrickplaySaved => 'ಟ್ರಿಕ್‌ಪ್ಲೇ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಉಳಿಸಲಾಗಿದೆ';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'trickplay ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+      'ಟ್ರಿಕ್‌ಪ್ಲೇ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6048,7 +6028,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminBaseUrl => 'ಮೂಲ URL';
 
   @override
-  String get adminBaseUrlHint => 'ಉದಾ. /jellyfin';
+  String get adminBaseUrlHint => 'ಉದಾ. / ಜೆಲ್ಲಿಫಿನ್';
 
   @override
   String get https => 'HTTPS';
@@ -6088,12 +6068,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'ಮೆಟಾಡೇಟಾ ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'ಮೆಟಾಡೇಟಾ ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6114,7 +6094,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'ಮೆಟಾಡೇಟಾ ರಿಫ್ರೆಶ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6128,7 +6108,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'ರಿಮೋಟ್ ಹುಡುಕಾಟ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6142,7 +6122,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'ವಿಷಯ ಪ್ರಕಾರವನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6157,12 +6137,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ನವೀಕರಿಸಲಾಗಿದೆ';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6173,27 +6153,27 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಳಿಸಿ';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಳಿಸಲಾಗಿದೆ';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6204,70 +6184,67 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'ಟ್ಯೂನರ್ ಅನ್ವೇಷಣೆ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'ಟ್ಯೂನರ್ ಸೇರಿಸಿ';
 
   @override
-  String get adminEditTuner => 'ಟ್ಯೂನರ್ ಸಂಪಾದಿಸಿ';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ಟ್ಯೂನರ್';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ಫೈಲ್ ಅಥವಾ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ಟ್ಯೂನರ್ IP ವಿಳಾಸ';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'ಪ್ರದರ್ಶನ ಹೆಸರು';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'ಬಳಕೆದಾರ ಏಜೆಂಟ್';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ಏಕಕಾಲಿಕ ಸಂಪರ್ಕ ಮಿತಿ';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ಟ್ಯೂನರ್ ಒಂದೇ ಬಾರಿಗೆ ಅನುಮತಿಸುವ ಗರಿಷ್ಠ ಸ್ಟ್ರೀಮ್‌ಗಳ ಸಂಖ್ಯೆ. ಅನಿಯಮಿತಕ್ಕೆ 0 ಗೆ ಹೊಂದಿಸಿ.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'ಪರ್ಯಾಯ ಗರಿಷ್ಠ ಸ್ಟ್ರೀಮಿಂಗ್ ಬಿಟ್‌ರೇಟ್';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'ಮೆಚ್ಚಿನ ಚಾನೆಲ್‌ಗಳನ್ನು ಮಾತ್ರ ಆಮದು ಮಾಡಿ';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'ಹಾರ್ಡ್‌ವೇರ್ ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ ಅನ್ನು ಅನುಮತಿಸಿ';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'fMP4 ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ ಕಂಟೇನರ್ ಅನ್ನು ಅನುಮತಿಸಿ';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ಸ್ಟ್ರೀಮ್ ಹಂಚಿಕೆಯನ್ನು ಅನುಮತಿಸಿ';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ಸ್ಟ್ರೀಮ್ ಲೂಪಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS ಅನ್ನು ನಿರ್ಲಕ್ಷಿಸಿ';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'ಸ್ಥಳೀಯ ಫ್ರೇಮ್ ದರದಲ್ಲಿ ಇನ್‌ಪುಟ್ ಓದಿ';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ಪೂರೈಕೆದಾರರನ್ನು ಸಂಪಾದಿಸಿ';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6276,50 +6253,50 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ಫೈಲ್ ಅಥವಾ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'ಚಲನಚಿತ್ರ ಪೂರ್ವಪ್ರತ್ಯಯ';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'ಚಲನಚಿತ್ರ ವರ್ಗಗಳು';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'ಬಹು ವರ್ಗಗಳನ್ನು ಲಂಬ ಗೆರೆಯಿಂದ ಬೇರ್ಪಡಿಸಿ.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'ಮಕ್ಕಳ ವರ್ಗಗಳು';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'ಸುದ್ದಿ ವರ್ಗಗಳು';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'ಕ್ರೀಡಾ ವರ್ಗಗಳು';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ಬಳಕೆದಾರ ಹೆಸರು';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'ಪಾಸ್‌ವರ್ಡ್';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'ದೇಶ';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'ದೇಶವನ್ನು ಆಯ್ಕೆಮಾಡಿ';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'ಅಂಚೆ ಕೋಡ್';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'ಪಟ್ಟಿಗಳನ್ನು ಪಡೆಯಿರಿ';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'ಪಟ್ಟಿಗಳು';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'ಎಲ್ಲಾ ಟ್ಯೂನರ್‌ಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ಟ್ಯೂನರ್ ಪ್ರಕಾರ';
@@ -6329,7 +6306,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'ಟ್ಯೂನರ್ ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6343,12 +6320,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'ಪೂರೈಕೆದಾರರನ್ನು ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'ಟ್ಯೂನರ್ ತೆಗೆದುಹಾಕಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6356,16 +6333,16 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'ಟ್ಯೂನರ್ ಮರುಹೊಂದಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'ಈ ಟ್ಯೂನರ್ ಪ್ರಕಾರವು ಮರುಹೊಂದಿಸುವಿಕೆಯನ್ನು ಬೆಂಬಲಿಸುವುದಿಲ್ಲ.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'ಪೂರೈಕೆದಾರರನ್ನು ತೆಗೆದುಹಾಕಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6384,44 +6361,43 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminSeriesRecordingPath => 'ಸರಣಿ ರೆಕಾರ್ಡಿಂಗ್ ಮಾರ್ಗ';
 
   @override
-  String get adminMovieRecordingPath => 'ಚಲನಚಿತ್ರ ರೆಕಾರ್ಡಿಂಗ್ ಪಥ';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'ಗೈಡ್ ಡೇಟಾ ದಿನಗಳು';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ಸ್ವಯಂಚಾಲಿತ';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ದಿನಗಳು';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'ನಂತರದ-ಸಂಸ್ಕರಣೆ ಅಪ್ಲಿಕೇಶನ್ ಪಥ';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'ನಂತರದ-ಸಂಸ್ಕಾರಕ ಆರ್ಗ್ಯುಮೆಂಟ್‌ಗಳು';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'ರೆಕಾರ್ಡಿಂಗ್ NFO ಮೆಟಾಡೇಟಾವನ್ನು ಉಳಿಸಿ';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'ರೆಕಾರ್ಡಿಂಗ್ ಚಿತ್ರಗಳನ್ನು ಉಳಿಸಿ';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'ಸಮಯ ನಿಗದಿ';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'ರೆಕಾರ್ಡಿಂಗ್ ಪಥಗಳು';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'ನಂತರದ-ಸಂಸ್ಕರಣೆ';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'ಗೈಡ್ ಡೇಟಾ: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6430,7 +6406,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6448,7 +6424,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'ಮ್ಯಾಪಿಂಗ್‌ಗಳನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6466,14 +6442,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminGuideProviders => 'ಮಾರ್ಗದರ್ಶಿ ಪೂರೈಕೆದಾರರು';
 
   @override
-  String get adminRefreshGuideData => 'ಗೈಡ್ ಡೇಟಾವನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಿ';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'ಗೈಡ್ ಡೇಟಾ ರಿಫ್ರೆಶ್ ಪ್ರಾರಂಭವಾಗಿದೆ';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'ಈ ಸರ್ವರ್‌ನಲ್ಲಿ ಗೈಡ್ ರಿಫ್ರೆಶ್ ಕಾರ್ಯ ಲಭ್ಯವಿಲ್ಲ.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'ಒದಗಿಸುವವರನ್ನು ಸೇರಿಸಿ';
@@ -6484,22 +6460,22 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'ರೆಕಾರ್ಡಿಂಗ್ ಪಥ: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'ಸರಣಿ ಪಥ: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'ಪೂರ್ವ-ಪ್ಯಾಡಿಂಗ್: $minutes ನಿಮಿ';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'ನಂತರದ-ಪ್ಯಾಡಿಂಗ್: $minutes ನಿಮಿ';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6532,7 +6508,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name ಬ್ಯಾಕಪ್ ಅನ್ನು ಈಗ ಮರುಸ್ಥಾಪಿಸುವುದೇ?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6556,7 +6532,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminLiveTvTitle => 'ಲೈವ್ ಟಿವಿ ಆಡಳಿತ';
 
   @override
-  String get adminApply => 'ಅನ್ವಯಿಸಿ';
+  String get adminApply => 'ಅನ್ವಯಿಸು';
 
   @override
   String get adminNotSet => 'ಹೊಂದಿಸಿಲ್ಲ';
@@ -6578,27 +6554,27 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutesನಿ ಹಿಂದೆ';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hoursಗಂ ಹಿಂದೆ';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$daysದಿ ಹಿಂದೆ';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count ಹೊಂದಾಣಿಕೆಗಳು';
+    return '$count matches';
   }
 
   @override
@@ -6608,7 +6584,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminMetadataEditorTitle => 'ಮೆಟಾಡೇಟಾ ಸಂಪಾದಕ';
 
   @override
-  String get adminMetadataIdentify => 'ಗುರುತಿಸಿ';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'ಟೈಪ್ ಮಾಡಿ';
@@ -6708,22 +6684,22 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ನವೀಕರಿಸಲಾಗಿದೆ';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಳಿಸಲಾಗಿದೆ';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6732,12 +6708,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಅಳಿಸಿ';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6746,12 +6722,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType ಚಿತ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಿ';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6785,7 +6761,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'ನವೀಕರಣ ಲಭ್ಯವಿದೆ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6809,7 +6785,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'ನವೀಕರಣವನ್ನು ಸ್ಥಾಪಿಸಿ (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6821,7 +6797,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" ಅನ್ನು ಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6841,7 +6817,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+    return '$name Settings';
   }
 
   @override
@@ -6881,7 +6857,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'ರೆಪೊಸಿಟರಿಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6889,7 +6865,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '\"$name\" ಅನ್ನು ತೆಗೆದುಹಾಕಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6897,7 +6873,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'ರೆಪೊಸಿಟರಿಗಳನ್ನು ಉಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7022,20 +6998,19 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminBrandingEnableSplash => 'ಸ್ಪ್ಲಾಶ್ ಪರದೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
-  String get adminBrandingSplashUpload => 'ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಿ';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'ಸ್ಪ್ಲಾಶ್‌ಸ್ಕ್ರೀನ್ ನವೀಕರಿಸಲಾಗಿದೆ';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'ಸ್ಪ್ಲಾಶ್‌ಸ್ಕ್ರೀನ್ ಅಪ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'ಸ್ಪ್ಲಾಶ್‌ಸ್ಕ್ರೀನ್ ತೆಗೆದುಹಾಕಲಾಗಿದೆ';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'ಕಸ್ಟಮ್ ಸ್ಪ್ಲಾಶ್‌ಸ್ಕ್ರೀನ್ ಇಲ್ಲ';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'ಯಂತ್ರಾಂಶ ವೇಗವರ್ಧನೆ';
@@ -7052,126 +7027,121 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಇದಕ್ಕಾಗಿ ಹಾರ್ಡ್‌ವೇರ್ ಡಿಕೋಡಿಂಗ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ಸಾಧನ';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'ವರ್ಧಿತ NVDEC ಡಿಕೋಡರ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'ಸಿಸ್ಟಂ ಸ್ಥಳೀಯ ಹಾರ್ಡ್‌ವೇರ್ ಡಿಕೋಡರ್‌ಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'ಹಾರ್ಡ್‌ವೇರ್ ಡಿಕೋಡಿಂಗ್ ಬಣ್ಣದ ಆಳ';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC ಡಿಕೋಡಿಂಗ್';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 ಡಿಕೋಡಿಂಗ್';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bit ಡಿಕೋಡಿಂಗ್';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit ಡಿಕೋಡಿಂಗ್';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'ಹಾರ್ಡ್‌ವೇರ್ ಎನ್‌ಕೋಡಿಂಗ್';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding =>
-      'HEVC ಎನ್‌ಕೋಡಿಂಗ್ ಅನ್ನು ಅನುಮತಿಸಿ';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 ಎನ್‌ಕೋಡಿಂಗ್ ಅನ್ನು ಅನುಮತಿಸಿ';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel ಕಡಿಮೆ-ಶಕ್ತಿಯ H.264 ಎನ್‌ಕೋಡರ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel ಕಡಿಮೆ-ಶಕ್ತಿಯ HEVC ಎನ್‌ಕೋಡರ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಅಲ್ಗಾರಿದಮ್';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಮೋಡ್';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ರೇಂಜ್';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಡಿಸ್ಯಾಚುರೇಶನ್';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಪೀಕ್';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಪ್ಯಾರಾಮೀಟರ್';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಹೊಳಪು';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP ಟೋನ್ ಮ್ಯಾಪಿಂಗ್ ಕಾಂಟ್ರಾಸ್ಟ್';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'ಪ್ರಿಸೆಟ್‌ಗಳು ಮತ್ತು ಗುಣಮಟ್ಟ';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'ಎನ್‌ಕೋಡರ್ ಪ್ರಿಸೆಟ್';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 ಎನ್‌ಕೋಡಿಂಗ್ CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) ಎನ್‌ಕೋಡಿಂಗ್ CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'ಡಿಇಂಟರ್‌ಲೇಸ್ ವಿಧಾನ';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ಡಿಇಂಟರ್‌ಲೇಸ್ ಮಾಡುವಾಗ ಫ್ರೇಮ್ ದರವನ್ನು ದ್ವಿಗುಣಗೊಳಿಸಿ';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ಆಡಿಯೋ';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'ಆಡಿಯೋ VBR ಎನ್‌ಕೋಡಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ಆಡಿಯೋ ಡೌನ್‌ಮಿಕ್ಸ್ ಬೂಸ್ಟ್';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ಸ್ಟೀರಿಯೋ ಡೌನ್‌ಮಿಕ್ಸ್ ಅಲ್ಗಾರಿದಮ್';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'ಗರಿಷ್ಠ ಮಕ್ಸಿಂಗ್ ಕ್ಯೂ ಗಾತ್ರ';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ಆಟೋ';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'ಎನ್ಕೋಡಿಂಗ್';
@@ -7292,10 +7262,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminTaskNeverRun => 'ಎಂದಿಗೂ ಓಡುವುದಿಲ್ಲ';
 
   @override
-  String get adminTaskStop => 'ನಿಲ್ಲಿಸಿ';
+  String get adminTaskStop => 'ನಿಲ್ಲಿಸು';
 
   @override
-  String get adminRunningTasks => 'ಚಾಲನೆಯಲ್ಲಿರುವ ಕಾರ್ಯಗಳು';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'ಓಡು';
@@ -7317,17 +7287,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'ಪ್ರತಿದಿನ $time ಕ್ಕೆ';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'ಪ್ರತಿ $day $time ಕ್ಕೆ';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'ಪ್ರತಿ $duration ಗೆ';
+    return 'Every $duration';
   }
 
   @override
@@ -7365,8 +7335,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಗಂಟೆಗಳು',
-      one: '1 ಗಂಟೆ',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7394,17 +7364,17 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$daysದಿ ಹಿಂದೆ';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hoursಗಂ ಹಿಂದೆ';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutesನಿ ಹಿಂದೆ';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7412,27 +7382,27 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesನಿ';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursಗಂ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysದಿ';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'ಸೀಕ್ ಪೂರ್ವವೀಕ್ಷಣೆ ಥಂಬ್‌ನೇಲ್‌ಗಳಿಗಾಗಿ trickplay ಚಿತ್ರ ರಚನೆಯನ್ನು ಕಾನ್ಫಿಗರ್ ಮಾಡಿ.';
+      'ಸೀಕ್ ಪ್ರಿವ್ಯೂ ಥಂಬ್‌ನೇಲ್‌ಗಳಿಗಾಗಿ ಟ್ರಿಕ್‌ಪ್ಲೇ ಇಮೇಜ್ ಜನರೇಷನ್ ಅನ್ನು ಕಾನ್ಫಿಗರ್ ಮಾಡಿ.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'ಸಾರ್ವಜನಿಕ HTTPS ಪೋರ್ಟ್';
@@ -7441,50 +7411,49 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'ಮೂಲ URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ಉದಾ. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ಉದಾ. / ಜೆಲ್ಲಿಫಿನ್';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'ಸಾರ್ವಜನಿಕ HTTP ಪೋರ್ಟ್';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS ಅಗತ್ಯವಿದೆ';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'ಎಲ್ಲಾ ರಿಮೋಟ್ ವಿನಂತಿಗಳನ್ನು HTTPS ಗೆ ಮರುನಿರ್ದೇಶಿಸಿ. ಸರ್ವರ್‌ಗೆ ಮಾನ್ಯ ಪ್ರಮಾಣಪತ್ರ ಇಲ್ಲದಿದ್ದರೆ ಇದು ಯಾವುದೇ ಪರಿಣಾಮ ಬೀರುವುದಿಲ್ಲ.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'ಪ್ರಮಾಣಪತ್ರ ಪಾಸ್‌ವರ್ಡ್';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'ಸ್ವಯಂಚಾಲಿತ ಪೋರ್ಟ್ ಮ್ಯಾಪಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN ನೆಟ್‌ವರ್ಕ್‌ಗಳು';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'ಸ್ಥಳೀಯ ನೆಟ್‌ವರ್ಕ್‌ನಲ್ಲಿವೆ ಎಂದು ಪರಿಗಣಿಸಲಾಗುವ IP ವಿಳಾಸಗಳು ಅಥವಾ CIDR ಸಬ್‌ನೆಟ್‌ಗಳ ಅಲ್ಪವಿರಾಮ ಅಥವಾ ಸಾಲಿನಿಂದ ಬೇರ್ಪಡಿಸಿದ ಪಟ್ಟಿ.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'ಪ್ರಕಟಿಸಿದ ಸರ್ವರ್ URI ಗಳು';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'ಸಬ್‌ನೆಟ್ ಅಥವಾ ವಿಳಾಸವನ್ನು ಪ್ರಕಟಿಸಿದ URL ಗೆ ಮ್ಯಾಪ್ ಮಾಡಿ, ಉದಾ. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'ಪ್ರಮಾಣಪತ್ರ ಮಾರ್ಗ';
@@ -7514,11 +7483,11 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'ಥ್ರೊಟಲ್ ಬಫರಿಂಗ್';
 
   @override
-  String get adminPlaybackThrottleDelay => 'ಥ್ರಾಟಲ್ ವಿಳಂಬ (ಸೆಕೆಂಡುಗಳು)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'ತಕ್ಷಣದ ಉಪಶೀರ್ಷಿಕೆ ಹೊರತೆಗೆಯುವಿಕೆಯನ್ನು ಅನುಮತಿಸಿ';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'ಕನಿಷ್ಠ ಪುನರಾರಂಭದ ಶೇಕಡಾವಾರು';
@@ -7568,7 +7537,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'ವಿಷಯ ಪ್ರಕಾರವನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7576,23 +7545,22 @@ class AppLocalizationsKn extends AppLocalizations {
       'ನಿಧಾನ ಪ್ರತಿಕ್ರಿಯೆ ಮಿತಿ (ಮಿಸೆ)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'ನಿಧಾನ ಪ್ರತಿಕ್ರಿಯೆ ಎಚ್ಚರಿಕೆಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'ಸರ್ವರ್';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'ಮೆಟಾಡೇಟಾ';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'ಪಥಗಳು';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'ಕಾರ್ಯಕ್ಷಮತೆ';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'ಸಂಗ್ರಹ ಮಾರ್ಗ';
@@ -7604,7 +7572,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminGeneralServerName => 'ಸರ್ವರ್ ಹೆಸರು';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ಆದ್ಯತೆಯ ಪ್ರದರ್ಶನ ಭಾಷೆ';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7615,19 +7583,19 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'ಮ್ಯಾಪಿಂಗ್‌ಗಳನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'ಸಮಯ ಮಿತಿ: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'ಫೋಲ್ಡರ್‌ಗಳು';
 
   @override
-  String get libraries => 'ಲೈಬ್ರರಿಗಳು';
+  String get libraries => 'ಗ್ರಂಥಾಲಯಗಳು';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7657,8 +7625,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ಭಾಗವಹಿಸುವವರು',
-      one: '# ಭಾಗವಹಿಸುವವರು',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7702,7 +7670,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'ಐಟಂ $index';
+    return 'Item $index';
   }
 
   @override
@@ -7750,12 +7718,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay ಗುಂಪಿಗೆ ಸೇರಿದರು';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay ಗುಂಪಿನಿಂದ ಹೊರಟರು';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7767,7 +7735,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName ಗೆ ಪ್ಲೇಬ್ಯಾಕ್ ಸಿಂಕ್ ಮಾಡಲಾಗುತ್ತಿದೆ';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7805,8 +7773,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ಸಾಲುಗಳು ಪತ್ತೆಯಾಗಿವೆ',
-      one: '# ಸಾಲು ಪತ್ತೆಯಾಗಿದೆ',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7847,21 +7815,20 @@ class AppLocalizationsKn extends AppLocalizations {
   String get offlineSavedMedia => 'ಉಳಿಸಿದ ಮಾಧ್ಯಮ';
 
   @override
-  String get offlineBannerTitle => 'ನೀವು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿದ್ದೀರಿ';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ತೋರಿಸಲಾಗುತ್ತಿದೆ';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ಡೌನ್‌ಲೋಡ್‌ಗಳು';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'ನಿಮ್ಮ ಸರ್ವರ್ ಅನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'ಅದು ಮರಳುವವರೆಗೆ ಡೌನ್‌ಲೋಡ್‌ಗಳಿಂದ ಪ್ಲೇ ಮಾಡಲಾಗುತ್ತಿದೆ';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7877,12 +7844,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'ಕಾಸ್ಟ್ ನಿಯಂತ್ರಣ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind ನಿಯಂತ್ರಣಗಳು';
+    return '$kind Controls';
   }
 
   @override
@@ -7893,7 +7860,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind ನಿಲ್ಲಿಸಿ';
+    return 'Stop $kind';
   }
 
   @override
@@ -7916,12 +7883,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length-ಅಂಕಿಯ PIN ನಮೂದಿಸಿ';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'ನಿಮ್ಮ $length-ಅಂಕಿಯ PIN ನಮೂದಿಸಿ';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7941,35 +7908,35 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get quickConnectAuthorized =>
-      'Quick Connect ವಿನಂತಿಯನ್ನು ಅಧಿಕೃತಗೊಳಿಸಲಾಗಿದೆ.';
+      'ತ್ವರಿತ ಸಂಪರ್ಕ ವಿನಂತಿಯನ್ನು ಅಧಿಕೃತಗೊಳಿಸಲಾಗಿದೆ.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect ಕೋಡ್ ಅಮಾನ್ಯವಾಗಿದೆ ಅಥವಾ ಅವಧಿ ಮೀರಿದೆ.';
+      'ತ್ವರಿತ ಸಂಪರ್ಕ ಕೋಡ್ ಅಮಾನ್ಯವಾಗಿದೆ ಅಥವಾ ಅವಧಿ ಮೀರಿದೆ.';
 
   @override
   String get quickConnectNotSupported =>
-      'ಈ ಸರ್ವರ್‌ನಲ್ಲಿ Quick Connect ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'ಈ ಸರ್ವರ್‌ನಲ್ಲಿ ತ್ವರಿತ ಸಂಪರ್ಕವು ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect ಕೋಡ್ ಅನ್ನು ಅಧಿಕೃತಗೊಳಿಸಲು ವಿಫಲವಾಗಿದೆ.';
+      'ತ್ವರಿತ ಸಂಪರ್ಕ ಕೋಡ್ ಅನ್ನು ದೃಢೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ.';
 
   @override
   String get quickConnectDisabled =>
-      'ಈ ಸರ್ವರ್‌ನಲ್ಲಿ Quick Connect ನಿಷ್ಕ್ರಿಯಗೊಂಡಿದೆ.';
+      'ಈ ಸರ್ವರ್‌ನಲ್ಲಿ ತ್ವರಿತ ಸಂಪರ್ಕವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ.';
 
   @override
   String get quickConnectForbidden =>
-      'ನಿಮ್ಮ ಖಾತೆಯು ಈ Quick Connect ವಿನಂತಿಯನ್ನು ಅಧಿಕೃತಗೊಳಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ.';
+      'ನಿಮ್ಮ ಖಾತೆಯು ಈ ತ್ವರಿತ ಸಂಪರ್ಕ ವಿನಂತಿಯನ್ನು ದೃಢೀಕರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect ಕೋಡ್ ಕಂಡುಬಂದಿಲ್ಲ. ಹೊಸ ಕೋಡ್ ಪ್ರಯತ್ನಿಸಿ.';
+      'ತ್ವರಿತ ಸಂಪರ್ಕ ಕೋಡ್ ಕಂಡುಬಂದಿಲ್ಲ. ಹೊಸ ಕೋಡ್ ಅನ್ನು ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ವಿಫಲವಾಗಿದೆ: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7980,7 +7947,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'ಆದೇಶ ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8010,7 +7977,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'ಕಾಸ್ಟಿಂಗ್ ಪ್ರಾರಂಭಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8055,7 +8022,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8075,7 +8042,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get shuffleSelectGenre => 'ಪ್ರಕಾರವನ್ನು ಆಯ್ಕೆಮಾಡಿ';
 
   @override
-  String get shuffleLibrary => 'ಲೈಬ್ರರಿ';
+  String get shuffleLibrary => 'ಗ್ರಂಥಾಲಯ';
 
   @override
   String get shuffleGenre => 'ಪ್ರಕಾರ';
@@ -8136,14 +8103,14 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಪ್ಲೇಬ್ಯಾಕ್ ಅನ್ನು ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ. ನೀವು ಇನ್ನೂ ನೋಡುತ್ತಿದ್ದೀರಾ?';
 
   @override
-  String get stillWatchingStop => 'ನಿಲ್ಲಿಸಿ';
+  String get stillWatchingStop => 'ನಿಲ್ಲಿಸು';
 
   @override
   String get stillWatchingContinue => 'ಮುಂದುವರಿಸಿ';
 
   @override
   String skipSegment(String segment) {
-    return '$segment ಬಿಟ್ಟುಬಿಡಿ';
+    return 'Skip $segment';
   }
 
   @override
@@ -8155,12 +8122,12 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$current/$total ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8198,7 +8165,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'ತಿರುಗುವಿಕೆಯನ್ನು ಅನುಮತಿಸಿ';
 
   @override
-  String get playerTooltipPrevious => 'ಹಿಂದಿನದು';
+  String get playerTooltipPrevious => 'ಹಿಂದಿನ';
 
   @override
   String get playerTooltipSeekBack => 'ಹಿಂತಿರುಗಿ ನೋಡಿ';
@@ -8223,13 +8190,13 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      '\"ನೋಡುವುದನ್ನು ಮುಂದುವರಿಸಿ\" ವಿಭಾಗದಿಂದ ಮರೆಮಾಡಿ';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => '\"ಮುಂದಿನದು\" ವಿಭಾಗದಿಂದ ಮರೆಮಾಡಿ';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'ಸಂಗ್ರಹಣೆಗೆ ಸೇರಿಸಿ';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8265,7 +8232,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'ಪ್ಲಗಿನ್ ಸಿಂಕ್, Seerr, ರೇಟಿಂಗ್‌ಗಳು ಮತ್ತು ಇನ್ನಷ್ಟು';
+      'ಪ್ಲಗಿನ್ ಸಿಂಕ್, ಸೀರ್, ರೇಟಿಂಗ್‌ಗಳು ಮತ್ತು ಇನ್ನಷ್ಟು';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8284,15 +8251,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get settingsAlphabetical => 'ವರ್ಣಮಾಲೆಯ';
 
   @override
-  String get settingsConnectionSection => 'ಸಂಪರ್ಕ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'ಸ್ವಯಂ-ಸಹಿ ಮಾಡಿದ ಪ್ರಮಾಣಪತ್ರಗಳನ್ನು ಅನುಮತಿಸಿ';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'ಸ್ವಯಂ-ಸಹಿ ಮಾಡಿದ ಅಥವಾ ಖಾಸಗಿ-CA TLS ಪ್ರಮಾಣಪತ್ರಗಳನ್ನು ಬಳಸುವ ಸರ್ವರ್‌ಗಳನ್ನು ನಂಬಿರಿ. ನೀವು ನಿಯಂತ್ರಿಸುವ ಸರ್ವರ್‌ಗಳಿಗೆ ಮಾತ್ರ ಸಕ್ರಿಯಗೊಳಿಸಿ. ಇದು ಎಲ್ಲಾ ಸಂಪರ್ಕಗಳಿಗೆ ಪ್ರಮಾಣಪತ್ರ ಮೌಲ್ಯೀಕರಣವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುತ್ತದೆ.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ಗೌಪ್ಯತೆ ಮತ್ತು ಸುರಕ್ಷತೆ';
@@ -8308,11 +8274,11 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಥೀಮ್ ಉಚ್ಚಾರಣೆಗಳು, ಬ್ಯಾಕ್‌ಡ್ರಾಪ್‌ಗಳು, ವೀಕ್ಷಿಸಿದ ಸೂಚಕಗಳು ಮತ್ತು ಥೀಮ್ ಸಂಗೀತ';
 
   @override
-  String get settingsDetailsScreen => 'ವಿವರ ಪರದೆ';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'ಶೈಲಿ, ಹಿನ್ನೆಲೆ ಬ್ಲರ್ ಮತ್ತು ಟ್ಯಾಬ್ ವರ್ತನೆ';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'ಮುಖಪುಟ';
@@ -8350,11 +8316,11 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'ನ್ಯಾವಿಗೇಶನ್ ಬಾರ್‌ನಲ್ಲಿ Seerr ಬಟನ್ ತೋರಿಸಿ';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'ಮೇಲಿನ ನ್ಯಾವಿಗೇಶನ್ ಬಾರ್‌ನಲ್ಲಿ ಪಠ್ಯ ಲೇಬಲ್‌ಗಳನ್ನು ಯಾವಾಗಲೂ ತೋರಿಸಿ';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8375,7 +8341,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'ಹೆಚ್ಚುವರಿ ರೇಟಿಂಗ್ ಮೂಲಗಳು, Seerr ವಿನಂತಿಗಳು ಮತ್ತು ಸಿಂಕ್ ಮಾಡಿದ ಆದ್ಯತೆಗಳು ಸೇರಿದಂತೆ ಸರ್ವರ್-ಸೈಡ್ ಸಂಯೋಜನೆಗಳಿಗೆ Moonbase ಶಕ್ತಿ ನೀಡುತ್ತದೆ.';
+      'Moonbase ಹೆಚ್ಚುವರಿ ರೇಟಿಂಗ್ ಮೂಲಗಳು, ಸೀರ್ ವಿನಂತಿಗಳು ಮತ್ತು ಸಿಂಕ್ ಮಾಡಲಾದ ಪ್ರಾಶಸ್ತ್ಯಗಳನ್ನು ಒಳಗೊಂಡಂತೆ ಸರ್ವರ್-ಸೈಡ್ ಇಂಟಿಗ್ರೇಷನ್‌ಗಳಿಗೆ ಶಕ್ತಿ ನೀಡುತ್ತದೆ.';
 
   @override
   String get settingsOfflineDownloads => 'ಆಫ್‌ಲೈನ್ ಡೌನ್‌ಲೋಡ್‌ಗಳು';
@@ -8423,7 +8389,8 @@ class AppLocalizationsKn extends AppLocalizations {
   String get settingsSupportMoonfin => 'ಬೆಂಬಲ Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'ಡೆವಲಪರ್‌ಗೆ ಒಂದು ಕಾಫಿ ದಾನ ಮಾಡಿ';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ಕಾನೂನುಬದ್ಧ';
@@ -8456,8 +8423,8 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ಪರವಾನಗಿ ಸೂಚನೆಗಳು',
-      one: '# ಪರವಾನಗಿ ಸೂಚನೆ',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8506,16 +8473,16 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಪರಿಚಯಗಳು ಮತ್ತು ಔಟ್ರೊಗಳನ್ನು ಬಿಟ್ಟುಬಿಡುವುದೇ?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'ಮಾಧ್ಯಮ ವಿಭಾಗ ಕೌಂಟ್‌ಡೌನ್';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'ಪ್ರಗತಿ ಪಟ್ಟಿ';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ಟೈಮರ್';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ಯಾವುದೂ ಇಲ್ಲ';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ಪ್ರಾಂಪ್ಟ್ ಬಳಕೆದಾರ';
@@ -8551,13 +8518,13 @@ class AppLocalizationsKn extends AppLocalizations {
       'Media3 (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (ಲೆಗಸಿ)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (ಪರಂಪರೆ)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision ಫಾಲ್‌ಬ್ಯಾಕ್';
@@ -8746,762 +8713,749 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'ಇತ್ತೀಚೆಗೆ ಬಿಡುಗಡೆಯಾದ $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'ಮುಂದಿನ ಸಂಚಿಕೆಯನ್ನು ಸ್ವಯಂ ಪ್ಲೇ ಮಾಡಿ';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'ಲಭ್ಯವಿದ್ದಾಗ ಮುಂದಿನ ಸಂಚಿಕೆಯನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ಲೇ ಮಾಡಿ.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'ಮೌನವನ್ನು ಬಿಟ್ಟುಬಿಡಿ';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'ಸ್ಟ್ರೀಮ್ ಬೆಂಬಲಿಸಿದಾಗ ಮೌನ ಆಡಿಯೋ ವಿಭಾಗಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಬಿಟ್ಟುಬಿಡಿ.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'ಬಾಹ್ಯ ಆಡಿಯೋ ಪರಿಣಾಮಗಳನ್ನು ಅನುಮತಿಸಿ';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'ಈಕ್ವಲೈಜರ್ ಮತ್ತು ಪರಿಣಾಮಗಳ ಆ್ಯಪ್‌ಗಳು (ಉದಾ. Wavelet) Media3 ಪ್ಲೇಬ್ಯಾಕ್ ಸೆಷನ್‌ಗಳಿಗೆ ಲಗತ್ತಿಸಲು ಅನುಮತಿಸಿ.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'ಟನೆಲಿಂಗ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'ಟನೆಲ್ ಮಾಡದ ಪ್ಲೇಬ್ಯಾಕ್ ಅನ್ನು ಒತ್ತಾಯಿಸಿ. ಟನೆಲಿಂಗ್ ಆಡಿಯೋ/ವಿಡಿಯೋ ಅಸಂಗತತೆ ಇರುವ ಸಾಧನಗಳಲ್ಲಿ ಉಪಯುಕ್ತ.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'ಟನೆಲಿಂಗ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'ಸುಧಾರಿತ. ಆಡಿಯೋ ಮತ್ತು ವಿಡಿಯೋವನ್ನು ಜೋಡಿಸಿದ ಹಾರ್ಡ್‌ವೇರ್ ಮಾರ್ಗದ ಮೂಲಕ ರೂಟ್ ಮಾಡುತ್ತದೆ. ಕೆಲವು ಸಾಧನಗಳಲ್ಲಿ ಆಡಿಯೋ/ವಿಡಿಯೋ ಡ್ರಾಪ್‌ಔಟ್‌ಗಳಿಗೆ ಕಾರಣವಾಗುವುದರಿಂದ ಪೂರ್ವನಿಯೋಜಿತವಾಗಿ ಆಫ್ ಆಗಿದೆ.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision ಪ್ರೊಫೈಲ್ 7 ಅನ್ನು HEVC ಗೆ ಮ್ಯಾಪ್ ಮಾಡಿ';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'DV ಅಲ್ಲದ ಸಾಧನಗಳಲ್ಲಿ Dolby Vision ಪ್ರೊಫೈಲ್ 7 ಸ್ಟ್ರೀಮ್‌ಗಳನ್ನು HDR10-ಹೊಂದಾಣಿಕೆಯ HEVC ಆಗಿ ಪ್ಲೇ ಮಾಡಿ.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'ಎಂಬೆಡೆಡ್ ಉಪಶೀರ್ಷಿಕೆ ಶೈಲಿಗಳನ್ನು ಬಳಸಿ';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'ಉಪಶೀರ್ಷಿಕೆ ಟ್ರ್ಯಾಕ್‌ನಲ್ಲಿ ಎಂಬೆಡ್ ಮಾಡಿದ ಬಣ್ಣಗಳು, ಫಾಂಟ್‌ಗಳು ಮತ್ತು ಸ್ಥಾನೀಕರಣವನ್ನು ಅನ್ವಯಿಸಿ. ಬದಲಿಗೆ ನಿಮ್ಮ ಶೀರ್ಷಿಕೆ ಶೈಲಿ ಆದ್ಯತೆಗಳನ್ನು ಬಳಸಲು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'ಎಂಬೆಡೆಡ್ ಉಪಶೀರ್ಷಿಕೆ ಫಾಂಟ್ ಗಾತ್ರಗಳನ್ನು ಬಳಸಿ';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'ಉಪಶೀರ್ಷಿಕೆ ಟ್ರ್ಯಾಕ್‌ನಲ್ಲಿ ಎಂಬೆಡ್ ಮಾಡಿದ ಫಾಂಟ್-ಗಾತ್ರ ಸೂಚನೆಗಳನ್ನು ಅನ್ವಯಿಸಿ. ನಿಮ್ಮ ಶೈಲಿ ಆದ್ಯತೆಗಳಿಂದ ಉಪಶೀರ್ಷಿಕೆ ಗಾತ್ರವನ್ನು ಬಳಸಲು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'ಮಾಧ್ಯಮ ವಿವರಗಳನ್ನು ತೋರಿಸಿ';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'ಲೈಬ್ರರಿ ಪುಟಗಳ ಮೇಲ್ಭಾಗದಲ್ಲಿ ಆಯ್ಕೆಮಾಡಿದ ಐಟಂನ ವಿವರಗಳನ್ನು ತೋರಿಸಿ.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಬ್ಯಾಕ್‌ಡ್ರಾಪ್‌ಗಳನ್ನು ಮರೆಮಾಡುವುದೇ?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'ವಿವರವಾದ ಉಪ-ಶೀರ್ಷಿಕೆಗಳನ್ನು ಬಳಸಿ';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'ಲೈಬ್ರರಿ ಪುಟಗಳಲ್ಲಿ ವಿವರವಾದ ಅಥವಾ ಕನಿಷ್ಠ ಉಪಸಾಲನ್ನು ತೋರಿಸಿ.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'ಉಳಿಸಿದ ಥೀಮ್ ಅನ್ನು ಅಳಿಸುವುದೇ?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'ಈ ಸಾಧನ ಕ್ಯಾಶ್‌ನಿಂದ \"$themeName\" ಅನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'ಥೀಮ್ ಸ್ಟೋರ್';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'ಸಮುದಾಯ ಥೀಮ್‌ಗಳನ್ನು ಬ್ರೌಸ್ ಮಾಡಿ ಮತ್ತು ಉಳಿಸಿ';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'ನಿಮ್ಮ ಇತರ ಉಳಿಸಿದ ಥೀಮ್‌ಗಳಂತೆ ಬಳಸಲು ಥೀಮ್ ಅನ್ನು ಉಳಿಸಿ.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ಸದ್ಯಕ್ಕೆ ಯಾವುದೇ ಥೀಮ್‌ಗಳು ಲಭ್ಯವಿಲ್ಲ.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'ಥೀಮ್ ಸ್ಟೋರ್ ಅನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ನಿಮ್ಮ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'ಉಳಿಸಿ';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'ಉಳಿಸಿ ಮತ್ತು ಅನ್ವಯಿಸಿ';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'ಉಳಿಸಲಾಗಿದೆ';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage =>
-      'ಈ ಥೀಮ್ ಅನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" ಉಳಿಸಲಾಗಿದೆ.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'ಈ ಸಾಧನದಿಂದ \"$themeName\" ಅಳಿಸಲಾಗಿದೆ.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" ಅನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'ಉಳಿಸಿದ ಥೀಮ್‌ಗಳು';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'ಇವು ಪ್ರಸ್ತುತ ಸರ್ವರ್‌ಗಾಗಿ Moonfin ಪ್ಲಗಿನ್‌ನಿಂದ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಥೀಮ್‌ಗಳು. ಅಳಿಸುವಿಕೆಯು ಈ ಸ್ಥಳೀಯ ಪ್ರತಿಯನ್ನು ಮಾತ್ರ ತೆಗೆದುಹಾಕುತ್ತದೆ.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'ಈ ಸರ್ವರ್‌ಗಾಗಿ ಯಾವುದೇ ಉಳಿಸಿದ ಥೀಮ್‌ಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • ಪ್ರಸ್ತುತ ಸಕ್ರಿಯ';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'ಉಳಿಸಿದ ಥೀಮ್ ಅನ್ನು ಅಳಿಸಿ';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'ಈ ಸಾಧನದಲ್ಲಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಪ್ಲಗಿನ್ ಥೀಮ್‌ಗಳನ್ನು ನಿರ್ವಹಿಸಿ';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'ಥೀಮ್ ಎಡಿಟರ್';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'ನಿಮ್ಮ ಬ್ರೌಸರ್‌ನಲ್ಲಿ Moonfin ಥೀಮ್ ಎಡಿಟರ್ ತೆರೆಯಿರಿ';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'ಹೋಮ್ ಪರದೆ';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'ಕೆಳಗಿನ ಪಟ್ಟಿ';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'ಕ್ಲಾಸಿಕ್';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'ಮಾಡರ್ನ್';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'ಹೋಮ್ ಸಾಲುಗಳು';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'ಹೋಮ್ ಸಾಲಿನ ಪ್ರದರ್ಶನ';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'ಹೋಮ್ ಸಾಲಿನ ವಿಭಾಗಗಳು';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'ಹೋಮ್ ಸಾಲಿನ ಟಾಗಲ್‌ಗಳು';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'ಲೈಬ್ರರಿ ಆಧಾರಿತ ಹೋಮ್ ಸಾಲಿನ ವರ್ಗಗಳನ್ನು ಸಕ್ರಿಯ ಅಥವಾ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಸಾಲುಗಳನ್ನು ಪ್ರದರ್ಶಿಸಲು ಈ ಕೆಳಗಿನ ಟಾಗಲ್‌ಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'ಕ್ಲಾಸಿಕ್ ಪ್ರತಿ-ಸಾಲಿನ ಚಿತ್ರ ಪ್ರಕಾರ ಮತ್ತು ಮಾಹಿತಿ ಓವರ್‌ಲೇ ಅನ್ನು ಉಳಿಸಿಕೊಳ್ಳುತ್ತದೆ. ಮಾಡರ್ನ್ ಪೋರ್ಟ್ರೇಟ್-ನಿಂದ-ಬ್ಯಾಕ್‌ಡ್ರಾಪ್ ಸಾಲುಗಳನ್ನು ಬಳಸುತ್ತದೆ.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'ಮೆಚ್ಚಿನವುಗಳ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಮೆಚ್ಚಿನ ಚಲನಚಿತ್ರಗಳು, ಸರಣಿ ಮತ್ತು ಇತರ ಮೆಚ್ಚಿನ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'ಮೆಚ್ಚಿನವುಗಳ ಸಾಲಿನ ವಿಂಗಡಣೆ';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'ಮೆಚ್ಚಿನವುಗಳ ಸಾಲುಗಳನ್ನು ಸೇರಿಸಿದ ದಿನಾಂಕ, ಬಿಡುಗಡೆ ದಿನಾಂಕ, ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಂಗಡಿಸಿ.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'ಸಂಗ್ರಹಣೆಗಳ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಸಂಗ್ರಹಣೆಗಳ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'ಸಂಗ್ರಹಣೆಗಳ ಸಾಲಿನ ವಿಂಗಡಣೆ';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'ಸಂಗ್ರಹಣೆಗಳ ಸಾಲುಗಳನ್ನು ಸೇರಿಸಿದ ದಿನಾಂಕ, ಬಿಡುಗಡೆ ದಿನಾಂಕ, ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಂಗಡಿಸಿ.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'ಪ್ರಕಾರಗಳ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಪ್ರಕಾರಗಳ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'ಪ್ರಕಾರಗಳ ಸಾಲಿನ ವಿಂಗಡಣೆ';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'ಪ್ರಕಾರಗಳ ಸಾಲುಗಳನ್ನು ಸೇರಿಸಿದ ದಿನಾಂಕ, ಬಿಡುಗಡೆ ದಿನಾಂಕ, ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಂಗಡಿಸಿ.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'ಪ್ರಕಾರಗಳ ಸಾಲಿನ ಐಟಂಗಳು';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'ಪ್ರಕಾರಗಳ ಸಾಲುಗಳಲ್ಲಿ ಚಲನಚಿತ್ರಗಳು, ಸರಣಿ ಅಥವಾ ಎರಡನ್ನೂ ತೋರಿಸಿ.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'ಪ್ಲೇಪಟ್ಟಿ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಪ್ಲೇಪಟ್ಟಿ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'ಪ್ಲೇಪಟ್ಟಿ ಸಾಲಿನ ವಿಂಗಡಣೆ';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'ಪ್ಲೇಪಟ್ಟಿ ಸಾಲುಗಳನ್ನು ಸೇರಿಸಿದ ದಿನಾಂಕ, ಬಿಡುಗಡೆ ದಿನಾಂಕ, ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಂಗಡಿಸಿ.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ಆಡಿಯೋ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'ಹೋಮ್ ವಿಭಾಗಗಳಲ್ಲಿ ಆಡಿಯೋ ಸಾಲುಗಳನ್ನು ತೋರಿಸಿ.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ಆಡಿಯೋ ಸಾಲುಗಳ ವಿಂಗಡಣೆ';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ಆಡಿಯೋ ಸಾಲುಗಳನ್ನು ಸೇರಿಸಿದ ದಿನಾಂಕ, ಬಿಡುಗಡೆ ದಿನಾಂಕ, ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ ಮತ್ತು ಇನ್ನಷ್ಟು ವಿಂಗಡಿಸಿ.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ಆಡಿಯೋ ಪ್ಲೇಪಟ್ಟಿಗಳು';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'ಗೋಚರತೆ';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'ವಿನ್ಯಾಸ';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'ಥೀಮ್';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'ಕೀಬೋರ್ಡ್';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'ಬಟನ್‌ಗಳು';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'ರೆಂಡರಿಂಗ್';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV ಕಾನ್ಫಿಗರೇಶನ್';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'ಬಾಹ್ಯ ಪ್ಲೇಯರ್ ಆ್ಯಪ್';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'ದೀರ್ಘ-ಒತ್ತಿ ಪ್ಲೇ ಆಯ್ಕೆಯನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಬಾಹ್ಯ ಪ್ಲೇಯರ್ ಅನ್ನು ಹೊಂದಿಸಿ';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'ಪ್ಲೇಬ್ಯಾಕ್ ಪ್ರಾರಂಭವಾದಾಗ ಆ್ಯಪ್ ಆಯ್ಕೆದಾರವನ್ನು ತೋರಿಸಿ.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'ಸ್ಥಾಪಿಸಿದ ಪ್ಲೇಯರ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'ಸಂಪರ್ಕ';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ಆಡಿಯೋ ಟ್ರಾನ್ಸ್‌ಕೋಡ್ ಗುರಿ';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'ಪಾಸ್‌ಥ್ರೂ';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'ಈ ಸಾಧನದಲ್ಲಿ ಬೆಂಬಲಿತ';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'ಈ ಸಾಧನದಲ್ಲಿ ಬೆಂಬಲಿತವಿಲ್ಲ';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) ಪಾಸ್‌ಥ್ರೂ';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) ಅನ್ನು ಬಾಹ್ಯ ಡಿಕೋಡರ್‌ಗೆ ಬಿಟ್‌ಸ್ಟ್ರೀಮ್ ಮಾಡಿ.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) ನೊಂದಿಗೆ TrueHD ಪಾಸ್‌ಥ್ರೂ';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'ಮೀಡಿಯಾ ಪ್ಲೇಯರ್ ವರ್ತನೆ';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'ಪ್ಲೇಬ್ಯಾಕ್ ವರ್ಧನೆಗಳು';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'ಯಾವಾಗಲೂ ಆನ್.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'ಸ್ಕಿಪ್ ಔಟ್ರೊ ಬದಲಿಗೆ ಮುಂದಿನದು ಪ್ರದರ್ಶನ';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'ಸ್ಕಿಪ್ ಔಟ್ರೊ ಬಟನ್ ಬದಲಿಗೆ ಮುಂದಿನದು ಓವರ್‌ಲೇ ತೋರಿಸಿ.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'ಪ್ಲೇಯರ್ ರೂಟಿಂಗ್';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'ಸಾಫ್ಟ್‌ವೇರ್ ಡಿಕೋಡರ್‌ಗಳಿಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'ಹಾರ್ಡ್‌ವೇರ್ ಡಿಕೋಡರ್‌ಗಳಿಗಿಂತ ಮೊದಲು FFmpeg (ಆಡಿಯೋ) ಮತ್ತು libgav1 (AV1) ಬಳಸಿ. HDMI ಆಡಿಯೋ ಪಾಸ್‌ಥ್ರೂ ಮುರಿದರೆ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV ನಲ್ಲಿ ನೀವು ಆಯ್ಕೆಮಾಡಿದ ಬಾಹ್ಯ ಆ್ಯಪ್‌ನಲ್ಲಿ ವಿಡಿಯೋ ಪ್ಲೇಬ್ಯಾಕ್ ತೆರೆಯಿರಿ.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'ಸ್ವಯಂಚಾಲಿತ ಕ್ಯೂಯಿಂಗ್';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH ಉಪಶೀರ್ಷಿಕೆಗಳಿಗೆ ಆದ್ಯತೆ ನೀಡಿ';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'ಸ್ವಯಂ-ಆಯ್ಕೆ ಮಾಡುವಾಗ SDH/CC ಉಪಶೀರ್ಷಿಕೆ ಟ್ರ್ಯಾಕ್‌ಗಳಿಗೆ ಆದ್ಯತೆ ನೀಡಿ.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'ವೆಬ್ ಡಯಾಗ್ನೋಸ್ಟಿಕ್ಸ್';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin ವೆಬ್ ಡಯಾಗ್ನೋಸ್ಟಿಕ್ಸ್';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'ಬ್ರೌಸರ್ ಸಂಪರ್ಕ ಸಮಸ್ಯೆಗಳನ್ನು (CORS, ಮಿಶ್ರ ವಿಷಯ ಮತ್ತು ಅನ್ವೇಷಣಾ ಸೆಟ್ಟಿಂಗ್‌ಗಳು) ಪತ್ತೆಹಚ್ಚಲು ಈ ಪುಟವನ್ನು ಬಳಸಿ.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'ಮಿಶ್ರ-ವಿಷಯ ವೈಫಲ್ಯ ಪತ್ತೆಯಾಗಿದೆ';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight ವೈಫಲ್ಯ ಪತ್ತೆಯಾಗಿದೆ';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'HTTPS ಪುಟವು HTTP ಸರ್ವರ್ URL ಅನ್ನು ಕರೆಯಲು ಪ್ರಯತ್ನಿಸುತ್ತಿರುವುದನ್ನು Moonfin ಪತ್ತೆ ಮಾಡಿದೆ. ಬ್ರೌಸರ್‌ಗಳು ಈ ವಿನಂತಿಯನ್ನು ನಿಮ್ಮ ಸರ್ವರ್ ತಲುಪುವ ಮೊದಲೇ ನಿರ್ಬಂಧಿಸುತ್ತವೆ.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'ಮಾಧ್ಯಮ ಸರ್ವರ್‌ನಲ್ಲಿ CORS ಅಥವಾ preflight ಹೆಡರ್‌ಗಳ ಕೊರತೆಯಿಂದ ಸಾಮಾನ್ಯವಾಗಿ ಉಂಟಾಗುವ ಬ್ರೌಸರ್-ಮಟ್ಟದ ವಿನಂತಿ ವೈಫಲ್ಯವನ್ನು Moonfin ಪತ್ತೆ ಮಾಡಿದೆ.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'ಗುರಿ URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'ವಿವರ: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'ಪ್ರಸ್ತುತ ರನ್‌ಟೈಮ್ ಸಂದರ್ಭ';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'ಮೂಲ';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'ಸ್ಕೀಮ್';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'ಪ್ಲಗಿನ್ ಮೋಡ್';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC ಸ್ಕ್ಯಾನ್';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'ಒತ್ತಾಯಿಸಿದ ಸರ್ವರ್ URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'ಡೀಫಾಲ್ಟ್ ಸರ್ವರ್ URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'ಅನ್ವೇಷಣಾ ಪ್ರಾಕ್ಸಿ URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'ಕಾನ್ಫಿಗರ್ ಮಾಡಿಲ್ಲ';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'ಮಿಶ್ರ ವಿಷಯ';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'ಈ ಪುಟವನ್ನು HTTPS ಮೂಲಕ ಲೋಡ್ ಮಾಡಲಾಗಿದೆ, ಆದರೆ ಕಾನ್ಫಿಗರ್ ಮಾಡಿದ ಒಂದು ಅಥವಾ ಹೆಚ್ಚು URL ಗಳು HTTP ಆಗಿವೆ. ಬ್ರೌಸರ್‌ಗಳು HTTPS ಪುಟಗಳು HTTP API ಗಳನ್ನು ಕರೆಯುವುದನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತವೆ.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'ಪರಿಹಾರ: ನಿಮ್ಮ ಮಾಧ್ಯಮ ಸರ್ವರ್ ಅಥವಾ ಪ್ರಾಕ್ಸಿ ಎಂಡ್‌ಪಾಯಿಂಟ್ ಅನ್ನು HTTPS ಮೂಲಕ ಒದಗಿಸಿ, ಅಥವಾ ವಿಶ್ವಾಸಾರ್ಹ ಸ್ಥಳೀಯ ನೆಟ್‌ವರ್ಕ್‌ಗಳಲ್ಲಿ ಮಾತ್ರ HTTP ಮೂಲಕ Moonfin ಲೋಡ್ ಮಾಡಿ.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'ಪ್ರಸ್ತುತ ರನ್‌ಟೈಮ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಂದ ಯಾವುದೇ ಸ್ಪಷ್ಟ ಮಿಶ್ರ-ವಿಷಯ ಕಾನ್ಫಿಗರೇಶನ್ ಪತ್ತೆಯಾಗಿಲ್ಲ.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS ಪರಿಶೀಲನಾ ಪಟ್ಟಿ';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin ನಲ್ಲಿ ಬ್ರೌಸರ್ ಮೂಲವನ್ನು ಅನುಮತಿಸಿ.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers ನಲ್ಲಿ Authorization, X-Emby-Authorization ಮತ್ತು X-Emby-Token ಅನ್ನು ಸೇರಿಸಿ.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ಸ್ಟ್ರೀಮಿಂಗ್ ಮತ್ತು ಸೀಕ್ ವರ್ತನೆಗಾಗಿ Content-Range ಮತ್ತು Accept-Ranges ಅನ್ನು ಬಹಿರಂಗಪಡಿಸಿ.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight ವಿನಂತಿಗಳಿಗೆ 204 ಅನ್ನು ಹಿಂತಿರುಗಿಸಿ.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'ಉದಾಹರಣೆ ಹೆಡರ್ ಸ್ನಿಪೆಟ್ (nginx-ಶೈಲಿ)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'ಗಮನಿಸಿ';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'ಈ ಡಯಾಗ್ನೋಸ್ಟಿಕ್ಸ್ ಮಾರ್ಗವು ವೆಬ್ ಬಿಲ್ಡ್‌ಗಳಿಗಾಗಿ ಉದ್ದೇಶಿಸಲಾಗಿದೆ. ನೀವು ಇದನ್ನು ಬೇರೆ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ ನೋಡುತ್ತಿದ್ದರೆ, ಈ ಪರಿಶೀಲನೆಗಳು ಅನ್ವಯಿಸದೇ ಇರಬಹುದು.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'ಸರ್ವರ್ ಆಯ್ಕೆಗೆ ಹಿಂತಿರುಗಿ';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'ಎಲ್ಲಾ ಬಳಕೆದಾರರನ್ನು ಸೈನ್ ಔಟ್ ಮಾಡಿ';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'ಮೈಕ್ರೊಫೋನ್ ಅನುಮತಿ ಶಾಶ್ವತವಾಗಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ಸಿಸ್ಟಂ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಇದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'ಧ್ವನಿ ಹುಡುಕಾಟಕ್ಕೆ ಮೈಕ್ರೊಫೋನ್ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'ಅದು ಅರ್ಥವಾಗಲಿಲ್ಲ. ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'ಯಾವುದೇ ಮಾತು ಪತ್ತೆಯಾಗಿಲ್ಲ.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'ಮೈಕ್ರೊಫೋನ್ ದೋಷ.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'ಧ್ವನಿ ಹುಡುಕಾಟಕ್ಕೆ ಇಂಟರ್ನೆಟ್ ಅಗತ್ಯವಿದೆ.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'ಧ್ವನಿ ಸೇವೆ ಕಾರ್ಯನಿರತವಾಗಿದೆ. ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'ಮೈಕ್ರೊಫೋನ್ ಅನುಮತಿ ಶಾಶ್ವತವಾಗಿ ನಿರಾಕರಿಸಲಾಗಿದೆ.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'ಮೈಕ್ರೊಫೋನ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'ಈ ಸಾಧನದಲ್ಲಿ ಮಾತು ಗುರುತಿಸುವಿಕೆ ಲಭ್ಯವಿಲ್ಲ.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS ಮಾರ್ಗ ಆಯ್ಕೆದಾರವನ್ನು ತೆರೆಯಿರಿ';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'ಈ ಸಾಧನದಲ್ಲಿ AirPlay ಮಾರ್ಗ ಆಯ್ಕೆದಾರ ಲಭ್ಯವಿಲ್ಲ.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'ವಿಡಿಯೋಗಳು';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'ಪ್ರೋಗ್ರಾಂಗಳು';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'ಹಾಡುಗಳು';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'ಫೋಟೋ ಆಲ್ಬಮ್‌ಗಳು';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'ಫೋಟೋಗಳು';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'ಜನರು';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'ಇತ್ತೀಚೆಗೆ ಬಿಡುಗಡೆಯಾದ ಸಂಚಿಕೆಗಳು';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'ಮತ್ತೆ ವೀಕ್ಷಿಸಿ';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'ಅತಿಥಿ ಪಾತ್ರಗಳು';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'ಪಾತ್ರಗಳು (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'ಸಿಬ್ಬಂದಿ ಕೊಡುಗೆಗಳು (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'ಗುಂಪಿನೊಂದಿಗೆ ವೀಕ್ಷಿಸಿ';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'ದೋಷಗಳು';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'ಎಚ್ಚರಿಕೆಗಳು';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'ಡಿಸ್ಕ್';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'ಬ್ರೌಸರ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ ಎಂಬೆಡೆಡ್ ಬ್ರೌಸರ್ ಲಭ್ಯವಿಲ್ಲ.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'ಸರ್ವರ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'ಸರ್ವರ್ ಅನ್ನು ಸ್ಥಗಿತಗೊಳಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ? ನೀವು ಅದನ್ನು ಹಸ್ತಚಾಲಿತವಾಗಿ ಮರುಪ್ರಾರಂಭಿಸಬೇಕಾಗುತ್ತದೆ.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'ಆಂತರಿಕ';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'ನಿಷ್ಕ್ರಿಯ';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'ಯಾವುದೇ ಬಳಕೆದಾರರು ಕಂಡುಬಂದಿಲ್ಲ';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'ನಿಮ್ಮ ಹುಡುಕಾಟಕ್ಕೆ ಯಾವುದೇ ಬಳಕೆದಾರರು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'ಯಾವುದೇ ಸಾಧನಗಳು ಕಂಡುಬಂದಿಲ್ಲ';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'ಪ್ರಸ್ತುತ ಫಿಲ್ಟರ್‌ಗಳಿಗೆ ಯಾವುದೇ ಸಾಧನಗಳು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'ಪಾಸ್‌ವರ್ಡ್ ಹೊಂದಿಸಲಾಗಿದೆ';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'ಯಾವುದೇ ಪಾಸ್‌ವರ್ಡ್ ಕಾನ್ಫಿಗರ್ ಮಾಡಿಲ್ಲ';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'ರಿಮೋಟ್ ಪ್ರವೇಶ';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'ಸ್ಥಳೀಯ ಮಾತ್ರ';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'ಮಾಧ್ಯಮ ವಿಶ್ಲೇಷಣೆಯನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'ಎಲ್ಲಾ ಮಾಧ್ಯಮ ಲೈಬ್ರರಿಗಳ ಸಂಯೋಜಿತ ವಿಶ್ಲೇಷಣೆ.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'ಪ್ರಮುಖ ಕಲಾವಿದರು';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'ಪ್ರಮುಖ ಲೇಖಕರು';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'ಪ್ರಮುಖ ಕೊಡುಗೆದಾರರು';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ಲೈಬ್ರರಿಗಳು',
-      one: '1 ಲೈಬ್ರರಿ',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'ಈ ಆಯ್ಕೆಗಾಗಿ ಇನ್ನೂ ಯಾವುದೇ ಇಂಡೆಕ್ಸ್ ಮಾಡಿದ ಮಾಧ್ಯಮ ಒಟ್ಟುಗಳು ಲಭ್ಯವಿಲ್ಲ.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'ಲೈಬ್ರರಿ ವಿವರಗಳು';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'ಲೈಬ್ರರಿ ವಿಭಜನೆ';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'ಯಾವುದೇ ಲೈಬ್ರರಿಗಳು ಲಭ್ಯವಿಲ್ಲ.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'ಸರ್ವರ್ ಆಡಳಿತ';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'ಡೇಟಾ';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'ಚಿತ್ರ ಕ್ಯಾಶ್';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'ಕ್ಯಾಶ್';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'ಲಾಗ್‌ಗಳು';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'ಮೆಟಾಡೇಟಾ';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'ಟ್ರಾನ್ಸ್‌ಕೋಡ್';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'ಈ ಸರ್ವರ್ ಯಾವುದೇ ಸರ್ವರ್ ಪಥಗಳನ್ನು ಹಿಂತಿರುಗಿಸಲಿಲ್ಲ.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% ಬಳಸಲಾಗಿದೆ';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'ಬಳಕೆದಾರ ಚಟುವಟಿಕೆ';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'ಸಿಸ್ಟಂ ಈವೆಂಟ್‌ಗಳು';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'ಗಮನ ಅಗತ್ಯವಿದೆ';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'ಸರ್ವರ್';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'ಪ್ಲೇಬ್ಯಾಕ್';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'ಸಾಧನಗಳು';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'ಸುಧಾರಿತ';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'ಪ್ಲಗಿನ್‌ಗಳು';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'ಲೈವ್ ಟಿವಿ';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'ಹೋಮ್ ವಿಡಿಯೋಗಳು';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'ಮಿಶ್ರ ವಿಷಯ';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'ಹೋಮ್ ವಿಡಿಯೋಗಳು ಮತ್ತು ಫೋಟೋಗಳು';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'ಮಿಶ್ರ ಚಲನಚಿತ್ರಗಳು ಮತ್ತು ಶೋಗಳು';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9513,300 +9467,299 @@ class AppLocalizationsKn extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'ಯಾವುದೇ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಕಂಡುಬಂದಿಲ್ಲ';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension ಆರ್ಕೈವ್ ಒಳಗೆ ಯಾವುದೇ ಚಿತ್ರ ಪುಟಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'ಎಂಬೆಡೆಡ್ ರೆಂಡರರ್ ವಿಫಲವಾಗಿದೆ ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB ರೆಂಡರರ್ ವಿಫಲವಾಗಿದೆ ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'ರೀಡರ್‌ಗೆ ಸ್ಥಳೀಯ ಫೈಲ್ ಕಾಣೆಯಾಗಿದೆ: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri ನಿಂದ ಪುಸ್ತಕ ಡೇಟಾ ತೆರೆಯುವಾಗ HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'ಯಾವುದೇ ಓದಬಹುದಾದ ಪುಸ್ತಕ ಎಂಡ್‌ಪಾಯಿಂಟ್ ಲಭ್ಯವಿಲ್ಲ';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'ಬೆಂಬಲಿಸದ ಕಾಮಿಕ್ ಆರ್ಕೈವ್ ಸ್ವರೂಪ: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ CBR ಹೊರತೆಗೆಯುವಿಕೆ ಪ್ಲಗಿನ್ ಲಭ್ಯವಿಲ್ಲ.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr ಆರ್ಕೈವ್ ಅನ್ನು ಹೊರತೆಗೆಯಲು ವಿಫಲವಾಗಿದೆ.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ CB7 ಹೊರತೆಗೆಯುವಿಕೆ ಲಭ್ಯವಿಲ್ಲ.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ CB7 ಹೊರತೆಗೆಯುವಿಕೆ ಪ್ಲಗಿನ್ ಲಭ್ಯವಿಲ್ಲ.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'ಪ್ರಕಾರ ಫಲಕವನ್ನು ಮುಚ್ಚಿ';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'ಷಫಲ್ ಲೋಡ್ ಆಗುತ್ತಿದೆ...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ಲೈಬ್ರರಿ ಷಫಲ್';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ಯಾದೃಚ್ಛಿಕ ಷಫಲ್';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ಪ್ರಕಾರಗಳ ಷಫಲ್';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'ಸ್ವಯಂ HDR ಬದಲಾವಣೆ';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR ವಿಡಿಯೋ ಪ್ಲೇಬ್ಯಾಕ್‌ಗಾಗಿ HDR ಅನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತು ನಿರ್ಗಮಿಸಿದಾಗ ಪ್ರದರ್ಶನ ಮೋಡ್ ಅನ್ನು ಮರುಸ್ಥಾಪಿಸಿ.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'ಪೂರ್ಣಪರದೆಯಲ್ಲಿದ್ದಾಗ';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'ಕಲಾಕೃತಿಯನ್ನು ಬದಲಾಯಿಸಿ';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'ಕಾಣೆಯಾಗಿದೆ';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'ಟ್ರಾನ್ಸ್‌ಕೋಡಿಂಗ್ ಮಿತಿಗಳು';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'ಎಲ್ಲಾ ಕಲಾಕೃತಿಯನ್ನು ತೆರವುಗೊಳಿಸುವುದೇ?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಎಲ್ಲಾ ಕಲಾಕೃತಿಯನ್ನು ತೆರವುಗೊಳಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'ತೆರವುಗೊಳಿಸುವಿಕೆಯನ್ನು ದೃಢೀಕರಿಸಿ';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'ಈ $itemType ಅನ್ನು ತೆರವುಗೊಳಿಸಲು ನಿಮಗೆ ಖಚಿತವೇ?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'ಅಪ್‌ಲೋಡ್ ಮಾಡುವುದೇ?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'ರೆಸಲ್ಯೂಶನ್: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'ಇಂಟರ್‌ಫೇಸ್ ಭಾಷೆಯಲ್ಲಿ ಮಾತ್ರ ಕಲಾಕೃತಿಯನ್ನು ತೋರಿಸಿ';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'ಎಲ್ಲವನ್ನೂ ತೆರವುಗೊಳಿಸುವುದನ್ನು ದೃಢೀಕರಿಸಿ';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'ಚಿತ್ರವನ್ನು ಯಶಸ್ವಿಯಾಗಿ ಅಪ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಪ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಹೊಂದಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ಚಿತ್ರವನ್ನು ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'ಎಲ್ಲಾ ಕಲಾಕೃತಿಯನ್ನು ತೆರವುಗೊಳಿಸಲು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ಹೌದು';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'ಪೋಸ್ಟರ್';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'ಬ್ಯಾಕ್‌ಡ್ರಾಪ್‌ಗಳು';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'ಬ್ಯಾನರ್';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'ಲೋಗೋ';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'ಥಂಬ್‌ನೇಲ್';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'ಆರ್ಟ್';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ಡಿಸ್ಕ್ ಆರ್ಟ್';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'ಸ್ಕ್ರೀನ್‌ಶಾಟ್';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'ಬಾಕ್ಸ್ ಕವರ್';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'ಬಾಕ್ಸ್ ಹಿಂಬದಿ ಕವರ್';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'ಮೆನು ಆರ್ಟ್';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'ಪೋಸ್ಟರ್';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ಬ್ಯಾಕ್‌ಡ್ರಾಪ್';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'ಬ್ಯಾನರ್';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'ಲೋಗೋ';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'ಥಂಬ್‌ನೇಲ್';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ಆರ್ಟ್';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ಡಿಸ್ಕ್ ಆರ್ಟ್';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ಸ್ಕ್ರೀನ್‌ಶಾಟ್';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'ಬಾಕ್ಸ್ ಕವರ್';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'ಬಾಕ್ಸ್ ಹಿಂಬದಿ ಕವರ್';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ಮೆನು ಆರ್ಟ್';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'ಎಲ್ಲಾ';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'ಹೆಚ್ಚು (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'ಮಧ್ಯಮ (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'ಕಡಿಮೆ (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'ಮೂಲಗಳು';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'ಅಧ್ಯಾಯಗಳು';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'ಟಿಪ್ಪಣಿಗಳು';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'ಸರತಿ';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ಟೈಮ್‌ಲೈನ್';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ಟೈಮ್‌ಲೈನ್ ಖಾಲಿಯಾಗಿದೆ';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'ಸಂಪೂರ್ಣ ಪುಸ್ತಕ';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'ಕೇಂದ್ರೀಕೃತ ಟೈಮ್‌ಲೈನ್';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'ಟಿಪ್ಪಣಿಗಳನ್ನು ರಫ್ತು ಮಾಡಿ';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'ಎಲ್ಲವನ್ನೂ ರಫ್ತು ಮಾಡಿ';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path ಗೆ ರಫ್ತು ಮಾಡಲಾಗಿದೆ';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'ರಫ್ತು ವಿಫಲವಾಗಿದೆ: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'ಸಾಹಿತ್ಯ';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'ಬುಕ್‌ಮಾರ್ಕ್ ಸೇರಿಸಿ';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'ಟಿಪ್ಪಣಿ ಸೇರಿಸಿ';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'ಟಿಪ್ಪಣಿ ಸಂಪಾದಿಸಿ';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'ಈ ಕ್ಷಣಕ್ಕಾಗಿ ಟಿಪ್ಪಣಿ ಬರೆಯಿರಿ';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'ಸ್ಲೀಪ್ ಟೈಮರ್';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ಆಫ್';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'ಅಧ್ಯಾಯದ ಕೊನೆ';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'ಕಸ್ಟಮ್';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining ಬಾಕಿ';
+    return '$remaining left';
   }
 
   @override
@@ -9814,58 +9767,58 @@ class AppLocalizationsKn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ನಿಮಿ',
-      one: '1 ನಿಮಿ',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'ಪ್ಲೇಬ್ಯಾಕ್ ವೇಗ';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'ಬಾಕಿ';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'ಕಳೆದದ್ದು';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$secondsಸೆ ಹಿಂದೆ';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$secondsಸೆ ಮುಂದೆ';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'ಹಿಂದಿನ ಅಧ್ಯಾಯ';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'ಮುಂದಿನ ಅಧ್ಯಾಯ';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total ರಲ್ಲಿ ಅಧ್ಯಾಯ $current';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'ಯಾವುದೇ ಅಧ್ಯಾಯಗಳಿಲ್ಲ';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'ಇನ್ನೂ ಯಾವುದೇ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳಿಲ್ಲ';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'ಇನ್ನೂ ಯಾವುದೇ ಟಿಪ್ಪಣಿಗಳಿಲ್ಲ';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position ನಲ್ಲಿ ಬುಕ್‌ಮಾರ್ಕ್ ಸೇರಿಸಲಾಗಿದೆ';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x ಗೆ ಮರುಹೊಂದಿಸಿ';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9873,252 +9826,249 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'ಉಳಿಸಿ';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'ರದ್ದುಮಾಡಿ';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'ಅಳಿಸಿ';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'ಉಪಶೀರ್ಷಿಕೆ ಆದ್ಯತೆಗಳು';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'ಉಪಶೀರ್ಷಿಕೆ ಮೋಡ್‌ಗಳು, ಡೀಫಾಲ್ಟ್ ಭಾಷೆಗಳು, ಗೋಚರತೆ ಮತ್ತು ರೆಂಡರಿಂಗ್ ಆಯ್ಕೆಗಳನ್ನು ಬದಲಾಯಿಸಿ.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'ಉಪಶೀರ್ಷಿಕೆ ರೆಂಡರಿಂಗ್';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'ಪ್ರದರ್ಶನ ಆಯ್ಕೆಗಳು';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'ಬಿಡುಗಡೆ ದಿನಾಂಕ (ಆರೋಹಣ)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'ಬಿಡುಗಡೆ ದಿನಾಂಕ (ಅವರೋಹಣ)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'ಕೊಡುಗೆಗಳನ್ನು ಗುಂಪು ಮಾಡಿ';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'ಬಹು ಪಾತ್ರಗಳನ್ನು ಗುಂಪು ಮಾಡಿ';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'ಲೈಬ್ರರಿ ಬರೆಯುವ ಪ್ರವೇಶ ಎಚ್ಚರಿಕೆ';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'ಇದನ್ನು ಸರಿಪಡಿಸುವುದು ಹೇಗೆ:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. ಸರ್ವರ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಮಾಧ್ಯಮ ಲೈಬ್ರರಿ ಫೋಲ್ಡರ್‌ಗಳಿಗಾಗಿ Jellyfin ಸೇವಾ ಬಳಕೆದಾರರಿಗೆ (ಉದಾ. jellyfin ಅಥವಾ Docker PUID/PGID) ಬರೆಯುವ ಅನುಮತಿಗಳನ್ನು ನೀಡಿ.\n\n2. ಅಥವಾ, ನಿಮ್ಮ Jellyfin ಡ್ಯಾಶ್‌ಬೋರ್ಡ್ -> Libraries ಗೆ ಹೋಗಿ, ಈ ಲೈಬ್ರರಿಯನ್ನು ಸಂಪಾದಿಸಿ, ಮತ್ತು Jellyfin ನ ಆಂತರಿಕ ಡೇಟಾಬೇಸ್‌ನಲ್ಲಿ ಕಲಾಕೃತಿಯನ್ನು ಸಂಗ್ರಹಿಸಲು \'Save artwork into media folders\' ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'ವಜಾಗೊಳಿಸಿ';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'ನಿಮ್ಮ \'$libraryName\' ಲೈಬ್ರರಿಯನ್ನು ಕಲಾಕೃತಿಯನ್ನು ನೇರವಾಗಿ ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಉಳಿಸಲು ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾಗಿದೆ (\'Save artwork into media folders\' ಸಕ್ರಿಯಗೊಂಡಿದೆ). ಆದಾಗ್ಯೂ, Jellyfin ಬರೆಯುವ ಪ್ರವೇಶವನ್ನು ಪರೀಕ್ಷಿಸಿದೆ ಮತ್ತು ಈ ಡೈರೆಕ್ಟರಿಗೆ ಫೈಲ್‌ಗಳನ್ನು ಬರೆಯಲು ಅನುಮತಿ ಇಲ್ಲ:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin ಕಲಾಕೃತಿಯನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾದಂತೆ ಕಾಣುತ್ತದೆ. ನಿಮ್ಮ ಲೈಬ್ರರಿಯನ್ನು ಕಲಾಕೃತಿಯನ್ನು ನೇರವಾಗಿ ಮಾಧ್ಯಮ ಫೋಲ್ಡರ್‌ಗಳಲ್ಲಿ ಉಳಿಸಲು ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾಗಿದೆ (\'Save artwork into media folders\' ಸಕ್ರಿಯಗೊಂಡಿದೆ). Jellyfin ಸರ್ವರ್ ಪ್ರಕ್ರಿಯೆಗೆ ನಿಮ್ಮ ಮಾಧ್ಯಮ ಡೈರೆಕ್ಟರಿಗಳಿಗೆ ಫೈಲ್‌ಗಳನ್ನು ಬರೆಯಲು ಅನುಮತಿ ಇಲ್ಲದಿದ್ದಾಗ ಈ ದೋಷ ಸಾಮಾನ್ಯವಾಗಿ ಸಂಭವಿಸುತ್ತದೆ.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'ಬಾಹ್ಯ ಪಟ್ಟಿಗಳು';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'ಮತ್ತೆ ಪ್ಲೇ ಮಾಡಿ';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ಫೈಲ್ ಮಾಹಿತಿ';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'ಗಾತ್ರ: $size  •  ಸ್ವರೂಪ: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'ಎಲ್ಲಾ ($count) ಆಡಿಯೋ ಟ್ರ್ಯಾಕ್‌ಗಳನ್ನು ತೋರಿಸಿ';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'ಎಲ್ಲಾ ($count) ಉಪಶೀರ್ಷಿಕೆ ಟ್ರ್ಯಾಕ್‌ಗಳನ್ನು ತೋರಿಸಿ';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'ಡೈರೆಕ್ಟ್ ಪ್ಲೇ ಸಾಮರ್ಥ್ಯವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'ಡೈರೆಕ್ಟ್ ಪ್ಲೇ ಸಾಮರ್ಥ್ಯ: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'ಫೋರ್ಸ್ಡ್';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'ಕಂಟೇನರ್ ಸ್ವರೂಪವನ್ನು ಪ್ಲೇಯರ್ ಬೆಂಬಲಿಸುವುದಿಲ್ಲ.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'ವಿಡಿಯೋ ಕೊಡೆಕ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'ಆಡಿಯೋ ಕೊಡೆಕ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'ಉಪಶೀರ್ಷಿಕೆ ಸ್ವರೂಪ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ (ಬರ್ನಿಂಗ್ ಅಗತ್ಯವಿದೆ).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ಆಡಿಯೋ ಪ್ರೊಫೈಲ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'ವಿಡಿಯೋ ಪ್ರೊಫೈಲ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'ವಿಡಿಯೋ ಲೆವೆಲ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'ಈ ಸಾಧನದಲ್ಲಿ ವಿಡಿಯೋ ರೆಸಲ್ಯೂಶನ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'ವಿಡಿಯೋ ಬಿಟ್ ಆಳ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'ವಿಡಿಯೋ ಫ್ರೇಮ್‌ರೇಟ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ಫೈಲ್ ಬಿಟ್‌ರೇಟ್ ಪ್ಲೇಯರ್ ಸ್ಟ್ರೀಮಿಂಗ್ ಮಿತಿಯನ್ನು ಮೀರಿದೆ.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'ವಿಡಿಯೋ ಬಿಟ್‌ರೇಟ್ ಸ್ಟ್ರೀಮಿಂಗ್ ಮಿತಿಯನ್ನು ಮೀರಿದೆ.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ಆಡಿಯೋ ಬಿಟ್‌ರೇಟ್ ಸ್ಟ್ರೀಮಿಂಗ್ ಮಿತಿಯನ್ನು ಮೀರಿದೆ.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ಆಡಿಯೋ ಚಾನೆಲ್‌ಗಳ ಸಂಖ್ಯೆ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'ಬಿಡುಗಡೆ ಕ್ರಮ (ಆರೋಹಣ)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'ಬಿಡುಗಡೆ ಕ್ರಮ (ಅವರೋಹಣ)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'ಕಸ್ಟಮ್ (ಎಳೆದು-ಬಿಡಿ)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'ಪ್ಲೇಪಟ್ಟಿ ವಿಂಗಡಣೆ ಆಯ್ಕೆಗಳು';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'ವಿಂಗಡಣೆಯನ್ನು ಮರುಹೊಂದಿಸಿ';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode ಅನ್ನು ಮತ್ತೆ ವೀಕ್ಷಿಸಿ';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'ಪ್ಲೇಪಟ್ಟಿಯನ್ನು ಮತ್ತೆ ವೀಕ್ಷಿಸಿ';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'ಯಾವುದೇ ಉಪಶೀರ್ಷಿಕೆಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'ನಿರ್ವಾಹಕ ನಿಯಂತ್ರಣಗಳು';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'ರೆಂಡರಿಂಗ್ ಎಂಜಿನ್ (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller ಎಂಬುದು ಸುಗಮ ಅನಿಮೇಶನ್‌ಗಳು ಮತ್ತು ಕಡಿಮೆ ಸ್ಟಟರ್‌ಗಾಗಿ Flutter ನ ಆಧುನಿಕ GPU ರೆಂಡರರ್. ಕೆಲವು TV ಬಾಕ್ಸ್‌ಗಳು ಮತ್ತು ಹಳೆಯ GPU ಗಳಲ್ಲಿ ಇದು ಗ್ಲಿಚ್‌ಗಳು ಅಥವಾ ಕಪ್ಪು ವಿಡಿಯೋಗೆ ಕಾರಣವಾಗಬಹುದು; ಅವು ಕಂಡುಬಂದರೆ ಇದನ್ನು ಆಫ್ ಮಾಡಿ. ಸ್ವಯಂಚಾಲಿತವು ನಿಮ್ಮ ಸಾಧನಕ್ಕೆ ಅತ್ಯುತ್ತಮ ಡೀಫಾಲ್ಟ್ ಆಯ್ಕೆಮಾಡುತ್ತದೆ. ಅನ್ವಯಿಸಲು Moonfin ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ಸ್ವಯಂಚಾಲಿತ';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ಆನ್';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ಆಫ್';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'ಮರುಪ್ರಾರಂಭ ಅಗತ್ಯವಿದೆ';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'ರೆಂಡರಿಂಗ್ ಎಂಜಿನ್ ಬದಲಾಯಿಸಲು Moonfin ಮರುಪ್ರಾರಂಭಿಸಬೇಕಾಗಿದೆ. ಈಗ ಆ್ಯಪ್ ಮುಚ್ಚಿ, ನಂತರ ಅನ್ವಯಿಸಲು ಅದನ್ನು ಮತ್ತೆ ತೆರೆಯಿರಿ.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ಈಗ ಆ್ಯಪ್ ಮುಚ್ಚಿ';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'ಲೈಬ್ರರಿಯನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಿ';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'ಎಲ್ಲಾ ಲೈಬ್ರರಿಗಳನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಿ';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹಳೆಯದು ಮೊದಲು)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'ಸೇರಿಸಿದ ದಿನಾಂಕ (ಹೊಸದು ಮೊದಲು)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ (A ಇಂದ Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'ವರ್ಣಮಾಲೆಯ ಪ್ರಕಾರ (Z ಇಂದ A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'ಸರ್ವರ್ ವಿಶ್ಲೇಷಣೆ ಲೋಡ್ ಆಗುತ್ತಿದೆ... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'ಮೂಲಕ್ಕೆ ಹೊಂದಿಸಿ';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb ಟಾಪ್ 250 ಚಲನಚಿತ್ರಗಳು';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb ಟಾಪ್ 250 ಟಿವಿ ಶೋಗಳು';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb ಅತ್ಯಂತ ಜನಪ್ರಿಯ ಚಲನಚಿತ್ರಗಳು';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb ಅತ್ಯಂತ ಜನಪ್ರಿಯ ಟಿವಿ ಶೋಗಳು';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'IMDb ಅತ್ಯಂತ ಕಡಿಮೆ ರೇಟ್ ಮಾಡಿದ ಚಲನಚಿತ್ರಗಳು';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb ಅತ್ಯುತ್ತಮ ರೇಟ್ ಮಾಡಿದ ಇಂಗ್ಲಿಷ್ ಚಲನಚಿತ್ರಗಳು';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9,30 +9,30 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => '달지느러미';
 
   @override
-  String get accountPreferences => '계정 환경설정';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => '인터페이스 언어';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => '시스템 기본값';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => '로그인';
 
   @override
-  String get empty => '비어 있음';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName에 연결하는 중';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => '빠른 연결';
 
   @override
   String get password => '비밀번호';
@@ -50,7 +50,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get waitingForAuthorization => '승인을 기다리는 중...';
 
   @override
-  String get back => '뒤로';
+  String get back => '뒤쪽에';
 
   @override
   String get serverUnavailable => '서버를 사용할 수 없습니다';
@@ -60,12 +60,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'Quick Connect를 사용할 수 없습니다: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'Quick Connect를 사용할 수 없습니다($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -79,7 +79,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin 버전 $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -105,14 +105,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '서버 목록에서 \"$serverName\"을(를) 제거할까요?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => '취소';
 
   @override
-  String get remove => '제거';
+  String get remove => '제거하다';
 
   @override
   String get connectToServer => '서버에 연결';
@@ -140,60 +140,62 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsAppearanceTheme => '앱 테마';
 
   @override
-  String get detailScreenStyle => '상세 화면 스타일';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '클래식은 기존의 가운데 정렬 Moonfin 레이아웃입니다. 모던은 반응형 시네마틱 레이아웃입니다.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => '클래식';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => '모던';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => '탭 자동 펼치기';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      '탭을 넘길 때 탭 내용을 자동으로 표시합니다. 끄면 각 탭을 직접 열고 닫습니다.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => '기술 정보를 표시할까요?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
-  String get showTechnicalDetailsSubtitle => '배너 요약에 코덱, 해상도, 스트림 정보를 표시합니다';
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => '추천 시스템';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      '로컬 라이브러리 기반 Moonfin 추천 알고리즘 또는 온라인 TMDb 유사도 지표를 사용합니다. 참고: 온라인 추천에는 Seerr 연동이 필요합니다.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin 추천';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb 유사도';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
-  String get recommendationsApplyParentalRatingCap => '시청 등급 제한을 적용할까요?';
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      '대상 미디어의 시청 등급에 따라 Moonfin 추천 항목을 제한합니다';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => '인터페이스 스타일';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '자동은 기기에 맞춰집니다. Apple 또는 Material을 선택하면 해당 스타일로 고정됩니다.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => '자동';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -202,41 +204,41 @@ class AppLocalizationsKo extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => '글래스 품질';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '자동은 이 기기에 가장 알맞은 글래스 효과를 선택합니다. 최고는 실제 블러를 적용하고, 낮음은 GPU 사용을 줄이는 가벼운 글래스를 사용합니다.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => '자동';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => '최고';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => '낮음';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       '앱을 다시 시작하지 않고도 Moonfin과 Neon Pulse 간에 전환할 수 있습니다.';
 
   @override
-  String get customThemeTitle => '사용자 지정 테마';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      '사용자 지정 테마는 Moonfin 전반의 시각 요소를 바꿉니다. 취향에 맞는 테마를 선택하세요.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => '시스템 키보드 우선 사용';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      '텍스트 입력 시 기기의 입력기를 기본으로 사용합니다';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => '달지느러미';
 
   @override
   String get themeMoonfinSubtitle => '현재 Moonfin 룩은 여러분 모두가 좋아하게 되었습니다.';
@@ -249,18 +251,18 @@ class AppLocalizationsKo extends AppLocalizations {
       '마젠타 빛, 청록색 텍스트 및 더 강한 크롬 대비를 사용한 신스웨이브 스타일';
 
   @override
-  String get themeGlass => '글래스';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      '흐르는 그라데이션 배경, 서리 낀 표면, Apple 블루 강조색을 사용한 리퀴드 글래스 스타일';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8비트 히어로';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      '투박한 색상, 각진 테두리, 진한 그림자, 픽셀 글꼴을 사용한 레트로 픽셀아트 스타일';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Emby Connect 계정으로 로그인하세요';
@@ -305,7 +307,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target에 연결할 수 없습니다';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -318,34 +320,35 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exit => '출구';
 
   @override
-  String get gameMenu => '메뉴';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => '일시정지됨';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => '상태 저장';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => '게임';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => '상태 불러오기';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => '빨리 감기';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => '에뮬레이터 설정';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => '이 코어에는 조정할 수 있는 옵션이 없습니다.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => '길게 눌러 메뉴 열기';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
-  String get gamePlaybackUnsupported => '이 기기에서는 아직 게임 플레이를 지원하지 않습니다.';
+  String get gamePlaybackUnsupported =>
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => '홈 행을 로드할 수 없습니다.';
@@ -360,7 +363,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get guide => '가이드';
 
   @override
-  String get recordings => '녹화';
+  String get recordings => '녹음';
 
   @override
   String get schedule => '일정';
@@ -372,7 +375,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get noItemsFound => '항목을 찾을 수 없습니다';
 
   @override
-  String get home => '홈';
+  String get home => '집';
 
   @override
   String get browseAll => '모두 찾아보기';
@@ -402,7 +405,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get noLibrariesFound => '라이브러리를 찾을 수 없습니다.';
 
   @override
-  String get library => '라이브러리';
+  String get library => '도서관';
 
   @override
   String get displaySettings => '디스플레이 설정';
@@ -415,7 +418,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return '폴더를 불러오지 못했습니다: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -423,7 +426,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count개 항목';
+    return '$count items';
   }
 
   @override
@@ -440,7 +443,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count개 항목';
+    return '$count Items';
   }
 
   @override
@@ -481,7 +484,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — 장르';
+    return '$name — Genres';
   }
 
   @override
@@ -519,17 +522,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count분 전';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count시간 전';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count일 전';
+    return '${count}d ago';
   }
 
   @override
@@ -539,7 +542,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get pickDiscoverySubjects => 'Discover에 표시할 주제 피드를 선택하세요.';
 
   @override
-  String get apply => '적용';
+  String get apply => '적용하다';
 
   @override
   String get openLink => '링크 열기';
@@ -561,7 +564,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count개 작품';
+    return '$count titles';
   }
 
   @override
@@ -586,7 +589,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get listen => '듣다';
 
   @override
-  String get resume => '이어하기';
+  String get resume => '재개하다';
 
   @override
   String get failedToLoadLibrary => '라이브러리를 로드하지 못했습니다.';
@@ -641,17 +644,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '저자 $count명';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '장르 $count개';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% 완료';
+    return '$percent% completed';
   }
 
   @override
@@ -668,11 +671,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '읽기 중심으로 정리된 $count개 작품입니다.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => '타이틀';
+  String get titles => '제목';
 
   @override
   String get allTitles => '모든 타이틀';
@@ -704,7 +707,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label을(를) 찾을 수 없습니다';
+    return 'No $label found';
   }
 
   @override
@@ -729,7 +732,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unread => '읽히지 않는';
 
   @override
-  String get unwatched => '미시청';
+  String get unwatched => '시청하지 않음';
 
   @override
   String get seriesStatus => '시리즈 현황';
@@ -741,43 +744,43 @@ class AppLocalizationsKo extends AppLocalizations {
   String get books => '서적';
 
   @override
-  String get latestBooks => '최신 도서';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => '최신 오디오북';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '도서 $count권',
-      one: '도서 1권',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => '도서';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => '오디오북';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% 읽음';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time 남음';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => '읽기';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => '듣기';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => '작가';
@@ -814,12 +817,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count개 섹션';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return '$year년 초판';
+    return 'First published $year';
   }
 
   @override
@@ -833,7 +836,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count권';
+    return '$count books';
   }
 
   @override
@@ -844,7 +847,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '저자 $count명';
+    return '$count Authors';
   }
 
   @override
@@ -852,8 +855,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '오디오북 $count개',
-      one: '오디오북 1개',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -871,7 +874,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get delete => '삭제';
 
   @override
-  String get save => '저장';
+  String get save => '구하다';
 
   @override
   String get moreLikeThis => '비슷한 제품 더 보기';
@@ -889,7 +892,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nextUp => '다음';
 
   @override
-  String get seasons => '시즌';
+  String get seasons => '계절';
 
   @override
   String get chapters => '장';
@@ -901,7 +904,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get movies => '영화 산업';
 
   @override
-  String get musicVideos => '뮤직비디오';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => '다른';
@@ -920,7 +923,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return '디스크 $number';
+    return 'Disc $number';
   }
 
   @override
@@ -943,7 +946,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String published(int year) {
-    return '$year년 출간';
+    return 'Published $year';
   }
 
   @override
@@ -954,52 +957,52 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '시즌 $count개',
-      one: '시즌 1개',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time에 종료';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => '항목';
+  String get items => 'Items';
 
   @override
-  String get extras => '부가 영상';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => '비하인드';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => '삭제 장면';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => '제작 영상';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => '인터뷰';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => '장면';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => '단편';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => '예고편';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time 남음';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time 후 종료';
+    return 'Ends in $time';
   }
 
   @override
@@ -1013,11 +1016,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position부터 이어보기';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => '재생';
+  String get play => '놀다';
 
   @override
   String get startOver => '다시 시작';
@@ -1041,10 +1044,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get version => '버전';
 
   @override
-  String get cast => '전송';
+  String get cast => '깁스';
 
   @override
-  String get trailer => '예고편';
+  String get trailer => '트레일러';
 
   @override
   String get finished => '완성된';
@@ -1111,7 +1114,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\"의 다운로드한 트랙을 삭제할까요?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1125,17 +1128,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '불러온 $itemLabel이(가) 없습니다';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title 다운로드 중($count개 항목)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '서버에서 \"$name\"을(를) 삭제할까요? 이 작업은 되돌릴 수 없습니다.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1146,7 +1149,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return '지원하지 않는 도서 형식: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1172,7 +1175,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return '자막을 다운로드하고 선택했습니다: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1181,7 +1184,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language 원격 자막을 찾을 수 없습니다.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1189,7 +1192,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return '버전 $number';
+    return 'Version $number';
   }
 
   @override
@@ -1209,7 +1212,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name 다운로드 중($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1217,7 +1220,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel의 로컬 파일을 삭제할까요?\n\n저장 공간이 확보되며, 나중에 다시 다운로드할 수 있습니다.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1233,25 +1236,25 @@ class AppLocalizationsKo extends AppLocalizations {
   String get director => '감독';
 
   @override
-  String get directors => '감독';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => '각본';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => '각본가';
+  String get writers => '작가';
 
   @override
   String get studio => '사진관';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count개 더';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count개 에피소드';
+    return '$count Episodes';
   }
 
   @override
@@ -1261,12 +1264,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return '$number화';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '챕터 $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1274,8 +1277,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '트랙 $count개',
-      one: '트랙 1개',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1285,25 +1288,25 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '챕터 $count개',
-      one: '챕터 1개',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return '$date 출생';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return '$date 사망';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return '$age세';
+    return 'Age $age';
   }
 
   @override
@@ -1313,20 +1316,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get readMore => '자세히 알아보기';
 
   @override
-  String get shuffle => '셔플';
+  String get shuffle => '혼합';
 
   @override
-  String get shuffleAllMusic => '전체 음악 셔플 재생';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => '휴대폰에서 Moonfin에 로그인하세요';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => '서버에 연결할 수 없습니다';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '다운로드 $count회';
+    return '$count downloads';
   }
 
   @override
@@ -1338,39 +1341,39 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get mono => '모노';
+  String get mono => '단핵증';
 
   @override
-  String get stereo => '스테레오';
+  String get stereo => '스테레오 재생';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '원격 자막 $action 작업에는 이 사용자의 Jellyfin 자막 관리 권한이 필요합니다.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return '원격 자막 $action 작업을 위한 항목을 서버에서 찾을 수 없습니다.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '원격 자막 $action 작업에 실패했습니다: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '원격 자막 $action 작업에 실패했습니다(HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return '원격 자막을 $action하지 못했습니다.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\"의 다운로드한 모든 에피소드';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1398,17 +1401,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label 작업에 실패했습니다: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return '캐스트 음량을 조절하지 못했습니다: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label 제어';
+    return '$label Controls';
   }
 
   @override
@@ -1418,14 +1421,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unavailable => '없는';
 
   @override
-  String get pause => '일시정지';
+  String get pause => '정지시키다';
 
   @override
   String get syncPosition => '동기화 위치';
 
   @override
   String stopCast(String label) {
-    return '$label 중지';
+    return 'Stop $label';
   }
 
   @override
@@ -1433,7 +1436,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '트랙 $number';
+    return 'Track $number';
   }
 
   @override
@@ -1450,14 +1453,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds초';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => '잠금을 해제하려면 길게 누르세요.';
 
   @override
-  String get off => '끔';
+  String get off => '끄다';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1492,7 +1495,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subtitleDelay => '자막 지연';
 
   @override
-  String get reset => '초기화';
+  String get reset => '다시 놓기';
 
   @override
   String get unknown => '알려지지 않은';
@@ -1543,7 +1546,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoBitrate => '비디오 비트레이트';
 
   @override
-  String get track => '트랙';
+  String get track => '길';
 
   @override
   String get channels => '채널';
@@ -1565,12 +1568,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol 세션 오류';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return '도서 정보를 불러오지 못했습니다: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1579,7 +1582,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return '이 형식(.$extension)은 아직 앱에서 표시할 수 없습니다.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1590,17 +1593,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return '앱 내 리더를 열지 못했습니다: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label에 이미 북마크가 있습니다.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return '북마크 추가됨: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1611,7 +1614,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '$number페이지';
+    return 'Page $number';
   }
 
   @override
@@ -1622,12 +1625,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return '형식: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% 읽음';
+    return '$percent% read';
   }
 
   @override
@@ -1650,7 +1653,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return '확대/축소 초기화(${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1673,7 +1676,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return '읽음 상태를 변경하지 못했습니다: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1705,7 +1708,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '이 플랫폼에서는 $extension 파일용 내장 문서 엔진을 사용할 수 없습니다.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1744,7 +1747,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return '편성표를 불러오지 못했습니다: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1755,22 +1758,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return '다음: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes분 남음';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours시간 남음';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours시간 $minutes분 남음';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1792,29 +1795,29 @@ class AppLocalizationsKo extends AppLocalizations {
   String get favoriteChannel => '즐겨찾는 채널';
 
   @override
-  String get record => '녹화 예약';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => '녹화 취소';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => '녹화가 예약되었습니다';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => '녹화가 취소되었습니다';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => '녹화를 예약할 수 없습니다';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => '시청';
+  String get watch => '보다';
 
   @override
-  String get close => '닫기';
+  String get close => '닫다';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name을(를) 재생하지 못했습니다';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1840,7 +1843,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\"의 예약 녹화를 취소할까요?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1866,7 +1869,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" 녹화를 중지할까요?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1880,12 +1883,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\"에 대한 검색 결과가 없습니다';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return '검색에 실패했습니다: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1926,12 +1929,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\"과(와) 해당 파일을 삭제할까요?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '트랙 $count개';
+    return '$count tracks';
   }
 
   @override
@@ -1942,16 +1945,16 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return '앨범을 불러오지 못했습니다: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name에 다운로드한 트랙이 없습니다.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => '시즌';
+  String get season => '계절';
 
   @override
   String get errorLoadingEpisodes => '에피소드를 로드하는 중에 오류가 발생했습니다.';
@@ -1964,12 +1967,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\"을(를) 삭제할까요?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes분';
+    return '$minutes min';
   }
 
   @override
@@ -1979,7 +1982,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return '$number화';
+    return 'Episode $number';
   }
 
   @override
@@ -1993,7 +1996,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return '시즌 $number';
+    return 'Season $number';
   }
 
   @override
@@ -2009,7 +2012,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season의 다운로드한 에피소드를 모두 삭제할까요?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2017,8 +2020,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '에피소드 $count개',
-      one: '에피소드 1개',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2052,7 +2055,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '다운로드한 항목 $count개를 삭제할까요?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2066,7 +2069,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '/ 제한 $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2146,7 +2149,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '옵션 $count개';
+    return '$count options';
   }
 
   @override
@@ -2235,7 +2238,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get themeMusicVolume => '테마 음악 볼륨';
 
   @override
-  String get themeMusicSettingsSubtitle => '상세 페이지, 홈 행, 음량';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2249,10 +2253,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => '홈 화면 탐색 시 재생';
 
   @override
-  String get loopThemeMusic => '테마 음악 반복 재생';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => '한 번만 재생하지 않고 트랙을 반복합니다';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => '세부 배경 흐림';
@@ -2275,23 +2280,23 @@ class AppLocalizationsKo extends AppLocalizations {
   String get playerZoomMode => '플레이어 줌 모드';
 
   @override
-  String get settingsScrollWheelAction => '마우스 휠 스크롤';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      '재생 중 영상 위에서 마우스 휠을 굴렸을 때의 동작을 선택하세요.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => '끔';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => '탐색(앞/뒤로)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => '음량';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => '음량';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => '맞다';
@@ -2306,7 +2311,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get refreshRateSwitching => '새로 고침 빈도 전환';
 
   @override
-  String get disabled => '사용 안 함';
+  String get disabled => '장애가 있는';
 
   @override
   String get scaleOnTv => 'TV의 규모';
@@ -2342,34 +2347,37 @@ class AppLocalizationsKo extends AppLocalizations {
   String get defaultAudioLanguage => '기본 오디오 언어';
 
   @override
-  String get fallbackAudioLanguage => '대체 오디오 언어';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => '기본 오디오 트랙 우선';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
-  String get preferDefaultAudioTrackDescription => '더빙 트랙보다 원어 오디오 트랙을 우선합니다.';
+  String get preferDefaultAudioTrackDescription =>
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => '화면 해설 트랙 우선';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
-  String get preferAudioDescriptionDescription => '일반 트랙보다 화면 해설 트랙을 우선합니다.';
+  String get preferAudioDescriptionDescription =>
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => '트랜스코딩(오디오)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => '다이렉트 스트림(리먹스)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
-  String get transcodingBitrateOrResolution => '트랜스코딩(비트레이트 또는 해상도)';
+  String get transcodingBitrateOrResolution =>
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => '트랜스코딩(비디오 및 오디오)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => '트랜스코딩(비디오)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => '자동(서버 기본값)';
@@ -2445,27 +2453,27 @@ class AppLocalizationsKo extends AppLocalizations {
   String get enableTrueHdAudio => 'TrueHD 오디오 활성화(일부 플랫폼에서는 작동하지 않을 수 있음)';
 
   @override
-  String get settingsAudioOutputMode => '오디오 출력 모드';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      '오디오 디코딩 방식을 선택하세요. AVR 패스스루는 원본 Dolby/DTS 스트림을 리시버로 그대로 보내고, 자동 또는 다운믹스는 기기에서 디코딩합니다.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR 패스스루';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => '대체 오디오 코덱';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      '원본 스트림을 다이렉트 재생하거나 패스스루할 수 없을 때 멀티채널 오디오를 트랜스코딩할 대상 형식을 선택하세요.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => '자동 감지\n(권장)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(기본값)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2474,113 +2482,113 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(무손실)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(스테레오 전용)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(고효율)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(무손실)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => '최대 오디오 채널';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      '사용 중인 오디오 환경의 최대 채널 수를 설정하세요. 이 제한을 넘는 멀티채널 스트림은 다운믹스되거나 트랜스코딩됩니다.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => '자동 감지\n(하드웨어 기본값)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 모노';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 스테레오';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 서라운드';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 쿼드러포닉';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 서라운드';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 서라운드';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 서라운드';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 서라운드';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => '패스스루(고급)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => '코덱 패스스루';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      '사용 중인 AVR 또는 HDMI 기기가 지원하는 형식만 켜세요.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 패스스루';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC(Atmos) 패스스루';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS 코어 패스스루';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA 패스스루';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD 패스스루';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos 패스스루';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus(EAC3)를 외부 디코더로 비트스트림 전송합니다.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3(JOC) 기반 Dolby Atmos를 외부 디코더로 비트스트림 전송합니다.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA(DTS 코어 포함)를 외부 디코더로 비트스트림 전송합니다.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos 메타데이터가 포함된 Dolby TrueHD를 외부 디코더로 비트스트림 전송합니다.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => '감지된 오디오 지원 정보';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      '아직 사용할 수 있는 런타임 지원 정보가 없습니다.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => '출력 경로';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => '디코딩';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => '패스스루';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD 오디오 경로';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2595,10 +2603,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => '스피커';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => '헤드폰';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2606,36 +2614,39 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => '진단 정보';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => '비디오 레벨';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => '비디오 범위';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => '자막 코덱';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => '허용된 오디오 코덱';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS 오디오 코덱';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs => 'HLS fMP4 오디오 코덱';
+  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif 패스스루';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => '현재 오디오 경로';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
-  String get settingsAudioDiagnosticsRouteHdAudioSupport => '경로의 HD 오디오 지원';
+  String get settingsAudioDiagnosticsRouteHdAudioSupport =>
+      'Route HD Audio Support';
 
   @override
   String get nightMode => '야간 모드';
@@ -2683,7 +2694,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value초';
+    return '${value}s';
   }
 
   @override
@@ -2697,7 +2708,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes편 재생 또는 $hours시간 후';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2772,42 +2783,45 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subtitleCustomizationDescription => '자막 모양 맞춤설정';
 
   @override
-  String get subtitleMode => '자막 모드';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => '플래그 기준';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => '항상';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => '외국어';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => '강제 자막';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      '미디어 파일의 메타데이터에 \"기본\" 또는 \"강제\"로 표시된 트랙을 재생합니다.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
-  String get subtitleModeAlwaysDescription => '영상을 재생할 때마다 자막을 자동으로 불러와 표시합니다.';
+  String get subtitleModeAlwaysDescription =>
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      '기본 오디오 트랙이 외국어일 때 자막을 자동으로 켭니다.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
-  String get subtitleModeForcedDescription => '강제 자막 플래그가 지정된 자막만 불러옵니다.';
+  String get subtitleModeForcedDescription =>
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
-  String get subtitleModeNoneDescription => '자막 자동 불러오기를 완전히 끕니다.';
+  String get subtitleModeNoneDescription =>
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => '대체 자막 언어';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => '자막 스트림';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => '날렵한 갈색여우는 게으른 개를 뛰어넘는다';
@@ -2865,17 +2879,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile 프로필 설정을 불러왔습니다.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile 프로필 설정을 불러오지 못했습니다.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return '로컬 설정을 $profile 프로필에 동기화했습니다.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3008,10 +3022,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showLibrariesInToolbar => '툴바에 라이브러리 표시';
 
   @override
-  String get navbarAlwaysExpanded => '탐색 바 라벨 항상 표시';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr 버튼 표시';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => '탐색바 불투명도';
@@ -3083,17 +3097,18 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showFolderBrowsingOption => '폴더 탐색 옵션 표시';
 
   @override
-  String get groupItemsIntoCollections => '항목을 컬렉션으로 묶기';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
-  String get hideCollectionAssociatedItems => '라이브러리를 탐색할 때 컬렉션에 속한 항목을 숨깁니다';
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => '라이브러리 그룹화 안내';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      '이 설정을 사용하려면 Jellyfin 또는 Emby 서버의 라이브러리 표시 설정에서 \"영화를 컬렉션으로 묶기\" 및/또는 \"TV 프로그램을 컬렉션으로 묶기\"가 켜져 있는지 확인하세요.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => '도서관 가시성';
@@ -3122,7 +3137,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count개 선택됨';
+    return '$count selected';
   }
 
   @override
@@ -3150,13 +3165,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mediaBarModeDescription => '다양한 미디어 바 스타일 중 하나를 선택하거나 미디어 바를 끄십시오';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => '달지느러미';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => '끔';
+  String get mediaBarModeOff => '끄다';
 
   @override
   String get enableMediaBar => '미디어 바 활성화';
@@ -3201,10 +3216,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get autoPlayTrailers => '3초 후에 미디어 바에서 예고편 자동 재생';
 
   @override
-  String get trailerAudio => '예고편 오디오';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => '미디어 바의 예고편에서 소리를 재생합니다';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => '에피소드 미리보기';
@@ -3278,10 +3293,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get combineBothRows => '두 행을 단일 홈 섹션으로 결합';
 
   @override
-  String get fullScreenRows => '홈 행 크게 보기';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => '화면당 홈 행을 1개로 제한합니다';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => '행별 이미지 유형';
@@ -3296,7 +3311,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get lastUser => '마지막 사용자';
 
   @override
-  String get currentUser => '현재 사용자';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '항상 인증';
@@ -3350,7 +3365,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get enableBuiltInScreensaver => '내장 화면 보호기 활성화';
 
   @override
-  String get mode => '모드';
+  String get mode => '방법';
 
   @override
   String get libraryArt => '도서관 예술';
@@ -3366,7 +3381,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes분';
+    return '$minutes min';
   }
 
   @override
@@ -3396,10 +3411,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get displayClockDuringScreensaver => '화면 보호기 동안 시계 표시';
 
   @override
-  String get clockModeStatic => '고정';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => '움직임';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => '로튼 토마토(비평가)';
@@ -3420,7 +3435,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get metacriticUser => '메타크리틱(사용자)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => '트랙트';
 
   @override
   String get letterboxd => '레터박스d';
@@ -3468,7 +3483,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get ratingSourcesDescription => '앱 전체에 표시되는 평가 소스를 활성화하고 재정렬합니다.';
 
   @override
-  String get pluginLabel => 'Moonbase 플러그인';
+  String get pluginLabel => '플러그인';
 
   @override
   String get pluginDetected => '플러그인이 감지되었습니다';
@@ -3486,7 +3501,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\n버전: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3539,7 +3554,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get networks => '네트워크';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr 둘러보기 행';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => '행을 기본값으로 재설정';
@@ -3560,44 +3575,46 @@ class AppLocalizationsKo extends AppLocalizations {
   String get hideAdultContent => '검색결과에서 성인용 콘텐츠 숨기기';
 
   @override
-  String get seerrNotificationsSection => '알림';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => '새 요청 알림';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => '누군가 요청을 등록하면 알려줍니다';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => '요청 상태 알림';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
-  String get seerrNotifyLibraryAddedSubtitle => '승인, 거절, 라이브러리 추가 알림';
+  String get seerrNotifyLibraryAddedSubtitle =>
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => '문제 알림';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => '새 문제, 댓글, 해결 알림';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return '로그인 계정: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr 디스커버리 페이지';
+  String get discoverRows => '행 검색';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr 메인 페이지에 표시할 행을 활성화하세요. 드래그하여 순서를 변경할 수 있습니다. 사용자 지정 순서는 Moonbase와 동기화됩니다.';
+      '재정렬하려면 드래그하세요. 행을 활성화하거나 비활성화합니다. 활성화된 행 순서는 Moonfin 플러그인과 동기화됩니다.';
 
   @override
-  String get discoverRowsDescription =>
-      'Seerr 메인 페이지에 표시할 행을 활성화하세요. 드래그하여 순서를 변경할 수 있습니다. 사용자 지정 순서는 Moonbase와 동기화됩니다.';
+  String get discoverRowsDescription => '재정렬하려면 드래그하세요. 행을 활성화하거나 비활성화합니다.';
 
   @override
-  String get enabled => '사용함';
+  String get enabled => '활성화됨';
 
   @override
   String get hidden => '숨겨진';
@@ -3607,7 +3624,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return '버전 $version';
+    return 'Version $version';
   }
 
   @override
@@ -3651,7 +3668,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return '업데이트 있음: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3662,7 +3679,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version 사용 가능';
+    return 'v$version Available';
   }
 
   @override
@@ -3721,7 +3738,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get imageCacheCleared => '이미지 캐시를 지웠습니다';
 
   @override
-  String get clear => '지우기';
+  String get clear => '분명한';
 
   @override
   String get browse => '먹다';
@@ -3737,19 +3754,19 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return '다운로드 중 · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => '가져오는 중';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count개 항목';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr 설정';
+  String get seerrSettings => '시르 설정';
 
   @override
   String get requestMore => '더 요청하기';
@@ -3765,7 +3782,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name 요청';
+    return 'Requested by $name';
   }
 
   @override
@@ -3782,12 +3799,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" 요청을 취소할까요?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\"의 요청 $count건을 취소할까요?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3801,12 +3818,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return '제작비: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return '수익: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3816,7 +3833,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type 요청';
+    return 'Request $type';
   }
 
   @override
@@ -3844,14 +3861,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showMore => '더보기';
 
   @override
-  String get appearances => '출연작';
+  String get appearances => '형세';
 
   @override
   String get crewSection => '승무원';
 
   @override
   String ageValue(int age) {
-    return '$age세';
+    return 'age $age';
   }
 
   @override
@@ -3882,146 +3899,148 @@ class AppLocalizationsKo extends AppLocalizations {
   String get deletedStatus => '삭제됨';
 
   @override
-  String get failedStatus => '실패';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => '처리 중';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name이(가) 변경';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => '완료됨';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => '이미 요청한 작품입니다';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => '요청 한도에 도달했습니다';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => '차단 목록에 있는 작품입니다';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => '요청할 수 있는 시즌이 없습니다';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => '이 요청을 할 권한이 없습니다';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => '요청';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => '문제';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => '최신순';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => '최근 변경순';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => '문제 없음';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '영화 요청 $limit건 중 $remaining건 남음';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '시즌 요청 $limit건 중 $remaining건 남음';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name 컬렉션의 일부';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => '컬렉션 보기';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => '컬렉션 요청';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '영화 $total편 · $available편 이용 가능';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '영화 $count편 요청';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total건 중 $current건 요청 중...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '영화 $count편을 요청했습니다';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '영화 $total편 중 $ok편을 요청했습니다';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => '모든 영화가 이미 이용 가능하거나 요청되었습니다';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => '문제 신고';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => '영상';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => '오디오';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => '어떤 문제인가요?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => '모든 에피소드';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => '에피소드';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => '미해결';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => '해결됨';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => '해결 처리';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => '다시 열기';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name 신고';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '댓글 $count개';
+    return '$count comments';
   }
 
   @override
-  String get addComment => '댓글 추가';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => '이 문제를 삭제할까요?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => '신고 제출';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB 점수';
@@ -4045,7 +4064,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get originalLanguageLabel => '원어';
 
   @override
-  String get seasonsLabel => '시즌';
+  String get seasonsLabel => '계절';
 
   @override
   String get episodesLabel => '에피소드';
@@ -4054,7 +4073,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get access => '입장';
 
   @override
-  String get add => '추가';
+  String get add => '추가하다';
 
   @override
   String get address => '주소';
@@ -4081,7 +4100,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get done => '완료';
 
   @override
-  String get edit => '편집';
+  String get edit => '편집하다';
 
   @override
   String get encoding => '부호화';
@@ -4093,7 +4112,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get forward => '앞으로';
 
   @override
-  String get general => '일반';
+  String get general => '일반적인';
 
   @override
   String get go => '가다';
@@ -4156,7 +4175,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get run => '달리다';
 
   @override
-  String get search => '검색';
+  String get search => '찾다';
 
   @override
   String get select => '선택하다';
@@ -4174,7 +4193,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get status => '상태';
 
   @override
-  String get stop => '정지';
+  String get stop => '멈추다';
 
   @override
   String get streaming => '스트리밍';
@@ -4183,7 +4202,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get time => '시간';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => '트릭플레이';
 
   @override
   String get uninstall => '제거';
@@ -4201,7 +4220,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unmute => '음소거 해제';
 
   @override
-  String get mute => '음소거';
+  String get mute => '무음';
 
   @override
   String get branding => '브랜딩';
@@ -4222,28 +4241,28 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminDrawerUsers => '사용자';
 
   @override
-  String get adminDrawerLibraries => '라이브러리';
+  String get adminDrawerLibraries => '도서관';
 
   @override
-  String get adminDrawerDisplay => '표시';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => '메타데이터';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO 설정';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => '트랜스코딩';
 
   @override
-  String get adminDrawerResume => '이어보기';
+  String get adminDrawerResume => '재개하다';
 
   @override
   String get adminDrawerStreaming => '스트리밍';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => '트릭플레이';
 
   @override
   String get adminDrawerDevices => '장치';
@@ -4292,22 +4311,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return '업데이트 가능한 플러그인: $count개';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return '재시작이 필요한 플러그인: $count개';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return '실패한 예약 작업: $count개';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return '최근 경고/오류 항목: $count개';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4366,7 +4385,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return '오류: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4392,7 +4411,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return '명령을 실행하지 못했습니다: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4411,7 +4430,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get sessionRewind => '되감기';
 
   @override
-  String get sessionForward => '빨리 감기';
+  String get sessionForward => '앞으로';
 
   @override
   String get sessionNext => '다음';
@@ -4429,7 +4448,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nowPlaying => '지금 재생 중';
 
   @override
-  String get volume => '음량';
+  String get volume => '용량';
 
   @override
   String get actions => '행위';
@@ -4456,14 +4475,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminClearDates => '날짜 지우기';
 
   @override
-  String get adminActivitySeverityAll => '모든 심각도';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => '기간';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return '활동 로그를 불러오지 못했습니다: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4480,7 +4499,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return '기기를 업데이트하지 못했습니다: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4491,28 +4510,28 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return '기기를 삭제하지 못했습니다: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' 기기를 삭제할까요? 이 기기에서 사용자가 다시 로그인해야 합니다.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => '모든 기기 삭제';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '기기 $count대를 삭제할까요? 해당 사용자는 다시 로그인해야 합니다. 현재 기기는 영향을 받지 않습니다.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => '기기를 삭제했습니다';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return '일부 기기를 삭제했습니다. $count대는 삭제하지 못했습니다.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4541,7 +4560,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return '검색을 시작하지 못했습니다: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4552,12 +4571,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return '라이브러리 이름을 \"$name\"(으)로 변경했습니다';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return '이름을 변경하지 못했습니다: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4565,17 +4584,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" 라이브러리를 삭제했습니다';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return '라이브러리를 삭제하지 못했습니다: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return '경로를 추가하지 못했습니다: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4583,12 +4602,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '이 라이브러리에서 \"$path\"을(를) 제거할까요?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return '경로를 제거하지 못했습니다: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4596,7 +4615,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return '옵션을 저장하지 못했습니다: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4627,236 +4646,251 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminMetadataCountryHint => '예를 들어 미국, 독일, 프랑스';
 
   @override
-  String get adminLibraryTabPaths => '경로';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => '옵션';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => '다운로더';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => '메타데이터 저장 도구';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => '자막 다운로더';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => '가사 다운로더';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return '메타데이터 다운로더: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return '이미지 수집기: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      '이 서버에는 해당 라이브러리 유형에 사용할 수 있는 다운로더가 없습니다.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => '일반';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => '메타데이터';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => '내장 정보';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => '자막';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => '이미지';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => '시리즈';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => '음악';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => '영화';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => '실시간 모니터링 사용';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
-  String get adminLibRealtimeMonitorHint => '파일 변경을 감지해 자동으로 처리합니다.';
+  String get adminLibRealtimeMonitorHint =>
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => '압축 파일을 미디어 파일로 취급';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => '사진 표시';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => '아트워크를 미디어 폴더에 저장';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => '메타데이터 자동 새로고침';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => '안 함';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => '기본값';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => '표시';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => '라이브러리 표시';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
-  String get adminLibFolderView => '일반 미디어 폴더를 보여주는 폴더 보기 표시';
+  String get adminLibFolderView =>
+      'Display a folder view to show plain media folders';
 
   @override
-  String get adminLibSpecialsInSeasons => '스페셜 에피소드를 방영된 시즌 안에 표시';
+  String get adminLibSpecialsInSeasons =>
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => '영화를 컬렉션으로 묶기';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'TV 프로그램을 컬렉션으로 묶기';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => '추천에 외부 콘텐츠 표시';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => '추가 날짜 처리 방식';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => '추가 날짜 기준';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => '라이브러리에 검색된 날짜';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => '파일이 생성된 날짜';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => '메타데이터 및 이미지';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => '선호 메타데이터 언어';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => '챕터';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => '임시 챕터 길이(초)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      '챕터가 없는 미디어에 생성할 챕터의 길이입니다. 0으로 설정하면 사용하지 않습니다.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => '챕터 이미지 해상도';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO 설정';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO 메타데이터는 Kodi 및 유사한 클라이언트와 호환됩니다. 이 설정은 NFO 메타데이터를 저장하는 모든 라이브러리에 적용됩니다.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'NFO 파일에 시청 기록을 저장할 사용자';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO 파일에 이미지 경로 저장';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
-  String get adminLibPathSubstitution => 'NFO 이미지 경로에 경로 치환 사용';
+  String get adminLibPathSubstitution =>
+      'Enable path substitution for NFO image paths';
 
   @override
-  String get adminLibExtraThumbs => 'extrafanart 이미지를 extrathumbs 폴더로 복사';
+  String get adminLibExtraThumbs =>
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => '없음';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days일';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => '내장 제목 사용';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => '부가 영상에 내장 제목 사용';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => '내장 에피소드 정보 사용';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => '내장 자막 허용';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => '모두 허용';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => '텍스트만';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => '이미지만';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => '없음';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
-  String get adminLibSkipIfEmbeddedSubs => '내장 자막이 있으면 다운로드 건너뛰기';
+  String get adminLibSkipIfEmbeddedSubs =>
+      'Skip download if embedded subtitles are present';
 
   @override
-  String get adminLibSkipIfAudioMatches => '오디오 트랙이 다운로드 언어와 일치하면 건너뛰기';
+  String get adminLibSkipIfAudioMatches =>
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => '완전히 일치하는 자막만 사용';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => '자막을 미디어 폴더에 저장';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => '챕터 이미지 추출';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
-  String get adminLibChapterImagesDuringScan => '라이브러리 검색 중 챕터 이미지 추출';
+  String get adminLibChapterImagesDuringScan =>
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Trickplay 이미지 추출 사용';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
-  String get adminLibTrickplayDuringScan => '라이브러리 검색 중 Trickplay 이미지 추출';
+  String get adminLibTrickplayDuringScan =>
+      'Extract trickplay images during the library scan';
 
   @override
-  String get adminLibSaveTrickplayWithMedia => 'Trickplay 이미지를 미디어 폴더에 저장';
+  String get adminLibSaveTrickplayWithMedia =>
+      'Save trickplay images into media folders';
 
   @override
-  String get adminLibAutomaticSeriesGrouping => '여러 폴더에 나뉜 시리즈 자동 병합';
+  String get adminLibAutomaticSeriesGrouping =>
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => '시즌 0 표시 이름';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => '오디오 음량 정규화를 위한 LUFS 분석 사용';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
-  String get adminLibPreferNonstandardArtist => '비표준 아티스트 태그 우선';
+  String get adminLibPreferNonstandardArtist =>
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => '영화를 컬렉션에 자동 추가';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => '라이브러리 이름은 필수 항목입니다.';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return '라이브러리를 만들지 못했습니다: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4882,27 +4916,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name을(를) 비활성화할까요? 로그인할 수 없게 됩니다.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name을(를) 활성화할까요? 다시 로그인할 수 있게 됩니다.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" 사용자를 비활성화했습니다';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" 사용자를 활성화했습니다';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return '사용자 정책을 업데이트하지 못했습니다: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -4919,7 +4953,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return '사용자를 만들지 못했습니다: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -4939,7 +4973,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return '저장하지 못했습니다: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -4950,7 +4984,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return '실패: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5081,137 +5115,143 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminEnableAllChannels => '모든 채널에 대한 액세스 활성화';
 
   @override
-  String get adminParentalControl => '자녀 보호';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => '허용할 최대 시청 등급';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
-  String get adminMaxParentalRatingHint => '등급이 더 높은 콘텐츠는 이 사용자에게 표시되지 않습니다.';
+  String get adminMaxParentalRatingHint =>
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => '없음';
+  String get adminParentalRatingNone => 'None';
 
   @override
-  String get adminBlockUnratedItems => '등급 정보가 없거나 인식되지 않는 항목 차단';
+  String get adminBlockUnratedItems =>
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => '도서';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => '채널';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => '실시간 TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => '영화';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => '음악';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => '예고편';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'TV 프로그램';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => '접속 시간 설정';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      '아래 지정한 시간에만 접속을 허용합니다. 설정이 없으면 하루 종일 접속할 수 있습니다.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => '일정 추가';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => '요일';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => '시작';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => '종료';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => '매일';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => '평일';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => '주말';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => '일요일';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => '월요일';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => '화요일';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => '수요일';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => '목요일';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => '금요일';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => '토요일';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => '허용 태그';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
-  String get adminAllowedTagsHint => '이 태그가 있는 콘텐츠만 표시됩니다. 비워 두면 모두 허용합니다.';
+  String get adminAllowedTagsHint =>
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => '차단 태그';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
-  String get adminBlockedTagsHint => '이 태그가 있는 콘텐츠는 이 사용자에게 표시되지 않습니다.';
+  String get adminBlockedTagsHint =>
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => '태그 추가';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => '허용된 기기';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => '허용된 채널';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => '인증 공급자';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => '비밀번호 재설정 공급자';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
-  String get adminLoginAttemptsBeforeLockout => '계정 잠금 전 최대 로그인 실패 횟수';
+  String get adminLoginAttemptsBeforeLockout =>
+      'Maximum failed login attempts before lockout';
 
   @override
-  String get adminLoginAttemptsHint => '기본값은 0, 잠금을 사용하지 않으려면 -1로 설정하세요.';
+  String get adminLoginAttemptsHint =>
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay 권한';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => '그룹 생성 및 참여 허용';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => '그룹 참여 허용';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => '권한 없음';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => '콘텐츠 삭제를 허용할 폴더';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5219,22 +5259,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return '서버가 HTTP $status을(를) 반환했습니다';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name을(를) 삭제할까요?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" 사용자를 삭제했습니다';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return '사용자를 삭제하지 못했습니다: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5255,7 +5295,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return '키를 만들지 못했습니다: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5266,7 +5306,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name의 키를 취소할까요?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5274,7 +5314,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return '키를 취소하지 못했습니다: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5294,29 +5334,29 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return '토큰: $token\\n생성: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => '백업 만들기';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => '백업에 포함할 항목을 선택하세요.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => '데이터베이스';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => '항상 포함됨';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => '메타데이터';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => '자막';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay 이미지';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => '백업 생성 중...';
@@ -5326,7 +5366,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return '백업을 만들지 못했습니다: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5334,12 +5374,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return '매니페스트: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return '매니페스트를 불러오지 못했습니다: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5350,7 +5390,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return '백업을 복원하지 못했습니다: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5382,17 +5422,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path에 저장했습니다';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return '파일을 저장하지 못했습니다: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName을(를) 불러오지 못했습니다';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5403,7 +5443,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return '작업을 불러오지 못했습니다: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5414,17 +5454,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return '작업을 시작하지 못했습니다: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return '작업을 중지하지 못했습니다: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return '작업을 불러오지 못했습니다: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5432,12 +5472,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return '트리거를 제거하지 못했습니다: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return '트리거를 추가하지 못했습니다: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5463,7 +5503,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours시간';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5474,7 +5514,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return '플러그인을 켜거나 끄지 못했습니다: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5482,27 +5522,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '\"$name\"을(를) 제거할까요?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return '플러그인을 제거하지 못했습니다: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return '패키지를 설치하지 못했습니다: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return '업데이트를 설치하지 못했습니다: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return '플러그인을 불러오지 못했습니다: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5513,12 +5553,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return '업데이트 설치(v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return '카탈로그를 불러오지 못했습니다: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5539,17 +5579,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '서버를 재시작하면 \"$name\"이(가) 제거됩니다';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return '제거하지 못했습니다: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\"을(를) v$version(으)로 업데이트하는 중...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5557,7 +5597,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return '플러그인을 불러오지 못했습니다: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5565,7 +5605,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return '버전 $version';
+    return 'Version $version';
   }
 
   @override
@@ -5585,17 +5625,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '\"$name\"을(를) 제거할까요?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return '저장소를 저장하지 못했습니다: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return '저장소를 불러오지 못했습니다: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5612,12 +5652,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return '플러그인 설정을 불러올 수 없습니다: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri을(를) 열 수 없습니다';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5732,10 +5772,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminThrottleBuffering => '스로틀 버퍼링';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay 설정이 저장되었습니다';
+  String get adminTrickplaySaved => '트릭플레이 설정이 저장되었습니다';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay 설정을 로드하지 못했습니다';
+  String get adminTrickplayLoadFailed => '트릭플레이 설정을 로드하지 못했습니다.';
 
   @override
   String get adminEnableHardwareAcceleration => '하드웨어 가속 활성화';
@@ -5878,12 +5918,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return '메타데이터를 불러오지 못했습니다: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return '메타데이터를 저장하지 못했습니다: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -5903,7 +5943,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return '메타데이터를 새로 고치지 못했습니다: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -5917,7 +5957,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return '원격 검색에 실패했습니다: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -5931,7 +5971,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return '콘텐츠 유형을 변경하지 못했습니다: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -5945,12 +5985,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType 이미지를 업데이트했습니다';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return '이미지를 다운로드하지 못했습니다: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -5961,27 +6001,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType 이미지를 업로드했습니다';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return '이미지를 업로드하지 못했습니다: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType 이미지 삭제';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType 이미지를 삭제했습니다';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return '이미지를 삭제하지 못했습니다: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -5992,66 +6032,67 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return '튜너를 검색하지 못했습니다: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => '튜너 추가';
 
   @override
-  String get adminEditTuner => '튜너 편집';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U 튜너';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => '파일 또는 URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => '튜너 IP 주소';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => '표시 이름';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => '사용자 에이전트';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => '동시 연결 제한';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      '튜너가 동시에 허용하는 최대 스트림 수입니다. 0으로 설정하면 무제한입니다.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => '대체 최대 스트리밍 비트레이트';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => '즐겨찾기 채널만 가져오기';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => '하드웨어 트랜스코딩 허용';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 트랜스코딩 컨테이너 허용';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => '스트림 공유 허용';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => '스트림 반복 사용';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS 무시';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
-  String get adminTunerReadAtNativeFramerate => '원본 프레임레이트로 입력 읽기';
+  String get adminTunerReadAtNativeFramerate =>
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => '공급자 편집';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6060,49 +6101,50 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => '파일 또는 URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => '영화 접두사';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => '영화 카테고리';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => '여러 카테고리는 세로줄(|)로 구분하세요.';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => '어린이 카테고리';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => '뉴스 카테고리';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => '스포츠 카테고리';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => '사용자 이름';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => '비밀번호';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => '국가';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => '국가를 선택하세요';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => '우편번호';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => '편성 정보 가져오기';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => '편성 정보';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => '모든 튜너 사용';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => '튜너 유형';
@@ -6112,7 +6154,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return '튜너를 추가하지 못했습니다: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6126,12 +6168,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return '공급자를 추가하지 못했습니다: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return '튜너를 제거하지 못했습니다: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6139,15 +6181,16 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return '튜너를 초기화하지 못했습니다: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported => '이 튜너 유형은 초기화를 지원하지 않습니다.';
+  String get adminTunerResetNotSupported =>
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return '공급자를 제거하지 못했습니다: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6166,43 +6209,43 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminSeriesRecordingPath => '시리즈 녹화 경로';
 
   @override
-  String get adminMovieRecordingPath => '영화 녹화 경로';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => '편성표 데이터 기간';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => '자동';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days일';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => '후처리 프로그램 경로';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => '후처리 인수';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => '녹화 NFO 메타데이터 저장';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => '녹화 이미지 저장';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => '시간 설정';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => '녹화 경로';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => '후처리';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return '편성표 데이터: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6210,7 +6253,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return '설정을 저장하지 못했습니다: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6227,7 +6270,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return '매핑을 업데이트하지 못했습니다: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6243,13 +6286,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminGuideProviders => '가이드 제공업체';
 
   @override
-  String get adminRefreshGuideData => '편성표 데이터 새로고침';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => '편성표 데이터 새로고침을 시작했습니다';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
-  String get adminGuideRefreshUnavailable => '이 서버에서는 편성표 새로고침 작업을 사용할 수 없습니다.';
+  String get adminGuideRefreshUnavailable =>
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => '공급자 추가';
@@ -6259,22 +6303,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return '녹화 경로: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return '시리즈 경로: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return '시작 여유 시간: $minutes분';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return '종료 여유 시간: $minutes분';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6303,7 +6347,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name 백업을 지금 복원할까요?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6326,13 +6370,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminLiveTvTitle => '라이브 TV 관리';
 
   @override
-  String get adminApply => '적용';
+  String get adminApply => '적용하다';
 
   @override
   String get adminNotSet => '설정되지 않음';
 
   @override
-  String get adminReset => '초기화';
+  String get adminReset => '다시 놓기';
 
   @override
   String get adminLogsTitle => '서버 로그';
@@ -6348,27 +6392,27 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes분 전';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours시간 전';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days일 전';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName을(를) 불러오지 못했습니다';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count개 일치';
+    return '$count matches';
   }
 
   @override
@@ -6378,7 +6422,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminMetadataEditorTitle => '메타데이터 편집기';
 
   @override
-  String get adminMetadataIdentify => '식별';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => '유형';
@@ -6478,22 +6522,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType 이미지를 업데이트했습니다';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType 이미지를 업로드했습니다';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType 이미지를 삭제했습니다';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return '이미지를 다운로드하지 못했습니다: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6501,12 +6545,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return '이미지를 업로드하지 못했습니다: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType 이미지 삭제';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6514,12 +6558,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return '이미지를 삭제하지 못했습니다: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType 이미지 선택';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6551,7 +6595,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return '업데이트 있음: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6574,7 +6618,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return '업데이트 설치(v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6585,7 +6629,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\"을(를) 설치하는 중...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6605,7 +6649,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name 설정';
+    return '$name Settings';
   }
 
   @override
@@ -6642,7 +6686,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return '저장소를 불러오지 못했습니다: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6650,15 +6694,15 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '\"$name\"을(를) 제거할까요?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => '제거';
+  String get adminReposRemove => '제거하다';
 
   @override
   String adminReposSaveFailed(String error) {
-    return '저장소를 저장하지 못했습니다: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6780,19 +6824,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminBrandingEnableSplash => '스플래시 화면 활성화';
 
   @override
-  String get adminBrandingSplashUpload => '이미지 업로드';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => '시작 화면을 업데이트했습니다';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => '시작 화면을 업로드하지 못했습니다';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => '시작 화면을 삭제했습니다';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => '사용자 지정 시작 화면 없음';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => '하드웨어 가속';
@@ -6807,115 +6851,121 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => '다음에 대해 하드웨어 디코딩을 활성화합니다.';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV 장치';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => '향상된 NVDEC 디코더 사용';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
-  String get adminPlaybackPreferNativeDecoder => '시스템 기본 하드웨어 디코더 우선';
+  String get adminPlaybackPreferNativeDecoder =>
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => '하드웨어 디코딩 색심도';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10비트 HEVC 디코딩';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10비트 VP9 디코딩';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10비트 디코딩';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12비트 디코딩';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => '하드웨어 인코딩';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC 인코딩 허용';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 인코딩 허용';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
-  String get adminPlaybackIntelLowPowerH264 => 'Intel 저전력 H.264 인코더 사용';
+  String get adminPlaybackIntelLowPowerH264 =>
+      'Enable Intel low-power H.264 encoder';
 
   @override
-  String get adminPlaybackIntelLowPowerHevc => 'Intel 저전력 HEVC 인코더 사용';
+  String get adminPlaybackIntelLowPowerHevc =>
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => '톤 매핑';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => '톤 매핑 사용';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP 톤 매핑 사용';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
-  String get adminPlaybackEnableVtTonemapping => 'VideoToolbox 톤 매핑 사용';
+  String get adminPlaybackEnableVtTonemapping =>
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => '톤 매핑 알고리즘';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => '톤 매핑 모드';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => '톤 매핑 범위';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => '톤 매핑 채도 감소';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => '톤 매핑 피크';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => '톤 매핑 매개변수';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'VPP 톤 매핑 밝기';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP 톤 매핑 대비';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => '프리셋 및 품질';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => '인코더 프리셋';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 인코딩 CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265(HEVC) 인코딩 CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => '디인터레이스 방식';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
-  String get adminPlaybackDeinterlaceDoubleRate => '디인터레이스 시 프레임레이트 두 배로 설정';
+  String get adminPlaybackDeinterlaceDoubleRate =>
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => '오디오';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => '오디오 VBR 인코딩 사용';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => '오디오 다운믹스 증폭';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => '스테레오 다운믹스 알고리즘';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => '최대 먹싱 큐 크기';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => '자동';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => '부호화';
@@ -7026,10 +7076,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminTaskNeverRun => '절대 뛰지 마세요';
 
   @override
-  String get adminTaskStop => '정지';
+  String get adminTaskStop => '멈추다';
 
   @override
-  String get adminRunningTasks => '실행 중인 작업';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => '달리다';
@@ -7051,17 +7101,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return '매일 $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return '매주 $day $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return '$duration마다';
+    return 'Every $duration';
   }
 
   @override
@@ -7099,8 +7149,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count시간',
-      one: '1시간',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7128,17 +7178,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days일 전';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours시간 전';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes분 전';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7146,17 +7196,17 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes분';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours시간';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days일';
+    return '${days}d';
   }
 
   @override
@@ -7166,7 +7216,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      '탐색 미리보기 썸네일을 위한 Trickplay 이미지 생성을 구성합니다.';
+      '미리보기 썸네일 탐색을 위한 트릭플레이 이미지 생성을 구성합니다.';
 
   @override
   String get adminNetworkingPublicHttpsPort => '공용 HTTPS 포트';
@@ -7181,43 +7231,43 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => '공개 HTTP 포트';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS 필수';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      '모든 원격 요청을 HTTPS로 리디렉션합니다. 서버에 유효한 인증서가 없으면 적용되지 않습니다.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => '인증서 비밀번호';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP 설정';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 사용';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 사용';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => '자동 포트 매핑 사용';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN 네트워크';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      '로컬 네트워크로 취급할 IP 주소 또는 CIDR 서브넷 목록입니다. 쉼표나 줄바꿈으로 구분하세요.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => '공개 서버 URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      '서브넷이나 주소를 공개 URL에 매핑합니다. 예: all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => '인증서 경로';
@@ -7247,10 +7297,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => '스로틀 버퍼링';
 
   @override
-  String get adminPlaybackThrottleDelay => '제한 지연 시간(초)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
-  String get adminPlaybackEnableSubtitleExtraction => '실시간 자막 추출 허용';
+  String get adminPlaybackEnableSubtitleExtraction =>
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => '최소 이력서 비율';
@@ -7297,29 +7348,29 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return '콘텐츠 유형을 변경하지 못했습니다: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => '느린 응답 임계값(ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => '느린 응답 경고 사용';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect 사용';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => '서버';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => '메타데이터';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => '경로';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => '성능';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => '캐시 경로';
@@ -7331,7 +7382,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminGeneralServerName => '서버 이름';
 
   @override
-  String get adminGeneralDisplayLanguage => '선호 표시 언어';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => '설정을 로드하지 못했습니다.';
@@ -7341,19 +7392,19 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return '매핑을 업데이트하지 못했습니다: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return '시간 제한: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => '폴더';
 
   @override
-  String get libraries => '라이브러리';
+  String get libraries => '도서관';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7382,8 +7433,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '참가자 #명',
-      one: '참가자 #명',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7423,7 +7474,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return '항목 $index';
+    return 'Item $index';
   }
 
   @override
@@ -7471,12 +7522,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName이(가) SyncPlay 그룹에 참여했습니다';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName이(가) SyncPlay 그룹에서 나갔습니다';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7488,7 +7539,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName에 재생을 동기화하는 중';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7525,8 +7576,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '행 #개 발견',
-      one: '행 #개 발견',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7565,19 +7616,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get offlineSavedMedia => '저장된 미디어';
 
   @override
-  String get offlineBannerTitle => '오프라인 상태입니다';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => '다운로드한 항목을 표시합니다';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => '다운로드';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => '서버에 연결할 수 없습니다';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
-  String get serverUnreachableBannerSubtitle => '복구될 때까지 다운로드한 항목을 재생합니다';
+  String get serverUnreachableBannerSubtitle =>
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7593,12 +7645,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return '캐스트 제어에 실패했습니다: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind 제어';
+    return '$kind Controls';
   }
 
   @override
@@ -7609,7 +7661,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind 중지';
+    return 'Stop $kind';
   }
 
   @override
@@ -7632,12 +7684,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length자리 PIN을 입력하세요';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '$length자리 PIN을 입력하세요';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7650,13 +7702,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get pinForgot => 'PIN을 잊으셨나요?';
 
   @override
-  String get pinClear => '지우기';
+  String get pinClear => '분명한';
 
   @override
   String get pinBackspace => '역행 키이';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect 요청이 승인되었습니다.';
+  String get quickConnectAuthorized => '빠른 연결 요청이 승인되었습니다.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -7669,18 +7721,17 @@ class AppLocalizationsKo extends AppLocalizations {
   String get quickConnectAuthorizeFailed => 'Quick Connect 코드를 승인하지 못했습니다.';
 
   @override
-  String get quickConnectDisabled => '이 서버에서는 Quick Connect가 비활성화되어 있습니다.';
+  String get quickConnectDisabled => '이 서버에서는 빠른 연결이 비활성화되어 있습니다.';
 
   @override
   String get quickConnectForbidden => '귀하의 계정은 이 Quick Connect 요청을 승인할 수 없습니다.';
 
   @override
-  String get quickConnectNotFound =>
-      'Quick Connect 코드를 찾을 수 없습니다. 새 코드를 사용해 보세요.';
+  String get quickConnectNotFound => '빠른 연결 코드를 찾을 수 없습니다. 새 코드를 사용해 보세요.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect에 실패했습니다: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7691,7 +7742,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return '명령을 실행하지 못했습니다: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7720,7 +7771,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return '캐스트를 시작하지 못했습니다: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7765,7 +7816,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name 다운로드 중...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -7784,7 +7835,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shuffleSelectGenre => '장르 선택';
 
   @override
-  String get shuffleLibrary => '라이브러리';
+  String get shuffleLibrary => '도서관';
 
   @override
   String get shuffleGenre => '장르';
@@ -7844,14 +7895,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get stillWatchingContent => '재생이 일시중지되었습니다. 아직도 보고 있나요?';
 
   @override
-  String get stillWatchingStop => '정지';
+  String get stillWatchingStop => '멈추다';
 
   @override
   String get stillWatchingContinue => '계속하다';
 
   @override
   String skipSegment(String segment) {
-    return '$segment 건너뛰기';
+    return 'Skip $segment';
   }
 
   @override
@@ -7862,12 +7913,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$total개 중 $current개 다운로드 중 — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName 다운로드 중';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -7904,7 +7955,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get playerTooltipUnlockOrientation => '순환 허용';
 
   @override
-  String get playerTooltipPrevious => '이전';
+  String get playerTooltipPrevious => '이전의';
 
   @override
   String get playerTooltipSeekBack => '뒤로 탐색';
@@ -7928,13 +7979,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get contextMenuGoToSeries => '시리즈로 이동';
 
   @override
-  String get contextMenuHideFromContinueWatching => '이어서 보기에서 숨기기';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => '다음 볼 항목에서 숨기기';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => '컬렉션에 추가';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => '서버 관리 패널에 액세스';
@@ -7983,14 +8035,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsAlphabetical => '알파벳순';
 
   @override
-  String get settingsConnectionSection => '연결';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => '자체 서명 인증서 허용';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      '자체 서명 또는 사설 CA TLS 인증서를 사용하는 서버를 신뢰합니다. 직접 관리하는 서버에만 사용하세요. 이 설정을 켜면 모든 연결에서 인증서 검증이 해제됩니다.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => '개인정보 보호 및 안전';
@@ -8005,10 +8057,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsGeneralStyleSubtitle => '테마 악센트, 배경, 시청 표시기 및 테마 음악';
 
   @override
-  String get settingsDetailsScreen => '상세 화면';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
-  String get settingsDetailsScreenSubtitle => '스타일, 배경 흐림, 탭 동작';
+  String get settingsDetailsScreenSubtitle =>
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => '홈 페이지';
@@ -8039,10 +8092,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsShowLibrariesButtonInNavigation => '탐색 모음에 라이브러리 버튼 표시';
 
   @override
-  String get settingsShowSeerrButtonInNavigation => '탐색 바에 Seerr 버튼을 표시합니다';
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
 
   @override
-  String get settingsAlwaysExpandNavbarLabels => '상단 탐색 바에 텍스트 라벨을 항상 표시합니다';
+  String get settingsAlwaysExpandNavbarLabels =>
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8108,7 +8163,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsSupportMoonfin => 'Moonfin 지원';
 
   @override
-  String get settingsSupportMoonfinSubtitle => '개발자에게 커피 한 잔 후원하기';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => '합법적인';
@@ -8139,8 +8195,8 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '라이선스 고지 #건',
-      one: '라이선스 고지 #건',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8184,16 +8240,16 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '인트로와 아웃트로를 건너뛰시겠습니까?';
 
   @override
-  String get settingsMediaSegmentCountdown => '미디어 구간 카운트다운';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => '진행 바';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => '타이머';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => '없음';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => '사용자에게 프롬프트';
@@ -8226,13 +8282,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3(권장)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3(레거시)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv(레거시)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv(권장)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision 폴백';
@@ -8410,721 +8466,749 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '최근 공개된 $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => '다음 에피소드 자동 재생';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
-  String get autoplayNextEpisodeSubtitle => '다음 에피소드가 있으면 자동으로 재생합니다.';
+  String get autoplayNextEpisodeSubtitle =>
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => '무음 구간 건너뛰기';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
-  String get skipSilenceSubtitle => '스트림이 지원하는 경우 무음 구간을 자동으로 건너뜁니다.';
+  String get skipSilenceSubtitle =>
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => '외부 오디오 효과 허용';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      '이퀄라이저 및 음향 효과 앱(예: Wavelet)이 Media3 재생 세션에 연결하도록 허용합니다.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => '터널링 끄기';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      '터널링을 사용하지 않고 재생합니다. 터널링 시 오디오/영상이 끊기는 기기에서 유용합니다.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => '터널링 켜기';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      '고급 설정입니다. 오디오와 영상을 결합된 하드웨어 경로로 처리합니다. 일부 기기에서 오디오/영상 끊김이 발생하므로 기본적으로 꺼져 있습니다.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Dolby Vision 프로필 7을 HEVC로 매핑';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Dolby Vision을 지원하지 않는 기기에서 Dolby Vision 프로필 7 스트림을 HDR10 호환 HEVC로 재생합니다.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => '내장 자막 스타일 사용';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      '자막 트랙에 내장된 색상, 글꼴, 위치를 적용합니다. 끄면 사용자가 지정한 자막 스타일이 적용됩니다.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
-  String get subtitlesUseEmbeddedFontSizes => '내장 자막 글자 크기 사용';
+  String get subtitlesUseEmbeddedFontSizes =>
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      '자막 트랙에 내장된 글자 크기 정보를 적용합니다. 끄면 사용자가 지정한 자막 크기가 적용됩니다.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => '미디어 정보 표시';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      '라이브러리 페이지 상단에 선택한 항목의 정보를 표시합니다.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => '탐색 중 배경 이미지를 숨길까요?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => '상세 소제목 사용';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      '라이브러리 페이지에 상세 또는 간단한 하위 행을 표시합니다.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => '저장된 테마를 삭제할까요?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '이 기기의 캐시에서 \"$themeName\"을(를) 삭제할까요?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => '테마 스토어';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => '커뮤니티 테마를 둘러보고 저장하세요';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
-  String get themeStoreDescription => '테마를 저장하면 다른 저장된 테마처럼 사용할 수 있습니다.';
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => '지금은 사용할 수 있는 테마가 없습니다.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      '테마 스토어를 불러올 수 없습니다. 연결 상태를 확인한 후 다시 시도하세요.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => '저장';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => '저장 후 적용';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => '저장됨';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => '이 테마를 불러올 수 없습니다.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\"을(를) 저장했습니다.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '이 기기에서 \"$themeName\"을(를) 삭제했습니다.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\"을(를) 삭제할 수 없습니다.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => '저장된 테마';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      '현재 서버의 Moonfin 플러그인에서 다운로드한 테마입니다. 삭제해도 이 기기의 사본만 지워집니다.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => '이 서버에 저장된 테마가 없습니다.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • 현재 사용 중';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => '저장된 테마 삭제';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
-  String get savedThemesManageSubtitle => '이 기기에 다운로드한 플러그인 테마를 관리합니다';
+  String get savedThemesManageSubtitle =>
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => '테마 편집기';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => '브라우저에서 Moonfin 테마 편집기를 엽니다';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => '홈 화면';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => '하단 바';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => '클래식';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => '모던';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => '홈 행';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => '홈 행 표시';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => '홈 행 섹션';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => '홈 행 켜기/끄기';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
-  String get homeRowTogglesSubtitle => '라이브러리 기반 홈 행 카테고리를 켜거나 끕니다';
+  String get homeRowTogglesSubtitle =>
+      'Enable or disable library-based home row categories';
 
   @override
-  String get homeRowTogglesDescription => '아래 항목을 켜면 홈 섹션에 해당 행이 표시됩니다.';
+  String get homeRowTogglesDescription =>
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      '클래식은 행별 이미지 유형과 정보 오버레이를 유지합니다. 모던은 세로형에서 가로형으로 이어지는 행을 사용합니다.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => '즐겨찾기 행 표시';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
-  String get displayFavoritesRowsSubtitle => '홈 섹션에 즐겨찾는 영화, 시리즈 등의 행을 표시합니다.';
+  String get displayFavoritesRowsSubtitle =>
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => '즐겨찾기 행 정렬';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      '즐겨찾기 행을 추가된 날짜, 공개일, 가나다순 등으로 정렬합니다.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => '컬렉션 행 표시';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
-  String get displayCollectionsRowsSubtitle => '홈 섹션에 컬렉션 행을 표시합니다.';
+  String get displayCollectionsRowsSubtitle =>
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => '컬렉션 행 정렬';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      '컬렉션 행을 추가된 날짜, 공개일, 가나다순 등으로 정렬합니다.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => '장르 행 표시';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => '홈 섹션에 장르 행을 표시합니다.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => '장르 행 정렬';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      '장르 행을 추가된 날짜, 공개일, 가나다순 등으로 정렬합니다.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => '장르 행 항목';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
-  String get genresRowItemsDescription => '장르 행에 영화, 시리즈 또는 둘 다를 표시합니다.';
+  String get genresRowItemsDescription =>
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => '재생목록 행 표시';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
-  String get displayPlaylistsRowsSubtitle => '홈 섹션에 재생목록 행을 표시합니다.';
+  String get displayPlaylistsRowsSubtitle =>
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => '재생목록 행 정렬';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      '재생목록 행을 추가된 날짜, 공개일, 가나다순 등으로 정렬합니다.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => '오디오 행 표시';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => '홈 섹션에 오디오 행을 표시합니다.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => '오디오 행 정렬';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      '오디오 행을 추가된 날짜, 공개일, 가나다순 등으로 정렬합니다.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => '오디오 재생목록';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => '모양';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => '레이아웃';
+  String get layout => 'Layout';
 
   @override
-  String get theme => '테마';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => '키보드';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => '버튼';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => '렌더링';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV 설정';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => '외부 플레이어 앱';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      '외부 플레이어를 지정하면 길게 눌러 재생하는 옵션을 사용할 수 있습니다';
+      'Set external player to enable long-press play option';
 
   @override
-  String get externalPlayerAskEachTimeSubtitle => '재생을 시작할 때 앱 선택 창을 표시합니다.';
+  String get externalPlayerAskEachTimeSubtitle =>
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => '설치된 플레이어를 불러오는 중...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => '연결';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => '오디오 트랜스코딩 대상';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => '패스스루';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => '이 기기에서 지원됨';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => '이 기기에서 지원되지 않음';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X(DTS UHD) 패스스루';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X(DTS UHD)를 외부 디코더로 비트스트림 전송합니다.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
-  String get settingsAudioTrueHdJocPassthrough => 'TrueHD Atmos(JOC) 패스스루';
+  String get settingsAudioTrueHdJocPassthrough =>
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => '미디어 플레이어 동작';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => '재생 향상 기능';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => '항상 켜짐.';
+  String get alwaysOn => 'Always on.';
 
   @override
-  String get replaceSkipOutroWithNextUpDisplay => '엔딩 건너뛰기 대신 다음 볼 항목 표시';
+  String get replaceSkipOutroWithNextUpDisplay =>
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '엔딩 건너뛰기 버튼 대신 다음 볼 항목 오버레이를 표시합니다.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => '플레이어 라우팅';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => '소프트웨어 디코더 우선';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      '하드웨어 디코더보다 FFmpeg(오디오)와 libgav1(AV1)을 먼저 사용합니다. HDMI 오디오 패스스루에 문제가 생기면 끄세요.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
-  String get useExternalPlayerSubtitle => 'Android TV에서 선택한 외부 앱으로 영상을 재생합니다.';
+  String get useExternalPlayerSubtitle =>
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => '자동 대기열 추가';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH 자막 우선';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
-  String get preferSdhSubtitlesSubtitle => '자막을 자동으로 선택할 때 SDH/CC 트랙을 우선합니다.';
+  String get preferSdhSubtitlesSubtitle =>
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => '웹 진단';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin 웹 진단';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      '이 페이지에서 브라우저 연결 문제(CORS, 혼합 콘텐츠, 검색 설정)를 진단할 수 있습니다.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
-  String get webDiagnosticsDetectedMixedContentFailure => '혼합 콘텐츠 오류 감지됨';
+  String get webDiagnosticsDetectedMixedContentFailure =>
+      'Detected Mixed-Content Failure';
 
   @override
-  String get webDiagnosticsDetectedCorsPreflightFailure => 'CORS/프리플라이트 오류 감지됨';
+  String get webDiagnosticsDetectedCorsPreflightFailure =>
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin이 HTTPS 페이지에서 HTTP 서버 URL을 호출하려는 시도를 감지했습니다. 브라우저는 이 요청이 서버에 도달하기 전에 차단합니다.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin이 브라우저 수준의 요청 실패를 감지했습니다. 보통 미디어 서버에 CORS 또는 프리플라이트 헤더가 없을 때 발생합니다.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return '대상 URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return '상세 정보: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => '현재 실행 환경';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => '출처';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => '스킴';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => '플러그인 모드';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC 검색';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => '강제 지정 서버 URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => '기본 서버 URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => '검색 프록시 URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => '설정되지 않음';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => '혼합 콘텐츠';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      '이 페이지는 HTTPS로 로드되었지만 설정된 URL 중 하나 이상이 HTTP입니다. 브라우저는 HTTPS 페이지에서 HTTP API를 호출하지 못하게 차단합니다.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      '해결 방법: 미디어 서버나 프록시 엔드포인트를 HTTPS로 제공하거나, 신뢰할 수 있는 로컬 네트워크에서만 Moonfin을 HTTP로 사용하세요.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      '현재 실행 설정에서 뚜렷한 혼합 콘텐츠 문제가 감지되지 않았습니다.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS 점검 목록';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin에 브라우저 출처를 허용하세요.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers에 Authorization, X-Emby-Authorization, X-Emby-Token을 포함하세요.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• 스트리밍과 탐색을 위해 Content-Range와 Accept-Ranges를 노출하세요.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS 프리플라이트 요청에 204를 반환하세요.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
-  String get webDiagnosticsHeaderSnippetTitle => '헤더 예시(nginx 형식)';
+  String get webDiagnosticsHeaderSnippetTitle =>
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => '참고';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      '이 진단 페이지는 웹 빌드용입니다. 다른 플랫폼에서 보고 있다면 여기의 점검 항목이 적용되지 않을 수 있습니다.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => '서버 선택으로 돌아가기';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => '모든 사용자 로그아웃';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      '마이크 권한이 영구적으로 거부되었습니다. 시스템 설정에서 허용하세요.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
-  String get voiceSearchPermissionRequired => '음성 검색을 사용하려면 마이크 권한이 필요합니다.';
+  String get voiceSearchPermissionRequired =>
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => '잘 알아듣지 못했습니다. 다시 시도하세요.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => '음성이 감지되지 않았습니다.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => '마이크 오류입니다.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => '음성 검색에는 인터넷 연결이 필요합니다.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => '음성 서비스가 사용 중입니다. 다시 시도하세요.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
-  String get microphonePermissionPermanentlyDenied => '마이크 권한이 영구적으로 거부되었습니다.';
+  String get microphonePermissionPermanentlyDenied =>
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => '마이크 권한이 거부되었습니다.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
-  String get speechRecognitionUnavailable => '이 기기에서는 음성 인식을 사용할 수 없습니다.';
+  String get speechRecognitionUnavailable =>
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS 출력 선택기 열기';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      '이 기기에서는 AirPlay 출력 선택기를 사용할 수 없습니다.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => '동영상';
+  String get videos => 'Videos';
 
   @override
-  String get programs => '프로그램';
+  String get programs => 'Programs';
 
   @override
-  String get songs => '노래';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => '사진 앨범';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => '사진';
+  String get photos => 'Photos';
 
   @override
-  String get people => '인물';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => '최근 공개된 에피소드';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => '다시 보기';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => '특별 출연';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => '출연작(Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => '제작 참여작(Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => '그룹과 함께 보기';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => '오류';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => '경고';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => '디스크';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => '브라우저에서 열기';
+  String get openInBrowser => 'Open in Browser';
 
   @override
-  String get embeddedBrowserNotAvailable => '이 플랫폼에서는 내장 브라우저를 사용할 수 없습니다.';
+  String get embeddedBrowserNotAvailable =>
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get adminRestartServerConfirmation => '서버를 재시작할까요?';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      '서버를 종료할까요? 다시 시작하려면 직접 실행해야 합니다.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => '내부';
+  String get internal => 'Internal';
 
   @override
-  String get idle => '대기 중';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => '사용자를 찾을 수 없습니다';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => '검색 조건과 일치하는 사용자가 없습니다';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => '기기를 찾을 수 없습니다';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
-  String get adminNoDevicesMatchCurrentFilters => '현재 필터와 일치하는 기기가 없습니다';
+  String get adminNoDevicesMatchCurrentFilters =>
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => '비밀번호 설정됨';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => '설정된 비밀번호 없음';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => '원격 접속';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => '로컬 전용';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => '미디어 분석 정보를 불러오지 못했습니다';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
-  String get analyticsCombinedAcrossLibraries => '모든 미디어 라이브러리를 합산한 분석입니다.';
+  String get analyticsCombinedAcrossLibraries =>
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => '인기 아티스트';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => '인기 저자';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => '주요 참여자';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '라이브러리 $count개',
-      one: '라이브러리 1개',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      '아직 이 선택 항목에 대한 색인된 미디어 집계가 없습니다.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => '라이브러리 상세 정보';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => '라이브러리별 분석';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => '사용할 수 있는 라이브러리가 없습니다.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => '서버 관리';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => '데이터';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => '이미지 캐시';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => '캐시';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => '로그';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => '메타데이터';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => '트랜스코딩';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => '이 서버에서 반환한 서버 경로가 없습니다.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% 사용 중';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => '사용자 활동';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => '시스템 이벤트';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => '확인 필요';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => '서버';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => '재생';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => '기기';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => '고급';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => '플러그인';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => '실시간 TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => '홈 비디오';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => '혼합 콘텐츠';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => '홈 비디오 및 사진';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => '영화 및 TV 프로그램 혼합';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9136,295 +9220,299 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => '녹화된 항목이 없습니다';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension 압축 파일에서 이미지 페이지를 찾을 수 없습니다.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return '내장 렌더러 오류($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB 렌더러 오류($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return '리더에서 사용할 로컬 파일이 없습니다: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri에서 도서 데이터를 여는 중 HTTP $status 오류가 발생했습니다';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => '읽을 수 있는 도서 엔드포인트가 없습니다';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return '지원하지 않는 만화 압축 형식: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      '이 플랫폼에서는 CBR 압축 해제 플러그인을 사용할 수 없습니다.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '.cbr 압축 파일을 풀지 못했습니다.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => '이 플랫폼에서는 CB7 압축 해제를 사용할 수 없습니다.';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      '이 플랫폼에서는 CB7 압축 해제 플러그인을 사용할 수 없습니다.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => '장르 패널 닫기';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => '셔플을 불러오는 중...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => '라이브러리 셔플';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => '랜덤 셔플';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => '장르 셔플';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'HDR 자동 전환';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR 영상을 재생할 때 HDR을 자동으로 켜고, 종료하면 원래 디스플레이 모드로 되돌립니다.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => '전체 화면일 때';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => '아트워크 변경';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => '없음';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => '트랜스코딩 제한';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => '모든 아트워크를 지울까요?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
-  String get clearAllArtworkWarning => '다운로드한 아트워크를 모두 지울까요?';
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => '지우기 확인';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return '이 $itemType을(를) 지울까요?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => '업로드할까요?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => '해상도: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => '인터페이스 언어의 아트워크만 표시';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => '모두 지우기 확인';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => '이미지를 업로드했습니다!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return '이미지를 업로드하지 못했습니다: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return '이미지를 설정하지 못했습니다: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return '이미지를 삭제하지 못했습니다: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return '모든 아트워크를 지우지 못했습니다: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => '예';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => '포스터';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => '배경 이미지';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => '배너';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => '로고';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => '썸네일';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => '아트';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => '디스크 아트';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => '스크린샷';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => '패키지 앞면';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => '패키지 뒷면';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => '메뉴 아트';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => '포스터';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => '배경 이미지';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => '배너';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => '로고';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => '썸네일';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => '아트';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => '디스크 아트';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => '스크린샷';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => '패키지 앞면';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => '패키지 뒷면';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => '메뉴 아트';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => '전체';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => '높음(1080p 이상)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => '보통(720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => '낮음(720p 미만)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => '제공처';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => '챕터';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => '북마크';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => '메모';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => '재생 대기열';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => '타임라인';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => '타임라인이 비어 있습니다';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => '전체 책';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => '집중 타임라인';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => '북마크 내보내기';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => '메모 내보내기';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => '전체 내보내기';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path에 내보냈습니다';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return '내보내기에 실패했습니다: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => '가사';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => '북마크 추가';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => '메모 추가';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => '메모 편집';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => '이 지점에 대한 메모를 작성하세요';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => '취침 타이머';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => '끔';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => '챕터 끝까지';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => '직접 설정';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining 남음';
+    return '$remaining left';
   }
 
   @override
@@ -9432,58 +9520,58 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count분',
-      one: '1분',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => '재생 속도';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => '남은 시간';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => '재생 시간';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds초 뒤로';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds초 앞으로';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => '이전 챕터';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => '다음 챕터';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '챕터 $current/$total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => '챕터 없음';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => '북마크가 없습니다';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => '메모가 없습니다';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position에 북마크를 추가했습니다';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x로 초기화';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9491,241 +9579,249 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => '저장';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => '취소';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => '삭제';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => '자막 환경설정';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      '자막 모드, 기본 언어, 모양, 렌더링 옵션을 변경합니다.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => '자막 렌더링';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => '표시 옵션';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => '공개일순(오름차순)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => '공개일순(내림차순)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => '참여작 묶기';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => '여러 역할 묶기';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => '라이브러리 쓰기 권한 경고';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => '해결 방법:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. 서버의 미디어 라이브러리 폴더에 대해 Jellyfin 서비스 사용자(예: jellyfin 또는 Docker PUID/PGID)에게 쓰기 권한을 부여하세요.\n\n2. 또는 Jellyfin 대시보드 -> 라이브러리에서 이 라이브러리를 편집해 \'아트워크를 미디어 폴더에 저장\'을 끄면 아트워크가 Jellyfin 내부 데이터베이스에 저장됩니다.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => '닫기';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '\'$libraryName\' 라이브러리가 아트워크를 미디어 폴더에 직접 저장하도록 설정되어 있습니다(\'아트워크를 미디어 폴더에 저장\'이 켜져 있음). 하지만 Jellyfin이 쓰기 권한을 확인한 결과 다음 디렉터리에 파일을 쓸 권한이 없습니다:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin이 아트워크를 업데이트하지 못한 것으로 보입니다. 이 라이브러리는 아트워크를 미디어 폴더에 직접 저장하도록 설정되어 있습니다(\'아트워크를 미디어 폴더에 저장\'이 켜져 있음). 이 오류는 보통 Jellyfin 서버 프로세스가 미디어 디렉터리에 파일을 쓸 권한이 없을 때 발생합니다.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => '외부 목록';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => '다시 재생';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => '파일 정보';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return '크기: $size  •  형식: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return '오디오 트랙 모두 보기($count개)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return '자막 트랙 모두 보기($count개)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => '다이렉트 재생 가능 여부 확인 중...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => '다이렉트 재생 가능 여부: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => '강제 자막';
+  String get forced => 'Forced';
 
   @override
-  String get transcodeContainerNotSupported => '플레이어가 지원하지 않는 컨테이너 형식입니다.';
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => '지원하지 않는 비디오 코덱입니다.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => '지원하지 않는 오디오 코덱입니다.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      '지원하지 않는 자막 형식입니다(영상에 입혀야 합니다).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => '지원하지 않는 오디오 프로필입니다.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => '지원하지 않는 비디오 프로필입니다.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => '지원하지 않는 비디오 레벨입니다.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      '이 기기에서 지원하지 않는 영상 해상도입니다.';
+      'Video resolution is not supported by this device.';
 
   @override
-  String get transcodeVideoBitDepthNotSupported => '지원하지 않는 비디오 비트 심도입니다.';
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
 
   @override
-  String get transcodeVideoFramerateNotSupported => '지원하지 않는 영상 프레임레이트입니다.';
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      '파일 비트레이트가 플레이어의 스트리밍 한도를 초과합니다.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
-  String get transcodeVideoBitrateExceedsLimit => '비디오 비트레이트가 스트리밍 한도를 초과합니다.';
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioBitrateExceedsLimit => '오디오 비트레이트가 스트리밍 한도를 초과합니다.';
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioChannelsNotSupported => '지원하지 않는 오디오 채널 수입니다.';
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => '가나다순';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => '공개순(오름차순)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => '공개순(내림차순)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => '사용자 지정(끌어서 놓기)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => '재생목록 정렬 옵션';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => '정렬 초기화';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode 다시 보기';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => '재생목록 다시 보기';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => '자막을 찾을 수 없습니다.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => '관리자 제어';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => '렌더링 엔진(Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller는 더 부드러운 애니메이션과 적은 끊김을 제공하는 Flutter의 최신 GPU 렌더러입니다. 일부 TV 박스나 오래된 GPU에서는 화면 깨짐이나 검은 영상이 나타날 수 있으며, 이 경우 끄세요. 자동은 기기에 가장 알맞은 기본값을 선택합니다. 적용하려면 Moonfin을 다시 시작하세요.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => '자동';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => '켬';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => '끔';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => '재시작 필요';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      '렌더링 엔진을 변경하려면 Moonfin을 다시 시작해야 합니다. 지금 앱을 종료한 후 다시 실행하면 적용됩니다.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => '지금 앱 종료';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => '라이브러리 새로고침';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => '모든 라이브러리 새로고침';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => '추가된 날짜(오래된순)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => '추가된 날짜(최신순)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => '가나다순(A~Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => '가나다 역순(Z~A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return '서버 분석 정보를 불러오는 중... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => '원본과 동일';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 상위 250개 영화';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 상위 250개 TV 프로그램';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb 인기 영화';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb 인기 TV 프로그램';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb 최저 평점 영화';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb 영어 영화 평점 순위';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -9,30 +9,30 @@ class AppLocalizationsLt extends AppLocalizations {
   AppLocalizationsLt([String locale = 'lt']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Mėnulio pelekas';
 
   @override
-  String get accountPreferences => 'PASKYROS NUOSTATOS';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Sąsajos kalba';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Sistemos numatytoji';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Prisijunkite';
 
   @override
-  String get empty => 'Tuščia';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Jungiamasi prie $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Greitas prisijungimas';
 
   @override
   String get password => 'Slaptažodis';
@@ -61,12 +61,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect nepasiekiamas: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect nepasiekiamas ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin versija $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Pašalinti „$serverName“ iš jūsų serverių?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsAppearanceTheme => 'Programos tema';
 
   @override
-  String get detailScreenStyle => 'Detalių ekrano stilius';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasikinis – originalus centruotas Moonfin išdėstymas. Modernus – prisitaikantis kinematografinis išdėstymas.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasikinis';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Modernus';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Išskleisti skirtukai';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automatiškai rodyti skirtuko turinį naršant skirtukus. Išjunkite, kad kiekvieną skirtuką atidarytumėte ir uždarytumėte rankiniu būdu.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Rodyti techninę informaciją?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Rodyti kodeko, raiškos ir srauto informaciją antraštės santraukoje';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Rekomendacijų sistema';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Naudokite Moonfin Recommends vietinės bibliotekos algoritmą arba internetinius TMDB panašumo rodiklius. Pastaba: internetinėms rekomendacijoms reikia Seerr integracijos.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb panašumas';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Taikyti amžiaus cenzo ribą?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Riboti Moonfin Recommends pasiūlymus pagal pasirinktos medijos amžiaus cenzą';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Sąsajos stilius';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatinis prisitaiko prie jūsų įrenginio. Pasirinkite Apple arba Material, kad nustatytumėte konkrečią išvaizdą.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatinis';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsLt extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Stiklo kokybė';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automatinis parenka geriausią stiklo efektą šiam įrenginiui. Visas įjungia tikrą suliejimą; Sumažintas naudoja lengvą stiklą, taupantį GPU energiją.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automatinis';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Visas';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Sumažintas';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Perjunkite „Moonfin“ ir „Neon Pulse“ iš naujo nepaleidę programos';
 
   @override
-  String get customThemeTitle => 'Pasirinktinė tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Pasirinktinės temos keičia vaizdo elementus visoje Moonfin programoje. Pasirinkite vieną iš šių parinkčių pagal savo stilių.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Pirmenybė sistemos klaviatūrai';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Tekstui įvesti pagal numatytuosius nustatymus naudoti įrenginio įvesties metodą';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Mėnulio pelekas';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsLt extends AppLocalizations {
       'Synthwave stilius su purpuriniu švytėjimu, žalsvai mėlynu tekstu ir stipresniu chromo kontrastu';
 
   @override
-  String get themeGlass => 'Stiklas';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Skysto stiklo stilius su slenkančiu gradiento fonu, matiniais paviršiais ir Apple mėlynu akcentu';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8 bitų herojus';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pikselių meno stilius su stambia palete, blokiniais rėmeliais, ryškiais šešėliais ir pikselių šriftu';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Nepavyko prisijungti prie $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,35 +327,35 @@ class AppLocalizationsLt extends AppLocalizations {
   String get exit => 'Išeiti';
 
   @override
-  String get gameMenu => 'Meniu';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pristabdyta';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Įrašyti būseną';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Žaidimai';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Įkelti būseną';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Pagreitinti';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emuliatoriaus nustatymai';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Šis branduolys neturi keičiamų parinkčių.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Palaikykite, kad atidarytumėte meniu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Žaidimai šiame įrenginyje kol kas nepalaikomi.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nepavyko įkelti jokių pradinių eilučių';
@@ -377,7 +377,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get schedule => 'Tvarkaraštis';
 
   @override
-  String get series => 'Serialai';
+  String get series => 'Serija';
 
   @override
   String get noItemsFound => 'Elementų nerasta';
@@ -413,7 +413,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noLibrariesFound => 'Bibliotekų nerasta';
 
   @override
-  String get library => 'Biblioteka';
+  String get library => 'biblioteka';
 
   @override
   String get displaySettings => 'Ekrano nustatymai';
@@ -426,7 +426,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Nepavyko įkelti aplanko: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -434,7 +434,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return 'Elementų: $count';
+    return '$count items';
   }
 
   @override
@@ -451,7 +451,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return 'Elementų: $count';
+    return '$count Items';
   }
 
   @override
@@ -492,7 +492,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — žanrai';
+    return '$name — Genres';
   }
 
   @override
@@ -505,7 +505,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get albumArtists => 'Albumo menininkai';
 
   @override
-  String get artists => 'Atlikėjai';
+  String get artists => 'Menininkai';
 
   @override
   String get bookmarks => 'Žymės';
@@ -530,17 +530,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'prieš $count min.';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'prieš $count val.';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'prieš $count d.';
+    return '${count}d ago';
   }
 
   @override
@@ -575,7 +575,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return 'Pavadinimų: $count';
+    return '$count titles';
   }
 
   @override
@@ -662,17 +662,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return 'Autorių: $count';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return 'Žanrų: $count';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return 'Užbaigta $percent%';
+    return '$percent% completed';
   }
 
   @override
@@ -689,7 +689,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'Pavadinimų: $count. Išdėstyta patogiam skaitymui.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -726,7 +726,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label nerasta';
+    return 'No $label found';
   }
 
   @override
@@ -745,13 +745,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get readStatus => 'Skaityti';
 
   @override
-  String get watched => 'Žiūrėta';
+  String get watched => 'Žiūrėjo';
 
   @override
   String get unread => 'Neskaityta';
 
   @override
-  String get unwatched => 'Nežiūrėta';
+  String get unwatched => 'Nežiūrėtas';
 
   @override
   String get seriesStatus => 'Serijos būsena';
@@ -763,45 +763,43 @@ class AppLocalizationsLt extends AppLocalizations {
   String get books => 'Knygos';
 
   @override
-  String get latestBooks => 'Naujausios knygos';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Naujausios garso knygos';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knygų',
-      many: '$count knygos',
-      few: '$count knygos',
-      one: '$count knyga',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Knyga';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Garso knyga';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Perskaityta $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Liko $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Skaityti';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Klausyti';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autorius';
@@ -839,12 +837,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return 'Skyrių: $count';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Pirmą kartą išleista $year';
+    return 'First published $year';
   }
 
   @override
@@ -859,7 +857,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return 'Knygų: $count';
+    return '$count books';
   }
 
   @override
@@ -870,7 +868,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return 'Autorių: $count';
+    return '$count Authors';
   }
 
   @override
@@ -878,10 +876,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count garso knygų',
-      many: '$count garso knygos',
-      few: '$count garso knygos',
-      one: '$count garso knyga',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -917,7 +913,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get nextUp => 'Kitas';
 
   @override
-  String get seasons => 'Sezonai';
+  String get seasons => 'Metų laikai';
 
   @override
   String get chapters => 'Skyriai';
@@ -929,7 +925,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get movies => 'Filmai';
 
   @override
-  String get musicVideos => 'Muzikiniai vaizdo klipai';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Kita';
@@ -944,11 +940,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tableOfContents => 'Turinys';
 
   @override
-  String get tracklist => 'Takelių sąrašas';
+  String get tracklist => 'Tracklist';
 
   @override
   String discNumber(int number) {
-    return '$number diskas';
+    return 'Disc $number';
   }
 
   @override
@@ -972,7 +968,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Išleista $year';
+    return 'Published $year';
   }
 
   @override
@@ -983,54 +979,52 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezonų',
-      many: '$count sezono',
-      few: '$count sezonai',
-      one: '$count sezonas',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Baigsis $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Elementai';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Priedai';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Užkulisiai';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Iškirptos scenos';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Apžvalginiai filmukai';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Interviu';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scenos';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Trumpametražiai filmai';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Anonsai';
+  String get trailers => 'Priekabos';
 
   @override
   String timeRemaining(String time) {
-    return 'Liko $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Baigsis po $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1044,11 +1038,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Tęsti nuo $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Leisti';
+  String get play => 'Žaisti';
 
   @override
   String get startOver => 'Pradėti iš naujo';
@@ -1072,10 +1066,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get version => 'Versija';
 
   @override
-  String get cast => 'Transliuoti';
+  String get cast => 'Aktoriai';
 
   @override
-  String get trailer => 'Anonsas';
+  String get trailer => 'Priekaba';
 
   @override
   String get finished => 'Baigta';
@@ -1142,7 +1136,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Ištrinti atsisiųstus „$title“ takelius?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1157,17 +1151,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel neįkelta';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Atsisiunčiama $title ($count elem.)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Ar tikrai norite ištrinti „$name“ iš serverio? Šio veiksmo anuliuoti nepavyks.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1178,7 +1172,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Nepalaikomas knygos formatas: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1205,7 +1199,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Subtitrai atsisiųsti ir pasirinkti: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1214,7 +1208,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Nuotolinių subtitrų ($language) nerasta.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1222,7 +1216,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return '$number versija';
+    return 'Version $number';
   }
 
   @override
@@ -1242,7 +1236,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Atsisiunčiama $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1250,7 +1244,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Ištrinti vietinius failus: $typeLabel?\n\nTaip atlaisvinsite vietos saugykloje. Vėliau galėsite atsisiųsti iš naujo.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1266,25 +1260,25 @@ class AppLocalizationsLt extends AppLocalizations {
   String get director => 'DIREKTORIAUS';
 
   @override
-  String get directors => 'REŽISIERIAI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENARISTAS';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARISTAI';
+  String get writers => 'RAŠYTOJAI';
 
   @override
   String get studio => 'STUDIJA';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count daugiau';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return 'Serijų: $count';
+    return '$count Episodes';
   }
 
   @override
@@ -1294,12 +1288,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return '$number serija';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '$number skyrius';
+    return 'Chapter $number';
   }
 
   @override
@@ -1307,10 +1301,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count takelių',
-      many: '$count takelio',
-      few: '$count takeliai',
-      one: '$count takelis',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1320,27 +1312,25 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count skyrių',
-      many: '$count skyriaus',
-      few: '$count skyriai',
-      one: '$count skyrius',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Gimė $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Mirė $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Amžius: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1353,17 +1343,17 @@ class AppLocalizationsLt extends AppLocalizations {
   String get shuffle => 'Maišyti';
 
   @override
-  String get shuffleAllMusic => 'Maišyti visą muziką';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Prisijunkite prie Moonfin telefone';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Nepavyksta pasiekti serverio';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return 'Atsisiuntimų: $count';
+    return '$count downloads';
   }
 
   @override
@@ -1371,7 +1361,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1382,32 +1372,32 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Nuotolinių subtitrų veiksmui „$action“ šiam naudotojui reikia Jellyfin subtitrų valdymo teisės.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Šio elemento serveryje rasti nepavyko, todėl nuotolinių subtitrų veiksmas „$action“ neįmanomas.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Nuotolinių subtitrų veiksmas „$action“ nepavyko: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Nuotolinių subtitrų veiksmas „$action“ nepavyko (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Nepavyko atlikti nuotolinių subtitrų veiksmo „$action“.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'visos atsisiųstos „$name“ serijos';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1436,17 +1426,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label veiksmas nepavyko: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Nepavyko nustatyti transliavimo garsumo: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label valdikliai';
+    return '$label Controls';
   }
 
   @override
@@ -1463,7 +1453,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Sustabdyti $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1471,7 +1461,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '$number takelis';
+    return 'Track $number';
   }
 
   @override
@@ -1488,7 +1478,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sek.';
+    return '$seconds seconds';
   }
 
   @override
@@ -1503,7 +1493,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automatinis';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1518,19 +1508,19 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
   String get subtitleDelay => 'Subtitrų vėlavimas';
 
   @override
-  String get reset => 'Atstatyti';
+  String get reset => 'Nustatyti iš naujo';
 
   @override
   String get unknown => 'Nežinoma';
@@ -1557,13 +1547,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get transcodeReasons => 'Perkodavimo priežastys';
 
   @override
-  String get player => 'Grotuvas';
+  String get player => 'Žaidėjas';
 
   @override
   String get container => 'Konteineris';
 
   @override
-  String get bitrate => 'Bitų sparta';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Vaizdo įrašas';
@@ -1581,7 +1571,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get videoBitrate => 'Vaizdo įrašo pralaidumas';
 
   @override
-  String get track => 'Takelis';
+  String get track => 'Trasa';
 
   @override
   String get channels => 'Kanalai';
@@ -1603,12 +1593,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol seanso klaida';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Nepavyko įkelti knygos informacijos: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1617,7 +1607,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Šis formatas (.$extension) programoje kol kas nerodomas.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1630,17 +1620,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Nepavyko atidaryti programos skaityklės: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Žymė ties $label jau išsaugota.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Žymė pridėta: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1652,7 +1642,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '$number psl.';
+    return 'Page $number';
   }
 
   @override
@@ -1663,12 +1653,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Formatas: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return 'Perskaityta $percent%';
+    return '$percent% read';
   }
 
   @override
@@ -1691,7 +1681,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Atstatyti mastelį (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1714,7 +1704,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Nepavyko atnaujinti skaitymo būsenos: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1748,7 +1738,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ši platforma negali paleisti integruoto $extension failų dokumentų variklio.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1787,7 +1777,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Nepavyko įkelti programų gido: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1798,22 +1788,22 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Toliau: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Liko $minutes min.';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Liko $hours val.';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Liko $hours val. $minutes min.';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1836,19 +1826,19 @@ class AppLocalizationsLt extends AppLocalizations {
   String get favoriteChannel => 'Mėgstamiausias kanalas';
 
   @override
-  String get record => 'Įrašyti';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Atšaukti įrašymą';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Laida suplanuota įrašyti';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Įrašymas atšauktas';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Nepavyko sukurti įrašo';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Žiūrėti';
@@ -1858,7 +1848,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Nepavyko paleisti $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1884,11 +1874,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Atšaukti suplanuotą „$name“ įrašymą?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Ne';
+  String get no => 'Nr';
 
   @override
   String get yesCancel => 'Taip, atšaukti';
@@ -1910,7 +1900,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Nutraukti „$name“ įrašymą?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1925,19 +1915,19 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Nieko nerasta pagal „$query“';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Paieška nepavyko: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr paskyros tipas';
+  String get seerrAccountType => 'Serr paskyros tipas';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1971,12 +1961,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Pašalinti „$name“ ir susijusius failus?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return 'Takelių: $count';
+    return '$count tracks';
   }
 
   @override
@@ -1987,12 +1977,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Nepavyko įkelti albumo: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Atsisiųstų „$name“ takelių nerasta.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2009,7 +1999,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Pašalinti „$name“?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2024,7 +2014,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return '$number serija';
+    return 'Episode $number';
   }
 
   @override
@@ -2038,12 +2028,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return '$number sezonas';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return '$number sez.';
+    return 'S$number';
   }
 
   @override
@@ -2054,7 +2044,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Ištrinti visas atsisiųstas $season serijas?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2062,10 +2052,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count serijų',
-      many: '$count serijos',
-      few: '$count serijos',
-      one: '$count serija',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2100,7 +2088,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Ištrinti atsisiųstus elementus ($count)?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2114,7 +2102,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'iš $limit limito';
+    return 'of $limit limit';
   }
 
   @override
@@ -2199,7 +2187,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return 'Parinkčių: $count';
+    return '$count options';
   }
 
   @override
@@ -2293,7 +2281,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Išsamios informacijos puslapiai, pradžios ekrano eilutės ir garsumas';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2308,18 +2296,18 @@ class AppLocalizationsLt extends AppLocalizations {
       'Leisti naršant pagrindiniame ekrane';
 
   @override
-  String get loopThemeMusic => 'Kartoti temos muziką';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Kartoti takelį, o ne paleisti jį vieną kartą';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Išsami informacija Fono suliejimas';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2335,23 +2323,23 @@ class AppLocalizationsLt extends AppLocalizations {
   String get playerZoomMode => 'Grotuvo mastelio keitimo režimas';
 
   @override
-  String get settingsScrollWheelAction => 'Pelės slinkties ratukas';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Pasirinkite, ką atlieka pelės ratuko sukimas virš vaizdo įrašo atkūrimo metu.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Išjungta';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Peršokti (pirmyn / atgal)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Garsumas';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Garsumas';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Tinka';
@@ -2405,38 +2393,37 @@ class AppLocalizationsLt extends AppLocalizations {
   String get defaultAudioLanguage => 'Numatytoji garso kalba';
 
   @override
-  String get fallbackAudioLanguage => 'Atsarginė garso takelio kalba';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Pirmenybė numatytajam garso takeliui';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Teikti pirmenybę originaliam garso takeliui, o ne lokalizuotam įgarsinimui.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'Pirmenybė garsinio vaizdavimo takeliams';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Teikti pirmenybę garsinio vaizdavimo takeliams, o ne įprastiems.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Perkodavimas (garsas)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Tiesioginis srautas (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Perkodavimas (bitų sparta arba raiška)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Perkodavimas (vaizdas ir garsas)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Perkodavimas (vaizdas)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatinis (numatytasis serveris)';
@@ -2513,29 +2500,27 @@ class AppLocalizationsLt extends AppLocalizations {
       'Įgalinti „TrueHD“ garsą (gali veikti ne visose platformose)';
 
   @override
-  String get settingsAudioOutputMode => 'Garso išvesties režimas';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Pasirinkite, kaip dekoduojamas garsas. „AVR tiesioginis perdavimas“ siunčia neapdorotus Dolby / DTS srautus į imtuvą; „Automatinis“ arba „Sumaišymas“ dekoduoja vietoje.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough =>
-      'AVR tiesioginis perdavimas';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Atsarginis garso kodekas';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Pasirinkite formatą, į kurį bus perkoduojamas daugiakanalis garsas, kai šaltinio srauto negalima paleisti tiesiogiai ar perduoti be pakeitimų.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Aptikti automatiškai\n(rekomenduojama)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(numatytasis)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2544,27 +2529,26 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(be nuostolių)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(tik stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(efektyvus)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(be nuostolių)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Daugiausia garso kanalų';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Nurodykite didžiausią garso sistemos kanalų skaičių. Šią ribą viršijantys daugiakanaliai srautai bus sumaišyti arba perkoduoti.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Aptikti automatiškai\n(įrangos numatytasis)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2573,90 +2557,85 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 erdvinis';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 kvadrofoninis';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 erdvinis';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 erdvinis';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 erdvinis';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 erdvinis';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced =>
-      'Tiesioginis perdavimas (išplėstiniai)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Kodekų tiesioginis perdavimas';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Įjunkite tik tuos formatus, kuriuos palaiko jūsų AVR arba HDMI imtuvas.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 tiesioginis perdavimas';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough =>
-      'EAC3 JOC (Atmos) tiesioginis perdavimas';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough =>
-      'DTS Core tiesioginis perdavimas';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough =>
-      'DTS-HD MA tiesioginis perdavimas';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD tiesioginis perdavimas';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough =>
-      'TrueHD Atmos tiesioginis perdavimas';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Perduoti Dolby Digital Plus (EAC3) bitų srautą į išorinį dekoderį.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Perduoti Dolby Atmos per EAC3 (JOC) bitų srautą į išorinį dekoderį.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Perduoti DTS-HD MA (įskaitant DTS Core) bitų srautą į išorinį dekoderį.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Perduoti Dolby TrueHD su Atmos metaduomenimis bitų srautą į išorinį dekoderį.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Aptiktos garso galimybės';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Vykdymo aplinkos galimybių momentinė kopija dar nepasiekiama.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Maršrutas';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekodavimas';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Tiesioginis perdavimas';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD garso maršrutas';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2671,51 +2650,50 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Garsiakalbis';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Ausinės';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostika';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Vaizdo lygis';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Vaizdo diapazonas';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitrų kodekas';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Leidžiami garso kodekai';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS garso kodekai';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 garso kodekai';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif tiesioginis perdavimas';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Aktyvus garso maršrutas';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Maršruto HD garso palaikymas';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Naktinis režimas';
@@ -2764,7 +2742,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2778,7 +2756,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Po $episodes serijų / $hours val.';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2855,45 +2833,45 @@ class AppLocalizationsLt extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Tinkinkite subtitrų išvaizdą';
 
   @override
-  String get subtitleMode => 'Subtitrų režimas';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Pažymėti';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Visada';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Užsienio kalba';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Priverstiniai';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Rodo takelius, kurie medijos failo metaduomenyse pažymėti kaip „default“ arba „forced“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automatiškai įkelia ir rodo subtitrus kaskart, kai pradedamas vaizdo įrašas.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automatiškai įjungia subtitrus, jei numatytasis garso takelis yra užsienio kalba.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Įkelia tik subtitrus, aiškiai pažymėtus „forced“ metaduomenų žyme.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Visiškai išjungia automatinį subtitrų įkėlimą.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Atsarginė subtitrų kalba';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Subtitrų srautas';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2953,17 +2931,17 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Įkelti $profile profilio nustatymai.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Nepavyko įkelti $profile profilio nustatymų.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Vietiniai nustatymai sinchronizuoti su $profile profiliu.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3098,11 +3076,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Rodyti bibliotekas įrankių juostoje';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Visada rodyti naršymo juostos pavadinimus';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Rodyti Seerr mygtuką';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navigacijos juostos neskaidrumas';
@@ -3123,7 +3100,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get teal => 'žalsvai mėlyna';
 
   @override
-  String get navy => 'Tamsiai mėlyna';
+  String get navy => 'Navy';
 
   @override
   String get charcoal => 'Anglis';
@@ -3176,19 +3153,18 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showFolderBrowsingOption => 'Rodyti aplanko naršymo parinktį';
 
   @override
-  String get groupItemsIntoCollections => 'Grupuoti elementus į rinkinius';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Naršant bibliotekas slėpti su rinkiniais susietus bibliotekos elementus';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Pranešimas apie bibliotekos grupavimą';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Kad galėtumėte naudoti šį nustatymą, savo Jellyfin arba Emby serveryje, bibliotekos rodymo nustatymuose, įjunkite bibliotekos parinktį „Grupuoti filmus į rinkinius“ ir (arba) „Grupuoti serialus į rinkinius“.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliotekos matomumas';
@@ -3217,7 +3193,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return 'Pasirinkta: $count';
+    return '$count selected';
   }
 
   @override
@@ -3247,7 +3223,7 @@ class AppLocalizationsLt extends AppLocalizations {
       'Pasirinkite iš įvairių medijos juostos stilių arba išjunkite medijos juostą';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Mėnulio pelekas';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3284,13 +3260,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noneExcluded => 'Nė vienas neįtrauktas';
 
   @override
-  String get autoAdvance => 'Automatinis perėjimas';
+  String get autoAdvance => 'Auto Advance';
 
   @override
   String get autoAdvanceSlides => 'Automatiškai pereiti prie kitos skaidrės';
 
   @override
-  String get autoAdvanceInterval => 'Automatinio perėjimo intervalas';
+  String get autoAdvanceInterval => 'Auto Advance Interval';
 
   @override
   String get trailerPreview => 'Anonso peržiūra';
@@ -3300,10 +3276,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Automatiškai paleiskite anonsus medijos juostoje po 3 sekundžių';
 
   @override
-  String get trailerAudio => 'Anonsų garsas';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Įjungti anonsų garsą medijos juostoje';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Epizodo peržiūra';
@@ -3380,11 +3356,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get combineBothRows => 'Sujunkite abi eilutes į vieną namų skyrių';
 
   @override
-  String get fullScreenRows => 'Išplėstos pradžios ekrano eilutės';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Rodyti tik po vieną pradžios ekrano eilutę';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Eilutės vaizdo tipas';
@@ -3399,7 +3374,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get lastUser => 'Paskutinis vartotojas';
 
   @override
-  String get currentUser => 'Dabartinis naudotojas';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Visada autentifikuoti';
@@ -3507,10 +3482,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Rodyti laikrodį ekrano užsklandos metu';
 
   @override
-  String get clockModeStatic => 'Statiškas';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Šokinėjantis';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Supuvę pomidorai (kritikai)';
@@ -3582,7 +3557,7 @@ class AppLocalizationsLt extends AppLocalizations {
       'Įgalinkite ir pertvarkykite įvertinimo šaltinius, rodomus visoje programoje';
 
   @override
-  String get pluginLabel => 'Moonbase papildinys';
+  String get pluginLabel => 'Papildinys';
 
   @override
   String get pluginDetected => 'Papildinys aptiktas';
@@ -3600,7 +3575,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersija: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3654,7 +3629,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get networks => 'Tinklai';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr atradimų eilutės';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3679,44 +3654,44 @@ class AppLocalizationsLt extends AppLocalizations {
       'Slėpti suaugusiesiems skirtą turinį rezultatuose';
 
   @override
-  String get seerrNotificationsSection => 'Pranešimai';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Pranešimai apie naujas užklausas';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Pranešti, kai kas nors pateikia užklausą';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Užklausų naujienos';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Patvirtinta, atmesta ir įtraukta į jūsų biblioteką';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Problemų naujienos';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Naujos problemos, atsakymai ir sprendimai';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Prisijungta kaip: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr atradimų puslapis';
+  String get discoverRows => 'Atraskite eilutes';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Įjunkite eilutes, kurias norite matyti Seerr pagrindiniame puslapyje. Vilkite, kad pertvarkytumėte. Pasirinktinė tvarka sinchronizuojama su Moonbase.';
+      'Norėdami pertvarkyti, vilkite. Įjungti arba išjungti eilutes. Įjungta eilučių tvarka sinchronizuojama su „Moonfin“ papildiniu.';
 
   @override
   String get discoverRowsDescription =>
-      'Įjunkite eilutes, kurias norite matyti Seerr pagrindiniame puslapyje. Vilkite, kad pertvarkytumėte. Pasirinktinė tvarka sinchronizuojama su Moonbase.';
+      'Norėdami pertvarkyti, vilkite. Įjungti arba išjungti eilutes.';
 
   @override
   String get enabled => 'Įjungta';
@@ -3729,7 +3704,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return '$version versija';
+    return 'Version $version';
   }
 
   @override
@@ -3780,7 +3755,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Galimas naujinys: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3791,7 +3766,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Galima v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3855,7 +3830,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get imageCacheCleared => 'Vaizdų talpykla išvalyta';
 
   @override
-  String get clear => 'Išvalyti';
+  String get clear => 'Aišku';
 
   @override
   String get browse => 'Naršyti';
@@ -3871,19 +3846,19 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Atsisiunčiama · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importuojama';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return 'Elementų: $count';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr nustatymai';
+  String get seerrSettings => 'Seller nustatymai';
 
   @override
   String get requestMore => 'Prašyti daugiau';
@@ -3899,7 +3874,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Užklausą pateikė $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3916,12 +3891,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Atšaukti „$title“ užklausą?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Atšaukti „$title“ užklausas ($count)?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3936,12 +3911,12 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Biudžetas: $amount \$';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Pajamos: $amount \$';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3951,7 +3926,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Pateikti $type užklausą';
+    return 'Request $type';
   }
 
   @override
@@ -3980,14 +3955,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showMore => 'Rodyti daugiau';
 
   @override
-  String get appearances => 'Filmografija';
+  String get appearances => 'Išvaizdos';
 
   @override
   String get crewSection => 'Įgula';
 
   @override
   String ageValue(int age) {
-    return 'amžius $age';
+    return 'age $age';
   }
 
   @override
@@ -4018,150 +3993,148 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deletedStatus => 'Ištrinta';
 
   @override
-  String get failedStatus => 'Nepavyko';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Apdorojama';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Pakeitė $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Užbaigta';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Šio pavadinimo užklausa jau pateikta';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Pasiektas užklausų limitas';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Šis pavadinimas įtrauktas į blokuojamųjų sąrašą';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Nebeliko sezonų, kuriems būtų galima pateikti užklausą';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Neturite teisės pateikti šios užklausos';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Užklausos';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemos';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Naujausi';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Paskutinį kartą keista';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Problemų nėra';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Liko $remaining iš $limit filmų užklausų';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Liko $remaining iš $limit sezonų užklausų';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Priklauso rinkiniui $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Peržiūrėti rinkinį';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Pateikti rinkinio užklausą';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'Filmų: $total · pasiekiama: $available';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Pateikti užklausą dėl $count filmų';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Pateikiama $current iš $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Pateikta užklausų dėl $count filmų';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Pateikta $ok iš $total filmų užklausų';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Visi filmai jau pasiekiami arba jų užklausos pateiktos';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Pranešti apie problemą';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vaizdas';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Garsas';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Kas negerai?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Visos serijos';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Serija';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Atvira';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Išspręsta';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Išspręsti';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Atidaryti iš naujo';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Pranešė $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return 'Komentarų: $count';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Pridėti komentarą';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Ištrinti šią problemą?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Pateikti pranešimą';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB balas';
@@ -4185,7 +4158,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get originalLanguageLabel => 'Originalo kalba';
 
   @override
-  String get seasonsLabel => 'Sezonai';
+  String get seasonsLabel => 'Metų laikai';
 
   @override
   String get episodesLabel => 'Epizodai';
@@ -4233,7 +4206,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get forward => 'Pirmyn';
 
   @override
-  String get general => 'Bendra';
+  String get general => 'Generolas';
 
   @override
   String get go => 'Eik';
@@ -4314,7 +4287,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get status => 'Būsena';
 
   @override
-  String get stop => 'Stabdyti';
+  String get stop => 'Sustok';
 
   @override
   String get streaming => 'Srautinis perdavimas';
@@ -4365,13 +4338,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotekos';
 
   @override
-  String get adminDrawerDisplay => 'Rodymas';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metaduomenys';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO nustatymai';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Perkodavimas';
@@ -4553,7 +4526,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get sessionRewind => 'Atsukti atgal';
 
   @override
-  String get sessionForward => 'Prasukti pirmyn';
+  String get sessionForward => 'Pirmyn';
 
   @override
   String get sessionNext => 'Kitas';
@@ -4562,7 +4535,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get sessionVolumeDown => 'tomas –';
 
   @override
-  String get sessionVolumeUp => 'Gars. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4571,7 +4544,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get nowPlaying => 'Dabar žaidžiama';
 
   @override
-  String get volume => 'Garsumas';
+  String get volume => 'Apimtis';
 
   @override
   String get actions => 'Veiksmai';
@@ -4583,7 +4556,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audioCodec => 'Garso kodekas';
 
   @override
-  String get hwAccel => 'Aparat. spartinimas';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Užbaigimas';
@@ -4598,10 +4571,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminClearDates => 'Aiškios datos';
 
   @override
-  String get adminActivitySeverityAll => 'Visi svarbumo lygiai';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datų intervalas';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4638,23 +4611,23 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Pašalinti įrenginį „$name“? Naudotojui reikės iš naujo prisijungti šiame įrenginyje.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Ištrinti visus įrenginius';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Pašalinti įrenginius ($count)? Paveiktiems naudotojams reikės prisijungti iš naujo. Jūsų dabartinis įrenginys nebus paveiktas.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Įrenginiai pašalinti';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Kai kurie įrenginiai pašalinti; $count pašalinti nepavyko.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4769,249 +4742,244 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminMetadataCountryHint => 'pvz. JAV, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Keliai';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Parinktys';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Atsisiuntimo šaltiniai';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metaduomenų saugotojai';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Subtitrų atsisiuntimo šaltiniai';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Dainų tekstų atsisiuntimo šaltiniai';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metaduomenų atsisiuntimo šaltiniai: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Vaizdų šaltiniai: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Šis serveris nesiūlo atsisiuntimo šaltinių šio tipo bibliotekai.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Bendra';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metaduomenys';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Įterptoji informacija';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtitrai';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Vaizdai';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serialai';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muzika';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmai';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Įjungti stebėjimą realiuoju laiku';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Aptikti failų pakeitimus ir apdoroti juos automatiškai.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Laikyti archyvus medijos failais';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Rodyti nuotraukas';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Įrašyti viršelius į medijos aplankus';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatinis metaduomenų atnaujinimas';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Niekada';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Numatytasis';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Rodymas';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotekos rodymas';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Rodyti aplankų rodinį su paprastais medijos aplankais';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Rodyti specialiąsias serijas tuose sezonuose, kuriuose jos buvo rodomos';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupuoti filmus į rinkinius';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupuoti serialus į rinkinius';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Rodyti išorinį turinį pasiūlymuose';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Pridėjimo datos veikimas';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Pridėjimo datą imti iš';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Nuskaitymo į biblioteką data';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Failo sukūrimo data';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metaduomenys ir vaizdai';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Pageidaujama metaduomenų kalba';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Skyriai';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Fiktyvių skyrių trukmė (sekundėmis)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Skyrių, sugeneruotų medijai, kuri jų neturi, trukmė. Nustatykite 0, kad išjungtumėte.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Skyrių vaizdų raiška';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO nustatymai';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO metaduomenys suderinami su Kodi ir panašiomis programomis. Nustatymai taikomi visoms bibliotekoms, kurios įrašo NFO metaduomenis.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Naudotojas, kurio žiūrėjimo duomenys bus įrašomi į NFO failus';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Įrašyti vaizdų kelius į NFO failus';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
-  String get adminLibPathSubstitution => 'Įjungti NFO vaizdų kelių pakeitimą';
+  String get adminLibPathSubstitution =>
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopijuoti extrafanart vaizdus į extrathumbs aplanką';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Nėra';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days d.';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Naudoti įterptuosius pavadinimus';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Naudoti įterptuosius priedų pavadinimus';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Naudoti įterptąją serijų informaciją';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Leisti įterptuosius subtitrus';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Leisti visus';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Tik tekstinius';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Tik vaizdinius';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Nėra';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Praleisti atsisiuntimą, jei yra įterptųjų subtitrų';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Praleisti atsisiuntimą, jei garso takelio kalba sutampa su atsisiuntimo kalba';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Reikalauti tikslaus subtitrų atitikmens';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Įrašyti subtitrus į medijos aplankus';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Išgauti skyrių vaizdus';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Išgauti skyrių vaizdus nuskaitant biblioteką';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Įjungti Trickplay vaizdų išgavimą';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Išgauti Trickplay vaizdus nuskaitant biblioteką';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Įrašyti Trickplay vaizdus į medijos aplankus';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automatiškai sujungti serialus, išsklaidytus keliuose aplankuose';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nulinio sezono rodomas pavadinimas';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Įjungti LUFS nuskaitymą garsui normalizuoti';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Teikti pirmenybę nestandartinei atlikėjų žymai';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automatiškai pridėti filmus į rinkinius';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Būtinas bibliotekos pavadinimas';
@@ -5130,7 +5098,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminDeleteUser => 'Ištrinti vartotoją';
 
   @override
-  String get admin => 'Administravimas';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5251,144 +5219,143 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminEnableAllChannels => 'Įgalinti prieigą prie visų kanalų';
 
   @override
-  String get adminParentalControl => 'Tėvų kontrolė';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Didžiausias leidžiamas amžiaus cenzas';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Aukštesnio cenzo turinys šiam naudotojui bus paslėptas.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Nėra';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokuoti elementus be cenzo informacijos arba su neatpažinta informacija';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Knygos';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanalai';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Tiesioginė TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmai';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muzika';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Anonsai';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serialai';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Prieigos tvarkaraščiai';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Leisti prieigą tik toliau nurodytu tvarkaraščio laiku. Kai tvarkaraštis nenustatytas, prieiga leidžiama visą parą.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Pridėti tvarkaraštį';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Diena';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Pradžia';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Pabaiga';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Kasdien';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Darbo diena';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Savaitgalis';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Sekmadienis';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Pirmadienis';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Antradienis';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Trečiadienis';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Ketvirtadienis';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Penktadienis';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Šeštadienis';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Leidžiamos žymos';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Rodomas tik turinys su šiomis žymomis. Palikite tuščią, kad būtų leidžiama viskas.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokuojamos žymos';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Turinys su šiomis žymomis šiam naudotojui bus paslėptas.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Pridėti žymą';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Įjungti įrenginiai';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Įjungti kanalai';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Tapatybės nustatymo tiekėjas';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Slaptažodžio atkūrimo tiekėjas';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Didžiausias nepavykusių prisijungimų skaičius iki užrakinimo';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Nustatykite 0 numatytajai reikšmei arba -1, kad išjungtumėte užrakinimą.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay prieiga';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Leisti kurti grupes ir prie jų prisijungti';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Leisti prisijungti prie grupių';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Prieigos nėra';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Leisti trinti turinį iš';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5476,26 +5443,25 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Kurti atsarginę kopiją';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Pasirinkite, ką įtraukti į atsarginę kopiją.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Duomenų bazė';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Įtraukiama visada';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metaduomenys';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtitrai';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay vaizdai';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Kuriama atsarginė kopija...';
@@ -5928,7 +5894,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminTrickplaySaved => 'Trickplay nustatymai išsaugoti';
 
   @override
-  String get adminTrickplayLoadFailed => 'Nepavyko įkelti Trickplay nustatymų';
+  String get adminTrickplayLoadFailed => 'Nepavyko įkelti gudrybės nustatymų';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6042,7 +6008,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminBaseUrl => 'Bazinis URL';
 
   @override
-  String get adminBaseUrlHint => 'pvz. /jellyfin';
+  String get adminBaseUrlHint => 'pvz. / želė';
 
   @override
   String get https => 'HTTPS';
@@ -6205,62 +6171,60 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminAddTuner => 'Pridėti imtuvą';
 
   @override
-  String get adminEditTuner => 'Redaguoti imtuvą';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U imtuvas';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Failas arba URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Imtuvo IP adresas';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Patogus pavadinimas';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Naudotojo agentas';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Vienalaikių ryšių limitas';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Didžiausias srautų skaičius, kurį imtuvas leidžia vienu metu. Nustatykite 0, kad būtų neribota.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Atsarginė didžiausia transliavimo bitų sparta';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importuoti tik mėgstamiausius kanalus';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Leisti aparatinį perkodavimą';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Leisti fMP4 perkodavimo konteinerį';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Leisti bendrinti srautą';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Įjungti srauto kartojimą';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Nepaisyti DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Skaityti įvestį natūraliu kadrų dažniu';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Redaguoti tiekėją';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6269,50 +6233,50 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Failas arba URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmų prefiksas';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmų kategorijos';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Kelias kategorijas atskirkite vertikaliu brūkšniu.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Vaikų kategorijos';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Naujienų kategorijos';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sporto kategorijos';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Naudotojo vardas';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Slaptažodis';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Šalis';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Pasirinkite šalį';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Pašto kodas';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Gauti sąrašus';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Sąrašai';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Įjungti visus imtuvus';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tunerio tipas';
@@ -6354,7 +6318,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Šio tipo imtuvas nepalaiko atstatymo.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6377,45 +6341,43 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serijos įrašymo kelias';
 
   @override
-  String get adminMovieRecordingPath => 'Filmų įrašymo kelias';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Gido duomenų dienos';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatiškai';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days d.';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Papildomo apdorojimo programos kelias';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Papildomo apdorojimo argumentai';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Įrašyti įrašų NFO metaduomenis';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Įrašyti įrašų vaizdus';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Laikas';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Įrašymo keliai';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Papildomas apdorojimas';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Gido duomenys: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6458,14 +6420,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminGuideProviders => 'Vadovų teikėjai';
 
   @override
-  String get adminRefreshGuideData => 'Atnaujinti gido duomenis';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Pradėtas gido duomenų atnaujinimas';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Gido atnaujinimo užduotis šiame serveryje nepasiekiama.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Pridėti teikėją';
@@ -6553,7 +6515,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminNotSet => 'Nenustatyta';
 
   @override
-  String get adminReset => 'Atstatyti';
+  String get adminReset => 'Nustatyti iš naujo';
 
   @override
   String get adminLogsTitle => 'Serverio žurnalai';
@@ -6599,7 +6561,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metaduomenų redaktorius';
 
   @override
-  String get adminMetadataIdentify => 'Identifikuoti';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipas';
@@ -7014,20 +6976,19 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Įgalinti prisilietimo ekraną';
 
   @override
-  String get adminBrandingSplashUpload => 'Įkelti vaizdą';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Pasveikinimo ekranas atnaujintas';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Nepavyko įkelti pasveikinimo ekrano';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Pasveikinimo ekranas pašalintas';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Pasirinktinio pasveikinimo ekrano nėra';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aparatinės įrangos pagreitis';
@@ -7044,128 +7005,121 @@ class AppLocalizationsLt extends AppLocalizations {
       'Įgalinti aparatinės įrangos dekodavimą:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV įrenginys';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Įjungti patobulintą NVDEC dekoderį';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Teikti pirmenybę sistemos aparatiniam dekoderiui';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Aparatinio dekodavimo spalvų gylis';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10 bitų HEVC dekodavimas';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10 bitų VP9 dekodavimas';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10 bitų dekodavimas';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12 bitų dekodavimas';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Aparatinis kodavimas';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Leisti HEVC kodavimą';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Leisti AV1 kodavimą';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Įjungti Intel mažos galios H.264 koduotuvą';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Įjungti Intel mažos galios HEVC koduotuvą';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tonų atvaizdavimas';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Įjungti tonų atvaizdavimą';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Įjungti VPP tonų atvaizdavimą';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Įjungti VideoToolbox tonų atvaizdavimą';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Tonų atvaizdavimo algoritmas';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Tonų atvaizdavimo režimas';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Tonų atvaizdavimo diapazonas';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Tonų atvaizdavimo sodrumo mažinimas';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Tonų atvaizdavimo pikas';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Tonų atvaizdavimo parametras';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP tonų atvaizdavimo ryškumas';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP tonų atvaizdavimo kontrastas';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Šablonai ir kokybė';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Koduotuvo šablonas';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 kodavimo CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) kodavimo CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Eilučių išpynimo metodas';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dvigubinti kadrų dažnį išpinant eilutes';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Garsas';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Įjungti garso VBR kodavimą';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Garso sumaišymo stiprinimas';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Stereo sumaišymo algoritmas';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Didžiausias multipleksavimo eilės dydis';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automatiškai';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodavimas';
@@ -7285,10 +7239,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminTaskNeverRun => 'Niekada nebėgioti';
 
   @override
-  String get adminTaskStop => 'Stabdyti';
+  String get adminTaskStop => 'Sustok';
 
   @override
-  String get adminRunningTasks => 'Vykdomos užduotys';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Bėk';
@@ -7358,10 +7312,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count valandų',
-      many: '$count valandos',
-      few: '$count valandos',
-      one: '$count valanda',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7407,22 +7359,22 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min.';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours val.';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d.';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$month-$day';
+    return '$month/$day';
   }
 
   @override
@@ -7436,50 +7388,49 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Bazinis URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'pvz. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'pvz. / želė';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Viešasis HTTP prievadas';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Reikalauti HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Nukreipti visas nuotolines užklausas į HTTPS. Neveikia, jei serveris neturi galiojančio sertifikato.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Sertifikato slaptažodis';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP nustatymai';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Įjungti IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Įjungti IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Įjungti automatinį prievadų susiejimą';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN tinklai';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Kableliais arba naujomis eilutėmis atskirtų IP adresų ar CIDR potinklių sąrašas, laikomas vietiniu tinklu.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Paskelbti serverio URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Susiekite potinklį ar adresą su paskelbtu URL, pvz. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Sertifikato kelias';
@@ -7509,11 +7460,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Droselio buferis';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Ribojimo delsa (sekundėmis)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Leisti išgauti subtitrus realiuoju laiku';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimalus atnaujinimo procentas';
@@ -7570,23 +7521,22 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Lėto atsako slenkstis (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Įjungti įspėjimus apie lėtą atsaką';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Įjungti Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Serveris';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metaduomenys';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Keliai';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Našumas';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Talpyklos kelias';
@@ -7598,7 +7548,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminGeneralServerName => 'Serverio pavadinimas';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Pageidaujama rodymo kalba';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nepavyko įkelti nustatymų';
@@ -7650,10 +7600,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# dalyvių',
-      many: '# dalyvio',
-      few: '# dalyviai',
-      one: '# dalyvis',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7800,10 +7748,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'rasta # eilučių',
-      many: 'rasta # eilutės',
-      few: 'rastos # eilutės',
-      one: 'rasta # eilutė',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7844,20 +7790,20 @@ class AppLocalizationsLt extends AppLocalizations {
   String get offlineSavedMedia => 'Išsaugota laikmena';
 
   @override
-  String get offlineBannerTitle => 'Esate neprisijungę';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Rodomi jūsų atsisiuntimai';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Atsisiuntimai';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Nepavyksta pasiekti serverio';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Kol serveris neveikia, leidžiama iš atsisiuntimų';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7931,40 +7877,42 @@ class AppLocalizationsLt extends AppLocalizations {
   String get pinForgot => 'Pamiršote PIN kodą?';
 
   @override
-  String get pinClear => 'Išvalyti';
+  String get pinClear => 'Aišku';
 
   @override
-  String get pinBackspace => 'Naikinti';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect užklausa patvirtinta.';
+  String get quickConnectAuthorized =>
+      'Greitojo prisijungimo užklausa patvirtinta.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect kodas neteisingas arba nebegalioja.';
+      'Greito prisijungimo kodas neteisingas arba pasibaigęs.';
 
   @override
   String get quickConnectNotSupported =>
-      'Šis serveris nepalaiko Quick Connect.';
+      'Greitasis prisijungimas šiame serveryje nepalaikomas.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Nepavyko patvirtinti Quick Connect kodo.';
+      'Nepavyko įgalioti greitojo prisijungimo kodo.';
 
   @override
-  String get quickConnectDisabled => 'Šiame serveryje Quick Connect išjungtas.';
+  String get quickConnectDisabled =>
+      'Greitasis prisijungimas šiame serveryje išjungtas.';
 
   @override
   String get quickConnectForbidden =>
-      'Jūsų paskyra negali patvirtinti šios Quick Connect užklausos.';
+      'Jūsų paskyra negali patvirtinti šios greitojo prisijungimo užklausos.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect kodas nerastas. Pabandykite naują kodą.';
+      'Greito prisijungimo kodas nerastas. Išbandykite naują kodą.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect nepavyko: $message';
+    return 'Greitas prisijungimas nepavyko: $message';
   }
 
   @override
@@ -8070,7 +8018,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get shuffleSelectGenre => 'Pasirinkite Žanras';
 
   @override
-  String get shuffleLibrary => 'Biblioteka';
+  String get shuffleLibrary => 'biblioteka';
 
   @override
   String get shuffleGenre => 'Žanras';
@@ -8131,7 +8079,7 @@ class AppLocalizationsLt extends AppLocalizations {
       'Atkūrimas buvo pristabdytas. Ar vis dar žiūrite?';
 
   @override
-  String get stillWatchingStop => 'Stabdyti';
+  String get stillWatchingStop => 'Sustok';
 
   @override
   String get stillWatchingContinue => 'Tęsti';
@@ -8170,7 +8118,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get playerTooltipCastControls => 'Cast valdikliai';
 
   @override
-  String get playerTooltipPlaybackQuality => 'Bitų sparta';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'Įeikite per visą ekraną';
@@ -8216,13 +8164,13 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Slėpti iš „Tęsti žiūrėjimą“';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Slėpti iš „Toliau“';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Pridėti į rinkinį';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8277,15 +8225,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsAlphabetical => 'Abėcėlinis';
 
   @override
-  String get settingsConnectionSection => 'RYŠYS';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Leisti savarankiškai pasirašytus sertifikatus';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Pasitikėti serveriais, naudojančiais savarankiškai pasirašytus arba privačios CA TLS sertifikatus. Įjunkite tik savo valdomiems serveriams. Tai išjungia sertifikatų tikrinimą visiems ryšiams.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVATUMAS IR SAUGA';
@@ -8301,11 +8248,11 @@ class AppLocalizationsLt extends AppLocalizations {
       'Teminiai akcentai, fonai, žiūrimi indikatoriai ir teminė muzika';
 
   @override
-  String get settingsDetailsScreen => 'Išsamios informacijos ekranas';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stilius, fono suliejimas ir skirtukų veikimas';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Pagrindinis puslapis';
@@ -8343,11 +8290,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Rodyti Seerr mygtuką naršymo juostoje';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Visada rodyti tekstinius pavadinimus viršutinėje naršymo juostoje';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8417,7 +8364,8 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsSupportMoonfin => 'Palaikykite Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Pavaišinkite kūrėją kava';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'TEISINĖ';
@@ -8451,10 +8399,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licencijos pranešimų',
-      many: '# licencijos pranešimo',
-      few: '# licencijos pranešimai',
-      one: '# licencijos pranešimas',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8503,17 +8449,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Praleisti įžangas ir pabaigas?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Medijos segmento atgalinis skaičiavimas';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Eigos juosta';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Laikmatis';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Nėra';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Raginti vartotoją';
@@ -8746,7 +8691,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Neseniai išleista: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8778,11 +8723,11 @@ class AppLocalizationsLt extends AppLocalizations {
       'Priverstinis netunelinis atkūrimas. Naudinga įrenginiuose su tuneliavimo garso / vaizdo pertrūkiais.';
 
   @override
-  String get enableTunnelingTitle => 'Įjungti tuneliavimą';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Išplėstinis. Nukreipia garsą ir vaizdą per susietą aparatinį kelią. Pagal numatytuosius nustatymus išjungta, nes kai kuriuose įrenginiuose sukelia garso ir vaizdo trikdžius.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Susieti Dolby Vision profilį 7 su HEVC';
@@ -8808,14 +8753,14 @@ class AppLocalizationsLt extends AppLocalizations {
       'Taikykite šrifto dydžio užuominas, įterptas į subtitrų takelį. Neleiskite naudoti subtitrų dydžio pagal savo stiliaus nuostatas.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Rodyti medijos informaciją';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Rodyti pasirinkto elemento informaciją bibliotekos puslapių viršuje.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Slėpti fono vaizdus naršant?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Naudokite išsamias antraštes';
@@ -8833,38 +8778,37 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Temų parduotuvė';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Naršykite ir išsaugokite bendruomenės temas';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Išsaugokite temą, kad galėtumėte ją naudoti kaip ir kitas išsaugotas temas.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Šiuo metu temų nėra.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Nepavyko įkelti temų parduotuvės. Patikrinkite ryšį ir bandykite dar kartą.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Išsaugoti';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Išsaugoti ir taikyti';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Išsaugota';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Šios temos įkelti nepavyko.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Išsaugota „$themeName“.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8922,21 +8866,21 @@ class AppLocalizationsLt extends AppLocalizations {
   String get homeRowsSection => 'Pradžios eilutės';
 
   @override
-  String get homeRowDisplay => 'Pradžios ekrano eilučių rodymas';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Pradžios ekrano eilučių skiltys';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Pradžios ekrano eilučių jungikliai';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Įjunkite arba išjunkite bibliotekomis pagrįstas pradžios ekrano eilučių kategorijas';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Įjunkite toliau esančius jungiklius, kad eilutės būtų rodomos pradžios ekrano skiltyse.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Eilučių tipas';
@@ -8995,56 +8939,55 @@ class AppLocalizationsLt extends AppLocalizations {
       'Rodyti filmus, serialus arba abu žanrų eilutėse.';
 
   @override
-  String get displayPlaylistsRows => 'Rodyti grojaraščių eilutes';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Rodyti grojaraščių eilutes pradžios ekrano skiltyse.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Grojaraščių eilučių rikiavimas';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Rikiuokite grojaraščių eilutes pagal pridėjimo datą, išleidimo datą, abėcėlę ir kitus kriterijus.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Rodyti garso eilutes';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Rodyti garso eilutes pradžios ekrano skiltyse.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Garso eilučių rikiavimas';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Rikiuokite garso eilutes pagal pridėjimo datą, išleidimo datą, abėcėlę ir kitus kriterijus.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Garso grojaraščiai';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Išvaizda';
 
   @override
-  String get layout => 'Išdėstymas';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klaviatūra';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Mygtukai';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Atvaizdavimas';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV konfigūracija';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kortelės dydis';
@@ -9054,7 +8997,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Nustatykite išorinę leistuvę, kad įjungtumėte paleidimą ilgai spaudžiant';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9320,10 +9263,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get guestAppearances => 'Svečių pasirodymai';
 
   @override
-  String get appearancesSeerr => 'Pasirodymai (Seerr)';
+  String get appearancesSeerr => 'Pasirodymai (Serr)';
 
   @override
-  String get crewContributionsSeerr => 'Kūrybinės grupės darbai (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Žiūrėkite su grupe';
@@ -9409,10 +9352,8 @@ class AppLocalizationsLt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bibliotekų',
-      many: '$count bibliotekos',
-      few: '$count bibliotekos',
-      one: '$count biblioteka',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9503,7 +9444,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mixedMoviesAndShows => 'Mišrūs filmai ir laidos';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => '„Intel“ greitasis sinchronizavimas';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9570,13 +9511,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get loadingShuffle => 'Įkeliamas maišymas...';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTEKOS MAIŠYMAS';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ATSITIKTINIS MAIŠYMAS';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ŽANRŲ MAIŠYMAS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Automatinis HDR perjungimas';
@@ -9589,221 +9530,222 @@ class AppLocalizationsLt extends AppLocalizations {
   String get whenFullscreen => 'Kai per visą ekraną';
 
   @override
-  String get changeArtwork => 'Keisti viršelį';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Trūksta';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Perkodavimo ribos';
 
   @override
-  String get clearAllArtworkButton => 'Išvalyti visus viršelius?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Ar tikrai norite išvalyti visus atsisiųstus viršelius?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Patvirtinti išvalymą';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Ar tikrai norite išvalyti šį elementą: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Įkelti?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Raiška: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => 'Rodyti tik sąsajos kalbos viršelius';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Patvirtinti visų išvalymą';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Vaizdas sėkmingai įkeltas!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Nepavyko įkelti vaizdo: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Nepavyko nustatyti vaizdo: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Nepavyko ištrinti vaizdo: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Nepavyko išvalyti visų viršelių: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Taip';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakatas';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fono vaizdai';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Reklamjuostė';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotipas';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatiūra';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Disko grafika';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ekrano kopija';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Dėžutės viršelis';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Dėžutės galinis viršelis';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Meniu grafika';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakatas';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fono vaizdas';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'reklamjuostė';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotipas';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatiūra';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'disko grafika';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ekrano kopija';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'dėžutės viršelis';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'dėžutės galinis viršelis';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'meniu grafika';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Visos';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Aukšta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Vidutinė (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Žema (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Šaltiniai';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Skyriai';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Žymės';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Pastabos';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Eilė';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Laiko juosta';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Laiko juosta tuščia';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Visa knyga';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Sutelkta laiko juosta';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksportuoti žymes';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksportuoti pastabas';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksportuoti viską';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksportuota į $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksportuoti nepavyko: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Dainų tekstai';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Pridėti žymę';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Pridėti pastabą';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Redaguoti pastabą';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Parašykite pastabą šiai akimirkai';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Miego laikmatis';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Išjungta';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Skyriaus pabaigoje';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Pasirinktinis';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Liko $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9818,51 +9760,51 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Atkūrimo greitis';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Liko';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Praėjo';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Atgal $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Pirmyn $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Ankstesnis skyrius';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Kitas skyrius';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$current skyrius iš $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Skyrių nėra';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Žymių dar nėra';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Pastabų dar nėra';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Žymė pridėta ties $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Atstatyti į 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9870,251 +9812,249 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Išsaugoti';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Atšaukti';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Ištrinti';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Subtitrų nuostatos';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Keiskite subtitrų režimus, numatytąsias kalbas, išvaizdą ir atvaizdavimo parinktis.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Subtitrų atvaizdavimas';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Rodymo parinktys';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Išleidimo data (didėjančiai)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Išleidimo data (mažėjančiai)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupuoti darbus';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupuoti kelis vaidmenis';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Įspėjimas apie bibliotekos rašymo teises';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kaip tai ištaisyti:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Suteikite Jellyfin tarnybos naudotojui (pvz., jellyfin arba Docker PUID/PGID) rašymo teises į serveryje esančius medijos bibliotekos aplankus.\n\n2. Arba eikite į Jellyfin valdymo skydelį -> Bibliotekos, redaguokite šią biblioteką ir išjunkite parinktį „Įrašyti viršelius į medijos aplankus“, kad viršeliai būtų saugomi vidinėje Jellyfin duomenų bazėje.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Atmesti';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Jūsų biblioteka „$libraryName“ sukonfigūruota įrašyti viršelius tiesiai į medijos aplankus (įjungta parinktis „Įrašyti viršelius į medijos aplankus“). Tačiau Jellyfin patikrino rašymo teises ir neturi leidimo įrašyti failų į šį katalogą:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Panašu, kad Jellyfin nepavyko atnaujinti viršelio. Jūsų biblioteka sukonfigūruota įrašyti viršelius tiesiai į medijos aplankus (įjungta parinktis „Įrašyti viršelius į medijos aplankus“). Ši klaida paprastai atsiranda, kai Jellyfin serverio procesas neturi leidimo įrašyti failų į jūsų medijos katalogus.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Išoriniai sąrašai';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Paleisti iš naujo';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Failo informacija';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Dydis: $size  •  Formatas: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Rodyti visus garso takelius ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Rodyti visus subtitrų takelius ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Tikrinama tiesioginio atkūrimo galimybė...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Tiesioginio atkūrimo galimybė: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Priverstiniai';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Leistuvė nepalaiko konteinerio formato.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Vaizdo kodekas nepalaikomas.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Garso kodekas nepalaikomas.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Subtitrų formatas nepalaikomas (reikia įdeginti).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Garso profilis nepalaikomas.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Vaizdo profilis nepalaikomas.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Vaizdo lygis nepalaikomas.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Šis įrenginys nepalaiko vaizdo raiškos.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Vaizdo bitų gylis nepalaikomas.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Vaizdo kadrų dažnis nepalaikomas.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Failo bitų sparta viršija leistuvės transliavimo limitą.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Vaizdo bitų sparta viršija transliavimo limitą.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Garso bitų sparta viršija transliavimo limitą.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Garso kanalų skaičius nepalaikomas.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Pagal abėcėlę';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Išleidimo tvarka (didėjančiai)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Išleidimo tvarka (mažėjančiai)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Pasirinktinė (vilkimu)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Grojaraščio rikiavimo parinktys';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Atstatyti rikiavimą';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Žiūrėti iš naujo S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Žiūrėti grojaraštį iš naujo';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Subtitrų nerasta.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administratoriaus valdikliai';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Atvaizdavimo variklis (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller – modernus Flutter GPU atvaizdavimo variklis, užtikrinantis sklandesnes animacijas ir mažiau trūkčiojimų. Kai kuriuose TV priedėliuose ir senesniuose GPU jis gali sukelti trikdžius ar juodą vaizdą; tokiu atveju jį išjunkite. „Automatinis“ parenka geriausią numatytąjį variantą jūsų įrenginiui. Kad pakeitimai įsigaliotų, paleiskite Moonfin iš naujo.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatinis';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Įjungta';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Išjungta';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Reikia paleisti iš naujo';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Kad būtų pakeistas atvaizdavimo variklis, Moonfin reikia paleisti iš naujo. Uždarykite programą dabar ir vėl ją atidarykite.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Uždaryti programą dabar';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Atnaujinti biblioteką';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Atnaujinti visas bibliotekas';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Pridėjimo data (nuo seniausių)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Pridėjimo data (nuo naujausių)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Pagal abėcėlę (A–Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Pagal abėcėlę (Z–A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Įkeliama serverio analitika... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Kaip šaltinio';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 250 geriausių filmų';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 250 geriausių serialų';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb populiariausi filmai';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb populiariausi serialai';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb prasčiausiai vertinami filmai';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb geriausiai vertinami filmai anglų kalba';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -12,19 +12,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'KONTA PREFERENCES';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Saskarnes valoda';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Sistēmas noklusējums';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Pierakstīties';
 
   @override
-  String get empty => 'Tukšs';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Ātrais savienojums';
 
   @override
   String get password => 'Parole';
@@ -141,62 +141,62 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsAppearanceTheme => 'Lietotnes motīvs';
 
   @override
-  String get detailScreenStyle => 'Detaļu ekrāna stils';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasiskais ir oriģinālais centrētais Moonfin izkārtojums. Modernais ir adaptīvs kinematogrāfisks izkārtojums.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasiskais';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Modernais';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Izvērstas cilnes';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automātiski rādīt cilnes saturu, pārlūkojot cilnes. Izslēdziet, lai katru cilni atvērtu un aizvērtu manuāli.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Rādīt tehnisko informāciju?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Rādīt kodeka, izšķirtspējas un straumes informāciju bannera kopsavilkumā';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Ieteikumu sistēma';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Izmantojiet Moonfin Recommends vietējās bibliotēkas algoritmu vai tiešsaistes TMDB līdzības rādītājus. Piezīme: tiešsaistes ieteikumiem nepieciešama Seerr integrācija.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb līdzība';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Piemērot vecuma ierobežojuma slieksni?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ierobežot Moonfin Recommends ieteikumus atbilstoši izvēlētā satura vecuma ierobežojumam';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Saskarnes stils';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automātiskais pielāgojas jūsu ierīcei. Izvēlieties Apple vai Material, lai noteiktu konkrētu izskatu.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automātiskais';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsLv extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Stikla kvalitāte';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automātiskais izvēlas šai ierīcei piemērotāko stikla efektu. Pilnais ieslēdz īstu izplūdumu; Samazinātais izmanto vieglu stiklu, kas taupa GPU jaudu.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automātiski';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Pilns';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Samazināts';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Pārslēdzieties starp Moonfin un Neon Pulse, nerestartējot lietotni';
 
   @override
-  String get customThemeTitle => 'Pielāgota tēma';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Pielāgotas tēmas maina vizuālos elementus visā Moonfin lietotnē. Izvēlieties vienu no šīm iespējām atbilstoši savam stilam.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Dod priekšroku sistēmas tastatūrai';
@@ -253,18 +253,18 @@ class AppLocalizationsLv extends AppLocalizations {
       'Synthwave stils ar fuksīna mirdzumu, ciāna tekstu un spēcīgāku hroma kontrastu';
 
   @override
-  String get themeGlass => 'Stikls';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Šķidra stikla stils ar plūstošu gradienta fonu, matētām virsmām un Apple zilo akcentu';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8 bitu varonis';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pikseļu mākslas stils ar rupju paleti, kvadrātveida apmalēm, asām ēnām un pikseļu fontu';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -328,35 +328,35 @@ class AppLocalizationsLv extends AppLocalizations {
   String get exit => 'Iziet';
 
   @override
-  String get gameMenu => 'Izvēlne';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pauzēts';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Saglabāt stāvokli';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Spēles';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Ielādēt stāvokli';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Paātrināt';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulatora iestatījumi';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Šim kodolam nav pielāgojamu opciju.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Turiet, lai atvērtu izvēlni';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spēles šajā ierīcē pagaidām netiek atbalstītas.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nevarēja ielādēt nevienu sākuma rindu';
@@ -378,7 +378,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get schedule => 'Grafiks';
 
   @override
-  String get series => 'Seriāli';
+  String get series => 'sērija';
 
   @override
   String get noItemsFound => 'Nav atrasts neviens vienums';
@@ -507,7 +507,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get albumArtists => 'Albuma mākslinieki';
 
   @override
-  String get artists => 'Izpildītāji';
+  String get artists => 'Mākslinieki';
 
   @override
   String get bookmarks => 'Grāmatzīmes';
@@ -554,7 +554,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'Izvēlieties, kuras tēmu plūsmas rādīt programmā Discover.';
 
   @override
-  String get apply => 'Lietot';
+  String get apply => 'Pieteikties';
 
   @override
   String get openLink => 'Atveriet saiti';
@@ -603,7 +603,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get listen => 'Klausies';
 
   @override
-  String get resume => 'Turpināt';
+  String get resume => 'Atsākt';
 
   @override
   String get failedToLoadLibrary => 'Neizdevās ielādēt bibliotēku';
@@ -748,13 +748,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get readStatus => 'Lasīt';
 
   @override
-  String get watched => 'Noskatīts';
+  String get watched => 'Noskatījos';
 
   @override
   String get unread => 'Nelasīts';
 
   @override
-  String get unwatched => 'Nenoskatīts';
+  String get unwatched => 'Neskatīts';
 
   @override
   String get seriesStatus => 'Sērijas statuss';
@@ -766,44 +766,43 @@ class AppLocalizationsLv extends AppLocalizations {
   String get books => 'Grāmatas';
 
   @override
-  String get latestBooks => 'Jaunākās grāmatas';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Jaunākās audiogrāmatas';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count grāmatas',
-      one: '$count grāmata',
-      zero: '$count grāmatu',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Grāmata';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiogrāmata';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Izlasīts $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Atlicis $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lasīt';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Klausīties';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autors';
@@ -880,9 +879,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiogrāmatas',
-      one: '$count audiogrāmata',
-      zero: '$count audiogrāmatu',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -918,7 +916,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get nextUp => 'Nākamais Uz augšu';
 
   @override
-  String get seasons => 'Sezonas';
+  String get seasons => 'Gadalaiki';
 
   @override
   String get chapters => 'Nodaļas';
@@ -985,9 +983,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezonas',
-      one: '$count sezona',
-      zero: '$count sezonu',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -998,40 +995,40 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get items => 'Vienumi';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Papildmateriāli';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Aizkulises';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Izgrieztās ainas';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Sižeti par filmu';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervijas';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Ainas';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Īsfilmas';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Treileri';
+  String get trailers => 'Piekabes';
 
   @override
   String timeRemaining(String time) {
-    return 'Atlicis $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Beigsies pēc $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,7 +1046,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get play => 'Atskaņot';
+  String get play => 'Spēlēt';
 
   @override
   String get startOver => 'Sāciet no jauna';
@@ -1073,7 +1070,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get version => 'Versija';
 
   @override
-  String get cast => 'Apraidīt';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Treileris';
@@ -1272,13 +1269,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get director => 'DIREKTORS';
 
   @override
-  String get directors => 'REŽISORI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENĀRISTS';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENĀRISTI';
+  String get writers => 'RAKSTNIEKI';
 
   @override
   String get studio => 'STUDIJA';
@@ -1313,9 +1310,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count celiņi',
-      one: '$count celiņš',
-      zero: '$count celiņu',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1325,9 +1321,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count nodaļas',
-      one: '$count nodaļa',
-      zero: '$count nodaļu',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1357,13 +1352,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get shuffle => 'Jaukt';
 
   @override
-  String get shuffleAllMusic => 'Jaukt visu mūziku';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Pierakstieties Moonfin savā tālrunī';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Nevar sasniegt serveri';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1375,7 +1370,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1508,7 +1503,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automātiski';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1523,12 +1518,12 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1562,7 +1557,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get transcodeReasons => 'Pārkodēšanas iemesli';
 
   @override
-  String get player => 'Atskaņotājs';
+  String get player => 'Spēlētājs';
 
   @override
   String get container => 'Konteiners';
@@ -1586,7 +1581,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get videoBitrate => 'Video bitu pārraides ātrums';
 
   @override
-  String get track => 'Celiņš';
+  String get track => 'Trase';
 
   @override
   String get channels => 'Kanāli';
@@ -1801,22 +1796,22 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Nākamā: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Atlicis $minutes min';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Atlicis $hours h';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Atlicis $hours h $minutes min';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1840,7 +1835,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get favoriteChannel => 'Mīļākais kanāls';
 
   @override
-  String get record => 'Ierakstīt';
+  String get record => 'Ieraksts';
 
   @override
   String get cancelRecordingAction => 'Atcelt ierakstīšanu';
@@ -1943,7 +1938,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr konta veids';
+  String get seerrAccountType => 'Serr konta veids';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2068,9 +2063,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizodes',
-      one: '$count epizode',
-      zero: '$count epizožu',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2298,7 +2292,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detaļu lapas, sākuma ekrāna rindas un skaļums';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2312,18 +2306,18 @@ class AppLocalizationsLv extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Atskaņot, pārlūkojot sākuma ekrānu';
 
   @override
-  String get loopThemeMusic => 'Atkārtot tēmas mūziku';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Atkārtot celiņu, nevis atskaņot to vienu reizi';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Sīkāka informācija Fona aizmiglojums';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2340,23 +2334,23 @@ class AppLocalizationsLv extends AppLocalizations {
   String get playerZoomMode => 'Spēlētāja tālummaiņas režīms';
 
   @override
-  String get settingsScrollWheelAction => 'Peles ritenītis';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Izvēlieties, ko atskaņošanas laikā dara peles ritenīša ritināšana virs video.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Izslēgts';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Pārtīt (uz priekšu / atpakaļ)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Skaļums';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Skaļums';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2410,37 +2404,37 @@ class AppLocalizationsLv extends AppLocalizations {
   String get defaultAudioLanguage => 'Noklusējuma audio valoda';
 
   @override
-  String get fallbackAudioLanguage => 'Rezerves audio valoda';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Priekšroka noklusējuma audio celiņam';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Dot priekšroku oriģinālajam audio celiņam, nevis lokalizētam dublējumam.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Priekšroka audioaprakstu celiņiem';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Dot priekšroku audioaprakstu celiņiem, nevis parastajiem celiņiem.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Pārkodēšana (audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Tiešā straume (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Pārkodēšana (bitu pārraides ātrums vai izšķirtspēja)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Pārkodēšana (video un audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Pārkodēšana (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automātiski (servera noklusējums)';
@@ -2521,7 +2515,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Izvēlieties, kā tiek dekodēts audio. „AVR caurlaide“ sūta neapstrādātas Dolby / DTS straumes uz uztvērēju; „Automātiski“ vai „Samiksēšana“ dekodē lokāli.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR caurlaide';
@@ -2531,14 +2525,13 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Izvēlieties formātu, uz kuru pārkodēt daudzkanālu audio, ja avota straumi nevar atskaņot tieši vai pārraidīt bez izmaiņām.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automātiska noteikšana\n(ieteicams)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(noklusējums)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2547,27 +2540,26 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(bez zudumiem)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(tikai stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(efektīvs)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(bez zudumiem)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maksimālais audio kanālu skaits';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Norādiet savas audio sistēmas maksimālo kanālu skaitu. Daudzkanālu straumes, kas pārsniedz šo ierobežojumu, tiks samiksētas vai pārkodētas.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automātiska noteikšana\n(aparatūras noklusējums)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2576,22 +2568,22 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 telpiskā skaņa';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 kvadrofoniskā';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 telpiskā skaņa';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 telpiskā skaņa';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 telpiskā skaņa';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 telpiskā skaņa';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Passthrough (papildu)';
@@ -2610,7 +2602,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) caurlaide';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core caurlaide';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'DTS-HD MA caurlaide';
@@ -2672,11 +2664,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Skaļrunis';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Austiņas';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2762,7 +2754,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2852,45 +2844,45 @@ class AppLocalizationsLv extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Pielāgojiet subtitru izskatu';
 
   @override
-  String get subtitleMode => 'Subtitru režīms';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Atzīmētie';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Vienmēr';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Svešvaloda';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Piespiedu';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Atskaņo celiņus, kas multivides faila metadatos atzīmēti kā „default“ vai „forced“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automātiski ielādē un rāda subtitrus katru reizi, kad sākas video.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automātiski ieslēdz subtitrus, ja noklusējuma audio celiņš ir svešvalodā.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Ielādē tikai subtitrus, kas nepārprotami atzīmēti ar „forced“ metadatu karodziņu.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Pilnībā atspējo automātisku subtitru ielādi.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Rezerves subtitru valoda';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Subtitru straume';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Ātrā brūnā lapsa lec pāri slinkajam sunim';
@@ -3095,11 +3087,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showLibrariesInToolbar => 'Rādīt bibliotēkas rīkjoslā';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Vienmēr rādīt navigācijas joslas nosaukumus';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Rādīt Seerr pogu';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navigācijas joslas necaurredzamība';
@@ -3117,10 +3108,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get purple => 'Violeta';
 
   @override
-  String get teal => 'Zilganzaļa';
+  String get teal => 'Teal';
 
   @override
-  String get navy => 'Tumši zila';
+  String get navy => 'Navy';
 
   @override
   String get charcoal => 'Ogles';
@@ -3174,19 +3165,18 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showFolderBrowsingOption => 'Rādīt mapju pārlūkošanas opciju';
 
   @override
-  String get groupItemsIntoCollections => 'Grupēt vienumus kolekcijās';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Pārlūkojot bibliotēkas, slēpt ar kolekcijām saistītos bibliotēkas vienumus';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Paziņojums par bibliotēkas grupēšanu';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Lai izmantotu šo iestatījumu, savā Jellyfin vai Emby serverī bibliotēkas attēlošanas iestatījumos iespējojiet bibliotēkas opciju „Grupēt filmas kolekcijās“ un/vai „Grupēt seriālus kolekcijās“.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliotēkas redzamība';
@@ -3298,10 +3288,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Automātiski atskaņojiet reklāmkadrus multivides joslā pēc 3 sekundēm';
 
   @override
-  String get trailerAudio => 'Treilera audio';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Iespējot treileru audio multivides joslā';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Sērijas priekšskatījums';
@@ -3378,11 +3368,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get combineBothRows => 'Apvienojiet abas rindas vienā sākuma sadaļā';
 
   @override
-  String get fullScreenRows => 'Izvērstas sākuma ekrāna rindas';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Rādīt tikai vienu sākuma ekrāna rindu';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Rindas attēla veids';
@@ -3397,7 +3386,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get lastUser => 'Pēdējais lietotājs';
 
   @override
-  String get currentUser => 'Pašreizējais lietotājs';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vienmēr autentificēt';
@@ -3503,10 +3492,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Parādīt pulksteni ekrānsaudzētāja laikā';
 
   @override
-  String get clockModeStatic => 'Statisks';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Lecošs';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Sapuvuši tomāti (kritiķi)';
@@ -3577,7 +3566,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'Iespējojiet un pārkārtojiet visā lietotnē rādītos vērtēšanas avotus';
 
   @override
-  String get pluginLabel => 'Moonbase spraudnis';
+  String get pluginLabel => 'Spraudnis';
 
   @override
   String get pluginDetected => 'Spraudnis konstatēts';
@@ -3649,7 +3638,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get networks => 'Tīkli';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr atklāšanas rindas';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3660,7 +3649,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get showSeerrInNavigation =>
-      'Rādīt Seerr navigācijā (nepieciešams servera spraudnis)';
+      'Rādīt Seer navigācijā (nepieciešams servera spraudnis)';
 
   @override
   String get seerrUnavailable =>
@@ -3674,29 +3663,28 @@ class AppLocalizationsLv extends AppLocalizations {
       'Paslēpt rezultātos pieaugušajiem paredzētu saturu';
 
   @override
-  String get seerrNotificationsSection => 'Paziņojumi';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Paziņojumi par jauniem pieprasījumiem';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Paziņot, kad kāds iesniedz pieprasījumu';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Pieprasījumu jaunumi';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Apstiprināts, noraidīts un pievienots jūsu bibliotēkai';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Problēmu jaunumi';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Jaunas problēmas, atbildes un risinājumi';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3704,15 +3692,15 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr atklāšanas lapa';
+  String get discoverRows => 'Atklājiet rindas';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Iespējojiet rindas, ko rādīt Seerr galvenajā lapā. Velciet, lai pārkārtotu. Pielāgotā kārtība tiek sinhronizēta ar Moonbase.';
+      'Velciet, lai pārkārtotu. Iespējot vai atspējot rindas. Iespējota rindu secība sinhronizējas ar spraudni Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Iespējojiet rindas, ko rādīt Seerr galvenajā lapā. Velciet, lai pārkārtotu. Pielāgotā kārtība tiek sinhronizēta ar Moonbase.';
+      'Velciet, lai pārkārtotu. Iespējot vai atspējot rindas.';
 
   @override
   String get enabled => 'Iespējots';
@@ -3850,7 +3838,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get imageCacheCleared => 'Attēlu kešatmiņa notīrīta';
 
   @override
-  String get clear => 'Notīrīt';
+  String get clear => 'Skaidrs';
 
   @override
   String get browse => 'Pārlūkot';
@@ -3866,11 +3854,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Lejupielādē · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importē';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3878,7 +3866,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Seerr iestatījumi';
+  String get seerrSettings => 'Redzēja iestatījumi';
 
   @override
   String get requestMore => 'Pieprasīt vairāk';
@@ -3975,7 +3963,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showMore => 'Rādīt vairāk';
 
   @override
-  String get appearances => 'Filmogrāfija';
+  String get appearances => 'Izskati';
 
   @override
   String get crewSection => 'Apkalpe';
@@ -4013,103 +4001,102 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deletedStatus => 'Izdzēsts';
 
   @override
-  String get failedStatus => 'Neizdevās';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Apstrādā';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Mainīja $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Pabeigts';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Šis nosaukums jau ir pieprasīts';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Sasniegts pieprasījumu ierobežojums';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Šis nosaukums ir bloķēto sarakstā';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Nav palikusi neviena sezona, ko pieprasīt';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Jums nav atļaujas veikt šo pieprasījumu';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Pieprasījumi';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problēmas';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Jaunākie';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Pēdējoreiz mainīts';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Nav problēmu';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Atlikuši $remaining no $limit filmu pieprasījumiem';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Atlikuši $remaining no $limit sezonu pieprasījumiem';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Pieder kolekcijai $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Skatīt kolekciju';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Pieprasīt kolekciju';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'Filmas: $total · pieejamas: $available';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Pieprasīt filmas ($count)';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Pieprasa $current no $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Pieprasītas filmas ($count)';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Pieprasītas $ok no $total filmām';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Visas filmas jau ir pieejamas vai pieprasītas';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Ziņot par problēmu';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4118,44 +4105,44 @@ class AppLocalizationsLv extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Kas nav kārtībā?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Visas epizodes';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizode';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Atvērta';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Atrisināta';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Atrisināt';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Atvērt atkārtoti';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Ziņoja $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return 'Komentāri: $count';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Pievienot komentāru';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Dzēst šo problēmu?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Iesniegt ziņojumu';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB rezultāts';
@@ -4179,7 +4166,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get originalLanguageLabel => 'Oriģinālvaloda';
 
   @override
-  String get seasonsLabel => 'Sezonas';
+  String get seasonsLabel => 'Gadalaiki';
 
   @override
   String get episodesLabel => 'Epizodes';
@@ -4194,7 +4181,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get address => 'Adrese';
 
   @override
-  String get analytics => 'Analītika';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalogs';
@@ -4227,7 +4214,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get forward => 'Uz priekšu';
 
   @override
-  String get general => 'Vispārīgi';
+  String get general => 'Ģenerālis';
 
   @override
   String get go => 'Aiziet';
@@ -4272,7 +4259,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get refresh => 'Atsvaidzināt';
 
   @override
-  String get remote => 'Attālināts';
+  String get remote => 'Tālvadības pults';
 
   @override
   String get rename => 'Pārdēvēt';
@@ -4308,7 +4295,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get status => 'Statuss';
 
   @override
-  String get stop => 'Apturēt';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Straumēšana';
@@ -4344,7 +4331,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminDrawerDashboard => 'Informācijas panelis';
 
   @override
-  String get adminDrawerAnalytics => 'Analītika';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Iestatījumi';
@@ -4359,19 +4346,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotēkas';
 
   @override
-  String get adminDrawerDisplay => 'Attēlošana';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadati';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO iestatījumi';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Pārkodēšana';
 
   @override
-  String get adminDrawerResume => 'Turpināt';
+  String get adminDrawerResume => 'Atsākt';
 
   @override
   String get adminDrawerStreaming => 'Straumēšana';
@@ -4549,16 +4536,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get sessionRewind => 'Attīt atpakaļ';
 
   @override
-  String get sessionForward => 'Patīt uz priekšu';
+  String get sessionForward => 'Uz priekšu';
 
   @override
-  String get sessionNext => 'Nākamais';
+  String get sessionNext => 'Tālāk';
 
   @override
-  String get sessionVolumeDown => 'Skaļ. –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Skaļ. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4579,7 +4566,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audioCodec => 'Audio kodeks';
 
   @override
-  String get hwAccel => 'Aparat. paātrin.';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Pabeigšana';
@@ -4594,10 +4581,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminClearDates => 'Skaidri datumi';
 
   @override
-  String get adminActivitySeverityAll => 'Visi nopietnības līmeņi';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datumu diapazons';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4634,23 +4621,23 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Noņemt ierīci “$name”? Lietotājam būs atkārtoti jāpierakstās šajā ierīcē.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Dzēst visas ierīces';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Noņemt ierīces ($count)? Skartajiem lietotājiem būs atkārtoti jāpierakstās. Jūsu pašreizējā ierīce netiks skarta.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Ierīces noņemtas';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Dažas ierīces noņemtas; $count nevarēja noņemt.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4765,250 +4752,244 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminMetadataCountryHint => 'piem. ASV, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Ceļi';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcijas';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Lejupielādes avoti';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadatu saglabātāji';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Subtitru lejupielādes avoti';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Dziesmu tekstu lejupielādes avoti';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadatu lejupielādes avoti: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Attēlu avoti: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Šis serveris nepiedāvā lejupielādes avotus šāda veida bibliotēkai.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Vispārīgi';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadati';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Iegultā informācija';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtitri';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Attēli';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Seriāli';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Mūzika';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmas';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Iespējot uzraudzību reāllaikā';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Noteikt failu izmaiņas un apstrādāt tās automātiski.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Uzskatīt arhīvus par multivides failiem';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Rādīt fotoattēlus';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Saglabāt vāka attēlus multivides mapēs';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automātiska metadatu atsvaidzināšana';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nekad';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Noklusējums';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Attēlošana';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotēkas attēlošana';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Rādīt mapju skatu ar vienkāršām multivides mapēm';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Rādīt speciālās epizodes tajās sezonās, kurās tās tika rādītas';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupēt filmas kolekcijās';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupēt seriālus kolekcijās';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Rādīt ārējo saturu ieteikumos';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Pievienošanas datuma darbība';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Pievienošanas datumu ņemt no';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Bibliotēkā skenēšanas datums';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Faila izveides datums';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadati un attēli';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Vēlamā metadatu valoda';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Nodaļas';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Fiktīvo nodaļu ilgums (sekundēs)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'To nodaļu ilgums, kas ģenerētas multividei bez nodaļām. Iestatiet 0, lai atspējotu.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Nodaļu attēlu izšķirtspēja';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO iestatījumi';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO metadati ir saderīgi ar Kodi un līdzīgām lietotnēm. Iestatījumi attiecas uz visām bibliotēkām, kas saglabā NFO metadatus.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Lietotājs, kura skatīšanās dati tiks saglabāti NFO failos';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Saglabāt attēlu ceļus NFO failos';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Iespējot ceļu aizstāšanu NFO attēlu ceļiem';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopēt extrafanart attēlus mapē extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Nav';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days d.';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Izmantot iegultos nosaukumus';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Izmantot iegultos papildmateriālu nosaukumus';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Izmantot iegulto epizožu informāciju';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Atļaut iegultos subtitrus';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Atļaut visus';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Tikai tekstu';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Tikai attēlus';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Nav';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Izlaist lejupielādi, ja ir iegultie subtitri';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Izlaist lejupielādi, ja audio celiņa valoda sakrīt ar lejupielādes valodu';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Pieprasīt precīzu subtitru atbilstību';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Saglabāt subtitrus multivides mapēs';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Iegūt nodaļu attēlus';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Iegūt nodaļu attēlus bibliotēkas skenēšanas laikā';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Iespējot Trickplay attēlu iegūšanu';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Iegūt Trickplay attēlus bibliotēkas skenēšanas laikā';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Saglabāt Trickplay attēlus multivides mapēs';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automātiski apvienot seriālus, kas izvietoti vairākās mapēs';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nulltās sezonas attēlojamais nosaukums';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Iespējot LUFS skenēšanu audio normalizēšanai';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Dot priekšroku nestandarta izpildītāju tagam';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automātiski pievienot filmas kolekcijām';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Jānorāda bibliotēkas nosaukums';
@@ -5246,146 +5227,143 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminEnableAllChannels => 'Iespējot piekļuvi visiem kanāliem';
 
   @override
-  String get adminParentalControl => 'Vecāku kontrole';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Maksimālais atļautais vecuma ierobežojums';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Saturs ar augstāku ierobežojumu šim lietotājam tiks paslēpts.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Nav';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloķēt vienumus bez vecuma ierobežojuma informācijas vai ar neatpazītu informāciju';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Grāmatas';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanāli';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Tiešraides TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmas';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Mūzika';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Treileri';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriāli';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Piekļuves grafiki';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Atļaut piekļuvi tikai turpmāk norādītajos grafika laikos. Ja grafiks nav iestatīts, piekļuve ir atļauta visu diennakti.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Pievienot grafiku';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Diena';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Sākums';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Beigas';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Katru dienu';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Darba diena';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Nedēļas nogale';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Svētdiena';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Pirmdiena';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Otrdiena';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Trešdiena';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Ceturtdiena';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Piektdiena';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sestdiena';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Atļautie tagi';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Tiek rādīts tikai saturs ar šiem tagiem. Atstājiet tukšu, lai atļautu visu.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Bloķētie tagi';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Saturs ar šiem tagiem šim lietotājam tiek paslēpts.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Pievienot tagu';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Iespējotās ierīces';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Iespējotie kanāli';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Autentifikācijas nodrošinātājs';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Paroles atiestatīšanas nodrošinātājs';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksimālais neveiksmīgo pieteikšanās mēģinājumu skaits pirms bloķēšanas';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Iestatiet 0 noklusējuma vērtībai vai -1, lai atspējotu bloķēšanu.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay piekļuve';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Atļaut veidot grupas un tām pievienoties';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Atļaut pievienoties grupām';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Nav piekļuves';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Atļaut satura dzēšanu no';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5472,25 +5450,25 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Izveidot dublējumu';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Izvēlieties, ko iekļaut dublējumā.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Datubāze';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Vienmēr iekļauts';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadati';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtitri';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay attēli';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Notiek dublējuma izveide...';
@@ -5923,7 +5901,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Neizdevās ielādēt Trickplay iestatījumus';
+      'Neizdevās ielādēt triku spēles iestatījumus';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6039,7 +6017,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminBaseUrl => 'Pamata URL';
 
   @override
-  String get adminBaseUrlHint => 'piem. /jellyfin';
+  String get adminBaseUrlHint => 'piem. /želeja';
 
   @override
   String get https => 'HTTPS';
@@ -6203,61 +6181,60 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminAddTuner => 'Pievienojiet uztvērēju';
 
   @override
-  String get adminEditTuner => 'Rediģēt uztvērēju';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U uztvērējs';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fails vai URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Uztvērēja IP adrese';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Draudzīgais nosaukums';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Lietotāja aģents';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Vienlaicīgo savienojumu ierobežojums';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Maksimālais straumju skaits, ko uztvērējs atļauj vienlaikus. Iestatiet 0, lai būtu neierobežots.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Rezerves maksimālais straumēšanas bitu ātrums';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importēt tikai izlases kanālus';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Atļaut aparatūras pārkodēšanu';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Atļaut fMP4 pārkodēšanas konteineru';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Atļaut straumes koplietošanu';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Iespējot straumes atkārtošanu';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorēt DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Nolasīt ievadi ar dabisko kadru nomaiņas ātrumu';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Rediģēt nodrošinātāju';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6266,50 +6243,50 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fails vai URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmu prefikss';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmu kategorijas';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Vairākas kategorijas atdaliet ar vertikālu svītru.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Bērnu kategorijas';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Ziņu kategorijas';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sporta kategorijas';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Lietotājvārds';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Parole';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Valsts';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Izvēlieties valsti';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Pasta indekss';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Iegūt sarakstus';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Saraksti';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Iespējot visus uztvērējus';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Uztvērēja tips';
@@ -6351,7 +6328,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Šāda veida uztvērējs neatbalsta atiestatīšanu.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6374,44 +6351,43 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Sērijas ierakstīšanas ceļš';
 
   @override
-  String get adminMovieRecordingPath => 'Filmu ierakstīšanas ceļš';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Programmas datu dienas';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automātiski';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days d.';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Pēcapstrādes lietojumprogrammas ceļš';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Pēcapstrādes argumenti';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Saglabāt ierakstu NFO metadatus';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Saglabāt ierakstu attēlus';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Laiks';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Ierakstīšanas ceļi';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Pēcapstrāde';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Programmas dati: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6456,15 +6432,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminGuideProviders => 'Ceļvežu sniedzēji';
 
   @override
-  String get adminRefreshGuideData => 'Atsvaidzināt programmas datus';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Uzsākta programmas datu atsvaidzināšana';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Programmas atsvaidzināšanas uzdevums šajā serverī nav pieejams.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Pievienot nodrošinātāju';
@@ -6547,7 +6522,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminLiveTvTitle => 'TV tiešraides administrācija';
 
   @override
-  String get adminApply => 'Lietot';
+  String get adminApply => 'Pieteikties';
 
   @override
   String get adminNotSet => 'Nav iestatīts';
@@ -6599,7 +6574,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadatu redaktors';
 
   @override
-  String get adminMetadataIdentify => 'Identificēt';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tips';
@@ -6642,7 +6617,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminMetadataFieldCriticRating => 'Kritiķu vērtējums';
 
   @override
-  String get adminMetadataFieldTagline => 'Sauklis';
+  String get adminMetadataFieldTagline => 'Tagline';
 
   @override
   String get adminMetadataFieldOverview => 'Pārskats';
@@ -7014,20 +6989,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Iespējot uzplaiksnījumu ekrānu';
 
   @override
-  String get adminBrandingSplashUpload => 'Augšupielādēt attēlu';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Sveiciena ekrāns atjaunināts';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Neizdevās augšupielādēt sveiciena ekrānu';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Sveiciena ekrāns noņemts';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Nav pielāgota sveiciena ekrāna';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aparatūras paātrinājums';
@@ -7042,126 +7016,121 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Iespējot aparatūras dekodēšanu:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ierīce';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Iespējot uzlaboto NVDEC dekodētāju';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Dot priekšroku sistēmas aparatūras dekodētājam';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Aparatūras dekodēšanas krāsu dziļums';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10 bitu HEVC dekodēšana';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10 bitu VP9 dekodēšana';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10 bitu dekodēšana';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12 bitu dekodēšana';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Aparatūras kodēšana';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Atļaut HEVC kodēšanu';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Atļaut AV1 kodēšanu';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Iespējot Intel mazjaudas H.264 kodētāju';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Iespējot Intel mazjaudas HEVC kodētāju';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Toņu kartēšana';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Iespējot toņu kartēšanu';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Iespējot VPP toņu kartēšanu';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Iespējot VideoToolbox toņu kartēšanu';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Toņu kartēšanas algoritms';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Toņu kartēšanas režīms';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Toņu kartēšanas diapazons';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Toņu kartēšanas piesātinājuma samazināšana';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Toņu kartēšanas maksimums';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Toņu kartēšanas parametrs';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP toņu kartēšanas spilgtums';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP toņu kartēšanas kontrasts';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Sagataves un kvalitāte';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Kodētāja sagatave';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 kodēšanas CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) kodēšanas CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Rindpārlēces novēršanas metode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dubultot kadru nomaiņas ātrumu, novēršot rindpārlēci';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Iespējot audio VBR kodēšanu';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Audio samiksēšanas pastiprinājums';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Stereo samiksēšanas algoritms';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maksimālais multipleksēšanas rindas izmērs';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automātiski';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodēšana';
@@ -7281,10 +7250,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminTaskNeverRun => 'Nekad neskrien';
 
   @override
-  String get adminTaskStop => 'Apturēt';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Aktīvie uzdevumi';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Skrien';
@@ -7354,9 +7323,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count stundas',
-      one: '$count stunda',
-      zero: '$count stundu',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7402,27 +7370,27 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d.';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$month-$day';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Konfigurējiet Trickplay attēlu ģenerēšanu pārtīšanas priekšskatījuma sīktēliem.';
+      'Konfigurējiet triku atskaņošanas attēlu ģenerēšanu priekšskatījuma sīktēlu meklēšanai.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Publisks HTTPS ports';
@@ -7431,50 +7399,49 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Pamata URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'piem. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'piem. /želeja';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Publiskais HTTP ports';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Pieprasīt HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Novirzīt visus attālinātos pieprasījumus uz HTTPS. Nedarbojas, ja serverim nav derīga sertifikāta.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Sertifikāta parole';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP iestatījumi';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Iespējot IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Iespējot IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Iespējot automātisku portu kartēšanu';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN tīkli';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Ar komatiem vai jaunām rindām atdalīts IP adrešu vai CIDR apakštīklu saraksts, ko uzskata par vietējo tīklu.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publicētie servera URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Kartējiet apakštīklu vai adresi uz publicētu URL, piem. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Sertifikāta ceļš';
@@ -7504,11 +7471,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Droseles buferizācija';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Ierobežošanas aizture (sekundēs)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Atļaut subtitru iegūšanu reāllaikā';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimālais atsākšanas procents';
@@ -7566,23 +7533,22 @@ class AppLocalizationsLv extends AppLocalizations {
       'Lēnas reakcijas slieksnis (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Iespējot brīdinājumus par lēnu atbildi';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Iespējot Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Serveris';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadati';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Ceļi';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Veiktspēja';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Kešatmiņas ceļš';
@@ -7594,7 +7560,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminGeneralServerName => 'Servera nosaukums';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Vēlamā attēlošanas valoda';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Neizdevās ielādēt iestatījumus';
@@ -7646,9 +7612,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# dalībnieki',
-      one: '# dalībnieks',
-      zero: '# dalībnieku',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7795,9 +7760,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'atrastas # rindas',
-      one: 'atrasta # rinda',
-      zero: 'atrasts # rindu',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7838,20 +7802,20 @@ class AppLocalizationsLv extends AppLocalizations {
   String get offlineSavedMedia => 'Saglabātie multivides līdzekļi';
 
   @override
-  String get offlineBannerTitle => 'Jūs esat bezsaistē';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Tiek rādītas jūsu lejupielādes';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Lejupielādes';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Nevar sasniegt serveri';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Līdz servera atjaunošanai atskaņo no lejupielādēm';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7925,41 +7889,42 @@ class AppLocalizationsLv extends AppLocalizations {
   String get pinForgot => 'Aizmirsāt PIN?';
 
   @override
-  String get pinClear => 'Notīrīt';
+  String get pinClear => 'Skaidrs';
 
   @override
-  String get pinBackspace => 'Atpakaļatkāpe';
+  String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized =>
-      'Quick Connect pieprasījums apstiprināts.';
+      'Ātrā savienojuma pieprasījums ir atļauts.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect kods nav derīgs vai tam beidzies termiņš.';
+      'Ātrā savienojuma kods ir nederīgs vai beidzies derīguma termiņš.';
 
   @override
   String get quickConnectNotSupported =>
-      'Šis serveris neatbalsta Quick Connect.';
+      'Ātrais savienojums šajā serverī netiek atbalstīts.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Neizdevās apstiprināt Quick Connect kodu.';
+      'Neizdevās autorizēt ātrā savienojuma kodu.';
 
   @override
-  String get quickConnectDisabled => 'Šajā serverī Quick Connect ir atspējots.';
+  String get quickConnectDisabled =>
+      'Ātrais savienojums šajā serverī ir atspējots.';
 
   @override
   String get quickConnectForbidden =>
-      'Jūsu konts nevar apstiprināt šo Quick Connect pieprasījumu.';
+      'Jūsu konts nevar autorizēt šo ātrās savienojuma pieprasījumu.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect kods netika atrasts. Mēģiniet jaunu kodu.';
+      'Ātrā savienojuma kods netika atrasts. Izmēģiniet jaunu kodu.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect neizdevās: $message';
+    return 'Ātrais savienojums neizdevās: $message';
   }
 
   @override
@@ -8126,7 +8091,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'Atskaņošana ir apturēta. Vai jūs joprojām skatāties?';
 
   @override
-  String get stillWatchingStop => 'Apturēt';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Turpināt';
@@ -8211,13 +8176,13 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Slēpt no “Turpināt skatīties”';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Slēpt no “Nākamais”';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Pievienot kolekcijai';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8253,7 +8218,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'Spraudņu sinhronizācija, Seerr, vērtējumi un citi';
+      'Spraudņu sinhronizācija, Serr, vērtējumi un daudz kas cits';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8272,15 +8237,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabētiskā secībā';
 
   @override
-  String get settingsConnectionSection => 'SAVIENOJUMS';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Atļaut pašparakstītus sertifikātus';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Uzticēties serveriem, kas izmanto pašparakstītus vai privātas CA TLS sertifikātus. Iespējojiet tikai saviem serveriem. Tas atspējo sertifikātu pārbaudi visiem savienojumiem.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVĀTUMS UN DROŠĪBA';
@@ -8296,11 +8260,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'Motīvu akcenti, foni, skatītie indikatori un motīvu mūzika';
 
   @override
-  String get settingsDetailsScreen => 'Detaļu ekrāns';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stils, fona izplūdums un ciļņu darbība';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Mājas lapa';
@@ -8338,11 +8302,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Rādīt Seerr pogu navigācijas joslā';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vienmēr rādīt teksta nosaukumus augšējā navigācijas joslā';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8411,7 +8375,8 @@ class AppLocalizationsLv extends AppLocalizations {
   String get settingsSupportMoonfin => 'Atbalstiet Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Uzsauciet izstrādātājam kafiju';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'JURIDISKĀS';
@@ -8444,9 +8409,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licences paziņojumi',
-      one: '# licences paziņojums',
-      zero: '# licenču paziņojumu',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8496,17 +8460,16 @@ class AppLocalizationsLv extends AppLocalizations {
       'Vai izlaist ievadus un noslēgumus?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Multivides segmenta atpakaļskaitīšana';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Progresa josla';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Taimeris';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Nav';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Pamudināt lietotāju';
@@ -8735,7 +8698,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nesen izdots: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8767,11 +8730,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'Piespiedu atskaņošana bez tunelēšanas. Noderīga ierīcēm ar tunelēšanas audio/video pārtraukumiem.';
 
   @override
-  String get enableTunnelingTitle => 'Iespējot tunelēšanu';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Paplašināts. Novirza audio un video caur saistītu aparatūras ceļu. Pēc noklusējuma izslēgts, jo dažās ierīcēs tas rada audio un video pārrāvumus.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Kartē Dolby Vision profilu 7 ar HEVC';
@@ -8797,15 +8760,14 @@ class AppLocalizationsLv extends AppLocalizations {
       'Lietojiet subtitru celiņā iegultos fonta lieluma ieteikumus. Atspējojiet, lai izmantotu subtitru izmēru no jūsu stila preferencēm.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Rādīt multivides informāciju';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Rādīt izvēlētā vienuma informāciju bibliotēkas lapu augšdaļā.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Slēpt fona attēlus pārlūkošanas laikā?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings =>
@@ -8824,37 +8786,37 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Tēmu veikals';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Pārlūkojiet un saglabājiet kopienas tēmas';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Saglabājiet tēmu, lai to izmantotu tāpat kā citas saglabātās tēmas.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Pašlaik nav pieejama neviena tēma.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Neizdevās ielādēt tēmu veikalu. Pārbaudiet savienojumu un mēģiniet vēlreiz.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Saglabāt';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Saglabāt un lietot';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Saglabāts';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Šo tēmu neizdevās ielādēt.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Saglabāts “$themeName”.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8913,21 +8875,21 @@ class AppLocalizationsLv extends AppLocalizations {
   String get homeRowsSection => 'Sākuma rindas';
 
   @override
-  String get homeRowDisplay => 'Sākuma ekrāna rindu attēlošana';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sākuma ekrāna rindu sadaļas';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Sākuma ekrāna rindu slēdži';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Iespējojiet vai atspējojiet uz bibliotēkām balstītas sākuma ekrāna rindu kategorijas';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Iespējojiet turpmākos slēdžus, lai rindas tiktu rādītas sākuma ekrāna sadaļās.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rindu veids';
@@ -8985,56 +8947,55 @@ class AppLocalizationsLv extends AppLocalizations {
       'Rādīt filmas, seriālus vai abus rindās Žanri.';
 
   @override
-  String get displayPlaylistsRows => 'Rādīt atskaņošanas sarakstu rindas';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Rādīt atskaņošanas sarakstu rindas sākuma ekrāna sadaļās.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Atskaņošanas sarakstu rindu kārtošana';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Kārtojiet atskaņošanas sarakstu rindas pēc pievienošanas datuma, izdošanas datuma, alfabēta un citiem kritērijiem.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Rādīt audio rindas';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Rādīt audio rindas sākuma ekrāna sadaļās.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Audio rindu kārtošana';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Kārtojiet audio rindas pēc pievienošanas datuma, izdošanas datuma, alfabēta un citiem kritērijiem.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Audio atskaņošanas saraksti';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Izskats';
 
   @override
-  String get layout => 'Izkārtojums';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tēma';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastatūra';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Pogas';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderēšana';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV konfigurācija';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kartes izmērs';
@@ -9044,7 +9005,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Iestatiet ārējo atskaņotāju, lai iespējotu atskaņošanu ar ilgu piespiešanu';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9312,10 +9273,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get guestAppearances => 'Viesu uzstāšanās';
 
   @override
-  String get appearancesSeerr => 'Parādīšanās (Seerr)';
+  String get appearancesSeerr => 'Izskati (Serr)';
 
   @override
-  String get crewContributionsSeerr => 'Filmēšanas grupas darbi (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Skatieties kopā ar grupu';
@@ -9401,9 +9362,8 @@ class AppLocalizationsLv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bibliotēkas',
-      one: '$count bibliotēka',
-      zero: '$count bibliotēku',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9470,28 +9430,28 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminDrawerSectionPlayback => 'Atskaņošana';
 
   @override
-  String get adminDrawerSectionDevices => 'Ierīces';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Paplašināti';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Spraudņi';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Tiešraides TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Mājas video';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Jaukts saturs';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Mājas video un fotoattēli';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Jauktas filmas un seriāli';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9503,299 +9463,299 @@ class AppLocalizationsLv extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Ieraksti nav atrasti';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Arhīvā .$extension nav atrasta neviena attēla lappuse.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Iegultajam renderētājam radās kļūda ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB renderētājam radās kļūda ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Trūkst lokālā faila lasītājam: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status, atverot grāmatas datus no $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nav pieejams neviens lasāms grāmatas galapunkts';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Neatbalstīts komiksu arhīva formāts: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'CBR izpakošanas spraudnis šajā platformā nav pieejams.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Neizdevās izpakot .cbr arhīvu.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7 izpakošana šajā platformā nav pieejama.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'CB7 izpakošanas spraudnis šajā platformā nav pieejams.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Aizvērt žanru paneli';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Ielādē jaukšanu...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTĒKAS JAUKŠANA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'NEJAUŠA JAUKŠANA';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ŽANRU JAUKŠANA';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automātiska HDR pārslēgšana';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Automātiski ieslēgt HDR HDR video atskaņošanai un pēc iziešanas atjaunot ekrāna režīmu.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Pilnekrāna režīmā';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Mainīt vāka attēlu';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Trūkst';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Pārkodēšanas ierobežojumi';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Notīrīt visus vāka attēlus?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Vai tiešām vēlaties notīrīt visus lejupielādētos vāka attēlus?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Apstiprināt notīrīšanu';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Vai tiešām vēlaties notīrīt šo vienumu: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Augšupielādēt?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Izšķirtspēja: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Rādīt tikai saskarnes valodas vāka attēlus';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Apstiprināt visu notīrīšanu';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Attēls veiksmīgi augšupielādēts!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Neizdevās augšupielādēt attēlu: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Neizdevās iestatīt attēlu: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Neizdevās dzēst attēlu: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Neizdevās notīrīt visus vāka attēlus: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Jā';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakāts';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fona attēli';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Baneris';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotips';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Sīktēls';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Diska grafika';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ekrānuzņēmums';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Kastītes vāks';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Kastītes aizmugurējais vāks';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Izvēlnes grafika';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakāts';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fona attēls';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'baneris';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotips';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'sīktēls';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'diska grafika';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ekrānuzņēmums';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'kastītes vāks';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'kastītes aizmugurējais vāks';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'izvēlnes grafika';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Visas';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Augsta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Vidēja (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Zema (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Avoti';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Nodaļas';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Grāmatzīmes';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Piezīmes';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Rinda';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Laika josla';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Laika josla ir tukša';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Visa grāmata';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokusētā laika josla';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksportēt grāmatzīmes';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksportēt piezīmes';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksportēt visu';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksportēts uz $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksportēšana neizdevās: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Dziesmu teksti';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Pievienot grāmatzīmi';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Pievienot piezīmi';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Rediģēt piezīmi';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Uzrakstiet piezīmi šim brīdim';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Miega taimeris';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Izslēgts';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Nodaļas beigās';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Pielāgots';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Atlicis $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9810,51 +9770,51 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Atskaņošanas ātrums';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Atlicis';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Pagājis';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Atpakaļ $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Uz priekšu $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Iepriekšējā nodaļa';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Nākamā nodaļa';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$current. nodaļa no $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Nav nodaļu';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Vēl nav grāmatzīmju';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Vēl nav piezīmju';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Grāmatzīme pievienota pie $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Atiestatīt uz 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9862,256 +9822,249 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Saglabāt';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Atcelt';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Dzēst';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Subtitru preferences';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Mainiet subtitru režīmus, noklusējuma valodas, izskatu un renderēšanas opcijas.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Subtitru renderēšana';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Attēlošanas opcijas';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Izdošanas datums (augoši)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Izdošanas datums (dilstoši)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupēt darbus';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupēt vairākas lomas';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Brīdinājums par bibliotēkas rakstīšanas piekļuvi';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kā to novērst:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Piešķiriet Jellyfin pakalpojuma lietotājam (piem., jellyfin vai Docker PUID/PGID) rakstīšanas atļaujas serverī esošajām multivides bibliotēkas mapēm.\n\n2. Vai arī dodieties uz Jellyfin vadības paneli -> Bibliotēkas, rediģējiet šo bibliotēku un atspējojiet opciju “Saglabāt vāka attēlus multivides mapēs”, lai vāka attēli tiktu glabāti Jellyfin iekšējā datubāzē.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Noraidīt';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Jūsu bibliotēka “$libraryName” ir konfigurēta saglabāt vāka attēlus tieši multivides mapēs (opcija “Saglabāt vāka attēlus multivides mapēs” ir iespējota). Tomēr Jellyfin pārbaudīja rakstīšanas piekļuvi un tam nav atļaujas rakstīt failus šajā direktorijā:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Šķiet, ka Jellyfin neizdevās atjaunināt vāka attēlu. Jūsu bibliotēka ir konfigurēta saglabāt vāka attēlus tieši multivides mapēs (opcija “Saglabāt vāka attēlus multivides mapēs” ir iespējota). Šī kļūda parasti rodas, kad Jellyfin servera procesam nav atļaujas rakstīt failus jūsu multivides direktorijās.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Ārējie saraksti';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Atskaņot no jauna';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Faila informācija';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Izmērs: $size  •  Formāts: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Rādīt visus audio celiņus ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Rādīt visus subtitru celiņus ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Pārbauda tiešās atskaņošanas iespēju...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Tiešās atskaņošanas iespēja: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Piespiedu';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Atskaņotājs neatbalsta konteinera formātu.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Video kodeks netiek atbalstīts.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Audio kodeks netiek atbalstīts.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Subtitru formāts netiek atbalstīts (nepieciešama iededzināšana).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Audio profils netiek atbalstīts.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Video profils netiek atbalstīts.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Video līmenis netiek atbalstīts.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Šī ierīce neatbalsta video izšķirtspēju.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Video bitu dziļums netiek atbalstīts.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Video kadru nomaiņas ātrums netiek atbalstīts.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Faila bitu ātrums pārsniedz atskaņotāja straumēšanas ierobežojumu.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Video bitu ātrums pārsniedz straumēšanas ierobežojumu.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Audio bitu ātrums pārsniedz straumēšanas ierobežojumu.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Audio kanālu skaits netiek atbalstīts.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Pēc alfabēta';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Izdošanas secība (augoši)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Izdošanas secība (dilstoši)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Pielāgota (velkot un nometot)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Atskaņošanas saraksta kārtošanas opcijas';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Atiestatīt kārtošanu';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Skatīties atkārtoti S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Skatīties atskaņošanas sarakstu atkārtoti';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Subtitri nav atrasti.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administratora vadīklas';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Renderēšanas dzinējs (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller ir Flutter modernais GPU renderētājs, kas nodrošina plūstošākas animācijas un mazāku raustīšanos. Dažās TV pierīcēs un vecākos GPU tas var radīt traucējumus vai melnu attēlu; tādā gadījumā izslēdziet to. “Automātiski” izvēlas jūsu ierīcei piemērotāko noklusējumu. Lai lietotu izmaiņas, restartējiet Moonfin.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automātiski';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ieslēgts';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Izslēgts';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Nepieciešams restarts';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Lai mainītu renderēšanas dzinēju, Moonfin ir jārestartē. Aizveriet lietotni tagad un atveriet to no jauna.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Aizvērt lietotni tagad';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Atsvaidzināt bibliotēku';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Atsvaidzināt visas bibliotēkas';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Pievienošanas datums (vecākie vispirms)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Pievienošanas datums (jaunākie vispirms)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Pēc alfabēta (no A līdz Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Pēc alfabēta (no Z līdz A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Ielādē servera analītiku... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Kā avotam';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 250 labākās filmas';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 250 labākie seriāli';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb populārākās filmas';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb populārākie seriāli';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb zemāk novērtētās filmas';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb augstāk novērtētās filmas angļu valodā';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -9,30 +9,30 @@ class AppLocalizationsMk extends AppLocalizations {
   AppLocalizationsMk([String locale = 'mk']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Месечината';
 
   @override
-  String get accountPreferences => 'ПРЕФЕРЕНЦИИ НА СМЕТКАТА';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Јазик на интерфејсот';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Системски стандард';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Пријавете се';
 
   @override
-  String get empty => 'Празно';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Поврзување со $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Брзо поврзување';
 
   @override
   String get password => 'Лозинка';
@@ -61,12 +61,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect е недостапен: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect е недостапен ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin верзија $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Да се отстрани „$serverName“ од вашите сервери?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsAppearanceTheme => 'Тема на апликацијата';
 
   @override
-  String get detailScreenStyle => 'Стил на екранот со детали';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Класичен е оригиналниот центриран распоред на Moonfin. Модерен е адаптивен кинематографски распоред.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Класичен';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Модерен';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Проширени јазичиња';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Автоматски прикажувај ја содржината на јазичињата при прегледување. Исклучете за рачно отворање и затворање на секое јазиче.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Прикажи технички детали?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Прикажувај кодек, резолуција и информации за стримот во резимето на банерот';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Систем за препораки';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Користете го алгоритамот Moonfin Recommends за локалната библиотека или онлајн метриките за сличност на TMDb. Забелешка: онлајн препораките бараат интеграција со Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Сличност според TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Примени ограничување според родителска оцена?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ограничи ги предлозите на Moonfin Recommends според родителската оцена на целната содржина';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стил на интерфејсот';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Автоматски се прилагодува на вашиот уред. Изберете Apple или Material за да наметнете изглед.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автоматски';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsMk extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Квалитет на стаклото';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Автоматски го избира најдобриот стаклен ефект за овој уред. Целосно наметнува вистинско заматување; Намалено користи лесно стакло што штеди GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Автоматски';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Целосно';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Намалено';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Префрлете се помеѓу Moonfin и Neon Pulse без да ја рестартирате апликацијата';
 
   @override
-  String get customThemeTitle => 'Прилагодена тема';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Прилагодените теми ги менуваат визуелните елементи низ Moonfin. Изберете една од овие опции според вашиот стил.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Претпочитај системска тастатура';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Стандардно користи го методот за внес на вашиот уред за внесување текст';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Месечината';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -257,14 +257,14 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Стил со течно стакло, подвижна градиентна позадина, заматени површини и акцент во Apple сина';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретро пиксел-арт стил со дебела палета, блокови рабови, остри сенки и пикселен фонт';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Не може да се поврзе со $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,35 +327,35 @@ class AppLocalizationsMk extends AppLocalizations {
   String get exit => 'Излезете';
 
   @override
-  String get gameMenu => 'Мени';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Паузирано';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Зачувај состојба';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Игри';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Вчитај состојба';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Брзо напред';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Поставки на емулаторот';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Ова јадро нема прилагодливи опции.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Задржете за мени';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Играњето игри сè уште не е поддржано на овој уред.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Не можеше да се вчитаат почетни редови';
@@ -383,7 +383,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get noItemsFound => 'Не се пронајдени ставки';
 
   @override
-  String get home => 'Почетна';
+  String get home => 'Дома';
 
   @override
   String get browseAll => 'Прелистајте ги сите';
@@ -427,7 +427,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Неуспешно вчитување на папката: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -435,7 +435,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count ставки';
+    return '$count items';
   }
 
   @override
@@ -452,7 +452,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Ставки';
+    return '$count Items';
   }
 
   @override
@@ -493,7 +493,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Жанрови';
+    return '$name — Genres';
   }
 
   @override
@@ -506,7 +506,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get albumArtists => 'Изведувачи на албуми';
 
   @override
-  String get artists => 'Изведувачи';
+  String get artists => 'Уметници';
 
   @override
   String get bookmarks => 'Обележувачи';
@@ -532,17 +532,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'пред $countм';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'пред $countч';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'пред $countд';
+    return '${count}d ago';
   }
 
   @override
@@ -553,7 +553,7 @@ class AppLocalizationsMk extends AppLocalizations {
       'Изберете која тема ќе се прикаже во Discover.';
 
   @override
-  String get apply => 'Примени';
+  String get apply => 'Пријавете се';
 
   @override
   String get openLink => 'Отворете ја врската';
@@ -577,7 +577,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count наслови';
+    return '$count titles';
   }
 
   @override
@@ -665,17 +665,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count автори';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count жанрови';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% завршено';
+    return '$percent% completed';
   }
 
   @override
@@ -692,7 +692,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count наслови подредени за прегледување ориентирано кон читање.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -729,7 +729,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Не се пронајдени $label';
+    return 'No $label found';
   }
 
   @override
@@ -754,7 +754,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get unread => 'Непрочитано';
 
   @override
-  String get unwatched => 'Негледано';
+  String get unwatched => 'Невидено';
 
   @override
   String get seriesStatus => 'Статус на серијата';
@@ -766,43 +766,43 @@ class AppLocalizationsMk extends AppLocalizations {
   String get books => 'Книги';
 
   @override
-  String get latestBooks => 'Најнови книги';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Најнови аудиокниги';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count книги',
-      one: '$count книга',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Книга';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудиокнига';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'уште $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Читај';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слушај';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Автор';
@@ -833,19 +833,19 @@ class AppLocalizationsMk extends AppLocalizations {
   String get internetArchive => 'Интернет архива';
 
   @override
-  String get rssFeed => 'RSS канал';
+  String get rssFeed => 'RSS Feed';
 
   @override
   String get downloadZip => 'Преземете Zip';
 
   @override
   String sectionCountLabel(int count) {
-    return '$count делови';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Првпат објавено $year';
+    return 'First published $year';
   }
 
   @override
@@ -860,7 +860,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count книги';
+    return '$count books';
   }
 
   @override
@@ -872,7 +872,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Автори';
+    return '$count Authors';
   }
 
   @override
@@ -880,8 +880,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудиокниги',
-      one: '$count аудиокнига',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -929,7 +929,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get movies => 'Филмови';
 
   @override
-  String get musicVideos => 'Музички видеа';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Друго';
@@ -948,7 +948,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Диск $number';
+    return 'Disc $number';
   }
 
   @override
@@ -973,7 +973,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Објавено $year';
+    return 'Published $year';
   }
 
   @override
@@ -984,52 +984,52 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Сезони',
-      one: '$count Сезона',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Завршува во $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Ставки';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Додатоци';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Зад сцената';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Избришани сцени';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Кратки материјали';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Интервјуа';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцени';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Краткометражни филмови';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Трејлери';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'уште $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Завршува за $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1043,11 +1043,11 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Продолжи од $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Пушти';
+  String get play => 'Играј';
 
   @override
   String get startOver => 'Започнете одново';
@@ -1071,7 +1071,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get version => 'Верзија';
 
   @override
-  String get cast => 'Емитувај';
+  String get cast => 'Улоги';
 
   @override
   String get trailer => 'Трејлер';
@@ -1142,7 +1142,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Да се избришат преземените песни за „$title“?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1157,17 +1157,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Не се вчитани $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Се презема $title ($count ставки)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Дали сте сигурни дека сакате да го избришете „$name“ од серверот? Ова дејство не може да се врати.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1179,7 +1179,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Неподдржан формат на книга: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1189,7 +1189,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get subtitleTrack => 'Песна со титл';
 
   @override
-  String get none => 'Нема';
+  String get none => 'Никој';
 
   @override
   String get downloadSubtitlesLabel => 'Преземете титлови...';
@@ -1206,7 +1206,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Преводот е преземен и избран: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1215,7 +1215,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Не се пронајдени оддалечени преводи за $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1223,7 +1223,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Верзија $number';
+    return 'Version $number';
   }
 
   @override
@@ -1245,7 +1245,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Се презема $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1253,7 +1253,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Да се избришат локалните датотеки за $typeLabel?\n\nОва ќе ослободи простор за складирање. Можете повторно да преземете подоцна.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1269,25 +1269,25 @@ class AppLocalizationsMk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕЖИСЕРИ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТИ';
+  String get writers => 'ПИСАТЕЛИ';
 
   @override
   String get studio => 'СТУДИО';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count повеќе';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count Епизоди';
+    return '$count Episodes';
   }
 
   @override
@@ -1297,12 +1297,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Епизода $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Поглавје $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1310,8 +1310,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count песни',
-      one: '$count песна',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1321,25 +1321,25 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count поглавја',
-      one: '$count поглавје',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Роден/а $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Починал/а $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Возраст $age';
+    return 'Age $age';
   }
 
   @override
@@ -1349,20 +1349,20 @@ class AppLocalizationsMk extends AppLocalizations {
   String get readMore => 'Прочитај повеќе';
 
   @override
-  String get shuffle => 'Измешај';
+  String get shuffle => 'Мешај';
 
   @override
-  String get shuffleAllMusic => 'Измешај ја целата музика';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Најавете се на Moonfin на вашиот телефон';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Не може да се пристапи до вашиот сервер';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count преземања';
+    return '$count downloads';
   }
 
   @override
@@ -1381,32 +1381,32 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '$action на оддалечени преводи бара дозвола за управување со преводи во Jellyfin за овој корисник.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Оваа ставка не може да се најде на серверот за $action на оддалечени преводи.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '$action на оддалечени преводи не успеа: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '$action на оддалечени преводи не успеа (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Неуспешно $action на оддалечени преводи.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'сите преземени епизоди за „$name“';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1438,17 +1438,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Дејството $label не успеа: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Неуспешно поставување на волуменот при емитување: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Контроли за $label';
+    return '$label Controls';
   }
 
   @override
@@ -1465,7 +1465,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Запри $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1473,7 +1473,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Песна $number';
+    return 'Track $number';
   }
 
   @override
@@ -1490,7 +1490,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds секунди';
+    return '$seconds seconds';
   }
 
   @override
@@ -1520,12 +1520,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$valueмс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$valueмс';
+    return '+${value}ms';
   }
 
   @override
@@ -1559,7 +1559,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get transcodeReasons => 'Причини за транскодирање';
 
   @override
-  String get player => 'Плеер';
+  String get player => 'Играч';
 
   @override
   String get container => 'Контејнер';
@@ -1583,7 +1583,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get videoBitrate => 'Брзина на битови на видеото';
 
   @override
-  String get track => 'Запис';
+  String get track => 'Песна';
 
   @override
   String get channels => 'Канали';
@@ -1605,12 +1605,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Грешка во $protocol сесијата';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Неуспешно вчитување на деталите за книгата: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1619,7 +1619,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Овој формат (.$extension) сè уште не може да се прикаже во апликацијата.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1632,17 +1632,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Неуспешно отворање на читачот во апликацијата: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Обележувачот е веќе зачуван на $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Додаден обележувач: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1654,7 +1654,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Страница $number';
+    return 'Page $number';
   }
 
   @override
@@ -1665,12 +1665,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Формат: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
@@ -1694,7 +1694,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Ресетирај го зумот (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1717,7 +1717,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Неуспешно ажурирање на статусот на читање: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1750,7 +1750,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Оваа платформа не може да го вгради документскиот погон за $extension датотеки.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1789,7 +1789,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Неуспешно вчитување на водичот: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1800,22 +1800,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Следно: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'уште $minutes мин';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'уште $hours ч';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'уште $hours ч $minutes мин';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1838,29 +1838,29 @@ class AppLocalizationsMk extends AppLocalizations {
   String get favoriteChannel => 'Омилен канал';
 
   @override
-  String get record => 'Снимај';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Откажи снимање';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Програмата е закажана за снимање';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Снимањето е откажано';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Не може да се создаде снимка';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Гледај';
+  String get watch => 'Гледајте';
 
   @override
   String get close => 'Затвори';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Неуспешно пуштање на $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1886,11 +1886,11 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Да се откаже закажаното снимање на „$name“?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Не';
+  String get no => 'бр';
 
   @override
   String get yesCancel => 'Да, Откажи';
@@ -1914,7 +1914,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Да се запре снимањето на „$name“?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1929,19 +1929,19 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Нема резултати за „$query“';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Пребарувањето не успеа: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Тип на Seerr сметка';
+  String get seerrAccountType => 'Вид на сметка на Seer';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1975,12 +1975,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Да се отстрани „$name“ и неговите датотеки?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count песни';
+    return '$count tracks';
   }
 
   @override
@@ -1991,12 +1991,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Неуспешно вчитување на албумот: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Не се пронајдени преземени песни за $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2013,22 +2013,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Да се отстрани „$name“?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Е$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Епизода $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2042,12 +2042,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Сезона $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2058,7 +2058,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Да се избришат сите преземени епизоди во $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2066,8 +2066,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count епизоди',
-      one: '$count епизода',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2102,7 +2102,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Да се избришат $count преземени ставки?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2116,7 +2116,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'од лимитот од $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2202,7 +2202,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count опции';
+    return '$count options';
   }
 
   @override
@@ -2296,7 +2296,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Страници со детали, почетни редови и волумен';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2311,11 +2311,11 @@ class AppLocalizationsMk extends AppLocalizations {
       'Репродуцирајте при прелистување на почетниот екран';
 
   @override
-  String get loopThemeMusic => 'Повторувај ја тематската музика';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Повторувај ја песната наместо да се пушти еднаш';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Детали Заматување на позадината';
@@ -2338,23 +2338,23 @@ class AppLocalizationsMk extends AppLocalizations {
   String get playerZoomMode => 'Режим на зумирање на играчот';
 
   @override
-  String get settingsScrollWheelAction => 'Тркалце на глувчето';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Изберете што прави движењето на тркалцето на глувчето врз видеото при репродукција.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Исклучено';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Премотување (напред / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Јачина на звук';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Јачина на звук';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Се вклопуваат';
@@ -2408,37 +2408,37 @@ class AppLocalizationsMk extends AppLocalizations {
   String get defaultAudioLanguage => 'Стандарден аудио јазик';
 
   @override
-  String get fallbackAudioLanguage => 'Резервен јазик на аудиото';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Претпочитај стандарден аудио запис';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Претпочитај го оригиналниот аудио запис наместо локализираната синхронизација.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Претпочитај записи со аудио опис';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Претпочитај ги записите со аудио опис наместо обичните записи.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскодирање (аудио)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Директен стрим (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскодирање (битрејт или резолуција)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскодирање (видео и аудио)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскодирање (видео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Автоматски (стандарден сервер)';
@@ -2515,28 +2515,27 @@ class AppLocalizationsMk extends AppLocalizations {
       'Овозможи звук TrueHD (може да не работи на сите платформи)';
 
   @override
-  String get settingsAudioOutputMode => 'Режим на аудио излез';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Изберете како се декодира аудиото. AVR Passthrough испраќа необработени Dolby/DTS стримови до вашиот ресивер; Автоматски или Downmix декодира локално.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Резервен аудио кодек';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Изберете го целниот формат за транскодирање на повеќеканално аудио кога изворниот стрим не може да се пушти директно или да помине без обработка.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Автоматско откривање\n(Препорачано)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Стандардно)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2545,39 +2544,38 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Без загуби)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Само стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Ефикасен)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Без загуби)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максимум аудио канали';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Поставете го максималниот број канали на вашиот аудио систем. Повеќеканалните стримови над овој лимит ќе бидат измешани или транскодирани.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Автоматско откривање\n(Стандардно за хардверот)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Квадрофонски';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2592,14 +2590,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (напредно)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough на кодеци';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Овозможете ги само форматите што ги поддржува вашиот AVR или HDMI приемник.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
   String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
@@ -2621,38 +2619,38 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Испраќај Dolby Digital Plus (EAC3) како битстрим до надворешен декодер.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Испраќај Dolby Atmos преку EAC3 (JOC) како битстрим до надворешен декодер.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Испраќај DTS-HD MA (го вклучува DTS core) како битстрим до надворешен декодер.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Испраќај Dolby TrueHD со Atmos метаподатоци како битстрим до надворешен декодер.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Откриени аудио можности';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Сè уште нема достапна снимка од можностите при извршување.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Рута';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Декодирање';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD аудио рута';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2667,10 +2665,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Звучник';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Слушалки';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2678,39 +2676,39 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Дијагностика';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Видео ниво';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Видео опсег';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Кодек на преводот';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Дозволени аудио кодеци';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS аудио кодеци';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 аудио кодеци';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Активна аудио рута';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Поддршка за HD аудио на рутата';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Ноќен режим';
@@ -2759,7 +2757,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueс';
+    return '${value}s';
   }
 
   @override
@@ -2774,7 +2772,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'По $episodes епизоди / $hoursч';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2850,45 +2848,45 @@ class AppLocalizationsMk extends AppLocalizations {
       'Приспособете го изгледот на титлите';
 
   @override
-  String get subtitleMode => 'Режим на преводите';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Означени';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Секогаш';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Странски';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Принудни';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Ги пушта записите означени во метаподатоците на медиумската датотека како „стандардни“ или „принудни“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Автоматски вчитува и прикажува преводи секогаш кога започнува видео.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Автоматски ги вклучува преводите ако стандардниот аудио запис е на странски јазик.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Вчитува само преводи што се експлицитно означени со принудното знаменце во метаподатоците.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Целосно го оневозможува автоматското вчитување преводи.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Резервен јазик на преводите';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Стрим на преводите';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2898,7 +2896,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get verticalOffset => 'Вертикално поместување';
 
   @override
-  String get pgsDirectPlay => 'PGS директно пуштање';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Директна репродукција на PGS преводи';
@@ -2948,17 +2946,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Вчитани се поставките за профилот $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Неуспешно вчитување на поставките за профилот $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Локалните поставки се синхронизирани со профилот $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3095,11 +3093,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи библиотеки во лентата со алатки';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Секогаш прошируј ги ознаките во навигацијата';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Прикажи го копчето Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Непроѕирност на навигација';
@@ -3174,19 +3171,18 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи ја опцијата за прелистување папки';
 
   @override
-  String get groupItemsIntoCollections => 'Групирај ги ставките во колекции';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Скриј ги ставките поврзани со колекција при прегледување на библиотеките';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Известување за групирање на библиотеката';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'За да ја користите оваа поставка, проверете дали поставките на библиотеката „Групирај ги филмовите во колекции“ и/или „Групирај ги сериите во колекции“ се овозможени во поставките за приказ на вашата библиотека на вашиот Jellyfin или Emby сервер.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Видливост на библиотеката';
@@ -3215,7 +3211,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count избрани';
+    return '$count selected';
   }
 
   @override
@@ -3245,7 +3241,7 @@ class AppLocalizationsMk extends AppLocalizations {
       'Изберете помеѓу различни стилови на медиумска лента или исклучете ја медиумската лента';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Месечината';
 
   @override
   String get mediaBarModeMakd => 'МакД';
@@ -3298,11 +3294,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Автоматска репродукција на трејлери во лентата за медиуми по 3 секунди';
 
   @override
-  String get trailerAudio => 'Аудио на трејлерите';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Овозможи аудио за трејлерите во медиумската лента';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Преглед на епизода';
@@ -3380,11 +3375,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Комбинирајте ги двата реда во еден домашен дел';
 
   @override
-  String get fullScreenRows => 'Проширени почетни редови';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Ограничи ги почетните редови на 1 ред по екран';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тип на слика по ред';
@@ -3399,7 +3393,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get lastUser => 'Последен корисник';
 
   @override
-  String get currentUser => 'Тековен корисник';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Секогаш автентицирај';
@@ -3476,7 +3470,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
@@ -3507,10 +3501,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Приказ на часовникот за време на заштитниот екран';
 
   @override
-  String get clockModeStatic => 'Статичен';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Отскокнувачки';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Расипани домати (критичари)';
@@ -3531,7 +3525,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get metacriticUser => 'Метакритик (корисник)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'Кутија со писмо';
@@ -3552,7 +3546,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get additionalRatings => 'Дополнителни оценки';
 
   @override
-  String get showMdbListAndTmdbRatings => 'Прикажи оцени од MDBList и TMDB';
+  String get showMdbListAndTmdbRatings => 'Прикажи рејтинзи на MDBL и TMDB';
 
   @override
   String get ratingLabels => 'Рејтинг етикети';
@@ -3580,7 +3574,7 @@ class AppLocalizationsMk extends AppLocalizations {
       'Овозможете ги и преуредите ги изворите за оценување прикажани низ апликацијата';
 
   @override
-  String get pluginLabel => 'Приклучок Moonbase';
+  String get pluginLabel => 'Приклучок';
 
   @override
   String get pluginDetected => 'Откриен е приклучокот';
@@ -3598,7 +3592,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nВерзија: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3652,7 +3646,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get networks => 'Мрежи';
 
   @override
-  String get seerrDiscoveryRows => 'Редови за откривање во Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Ресетирајте ги редовите на стандардни';
@@ -3675,43 +3669,44 @@ class AppLocalizationsMk extends AppLocalizations {
   String get hideAdultContent => 'Сокријте содржини за возрасни во резултатите';
 
   @override
-  String get seerrNotificationsSection => 'Известувања';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Известувања за нови барања';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Извести ме кога некој ќе поднесе барање';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Ажурирања на барањата';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Одобрени, одбиени и додадени во вашата библиотека';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ажурирања на проблемите';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Нови проблеми, одговори и решенија';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Најавен како: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Страница за откривање во Seerr';
+  String get discoverRows => 'Откријте редови';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Овозможете ги редовите што сакате да ги гледате на главната страница на Seerr. Влечете за да ги преуредите. Прилагодениот редослед се синхронизира со Moonbase.';
+      'Повлечете за повторно да нарачате. Овозможете или оневозможете редови. Овозможеното нарачка на редови се синхронизира со приклучокот Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Овозможете ги редовите што сакате да ги гледате на главната страница на Seerr. Влечете за да ги преуредите. Прилагодениот редослед се синхронизира со Moonbase.';
+      'Повлечете за повторно да нарачате. Овозможете или оневозможете редови.';
 
   @override
   String get enabled => 'Овозможено';
@@ -3724,7 +3719,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Верзија $version';
+    return 'Version $version';
   }
 
   @override
@@ -3775,7 +3770,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Достапно ажурирање: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3786,7 +3781,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Достапна е v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3828,7 +3823,7 @@ class AppLocalizationsMk extends AppLocalizations {
       'Големина на постер, тип на слика, приказ на папка';
 
   @override
-  String get mdbListTmdbRatingSources => 'MDBList, TMDB и извори на оцени';
+  String get mdbListTmdbRatingSources => 'MDBLlist, TMDB и извори на оценување';
 
   @override
   String gbValue(String value) {
@@ -3850,7 +3845,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get imageCacheCleared => 'Кешот за слики е исчистен';
 
   @override
-  String get clear => 'Исчисти';
+  String get clear => 'Јасно';
 
   @override
   String get browse => 'Прелистајте';
@@ -3866,19 +3861,19 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Се презема · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Се увезува';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count Ставки';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Поставки за Seerr';
+  String get seerrSettings => 'Поставки на Seer';
 
   @override
   String get requestMore => 'Побарајте повеќе';
@@ -3894,7 +3889,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Побарано од $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3911,12 +3906,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Да се откаже барањето за „$title“?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Да се откажат $count барања за „$title“?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3931,12 +3926,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Буџет: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Приход: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3946,7 +3941,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Побарај $type';
+    return 'Request $type';
   }
 
   @override
@@ -3975,14 +3970,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get showMore => 'Прикажи повеќе';
 
   @override
-  String get appearances => 'Појавувања';
+  String get appearances => 'Изгледи';
 
   @override
   String get crewSection => 'Екипаж';
 
   @override
   String ageValue(int age) {
-    return 'возраст $age';
+    return 'age $age';
   }
 
   @override
@@ -4013,149 +4008,148 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deletedStatus => 'Избришано';
 
   @override
-  String get failedStatus => 'Неуспешно';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Се обработува';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Изменето од $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завршено';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Овој наслов е веќе побаран';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Достигнат е лимитот на барања';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Овој наслов е на списокот на блокирани';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Не останаа сезони за барање';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Немате дозвола да го поднесете ова барање';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Барања';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Проблеми';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Најнови';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Последно изменети';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Нема проблеми';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Преостанати $remaining од $limit барања за филмови';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Преостанати $remaining од $limit барања за сезони';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Дел од $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Прикажи ја колекцијата';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Побарај ја колекцијата';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total филмови · $available достапни';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Побарај $count филмови';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Се бара $current од $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Побарани се $count филмови';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Побарани се $ok од $total филмови';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Сите филмови се веќе достапни или побарани';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Пријави проблем';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Видео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Аудио';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Што е проблемот?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Сите епизоди';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Епизода';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Отворено';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Решен';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Реши';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Отвори повторно';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Пријавено од $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count коментари';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Додадете коментар';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Да се избрише овој проблем?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Испрати извештај';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Резултат на TMDB';
@@ -4188,7 +4182,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get access => 'Пристап';
 
   @override
-  String get add => 'Додај';
+  String get add => 'Додадете';
 
   @override
   String get address => 'Адреса';
@@ -4272,7 +4266,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get refresh => 'Освежи';
 
   @override
-  String get remote => 'Далечински управувач';
+  String get remote => 'Далечински';
 
   @override
   String get rename => 'Преименувај';
@@ -4317,7 +4311,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get time => 'Време';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Трик игра';
 
   @override
   String get uninstall => 'Деинсталирајте';
@@ -4359,13 +4353,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminDrawerLibraries => 'Библиотеки';
 
   @override
-  String get adminDrawerDisplay => 'Приказ';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метаподатоци';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO поставки';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Транскодирање';
@@ -4377,7 +4371,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminDrawerStreaming => 'Стриминг';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Трик игра';
 
   @override
   String get adminDrawerDevices => 'Уреди';
@@ -4429,22 +4423,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Достапни ажурирања за приклучоци: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Приклучоци што бараат рестартирање: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Неуспешни закажани задачи: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Скорешни записи со предупредување/грешка: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4503,7 +4497,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Грешка: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4530,7 +4524,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Командата не успеа: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4558,7 +4552,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get sessionVolumeDown => 'Том -';
 
   @override
-  String get sessionVolumeUp => 'Вол +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4К';
@@ -4567,7 +4561,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get nowPlaying => 'Сега се игра';
 
   @override
-  String get volume => 'Јачина на звук';
+  String get volume => 'Волумен';
 
   @override
   String get actions => 'Акции';
@@ -4579,7 +4573,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audioCodec => 'Аудио кодек';
 
   @override
-  String get hwAccel => 'Хард. забрзување';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Завршување';
@@ -4594,14 +4588,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminClearDates => 'Јасни датуми';
 
   @override
-  String get adminActivitySeverityAll => 'Сите нивоа';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Временски опсег';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Неуспешно вчитување на дневникот на активности: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4618,7 +4612,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Неуспешно ажурирање на уредот: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4629,28 +4623,28 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Неуспешно бришење на уредот: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Да се отстрани уредот „$name“? Корисникот ќе треба повторно да се најави на овој уред.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Избриши ги сите уреди';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Да се отстранат $count уреди? Засегнатите корисници ќе треба повторно да се најават. Вашиот тековен уред не е засегнат.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Уредите се отстранети';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Некои уреди се отстранети; $count не можеа да се отстранат.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4679,7 +4673,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Неуспешно започнување на скенирањето: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4690,12 +4684,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Библиотеката е преименувана во „$name“';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Неуспешно преименување: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4703,17 +4697,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Библиотеката „$name“ е избришана';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Неуспешно бришење на библиотеката: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Неуспешно додавање на патеката: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4721,12 +4715,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Да се отстрани „$path“ од оваа библиотека?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Неуспешно отстранување на патеката: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4734,7 +4728,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Неуспешно зачувување на опциите: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4767,264 +4761,251 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminMetadataCountryHint => 'на пр. САД, ДЕ, ФР';
 
   @override
-  String get adminLibraryTabPaths => 'Патеки';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Опции';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Преземачи';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Зачувувачи на метаподатоци';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Преземачи на преводи';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Преземачи на текстови';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Преземачи на метаподатоци: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Добавувачи на слики: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Овој сервер не нуди преземачи за овој тип библиотека.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Општо';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метаподатоци';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Вградени информации';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Преводи';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Слики';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Серии';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музика';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Филмови';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Овозможи следење во реално време';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Откривај промени во датотеките и обработувај ги автоматски.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Третирај ги архивите како медиумски датотеки';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Прикажувај фотографии';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Зачувувај ги сликите во медиумските папки';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval =>
-      'Автоматско освежување на метаподатоците';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Никогаш';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Стандардно';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Приказ';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Приказ на библиотеката';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Прикажувај приказ со папки за обичните медиумски папки';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Прикажувај ги специјалните епизоди во сезоните во кои се емитувани';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Групирај ги филмовите во колекции';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Групирај ги сериите во колекции';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Прикажувај надворешна содржина во предлозите';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Однесување на датумот на додавање';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Користи датум на додавање од';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Датумот на скенирање во библиотеката';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Датумот на создавање на датотеката';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метаподатоци и слики';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection =>
-      'Претпочитан јазик на метаподатоците';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Поглавја';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Времетраење на фиктивните поглавја (секунди)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Должина на поглавјата генерирани за медиуми што немаат такви. Поставете 0 за оневозможување.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Резолуција на сликите за поглавјата';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO поставки';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO метаподатоците се компатибилни со Kodi и слични клиенти. Поставките важат за сите библиотеки што зачувуваат NFO метаподатоци.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Корисник за кого се зачувуваат податоците за гледање во NFO датотеките';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Зачувувај ги патеките на сликите во NFO датотеките';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Овозможи замена на патеките за сликите во NFO датотеките';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Копирај ги extrafanart сликите во папка extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Нема';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days дена';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Користи ги вградените наслови';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Користи ги вградените наслови за додатоците';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Користи ги вградените информации за епизодите';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Дозволи вградени преводи';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Сите';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Само текст';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Само слики';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Нема';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Прескокни го преземањето ако постојат вградени преводи';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Прескокни го преземањето ако аудио записот се совпаѓа со јазикот за преземање';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Барај совршено совпаѓање на преводот';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Зачувувај ги преводите во медиумските папки';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Извлекувај слики за поглавјата';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Извлекувај ги сликите за поглавјата при скенирањето на библиотеката';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Овозможи извлекување на Trickplay слики';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Извлекувај ги Trickplay сликите при скенирањето на библиотеката';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Зачувувај ги Trickplay сликите во медиумските папки';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Автоматски спојувај серии што се распространети во повеќе папки';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Име за приказ на нултата сезона';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Овозможи LUFS скенирање за нормализација на аудиото';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Претпочитај нестандардна ознака за изведувачи';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Автоматски додавај ги филмовите во колекции';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Потребно е името на библиотеката';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Неуспешно создавање на библиотеката: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5051,27 +5032,27 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Да се оневозможи $name? Нема да може да се најави.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Да се овозможи $name? Ќе може повторно да се најави.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Корисникот „$name“ е оневозможен';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Корисникот „$name“ е овозможен';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Неуспешно ажурирање на политиката за корисникот: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5088,7 +5069,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Неуспешно создавање на корисникот: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5108,7 +5089,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Неуспешно зачувување: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5119,7 +5100,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Неуспешно: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5256,144 +5237,143 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminEnableAllChannels => 'Овозможете пристап до сите канали';
 
   @override
-  String get adminParentalControl => 'Родителска контрола';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Максимална дозволена родителска оцена';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Содржината со повисока оцена ќе биде скриена од овој корисник.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Нема';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блокирај ставки без или со непрепознаени информации за оцена';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Книги';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Канали';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ТВ во живо';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Филмови';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музика';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трејлери';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Серии';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Распореди за пристап';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Дозволи пристап само во закажаните времиња подолу. Кога не е поставен распоред, пристапот е дозволен цел ден.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Додај распоред';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Ден';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Почеток';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Крај';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Секој ден';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Работен ден';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Викенд';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Недела';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Понеделник';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Вторник';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Среда';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Четврток';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Петок';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Сабота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Дозволени ознаки';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Се прикажува само содржина со овие ознаки. Оставете празно за да дозволите сè.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Блокирани ознаки';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Содржината со овие ознаки е скриена од овој корисник.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Додај ознака';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Овозможени уреди';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Овозможени канали';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Провајдер за автентикација';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Провајдер за ресетирање лозинка';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максимален број неуспешни обиди за најава пред заклучување';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Поставете 0 за стандардната вредност или -1 за да го оневозможите заклучувањето.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Пристап до SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Дозволи создавање и придружување кон групи';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Дозволи придружување кон групи';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Без пристап';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Дозволи бришење содржина од';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5401,22 +5381,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Серверот врати HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Дали сте сигурни дека сакате да го избришете $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Корисникот „$name“ е избришан';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Неуспешно бришење на корисникот: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5437,7 +5417,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Неуспешно создавање на клучот: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5449,7 +5429,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Да се отповика клучот за $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5457,7 +5437,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Неуспешно отповикување на клучот: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5478,30 +5458,29 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Токен: $token\\nСоздаден: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Создај резервна копија';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Изберете што да се вклучи во резервната копија.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База на податоци';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Секогаш вклучена';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метаподатоци';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Преводи';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay слики';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Се создава резервна копија...';
@@ -5511,7 +5490,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Неуспешно создавање на резервната копија: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5520,12 +5499,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Манифест: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Неуспешно вчитување на манифестот: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5536,7 +5515,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Неуспешно враќање на резервната копија: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5569,17 +5548,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Зачувано во $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Неуспешно зачувување на датотеката: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Неуспешно вчитување на $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5590,7 +5569,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Неуспешно вчитување на задачите: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5602,17 +5581,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Неуспешно стартување на задачата: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Неуспешно запирање на задачата: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Неуспешно вчитување на задачата: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5620,12 +5599,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Неуспешно отстранување на активирањето: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Неуспешно додавање на активирање: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5651,7 +5630,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours час(а)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5662,7 +5641,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Неуспешно префрлање на приклучокот: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5670,27 +5649,27 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Дали сте сигурни дека сакате да го деинсталирате „$name“?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Неуспешна деинсталација на приклучокот: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Неуспешна инсталација на пакетот: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Неуспешна инсталација на ажурирањето: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Неуспешно вчитување на приклучоците: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5702,12 +5681,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Инсталирај ажурирање (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Неуспешно вчитување на каталогот: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5729,17 +5708,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '„$name“ ќе биде отстранет по рестартирање на серверот';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Неуспешна деинсталација: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Се ажурира „$name“ на v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5748,7 +5727,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Неуспешно вчитување на приклучокот: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5756,7 +5735,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Верзија $version';
+    return 'Version $version';
   }
 
   @override
@@ -5776,17 +5755,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Дали сте сигурни дека сакате да го отстраните „$name“?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Неуспешно зачувување на складиштата: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Неуспешно вчитување на складиштата: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5803,12 +5782,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Не може да се вчитаат поставките на приклучокот: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Не може да се отвори $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6054,7 +6033,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminBaseUrl => 'Основен URL';
 
   @override
-  String get adminBaseUrlHint => 'на пр. /jellyfin';
+  String get adminBaseUrlHint => 'на пр. /желефин';
 
   @override
   String get https => 'HTTPS';
@@ -6094,12 +6073,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Неуспешно вчитување на метаподатоците: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Неуспешно зачувување на метаподатоците: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6120,7 +6099,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Неуспешно освежување на метаподатоците: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6134,7 +6113,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Оддалеченото пребарување не успеа: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6148,7 +6127,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Неуспешно ажурирање на типот содржина: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6163,12 +6142,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Сликата $imageType е ажурирана';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Неуспешно преземање на сликата: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6179,27 +6158,27 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Сликата $imageType е подигната';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Неуспешно подигање на сликата: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Избриши ја сликата $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Сликата $imageType е избришана';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Неуспешно бришење на сликата: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6210,68 +6189,67 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Откривањето на тјунери не успеа: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Додадете тјунер';
 
   @override
-  String get adminEditTuner => 'Уреди тјунер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U тјунер';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Датотека или URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP адреса на тјунерот';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Име за приказ';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Лимит на истовремени врски';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максималниот број стримови што тјунерот ги дозволува истовремено. Поставете 0 за неограничено.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Резервен максимален битрејт за стриминг';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Увезувај само омилени канали';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Дозволи хардверско транскодирање';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Дозволи fMP4 контејнер за транскодирање';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Дозволи споделување на стримот';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Овозможи повторување на стримот';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Игнорирај DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Читај го влезот со изворната честота на кадри';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Уреди провајдер';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6280,50 +6258,50 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Датотека или URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Префикс за филмови';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Категории за филмови';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Одделете повеќе категории со вертикална црта.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Категории за деца';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Категории за вести';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Категории за спорт';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Корисничко име';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Лозинка';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Држава';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Изберете држава';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Поштенски код';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Преземи ја програмата';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Програма';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Овозможи ги сите тјунери';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тип на тјунер';
@@ -6333,7 +6311,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Неуспешно додавање на тјунер: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6347,12 +6325,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Неуспешно додавање на провајдер: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Неуспешно отстранување на тјунерот: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6360,16 +6338,16 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Неуспешно ресетирање на тјунерот: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Овој тип тјунер не поддржува ресетирање.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Неуспешно отстранување на провајдерот: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6388,45 +6366,43 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Патека за снимање на серии';
 
   @override
-  String get adminMovieRecordingPath => 'Патека за снимките на филмови';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Денови со податоци за водичот';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автоматски';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days дена';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Патека до апликацијата за последователна обработка';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Аргументи за последователната обработка';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Зачувувај NFO метаподатоци за снимките';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Зачувувај слики за снимките';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Тајминг';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Патеки за снимките';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Последователна обработка';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Податоци за водичот: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6434,7 +6410,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Неуспешно зачувување на поставките: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6452,7 +6428,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Неуспешно ажурирање на мапирањата: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6469,15 +6445,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminGuideProviders => 'Даватели на водичи';
 
   @override
-  String get adminRefreshGuideData => 'Освежи ги податоците за водичот';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Освежувањето на податоците за водичот започна';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Задачата за освежување на водичот не е достапна на овој сервер.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Додадете провајдер';
@@ -6488,22 +6463,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Патека за снимки: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Патека за серии: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Време пред снимањето: $minutes мин';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Време по снимањето: $minutes мин';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6536,7 +6511,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Да се врати резервната копија $name сега?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6560,7 +6535,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminLiveTvTitle => 'Администрација на ТВ во живо';
 
   @override
-  String get adminApply => 'Примени';
+  String get adminApply => 'Пријавете се';
 
   @override
   String get adminNotSet => 'Не е поставено';
@@ -6582,27 +6557,27 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'пред $minutesм';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'пред $hoursч';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'пред $daysд';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Неуспешно вчитување на $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count совпаѓања';
+    return '$count matches';
   }
 
   @override
@@ -6612,7 +6587,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Уредувач на метаподатоци';
 
   @override
-  String get adminMetadataIdentify => 'Идентификувај';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тип';
@@ -6712,22 +6687,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Сликата $imageType е ажурирана';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Сликата $imageType е подигната';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Сликата $imageType е избришана';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Неуспешно преземање на сликата: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6736,12 +6711,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Неуспешно подигање на сликата: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Избриши ја сликата $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6750,12 +6725,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Неуспешно бришење на сликата: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Изберете слика $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6788,7 +6763,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Достапно ажурирање: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6812,7 +6787,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Инсталирај ажурирање (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6824,7 +6799,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '„$name“ се инсталира...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6844,7 +6819,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Поставки за $name';
+    return '$name Settings';
   }
 
   @override
@@ -6884,7 +6859,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Неуспешно вчитување на складиштата: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6892,7 +6867,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Дали сте сигурни дека сакате да го отстраните „$name“?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6900,7 +6875,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Неуспешно зачувување на складиштата: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7027,20 +7002,19 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Овозможи прскање на екранот';
 
   @override
-  String get adminBrandingSplashUpload => 'Подигни слика';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Почетниот екран е ажуриран';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Неуспешно подигање на почетниот екран';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Почетниот екран е отстранет';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Нема прилагоден почетен екран';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Хардверско забрзување';
@@ -7056,129 +7030,121 @@ class AppLocalizationsMk extends AppLocalizations {
       'Овозможете хардверско декодирање за:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV уред';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Овозможи подобрен NVDEC декодер';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Претпочитај го системскиот хардверски декодер';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Длабочина на бојата при хардверско декодирање';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-битно HEVC декодирање';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-битно VP9 декодирање';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-битно декодирање';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-битно декодирање';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Хардверско кодирање';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Дозволи HEVC кодирање';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Дозволи AV1 кодирање';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Овозможи Intel нискоенергетски H.264 кодер';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Овозможи Intel нискоенергетски HEVC кодер';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тонско мапирање';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Овозможи тонско мапирање';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Овозможи VPP тонско мапирање';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Овозможи VideoToolbox тонско мапирање';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Алгоритам за тонско мапирање';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Режим на тонско мапирање';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Опсег на тонско мапирање';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Десатурација при тонско мапирање';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Врв на тонско мапирање';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Параметар за тонско мапирање';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Осветленост при VPP тонско мапирање';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Контраст при VPP тонско мапирање';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Пресети и квалитет';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Пресет на кодерот';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF при H.264 кодирање';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF при H.265 (HEVC) кодирање';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метод на деинтерлејсинг';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Удвој ја честотата на кадри при деинтерлејсинг';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Аудио';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Овозможи VBR кодирање на аудиото';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Засилување при downmix на аудиото';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгоритам за стерео downmix';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максимална големина на редицата за муксирање';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Автоматски';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодирање';
@@ -7300,7 +7266,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminTaskStop => 'Стоп';
 
   @override
-  String get adminRunningTasks => 'Активни задачи';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Трчај';
@@ -7322,17 +7288,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Секој ден во $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Секој $day во $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Секои $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7370,8 +7336,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count часа',
-      one: '$count час',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7399,17 +7365,17 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'пред $daysд';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'пред $hoursч';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'пред $minutesм';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7417,22 +7383,22 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesм';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursч';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysд';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
@@ -7446,50 +7412,49 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Основен URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'на пр. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'на пр. /желефин';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Јавен HTTP порт';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Барај HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Пренасочи ги сите оддалечени барања кон HTTPS. Нема ефект ако серверот нема важечки сертификат.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Лозинка на сертификатот';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP поставки';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Овозможи IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Овозможи IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Овозможи автоматско мапирање на портови';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN мрежи';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Список со IP адреси или CIDR подмрежи, одделени со запирка или нов ред, кои се третираат како дел од локалната мрежа.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Објавени URI адреси на серверот';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Мапирајте подмрежа или адреса кон објавен URL, на пр. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Патека за сертификат';
@@ -7520,12 +7485,11 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Пуферирање на гас';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Одложување при ограничување (секунди)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Дозволи извлекување на преводи во реално време';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Минимален процент на биографија';
@@ -7575,30 +7539,29 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Неуспешно ажурирање на типот содржина: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Бавен праг на одговор (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Овозможи предупредувања за бавен одговор';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Овозможи Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метаподатоци';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Патеки';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Перформанси';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Патека на кешот';
@@ -7610,7 +7573,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminGeneralServerName => 'Име на серверот';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Претпочитан јазик за приказ';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Не успеа да се вчитаат поставките';
@@ -7620,12 +7583,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Неуспешно ажурирање на мапирањата: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Временско ограничување: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7662,8 +7625,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# учесници',
-      one: '# учесник',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7707,7 +7670,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Ставка $index';
+    return 'Item $index';
   }
 
   @override
@@ -7756,12 +7719,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName се приклучи на SyncPlay групата';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName ја напушти SyncPlay групата';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7773,7 +7736,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Синхронизирање на репродукцијата со $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7811,8 +7774,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'откриени # редови',
-      one: 'откриен # ред',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7853,21 +7816,20 @@ class AppLocalizationsMk extends AppLocalizations {
   String get offlineSavedMedia => 'Зачувани медиуми';
 
   @override
-  String get offlineBannerTitle => 'Не сте поврзани';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Се прикажуваат вашите преземања';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Преземања';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Не може да се пристапи до вашиот сервер';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Се пушта од преземањата додека не се врати';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7883,12 +7845,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Контролата за емитување не успеа: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Контроли за $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7899,7 +7861,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Запри $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7923,12 +7885,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Внесете $length-цифрен PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Внесете го вашиот $length-цифрен PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7941,41 +7903,42 @@ class AppLocalizationsMk extends AppLocalizations {
   String get pinForgot => 'Го заборавивте ПИН-кодот?';
 
   @override
-  String get pinClear => 'Исчисти';
+  String get pinClear => 'Јасно';
 
   @override
-  String get pinBackspace => 'Бришење';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Барањето за Quick Connect е одобрено.';
+  String get quickConnectAuthorized =>
+      'Барањето за брзо поврзување е овластено.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Кодот за Quick Connect е неважечки или истечен.';
+      'Кодот за брзо поврзување е неважечки или истечен.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect не е поддржан на овој сервер.';
+      'Брзо поврзување не е поддржано на овој сервер.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Неуспешно одобрување на кодот за Quick Connect.';
+      'Не успеа да се овласти кодот за брзо поврзување.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect е оневозможен на овој сервер.';
+      'Брзо поврзување е оневозможено на овој сервер.';
 
   @override
   String get quickConnectForbidden =>
-      'Вашата сметка не може да го одобри ова барање за Quick Connect.';
+      'Вашата сметка не може да го овласти ова барање за брзо поврзување.';
 
   @override
   String get quickConnectNotFound =>
-      'Кодот за Quick Connect не е пронајден. Обидете се со нов код.';
+      'Кодот за брзо поврзување не е пронајден. Обидете се со нов код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect не успеа: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7986,7 +7949,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Командата не успеа: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8015,7 +7978,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Неуспешно започнување на емитувањето: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8061,7 +8024,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Се презема $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8150,7 +8113,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return 'Прескокни $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8161,12 +8124,12 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Се презема $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Се презема $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8203,7 +8166,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Дозволете ротација';
 
   @override
-  String get playerTooltipPrevious => 'Претходно';
+  String get playerTooltipPrevious => 'Претходна';
 
   @override
   String get playerTooltipSeekBack => 'Барај назад';
@@ -8228,13 +8191,13 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Скриј од „Продолжи со гледање“';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Скриј од „Следно“';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Додај во колекција';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8289,15 +8252,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsAlphabetical => 'Азбучно';
 
   @override
-  String get settingsConnectionSection => 'ВРСКА';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Дозволи самопотпишани сертификати';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Верувај им на серверите што користат самопотпишани TLS сертификати или сертификати од приватен CA. Овозможете само за сервери што ги контролирате. Ова ја оневозможува проверката на сертификатите за сите врски.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ПРИВАТНОСТ И БЕЗБЕДНОСТ';
@@ -8313,11 +8275,11 @@ class AppLocalizationsMk extends AppLocalizations {
       'Акценти на теми, заднини, гледани индикатори и тематска музика';
 
   @override
-  String get settingsDetailsScreen => 'Екран со детали';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стил, заматување на позадината и однесување на јазичињата';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Почетна страница';
@@ -8355,11 +8317,11 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Прикажи го копчето Seerr во навигациската лента';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Секогаш прикажувај ги текстуалните ознаки во горната навигациска лента';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8429,7 +8391,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Почестете го развивачот со кафе';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ПРАВНИ';
@@ -8463,8 +8425,8 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лиценцни известувања',
-      one: '# лиценцно известување',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8514,17 +8476,16 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескокнете воведни и аутроси?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Одбројување за медиумските сегменти';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Лента за напредок';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Тајмер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Нема';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Пратен корисник';
@@ -8559,13 +8520,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (препорачано)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (застарено)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (наследство)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (препорачано)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback =>
@@ -8659,7 +8620,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8756,760 +8717,749 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Неодамна издадени $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Автоматски пушти ја следната епизода';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Автоматски пушти ја следната епизода кога е достапна.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Прескокни тишина';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Автоматски прескокнувај ги тивките аудио сегменти кога стримот го поддржува тоа.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Дозволи надворешни аудио ефекти';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Дозволи им на апликациите за еквилајзер и ефекти (на пр. Wavelet) да се прикачат на Media3 сесиите за репродукција.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Оневозможи тунелирање';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Наметни репродукција без тунелирање. Корисно на уреди со прекини на аудиото/видеото при тунелирање.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Овозможи тунелирање';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'За напредни корисници. Го насочува аудиото и видеото преку спрегнат хардверски пат. Стандардно исклучено бидејќи предизвикува прекини на аудиото/видеото на некои уреди.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Мапирај Dolby Vision профил 7 во HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Пуштај ги стримовите со Dolby Vision профил 7 како HDR10-компатибилен HEVC на уреди без DV.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Користи вградени стилови на преводите';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Применувај ги боите, фонтовите и позиционирањето вградени во преводот. Оневозможете за да ги користите вашите преференции за стил на преводите.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Користи вградени големини на фонтот на преводите';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Применувај ги предлозите за големина на фонтот вградени во преводот. Оневозможете за да ја користите големината на преводите од вашите преференции за стил.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Прикажи детали за медиумот';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Прикажувај детали за избраната ставка на врвот на страниците со библиотеки.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Скриј ги позадините при прегледување?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Користи детални поднаслови';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Прикажувај детален или минимален поднаслов на страниците со библиотеки.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Да се избрише зачуваната тема?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Да се отстрани „$themeName“ од кешот на овој уред?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Продавница за теми';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Прегледувајте и зачувувајте теми од заедницата';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Зачувајте тема за да ја користите како другите ваши зачувани теми.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Во моментот нема достапни теми.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Продавницата за теми не можеше да се вчита. Проверете ја врската и обидете се повторно.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Зачувај';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Зачувај и примени';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Зачувана';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Оваа тема не можеше да се вчита.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '„$themeName“ е зачувана.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '„$themeName“ е избришана од овој уред.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '„$themeName“ не можеше да се избрише.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Зачувани теми';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Ова се теми преземени од приклучокот на Moonfin за тековниот сервер. Бришењето ја отстранува само оваа локална копија.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Не се пронајдени зачувани теми за овој сервер.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Моментално активна';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Избриши ја зачуваната тема';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Управувајте со преземените теми од приклучоци на овој уред';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Уредувач на теми';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Отворете го уредувачот на теми на Moonfin во вашиот прелистувач';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Почетен екран';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Долна лента';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Класичен';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Модерен';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Почетни редови';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Приказ на почетните редови';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Секции на почетните редови';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Прекинувачи за почетните редови';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Овозможете или оневозможете ги категориите почетни редови базирани на библиотеки';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Овозможете ги следните прекинувачи за да се прикажуваат редовите во почетните секции.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Класичниот задржува тип на слика по ред и информативен слој. Модерниот користи редови од портрет до позадина.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Прикажи редови со омилени';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Прикажувај редови со омилени филмови, серии и други омилени во почетните секции.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Подредување на редовите со омилени';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Подредувајте ги редовите со омилени по датум на додавање, датум на издавање, азбучно и повеќе.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Прикажи редови со колекции';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Прикажувај редови со колекции во почетните секции.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Подредување на редовите со колекции';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Подредувајте ги редовите со колекции по датум на додавање, датум на издавање, азбучно и повеќе.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Прикажи редови со жанрови';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Прикажувај редови со жанрови во почетните секции.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Подредување на редовите со жанрови';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Подредувајте ги редовите со жанрови по датум на додавање, датум на издавање, азбучно и повеќе.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Ставки во редовите со жанрови';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Прикажувај филмови, серии или и двете во редовите со жанрови.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Прикажи редови со плејлисти';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Прикажувај редови со плејлисти во почетните секции.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Подредување на редовите со плејлисти';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Подредувајте ги редовите со плејлисти по датум на додавање, датум на издавање, азбучно и повеќе.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Прикажи аудио редови';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Прикажувај аудио редови во почетните секции.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Подредување на аудио редовите';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Подредувајте ги аудио редовите по датум на додавање, датум на издавање, азбучно и повеќе.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудио плејлисти';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Изглед';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Распоред';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тема';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Тастатура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Копчиња';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Рендерирање';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV конфигурација';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Надворешна апликација за пуштање';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Поставете надворешен плеер за да ја овозможите опцијата за пуштање со долг притисок';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Прикажи избирач на апликации кога започнува репродукцијата.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Се вчитуваат инсталираните плеери...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Врска';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Цел за транскодирање на аудиото';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Поддржано на овој уред';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Не е поддржано на овој уред';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Испраќај DTS:X (DTS UHD) како битстрим до надворешен декодер.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD со Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Однесување на медиумскиот плеер';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Подобрувања на репродукцијата';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Секогаш вклучено.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Замени го „Прескокни ја шпицата“ со приказот „Следно“';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Прикажи го слојот „Следно“ наместо копчето „Прескокни ја шпицата“.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Насочување на плеерот';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Претпочитај софтверски декодери';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Користи FFmpeg (аудио) и libgav1 (AV1) пред хардверските декодери. Оневозможете ако HDMI аудио passthrough не работи.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Отворај ја видео репродукцијата во избраната надворешна апликација на Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Автоматско редење';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Претпочитај SDH преводи';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Дај приоритет на SDH/CC преводите при автоматски избор.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Веб дијагностика';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin веб дијагностика';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Користете ја оваа страница за да дијагностицирате проблеми со поврзувањето во прелистувачот (CORS, мешана содржина и поставки за откривање).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Откриен е неуспех поради мешана содржина';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Откриен е неуспех на CORS/Preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin откри HTTPS страница што се обидува да повика HTTP URL на серверот. Прелистувачите го блокираат ова барање пред да стигне до вашиот сервер.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin откри неуспех на барање на ниво на прелистувач, што обично е предизвикано од недостасувачки CORS или preflight заглавја на медиумскиот сервер.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Целен URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Детал: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Тековен контекст на извршување';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Потекло';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Шема';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Режим на приклучок';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC скенирање';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Наметнат URL на серверот';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Стандарден URL на серверот';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL на прокси за откривање';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'не е конфигурирано';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Мешана содржина';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Оваа страница е вчитана преку HTTPS, но една или повеќе конфигурирани URL-адреси се HTTP. Прелистувачите блокираат HTTPS страници да повикуваат HTTP API-ја.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Решение: сервирајте го вашиот медиумски сервер или прокси крајна точка преку HTTPS, или вчитувајте го Moonfin преку HTTP само на доверливи локални мрежи.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Не е откриена очигледна конфигурација со мешана содржина од тековните поставки за извршување.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS список за проверка';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Дозволете го потеклото на прелистувачот во Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Вклучете Authorization, X-Emby-Authorization и X-Emby-Token во Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Изложете Content-Range и Accept-Ranges за стриминг и премотување.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Враќајте 204 на OPTIONS preflight барањата.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Пример за заглавје (nginx-стил)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Забелешка';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Оваа рута за дијагностика е наменета за веб верзии. Ако го гледате ова на друга платформа, овие проверки може да не важат.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Назад кон изборот на сервер';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Одјави ги сите корисници';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Дозволата за микрофон е трајно одбиена. Овозможете ја во системските поставки.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Потребна е дозвола за микрофон за гласовно пребарување.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Не разбрав. Обидете се повторно.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Не е откриен говор.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Грешка со микрофонот.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Гласовното пребарување бара интернет.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Гласовната услуга е зафатена. Обидете се повторно.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Дозволата за микрофон е трајно одбиена.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Дозволата за микрофон е одбиена.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Препознавањето на говор не е достапно на овој уред.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Отвори го iOS избирачот на рути';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay избирачот на рути не е достапен на овој уред.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Видеа';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Програми';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Песни';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Фото албуми';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Фотографии';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Луѓе';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Неодамна издадени епизоди';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Гледај повторно';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Гостински појавувања';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Појавувања (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Придонеси на екипата (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Гледај со група';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Грешки';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Предупредувања';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Диск';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Отвори во прелистувач';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Вградениот прелистувач не е достапен на оваа платформа.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Дали сте сигурни дека сакате да го рестартирате серверот?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Дали сте сигурни дека сакате да го исклучите серверот? Ќе треба рачно да го рестартирате.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Внатрешно';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Неактивно';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Не се пронајдени корисници';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Ниту еден корисник не одговара на вашето пребарување';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Не се пронајдени уреди';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Ниту еден уред не одговара на тековните филтри';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Лозинката е поставена';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Нема конфигурирана лозинка';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Оддалечен пристап';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Само локално';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Неуспешно вчитување на аналитиката за медиуми';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Комбинирана аналитика низ сите медиумски библиотеки.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Топ изведувачи';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Топ автори';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Топ придонесувачи';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Библиотеки',
-      one: '$count Библиотека',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Сè уште нема достапни вкупни индексирани медиуми за овој избор.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Детали за библиотеката';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Распределба по библиотеки';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Нема достапни библиотеки.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Администрација на серверот';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Податоци';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Кеш за слики';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Кеш';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Дневници';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Метаподатоци';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Транскодирање';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'Овој сервер не врати патеки.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% искористено';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Активност на корисниците';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Системски настани';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Бара внимание';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Сервер';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Репродукција';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Уреди';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Напредно';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Приклучоци';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'ТВ во живо';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Домашни видеа';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Мешана содржина';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Домашни видеа и фотографии';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Мешани филмови и серии';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9521,300 +9471,299 @@ class AppLocalizationsMk extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Не се пронајдени снимки';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Не се пронајдени страници со слики во .$extension архивата.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Вградениот рендерер не успеа ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB рендерерот не успеа ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Недостасува локална датотека за читачот: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status при отворање на податоците за книгата од $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Нема достапна крајна точка за читање на книгата';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Неподдржан формат на архива за стрип: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Приклучокот за извлекување CBR не е достапен на оваа платформа.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Неуспешно извлекување на .cbr архивата.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Извлекувањето на CB7 не е достапно на оваа платформа.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Приклучокот за извлекување CB7 не е достапен на оваа платформа.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Затвори го панелот со жанрови';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Се вчитува мешањето...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'МЕШАЊЕ НА БИБЛИОТЕКАТА';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'СЛУЧАЈНО МЕШАЊЕ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'МЕШАЊЕ ПО ЖАНРОВИ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Автоматско префрлање на HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Автоматски овозможи HDR за репродукција на HDR видео и врати го режимот на приказ при излез.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Кога е на цел екран';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Промени ја сликата';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Недостасува';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Ограничувања за транскодирање';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Да се исчистат сите слики?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Дали сте сигурни дека сакате да ги исчистите сите преземени слики?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Потврди го чистењето';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Дали сте сигурни дека сакате да го исчистите следново: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Подигање?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Резолуција: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Прикажувај само слики на јазикот на интерфејсот';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Потврди чистење на сè';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Сликата е успешно подигната!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Неуспешно подигање на сликата: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Неуспешно поставување на сликата: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Неуспешно бришење на сликата: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Неуспешно чистење на сите слики: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Да';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Позадини';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Банер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Лого';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Минијатура';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Слика';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Слика на дискот';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Слика од екранот';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Предна корица';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задна корица';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Слика на менито';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'позадина';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'банер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'лого';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'минијатура';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'слика';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'слика на дискот';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'слика од екранот';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'предна корица';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задна корица';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'слика на менито';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Сите';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Висока (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Средна (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Ниска (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Извори';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Поглавја';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Обележувачи';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Белешки';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Редица';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Временска линија';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Временската линија е празна';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Цела книга';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Фокусирана временска линија';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Извези ги обележувачите';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Извези ги белешките';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Извези сè';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Извезено во $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Извозот не успеа: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Текст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Додај обележувач';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Додај белешка';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Уреди ја белешката';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напишете белешка за овој момент';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Тајмер за спиење';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Исклучено';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Крај на поглавјето';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Прилагоден';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'уште $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9822,58 +9771,58 @@ class AppLocalizationsMk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Брзина на репродукција';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Преостанато';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Изминато';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $secondsс';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Напред $secondsс';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Претходно поглавје';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Следно поглавје';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Поглавје $current од $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Нема поглавја';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Сè уште нема обележувачи';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Сè уште нема белешки';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Додаден е обележувач на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Врати на 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9881,252 +9830,249 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Зачувај';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Откажи';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Избриши';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Преференции за преводите';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Променете ги режимите на преводите, стандардните јазици, изгледот и опциите за рендерирање.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Рендерирање на преводите';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Опции за приказ';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Датум на издавање (растечки)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Датум на издавање (опаѓачки)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Групирај ги придонесите';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Групирај повеќе улоги';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Предупредување за пристап за запишување во библиотеката';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Како да го поправите ова:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Дајте дозволи за запишување на корисникот на услугата Jellyfin (на пр. jellyfin или Docker PUID/PGID) за папките на вашата медиумска библиотека на серверот.\n\n2. Или, одете во таблата на Jellyfin -> Библиотеки, уредете ја оваа библиотека и оневозможете „Зачувувај ги сликите во медиумските папки“ за сликите да се складираат во внатрешната база на податоци на Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Отфрли';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Вашата библиотека „$libraryName“ е конфигурирана да ги зачувува сликите директно во медиумските папки (овозможено е „Зачувувај ги сликите во медиумските папки“). Меѓутоа, Jellyfin го тестираше пристапот за запишување и нема дозвола да запишува датотеки во овој директориум:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Изгледа дека Jellyfin не успеа да ја ажурира сликата. Вашата библиотека е конфигурирана да ги зачувува сликите директно во медиумските папки (овозможено е „Зачувувај ги сликите во медиумските папки“). Оваа грешка обично се јавува кога процесот на серверот Jellyfin нема дозвола да запишува датотеки во вашите медиумски директориуми.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Надворешни списоци';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Пушти повторно';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Информации за датотеката';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Големина: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Прикажи ги сите ($count) аудио записи';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Прикажи ги сите ($count) преводи';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Се проверува можноста за директно пуштање...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Можност за директно пуштање: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Принудни';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Форматот на контејнерот не е поддржан од плеерот.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видео кодекот не е поддржан.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудио кодекот не е поддржан.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Форматот на преводот не е поддржан (бара втиснување).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Аудио профилот не е поддржан.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Видео профилот не е поддржан.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Видео нивото не е поддржано.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Видео резолуцијата не е поддржана од овој уред.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Битската длабочина на видеото не е поддржана.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Честотата на кадри не е поддржана.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Битрејтот на датотеката го надминува лимитот за стриминг на плеерот.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Битрејтот на видеото го надминува лимитот за стриминг.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Битрејтот на аудиото го надминува лимитот за стриминг.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Бројот на аудио канали не е поддржан.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Азбучно';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Редослед на издавање (растечки)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Редослед на издавање (опаѓачки)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Прилагоден (со влечење)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Опции за подредување на плејлистата';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Ресетирај го подредувањето';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Гледај повторно С$season:Е$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Гледај ја плејлистата повторно';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Не се пронајдени преводи.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Административни контроли';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Мотор за рендерирање (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller е модерниот GPU рендерер на Flutter за помазни анимации и помалку засекнувања. На некои TV уреди и постари GPU може да предизвика дефекти или црно видео; исклучете го ако забележите такви. „Автоматски“ ја избира најдобрата стандардна поставка за вашиот уред. Рестартирајте го Moonfin за да се примени.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автоматски';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Вклучено';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Исклучено';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Потребно е рестартирање';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin треба да се рестартира за да го смени моторот за рендерирање. Затворете ја апликацијата сега, потоа отворете ја повторно за да се примени.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Затвори ја апликацијата сега';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Освежи ја библиотеката';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Освежи ги сите библиотеки';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Датум на додавање (најстарите први)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Датум на додавање (најновите први)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Азбучно (А до Ш)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Азбучно (Ш до А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Се вчитува аналитиката на серверот... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Како изворот';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Топ 250 филмови';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Топ 250 ТВ серии';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Најпопуларни филмови';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Најпопуларни ТВ серии';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Најниско оценети филмови';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb Најдобро оценети филмови на англиски';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -9,30 +9,30 @@ class AppLocalizationsMl extends AppLocalizations {
   AppLocalizationsMl([String locale = 'ml']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'മൂൺഫിൻ';
 
   @override
-  String get accountPreferences => 'അക്കൗണ്ട് മുൻഗണനകൾ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ഇന്റർഫേസ് ഭാഷ';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'സിസ്റ്റം ഡിഫോൾട്ട്';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'സൈൻ ഇൻ';
 
   @override
-  String get empty => 'ശൂന്യം';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName ലേക്ക് കണക്റ്റ് ചെയ്യുന്നു';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'ദ്രുത കണക്ഷൻ';
 
   @override
   String get password => 'രഹസ്യവാക്ക്';
@@ -61,12 +61,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ലഭ്യമല്ല: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ലഭ്യമല്ല ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin പതിപ്പ് $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'നിങ്ങളുടെ സെർവറുകളിൽ നിന്ന് \"$serverName\" നീക്കം ചെയ്യണോ?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsMl extends AppLocalizations {
   String get settingsAppearanceTheme => 'ആപ്പ് തീം';
 
   @override
-  String get detailScreenStyle => 'വിശദാംശ സ്ക്രീൻ ശൈലി';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'ക്ലാസിക് എന്നത് യഥാർത്ഥ കേന്ദ്രീകൃത Moonfin ലേഔട്ടാണ്. മോഡേൺ എന്നത് ഒരു റെസ്പോൺസീവ് സിനിമാറ്റിക് ലേഔട്ടാണ്.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'ക്ലാസിക്';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'മോഡേൺ';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'വിപുലീകരിച്ച ടാബുകൾ';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ടാബുകൾ ബ്രൗസ് ചെയ്യുമ്പോൾ ടാബ് ഉള്ളടക്കം സ്വയമേവ കാണിക്കുക. ഓരോ ടാബും സ്വമേധയാ തുറക്കാനും അടയ്ക്കാനും ഓഫ് ചെയ്യുക.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'സാങ്കേതിക വിശദാംശങ്ങൾ കാണിക്കണോ?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'ബാനർ സംഗ്രഹത്തിൽ കോഡെക്, റെസലൂഷൻ, സ്ട്രീം വിവരങ്ങൾ കാണിക്കുക';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'ശുപാർശ സംവിധാനം';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends ലോക്കൽ-ലൈബ്രറി അൽഗോരിതം അല്ലെങ്കിൽ ഓൺലൈൻ TMDb യുടെ സാമ്യതാ മെട്രിക്സ് ഉപയോഗിക്കുക. ശ്രദ്ധിക്കുക: ഓൺലൈൻ ശുപാർശകൾക്ക് Seerr സംയോജനം ആവശ്യമാണ്.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb സാമ്യത';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'പേരന്റൽ റേറ്റിംഗ് പരിധി പ്രയോഗിക്കണോ?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'ലക്ഷ്യ മീഡിയയുടെ പേരന്റൽ റേറ്റിംഗ് അനുസരിച്ച് Moonfin Recommends നിർദ്ദേശങ്ങൾ പരിമിതപ്പെടുത്തുക';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'ഇന്റർഫേസ് ശൈലി';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ഓട്ടോമാറ്റിക് നിങ്ങളുടെ ഉപകരണവുമായി പൊരുത്തപ്പെടുന്നു. ഒരു രൂപം നിർബന്ധമാക്കാൻ Apple അല്ലെങ്കിൽ Material തിരഞ്ഞെടുക്കുക.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ഓട്ടോമാറ്റിക്';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsMl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'ഗ്ലാസ് ഗുണനിലവാരം';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ഓട്ടോ ഈ ഉപകരണത്തിനുള്ള മികച്ച ഗ്ലാസ് ഇഫക്റ്റ് തിരഞ്ഞെടുക്കുന്നു. ഫുൾ യഥാർത്ഥ ബ്ലർ നിർബന്ധമാക്കുന്നു; റിഡ്യൂസ്ഡ് GPU പവർ ലാഭിക്കുന്ന ഭാരം കുറഞ്ഞ ഗ്ലാസ് ഉപയോഗിക്കുന്നു.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ഓട്ടോ';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'ഫുൾ';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'റിഡ്യൂസ്ഡ്';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'ആപ്പ് പുനരാരംഭിക്കാതെ തന്നെ Moonfin, Neon Pulse എന്നിവയ്ക്കിടയിൽ മാറുക';
 
   @override
-  String get customThemeTitle => 'ഇഷ്ടാനുസൃത തീം';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ഇഷ്ടാനുസൃത തീമുകൾ Moonfin-ൽ ഉടനീളം വിഷ്വൽ ഘടകങ്ങൾ മാറ്റുന്നു. നിങ്ങളുടെ ശൈലിക്ക് അനുയോജ്യമായ ഒന്ന് തിരഞ്ഞെടുക്കുക.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'സിസ്റ്റം കീബോർഡ് തിരഞ്ഞെടുക്കുക';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'ടെക്സ്റ്റ് നൽകുന്നതിന് ഡിഫോൾട്ടായി നിങ്ങളുടെ ഉപകരണത്തിന്റെ ഇൻപുട്ട് രീതി ഉപയോഗിക്കുക';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'മൂൺഫിൻ';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsMl extends AppLocalizations {
       'മജന്ത ഗ്ലോ, സിയാൻ ടെക്‌സ്‌റ്റ്, ശക്തമായ ക്രോം കോൺട്രാസ്റ്റ് എന്നിവയ്‌ക്കൊപ്പം സിന്ത്‌വേവ് സ്‌റ്റൈലിംഗ്';
 
   @override
-  String get themeGlass => 'ഗ്ലാസ്';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'ഒഴുകുന്ന ഗ്രേഡിയന്റ് പശ്ചാത്തലം, ഫ്രോസ്റ്റഡ് പ്രതലങ്ങൾ, Apple-നീല ആക്സന്റ് എന്നിവയുള്ള ലിക്വിഡ്-ഗ്ലാസ് ശൈലി';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'കട്ടിയുള്ള പാലറ്റ്, ബ്ലോക്കി ബോർഡറുകൾ, കടുത്ത ഡ്രോപ്പ്-ഷാഡോകൾ, പിക്സൽ ഫോണ്ട് എന്നിവയുള്ള റെട്രോ പിക്സൽ-ആർട്ട് ശൈലി';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -315,7 +315,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target ലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -328,36 +328,35 @@ class AppLocalizationsMl extends AppLocalizations {
   String get exit => 'പുറത്ത്';
 
   @override
-  String get gameMenu => 'മെനു';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'താൽക്കാലികമായി നിർത്തി';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'സ്റ്റേറ്റ് സംരക്ഷിക്കുക';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ഗെയിമുകൾ';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'സ്റ്റേറ്റ് ലോഡ് ചെയ്യുക';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'ഫാസ്റ്റ്-ഫോർവേഡ്';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'എമുലേറ്റർ ക്രമീകരണങ്ങൾ';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'ഈ കോറിന് ക്രമീകരിക്കാവുന്ന ഓപ്ഷനുകളൊന്നുമില്ല.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'മെനു തുറക്കാൻ അമർത്തിപ്പിടിക്കുക';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'ഈ ഉപകരണത്തിൽ ഗെയിം കളിക്കുന്നത് ഇതുവരെ പിന്തുണയ്ക്കുന്നില്ല.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ഹോം വരികളൊന്നും ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല';
@@ -379,13 +378,13 @@ class AppLocalizationsMl extends AppLocalizations {
   String get schedule => 'ഷെഡ്യൂൾ';
 
   @override
-  String get series => 'പരമ്പരകൾ';
+  String get series => 'പരമ്പര';
 
   @override
   String get noItemsFound => 'ഇനങ്ങളൊന്നും കണ്ടെത്തിയില്ല';
 
   @override
-  String get home => 'ഹോം';
+  String get home => 'വീട്';
 
   @override
   String get browseAll => 'എല്ലാം ബ്രൗസ് ചെയ്യുക';
@@ -430,7 +429,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'ഫോൾഡർ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -438,7 +437,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count ഇനങ്ങൾ';
+    return '$count items';
   }
 
   @override
@@ -455,7 +454,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count ഇനങ്ങൾ';
+    return '$count Items';
   }
 
   @override
@@ -496,7 +495,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — വിഭാഗങ്ങൾ';
+    return '$name — Genres';
   }
 
   @override
@@ -535,17 +534,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$countമി മുമ്പ്';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$countമ മുമ്പ്';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$countദി മുമ്പ്';
+    return '${count}d ago';
   }
 
   @override
@@ -556,7 +555,7 @@ class AppLocalizationsMl extends AppLocalizations {
       'Discover-ൽ കാണിക്കേണ്ട വിഷയ ഫീഡുകൾ തിരഞ്ഞെടുക്കുക.';
 
   @override
-  String get apply => 'പ്രയോഗിക്കുക';
+  String get apply => 'അപേക്ഷിക്കുക';
 
   @override
   String get openLink => 'ലിങ്ക് തുറക്കുക';
@@ -580,7 +579,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count ശീർഷകങ്ങൾ';
+    return '$count titles';
   }
 
   @override
@@ -605,7 +604,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get listen => 'കേൾക്കുക';
 
   @override
-  String get resume => 'തുടരുക';
+  String get resume => 'പുനരാരംഭിക്കുക';
 
   @override
   String get failedToLoadLibrary => 'ലൈബ്രറി ലോഡ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു';
@@ -668,17 +667,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count രചയിതാക്കൾ';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count വിഭാഗങ്ങൾ';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% പൂർത്തിയായി';
+    return '$percent% completed';
   }
 
   @override
@@ -695,7 +694,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'വായന-ആദ്യ ബ്രൗസിംഗിനായി ക്രമീകരിച്ച $count ശീർഷകങ്ങൾ.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -732,7 +731,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label ഒന്നും കണ്ടെത്തിയില്ല';
+    return 'No $label found';
   }
 
   @override
@@ -751,13 +750,13 @@ class AppLocalizationsMl extends AppLocalizations {
   String get readStatus => 'വായിക്കുക';
 
   @override
-  String get watched => 'കണ്ടവ';
+  String get watched => 'നിരീക്ഷിച്ചു';
 
   @override
   String get unread => 'വായിക്കാത്തത്';
 
   @override
-  String get unwatched => 'കാണാത്തവ';
+  String get unwatched => 'കാണാത്തത്';
 
   @override
   String get seriesStatus => 'സീരീസ് സ്റ്റാറ്റസ്';
@@ -769,43 +768,43 @@ class AppLocalizationsMl extends AppLocalizations {
   String get books => 'പുസ്തകങ്ങൾ';
 
   @override
-  String get latestBooks => 'ഏറ്റവും പുതിയ പുസ്തകങ്ങൾ';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'ഏറ്റവും പുതിയ ഓഡിയോബുക്കുകൾ';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count പുസ്തകങ്ങൾ',
-      one: '1 പുസ്തകം',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'പുസ്തകം';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ഓഡിയോബുക്ക്';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% വായിച്ചു';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time ബാക്കി';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'വായിക്കുക';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'കേൾക്കുക';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'രചയിതാവ്';
@@ -843,12 +842,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count വിഭാഗങ്ങൾ';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'ആദ്യം പ്രസിദ്ധീകരിച്ചത് $year';
+    return 'First published $year';
   }
 
   @override
@@ -863,7 +862,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count പുസ്തകങ്ങൾ';
+    return '$count books';
   }
 
   @override
@@ -874,7 +873,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count രചയിതാക്കൾ';
+    return '$count Authors';
   }
 
   @override
@@ -882,8 +881,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ഓഡിയോബുക്കുകൾ',
-      one: '1 ഓഡിയോബുക്ക്',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -931,7 +930,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get movies => 'സിനിമകൾ';
 
   @override
-  String get musicVideos => 'മ്യൂസിക് വീഡിയോകൾ';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'മറ്റുള്ളവ';
@@ -950,7 +949,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'ഡിസ്ക് $number';
+    return 'Disc $number';
   }
 
   @override
@@ -975,7 +974,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'പ്രസിദ്ധീകരിച്ചത് $year';
+    return 'Published $year';
   }
 
   @override
@@ -986,52 +985,52 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count സീസണുകൾ',
-      one: '1 സീസൺ',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time ന് അവസാനിക്കുന്നു';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'ഇനങ്ങൾ';
+  String get items => 'Items';
 
   @override
-  String get extras => 'എക്സ്ട്രാകൾ';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'ബിഹൈൻഡ് ദ സീൻസ്';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ഒഴിവാക്കിയ രംഗങ്ങൾ';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ഫീച്ചറെറ്റുകൾ';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'അഭിമുഖങ്ങൾ';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'രംഗങ്ങൾ';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'ഹ്രസ്വചിത്രങ്ങൾ';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'ട്രെയിലറുകൾ';
 
   @override
   String timeRemaining(String time) {
-    return '$time ബാക്കി';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time ൽ അവസാനിക്കുന്നു';
+    return 'Ends in $time';
   }
 
   @override
@@ -1045,11 +1044,11 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position ൽ നിന്ന് പുനരാരംഭിക്കുക';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'പ്ലേ ചെയ്യുക';
+  String get play => 'കളിക്കുക';
 
   @override
   String get startOver => 'വീണ്ടും ആരംഭിക്കുക';
@@ -1073,7 +1072,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get version => 'പതിപ്പ്';
 
   @override
-  String get cast => 'കാസ്റ്റ് ചെയ്യുക';
+  String get cast => 'കാസ്റ്റ്';
 
   @override
   String get trailer => 'ട്രെയിലർ';
@@ -1145,7 +1144,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" നായി ഡൗൺലോഡ് ചെയ്ത ട്രാക്കുകൾ ഇല്ലാതാക്കണോ?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1160,17 +1159,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel ഒന്നും ലോഡ് ചെയ്തിട്ടില്ല';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title ഡൗൺലോഡ് ചെയ്യുന്നു ($count ഇനങ്ങൾ)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'സെർവറിൽ നിന്ന് \"$name\" ഇല്ലാതാക്കണമെന്ന് ഉറപ്പാണോ? ഈ പ്രവർത്തനം പഴയപടിയാക്കാൻ കഴിയില്ല.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1182,7 +1181,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'പിന്തുണയ്ക്കാത്ത പുസ്തക ഫോർമാറ്റ്: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1209,7 +1208,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'സബ്ടൈറ്റിൽ ഡൗൺലോഡ് ചെയ്ത് തിരഞ്ഞെടുത്തു: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1218,7 +1217,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language നായി റിമോട്ട് സബ്ടൈറ്റിലുകളൊന്നും കണ്ടെത്തിയില്ല.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1226,7 +1225,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'പതിപ്പ് $number';
+    return 'Version $number';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name ഡൗൺലോഡ് ചെയ്യുന്നു ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1255,7 +1254,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel നായുള്ള ലോക്കൽ ഫയലുകൾ ഇല്ലാതാക്കണോ?\n\nഇത് സ്റ്റോറേജ് സ്ഥലം ഒഴിവാക്കും. നിങ്ങൾക്ക് പിന്നീട് വീണ്ടും ഡൗൺലോഡ് ചെയ്യാം.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1271,25 +1270,25 @@ class AppLocalizationsMl extends AppLocalizations {
   String get director => 'ഡയറക്ടർ';
 
   @override
-  String get directors => 'സംവിധായകർ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'രചയിതാവ്';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'തിരക്കഥാകൃത്തുക്കൾ';
+  String get writers => 'എഴുത്തുകാർ';
 
   @override
   String get studio => 'സ്റ്റുഡിയോ';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count കൂടുതൽ';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count എപ്പിസോഡുകൾ';
+    return '$count Episodes';
   }
 
   @override
@@ -1299,12 +1298,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'എപ്പിസോഡ് $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'അധ്യായം $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1312,8 +1311,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ട്രാക്കുകൾ',
-      one: '1 ട്രാക്ക്',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1323,25 +1322,25 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count അധ്യായങ്ങൾ',
-      one: '1 അധ്യായം',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'ജനനം $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'മരണം $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'വയസ്സ് $age';
+    return 'Age $age';
   }
 
   @override
@@ -1351,21 +1350,20 @@ class AppLocalizationsMl extends AppLocalizations {
   String get readMore => 'കൂടുതൽ വായിക്കുക';
 
   @override
-  String get shuffle => 'ഷഫിൾ';
+  String get shuffle => 'ഷഫിൾ ചെയ്യുക';
 
   @override
-  String get shuffleAllMusic => 'എല്ലാ സംഗീതവും ഷഫിൾ ചെയ്യുക';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'നിങ്ങളുടെ ഫോണിൽ Moonfin ലേക്ക് സൈൻ ഇൻ ചെയ്യുക';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable =>
-      'നിങ്ങളുടെ സെർവറിലേക്ക് എത്താൻ കഴിയുന്നില്ല';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count ഡൗൺലോഡുകൾ';
+    return '$count downloads';
   }
 
   @override
@@ -1384,32 +1382,32 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'റിമോട്ട് സബ്ടൈറ്റിൽ $action ന് ഈ ഉപയോക്താവിന് Jellyfin സബ്ടൈറ്റിൽ മാനേജ്മെന്റ് അനുമതി ആവശ്യമാണ്.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'റിമോട്ട് സബ്ടൈറ്റിൽ $action നായി ഈ ഇനം സെർവറിൽ കണ്ടെത്താൻ കഴിഞ്ഞില്ല.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'റിമോട്ട് സബ്ടൈറ്റിൽ $action പരാജയപ്പെട്ടു: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'റിമോട്ട് സബ്ടൈറ്റിൽ $action പരാജയപ്പെട്ടു (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'റിമോട്ട് സബ്ടൈറ്റിലുകൾ $action ചെയ്യാൻ കഴിഞ്ഞില്ല.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" നായി ഡൗൺലോഡ് ചെയ്ത എല്ലാ എപ്പിസോഡുകളും';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1440,17 +1438,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label പ്രവർത്തനം പരാജയപ്പെട്ടു: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'കാസ്റ്റ് വോളിയം സജ്ജമാക്കാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label നിയന്ത്രണങ്ങൾ';
+    return '$label Controls';
   }
 
   @override
@@ -1467,7 +1465,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$label നിർത്തുക';
+    return 'Stop $label';
   }
 
   @override
@@ -1475,7 +1473,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ട്രാക്ക് $number';
+    return 'Track $number';
   }
 
   @override
@@ -1492,7 +1490,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds സെക്കൻഡുകൾ';
+    return '$seconds seconds';
   }
 
   @override
@@ -1561,7 +1559,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get transcodeReasons => 'ട്രാൻസ്കോഡ് കാരണങ്ങൾ';
 
   @override
-  String get player => 'പ്ലെയർ';
+  String get player => 'കളിക്കാരൻ';
 
   @override
   String get container => 'കണ്ടെയ്നർ';
@@ -1607,12 +1605,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol സെഷൻ പിശക്';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'പുസ്തക വിശദാംശങ്ങൾ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1621,7 +1619,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'ഈ ഫോർമാറ്റ് (.$extension) ഇതുവരെ ആപ്പിനുള്ളിൽ കാണിക്കാൻ കഴിയില്ല.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1633,17 +1631,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'ആപ്പിനുള്ളിലെ റീഡർ തുറക്കാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label ൽ ബുക്ക്മാർക്ക് ഇതിനകം സംരക്ഷിച്ചു.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'ബുക്ക്മാർക്ക് ചേർത്തു: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1655,7 +1653,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'പേജ് $number';
+    return 'Page $number';
   }
 
   @override
@@ -1666,12 +1664,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'ഫോർമാറ്റ്: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% വായിച്ചു';
+    return '$percent% read';
   }
 
   @override
@@ -1695,7 +1693,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'സൂം പുനഃസജ്ജമാക്കുക (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1718,7 +1716,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'വായന നില അപ്ഡേറ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1750,7 +1748,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'ഈ പ്ലാറ്റ്ഫോമിന് $extension ഫയലുകൾക്കായി എംബഡഡ് ഡോക്യുമെന്റ് എഞ്ചിൻ ഹോസ്റ്റ് ചെയ്യാൻ കഴിയില്ല.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1789,7 +1787,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'ഗൈഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1800,22 +1798,22 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'അടുത്തത്: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesമി ബാക്കി';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursമ ബാക്കി';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursമ $minutesമി ബാക്കി';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1839,19 +1837,19 @@ class AppLocalizationsMl extends AppLocalizations {
   String get favoriteChannel => 'പ്രിയപ്പെട്ട ചാനൽ';
 
   @override
-  String get record => 'റെക്കോർഡ് ചെയ്യുക';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'റെക്കോർഡിംഗ് റദ്ദാക്കുക';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'പ്രോഗ്രാം റെക്കോർഡ് ചെയ്യാൻ സജ്ജമാക്കി';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'റെക്കോർഡിംഗ് റദ്ദാക്കി';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'റെക്കോർഡിംഗ് സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'കാണുക';
@@ -1861,7 +1859,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name പ്ലേ ചെയ്യാൻ കഴിഞ്ഞില്ല';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1888,7 +1886,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" ന്റെ ഷെഡ്യൂൾ ചെയ്ത റെക്കോർഡിംഗ് റദ്ദാക്കണോ?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1916,7 +1914,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" റെക്കോർഡിംഗ് നിർത്തണോ?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1931,19 +1929,19 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" നായി ഫലങ്ങളൊന്നുമില്ല';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'തിരയൽ പരാജയപ്പെട്ടു: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr അക്കൗണ്ട് തരം';
+  String get seerrAccountType => 'സീർ അക്കൗണ്ട് തരം';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1977,12 +1975,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" ഉം അതിന്റെ ഫയലുകളും നീക്കം ചെയ്യണോ?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ട്രാക്കുകൾ';
+    return '$count tracks';
   }
 
   @override
@@ -1993,12 +1991,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ആൽബം ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name നായി ഡൗൺലോഡ് ചെയ്ത ട്രാക്കുകളൊന്നും കണ്ടെത്തിയില്ല.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2015,12 +2013,12 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" നീക്കം ചെയ്യണോ?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes മിനി';
+    return '$minutes min';
   }
 
   @override
@@ -2030,7 +2028,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'എപ്പിസോഡ് $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2044,7 +2042,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'സീസൺ $number';
+    return 'Season $number';
   }
 
   @override
@@ -2060,7 +2058,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season ലെ ഡൗൺലോഡ് ചെയ്ത എല്ലാ എപ്പിസോഡുകളും ഇല്ലാതാക്കണോ?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2068,8 +2066,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count എപ്പിസോഡുകൾ',
-      one: '1 എപ്പിസോഡ്',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2104,7 +2102,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'ഡൗൺലോഡ് ചെയ്ത $count ഇനങ്ങൾ ഇല്ലാതാക്കണോ?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2118,7 +2116,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit പരിധിയിൽ';
+    return 'of $limit limit';
   }
 
   @override
@@ -2200,7 +2198,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count ഓപ്ഷനുകൾ';
+    return '$count options';
   }
 
   @override
@@ -2294,7 +2292,8 @@ class AppLocalizationsMl extends AppLocalizations {
   String get themeMusicVolume => 'തീം മ്യൂസിക് വോളിയം';
 
   @override
-  String get themeMusicSettingsSubtitle => 'വിശദാംശ പേജുകൾ, ഹോം വരികൾ, വോളിയം';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2309,11 +2308,11 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഹോം സ്‌ക്രീൻ ബ്രൗസ് ചെയ്യുമ്പോൾ പ്ലേ ചെയ്യുക';
 
   @override
-  String get loopThemeMusic => 'തീം സംഗീതം ലൂപ്പ് ചെയ്യുക';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'ട്രാക്ക് ഒരിക്കൽ പ്ലേ ചെയ്യുന്നതിന് പകരം ആവർത്തിക്കുക';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'വിശദാംശങ്ങളുടെ പശ്ചാത്തല മങ്ങൽ';
@@ -2336,23 +2335,23 @@ class AppLocalizationsMl extends AppLocalizations {
   String get playerZoomMode => 'പ്ലെയർ സൂം മോഡ്';
 
   @override
-  String get settingsScrollWheelAction => 'മൗസ് സ്ക്രോൾ വീൽ';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'പ്ലേബാക്ക് സമയത്ത് വീഡിയോയ്ക്ക് മുകളിലൂടെ മൗസ് വീൽ സ്ക്രോൾ ചെയ്യുമ്പോൾ എന്ത് സംഭവിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ഓഫ്';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'സീക്ക് (മുന്നോട്ട് / പിന്നോട്ട്)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'വോളിയം';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'വോളിയം';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'അനുയോജ്യം';
@@ -2367,7 +2366,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get refreshRateSwitching => 'പുതുക്കിയ നിരക്ക് സ്വിച്ചിംഗ്';
 
   @override
-  String get disabled => 'പ്രവർത്തനരഹിതം';
+  String get disabled => 'അപ്രാപ്തമാക്കി';
 
   @override
   String get scaleOnTv => 'ടിവിയിൽ സ്കെയിൽ';
@@ -2407,38 +2406,37 @@ class AppLocalizationsMl extends AppLocalizations {
   String get defaultAudioLanguage => 'ഡിഫോൾട്ട് ഓഡിയോ ഭാഷ';
 
   @override
-  String get fallbackAudioLanguage => 'ഫോൾബാക്ക് ഓഡിയോ ഭാഷ';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'ഡിഫോൾട്ട് ഓഡിയോ ട്രാക്ക് തിരഞ്ഞെടുക്കുക';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'ലോക്കലൈസ് ചെയ്ത ഡബ്ബിനേക്കാൾ യഥാർത്ഥ ഓഡിയോ ട്രാക്ക് തിരഞ്ഞെടുക്കുക.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ഓഡിയോ വിവരണ ട്രാക്കുകൾ തിരഞ്ഞെടുക്കുക';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'സാധാരണ ട്രാക്കുകളേക്കാൾ ഓഡിയോ വിവരണ ട്രാക്കുകൾ തിരഞ്ഞെടുക്കുക.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ട്രാൻസ്കോഡിംഗ് (ഓഡിയോ)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'ഡയറക്റ്റ് സ്ട്രീം (റീമക്സ്)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ട്രാൻസ്കോഡിംഗ് (ബിറ്റ്റേറ്റ് അല്ലെങ്കിൽ റെസലൂഷൻ)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ട്രാൻസ്കോഡിംഗ് (വീഡിയോയും ഓഡിയോയും)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ട്രാൻസ്കോഡിംഗ് (വീഡിയോ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'സ്വയമേവ (സെർവർ ഡിഫോൾട്ട്)';
@@ -2515,28 +2513,27 @@ class AppLocalizationsMl extends AppLocalizations {
       'TrueHD ഓഡിയോ പ്രവർത്തനക്ഷമമാക്കുക (എല്ലാ പ്ലാറ്റ്ഫോമുകളിലും പ്രവർത്തിച്ചേക്കില്ല)';
 
   @override
-  String get settingsAudioOutputMode => 'ഓഡിയോ ഔട്ട്പുട്ട് മോഡ്';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ഓഡിയോ എങ്ങനെ ഡീകോഡ് ചെയ്യണമെന്ന് തിരഞ്ഞെടുക്കുക. AVR പാസ്ത്രൂ റോ Dolby/DTS സ്ട്രീമുകൾ നിങ്ങളുടെ റിസീവറിലേക്ക് അയയ്ക്കുന്നു; ഓട്ടോ അല്ലെങ്കിൽ ഡൗൺമിക്സ് ലോക്കലായി ഡീകോഡ് ചെയ്യുന്നു.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR പാസ്ത്രൂ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'ഓഡിയോ ഫോൾബാക്ക് കോഡെക്';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'സോഴ്സ് സ്ട്രീം നേരിട്ട് പ്ലേ ചെയ്യാനോ പാസ്ത്രൂ ചെയ്യാനോ കഴിയാത്തപ്പോൾ മൾട്ടി-ചാനൽ ഓഡിയോ ട്രാൻസ്കോഡ് ചെയ്യുന്നതിനുള്ള ലക്ഷ്യ ഫോർമാറ്റ് തിരഞ്ഞെടുക്കുക.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'ഓട്ടോ ഡിറ്റക്റ്റ്\n(ശുപാർശ ചെയ്യുന്നത്)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ഡിഫോൾട്ട്)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2545,27 +2542,26 @@ class AppLocalizationsMl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ലോസ്‌ലെസ്)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(സ്റ്റീരിയോ മാത്രം)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(കാര്യക്ഷമം)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ലോസ്‌ലെസ്)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'പരമാവധി ഓഡിയോ ചാനലുകൾ';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'നിങ്ങളുടെ ഓഡിയോ സെറ്റപ്പിന്റെ പരമാവധി ചാനലുകൾ കോൺഫിഗർ ചെയ്യുക. ഈ പരിധി കവിയുന്ന മൾട്ടിചാനൽ സ്ട്രീമുകൾ ഡൗൺമിക്സ് അല്ലെങ്കിൽ ട്രാൻസ്കോഡ് ചെയ്യപ്പെടും.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ഓട്ടോ ഡിറ്റക്റ്റ്\n(ഹാർഡ്‌വെയർ ഡിഫോൾട്ട്)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2592,67 +2588,67 @@ class AppLocalizationsMl extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'പാസ്ത്രൂ (വിപുലം)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'കോഡെക് പാസ്ത്രൂ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'നിങ്ങളുടെ AVR അല്ലെങ്കിൽ HDMI സിങ്ക് പിന്തുണയ്ക്കുന്ന ഫോർമാറ്റുകൾ മാത്രം പ്രവർത്തനക്ഷമമാക്കുക.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 പാസ്ത്രൂ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) പാസ്ത്രൂ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core പാസ്ത്രൂ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA പാസ്ത്രൂ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD പാസ്ത്രൂ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos പാസ്ത്രൂ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) ബാഹ്യ ഡീകോഡറിലേക്ക് ബിറ്റ്സ്ട്രീം ചെയ്യുക.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) വഴി Dolby Atmos ബാഹ്യ ഡീകോഡറിലേക്ക് ബിറ്റ്സ്ട്രീം ചെയ്യുക.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS core ഉൾപ്പെടെ) ബാഹ്യ ഡീകോഡറിലേക്ക് ബിറ്റ്സ്ട്രീം ചെയ്യുക.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos മെറ്റാഡാറ്റയോടുകൂടിയ Dolby TrueHD ബാഹ്യ ഡീകോഡറിലേക്ക് ബിറ്റ്സ്ട്രീം ചെയ്യുക.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'കണ്ടെത്തിയ ഓഡിയോ കഴിവുകൾ';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'ഇതുവരെ റൺടൈം കപ്പാബിലിറ്റി സ്നാപ്ഷോട്ട് ലഭ്യമല്ല.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'റൂട്ട്';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'ഡീകോഡ്';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'പാസ്ത്രൂ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ഓഡിയോ റൂട്ട്';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2667,10 +2663,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'സ്പീക്കർ';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'ഹെഡ്ഫോണുകൾ';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2678,39 +2674,39 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'ഡയഗ്നോസ്റ്റിക്സ്';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'വീഡിയോ ലെവൽ';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'വീഡിയോ റേഞ്ച്';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'സബ്ടൈറ്റിൽ കോഡെക്';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'അനുവദനീയമായ ഓഡിയോ കോഡെക്കുകൾ';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ഓഡിയോ കോഡെക്കുകൾ';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ഓഡിയോ കോഡെക്കുകൾ';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif പാസ്ത്രൂ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'സജീവ ഓഡിയോ റൂട്ട്';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'റൂട്ട് HD ഓഡിയോ പിന്തുണ';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'രാത്രി മോഡ്';
@@ -2760,7 +2756,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueസെ';
+    return '${value}s';
   }
 
   @override
@@ -2774,7 +2770,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes എപ്പിസോഡുകൾക്ക് ശേഷം / $hoursമ';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2852,45 +2848,45 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഉപശീർഷക രൂപം ഇഷ്ടാനുസൃതമാക്കുക';
 
   @override
-  String get subtitleMode => 'സബ്ടൈറ്റിൽ മോഡ്';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ഫ്ലാഗ് ചെയ്തത്';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'എപ്പോഴും';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'വിദേശ';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'ഫോഴ്സ്ഡ്';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'മീഡിയ ഫയലിന്റെ മെറ്റാഡാറ്റയിൽ \"default\" അല്ലെങ്കിൽ \"forced\" എന്ന് ആന്തരികമായി ഫ്ലാഗ് ചെയ്ത ട്രാക്കുകൾ പ്ലേ ചെയ്യുന്നു.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'ഒരു വീഡിയോ ആരംഭിക്കുമ്പോഴെല്ലാം സബ്ടൈറ്റിലുകൾ സ്വയമേവ ലോഡ് ചെയ്ത് പ്രദർശിപ്പിക്കുന്നു.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'ഡിഫോൾട്ട് ഓഡിയോ ട്രാക്ക് ഒരു വിദേശ ഭാഷയിലാണെങ്കിൽ സബ്ടൈറ്റിലുകൾ സ്വയമേവ ഓണാക്കുന്നു.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'ഫോഴ്സ്ഡ് മെറ്റാഡാറ്റ ഫ്ലാഗ് ഉപയോഗിച്ച് വ്യക്തമായി ടാഗ് ചെയ്ത സബ്ടൈറ്റിലുകൾ മാത്രം ലോഡ് ചെയ്യുന്നു.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'സ്വയമേവയുള്ള സബ്ടൈറ്റിൽ ലോഡിംഗ് പൂർണ്ണമായി പ്രവർത്തനരഹിതമാക്കുന്നു.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ഫോൾബാക്ക് സബ്ടൈറ്റിൽ ഭാഷ';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'സബ്ടൈറ്റിൽ സ്ട്രീം';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2950,17 +2946,17 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile പ്രൊഫൈൽ ക്രമീകരണങ്ങൾ ലോഡ് ചെയ്തു.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile പ്രൊഫൈൽ ക്രമീകരണങ്ങൾ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'ലോക്കൽ ക്രമീകരണങ്ങൾ $profile പ്രൊഫൈലിലേക്ക് സിങ്ക് ചെയ്തു.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3097,10 +3093,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showLibrariesInToolbar => 'ടൂൾബാറിൽ ലൈബ്രറികൾ കാണിക്കുക';
 
   @override
-  String get navbarAlwaysExpanded => 'നാവ്ബാർ ലേബലുകൾ എപ്പോഴും വിപുലീകരിക്കുക';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr ബട്ടൺ കാണിക്കുക';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'നവബാർ അതാര്യത';
@@ -3175,19 +3171,18 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showFolderBrowsingOption => 'ഫോൾഡർ ബ്രൗസിംഗ് ഓപ്ഷൻ കാണിക്കുക';
 
   @override
-  String get groupItemsIntoCollections => 'ഇനങ്ങൾ ശേഖരങ്ങളായി ഗ്രൂപ്പ് ചെയ്യുക';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ലൈബ്രറികൾ ബ്രൗസ് ചെയ്യുമ്പോൾ ശേഖരവുമായി ബന്ധപ്പെട്ട ലൈബ്രറി ഇനങ്ങൾ മറയ്ക്കുക';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'ലൈബ്രറി ഗ്രൂപ്പിംഗ് അറിയിപ്പ്';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'ഈ ക്രമീകരണം ഉപയോഗിക്കാൻ, നിങ്ങളുടെ Jellyfin അല്ലെങ്കിൽ Emby സെർവറിലെ നിങ്ങളുടെ ലൈബ്രറിയുടെ ഡിസ്പ്ലേ ക്രമീകരണങ്ങൾക്ക് കീഴിൽ \"Group movies into collections\" കൂടാതെ/അല്ലെങ്കിൽ \"Group shows into collections\" ലൈബ്രറി ക്രമീകരണങ്ങൾ പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'ലൈബ്രറി ദൃശ്യപരത';
@@ -3216,7 +3211,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count തിരഞ്ഞെടുത്തു';
+    return '$count selected';
   }
 
   @override
@@ -3246,7 +3241,7 @@ class AppLocalizationsMl extends AppLocalizations {
       'Moonfin, MakD എന്നിവയ്ക്കിടയിൽ തിരഞ്ഞെടുക്കുക അല്ലെങ്കിൽ മീഡിയ ബാർ ഓഫാക്കുക';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'മൂൺഫിൻ';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3299,11 +3294,10 @@ class AppLocalizationsMl extends AppLocalizations {
       '3 സെക്കൻഡിന് ശേഷം മീഡിയ ബാറിൽ ട്രെയിലറുകൾ സ്വയമേവ പ്ലേ ചെയ്യുക';
 
   @override
-  String get trailerAudio => 'ട്രെയിലർ ഓഡിയോ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'മീഡിയ ബാറിലെ ട്രെയിലറുകൾക്ക് ഓഡിയോ പ്രവർത്തനക്ഷമമാക്കുക';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'എപ്പിസോഡ് പ്രിവ്യൂ';
@@ -3381,11 +3375,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'രണ്ട് വരികളും ഒരു ഹോം വിഭാഗത്തിലേക്ക് സംയോജിപ്പിക്കുക';
 
   @override
-  String get fullScreenRows => 'വിപുലീകരിച്ച ഹോം വരികൾ';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'ഹോം വരികൾ ഒരു സ്ക്രീനിന് 1 വരിയായി പരിമിതപ്പെടുത്തുക';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ഓരോ വരി ചിത്ര തരം';
@@ -3400,7 +3393,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get lastUser => 'അവസാന ഉപയോക്താവ്';
 
   @override
-  String get currentUser => 'നിലവിലെ ഉപയോക്താവ്';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'എപ്പോഴും പ്രാമാണീകരിക്കുക';
@@ -3509,10 +3502,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'സ്ക്രീൻസേവർ സമയത്ത് ക്ലോക്ക് പ്രദർശിപ്പിക്കുക';
 
   @override
-  String get clockModeStatic => 'സ്ഥിരം';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'കുതിക്കുന്ന';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'റോട്ടൻ തക്കാളി (വിമർശകർ)';
@@ -3524,7 +3517,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get imdb => 'IMDb';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'ടിഎംഡിബി';
 
   @override
   String get metacritic => 'മെറ്റാക്രിറ്റിക്';
@@ -3533,7 +3526,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get metacriticUser => 'മെറ്റാക്രിറ്റിക് (ഉപയോക്താവ്)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ട്രാക്റ്റ്';
 
   @override
   String get letterboxd => 'ലെറ്റർബോക്സ്ഡ്';
@@ -3585,7 +3578,7 @@ class AppLocalizationsMl extends AppLocalizations {
       'ആപ്പിലുടനീളം കാണിച്ചിരിക്കുന്ന റേറ്റിംഗ് ഉറവിടങ്ങൾ പ്രവർത്തനക്ഷമമാക്കുകയും പുനഃക്രമീകരിക്കുകയും ചെയ്യുക';
 
   @override
-  String get pluginLabel => 'Moonbase പ്ലഗിൻ';
+  String get pluginLabel => 'പ്ലഗിൻ';
 
   @override
   String get pluginDetected => 'പ്ലഗിൻ കണ്ടെത്തി';
@@ -3657,21 +3650,21 @@ class AppLocalizationsMl extends AppLocalizations {
   String get networks => 'നെറ്റ്വർക്കുകൾ';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr ഡിസ്കവറി വരികൾ';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'വരികൾ ഡിഫോൾട്ടിലേക്ക് പുനഃസജ്ജമാക്കുക';
 
   @override
-  String get enableSeerr => 'Seerr പ്രവർത്തനക്ഷമമാക്കുക';
+  String get enableSeerr => 'സീർ പ്രവർത്തനക്ഷമമാക്കുക';
 
   @override
   String get showSeerrInNavigation =>
-      'നാവിഗേഷനിൽ Seerr കാണിക്കുക (സെർവർ പ്ലഗിൻ ആവശ്യമാണ്)';
+      'നാവിഗേഷനിൽ സീർ കാണിക്കുക (സെർവർ പ്ലഗിൻ ആവശ്യമാണ്)';
 
   @override
   String get seerrUnavailable =>
-      'സെർവർ പ്ലഗിന്റെ Seerr പിന്തുണ പ്രവർത്തനരഹിതമായതിനാൽ ലഭ്യമല്ല.';
+      'സെർവർ പ്ലഗിൻ സീർ പിന്തുണ പ്രവർത്തനരഹിതമാക്കിയതിനാൽ ലഭ്യമല്ല.';
 
   @override
   String get nsfwFilter => 'NSFW ഫിൽട്ടർ';
@@ -3681,28 +3674,28 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഫലങ്ങളിൽ മുതിർന്നവർക്കുള്ള ഉള്ളടക്കം മറയ്ക്കുക';
 
   @override
-  String get seerrNotificationsSection => 'അറിയിപ്പുകൾ';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'പുതിയ അഭ്യർത്ഥന അറിയിപ്പുകൾ';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'ആരെങ്കിലും ഒരു അഭ്യർത്ഥന സമർപ്പിക്കുമ്പോൾ എന്നെ അറിയിക്കുക';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'അഭ്യർത്ഥന അപ്ഡേറ്റുകൾ';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'അംഗീകരിച്ചു, നിരസിച്ചു, നിങ്ങളുടെ ലൈബ്രറിയിലേക്ക് ചേർത്തു';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'പ്രശ്ന അപ്ഡേറ്റുകൾ';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'പുതിയ പ്രശ്നങ്ങൾ, മറുപടികൾ, പരിഹാരങ്ങൾ';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3710,18 +3703,18 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr ഡിസ്കവറി പേജ്';
+  String get discoverRows => 'വരികൾ കണ്ടെത്തുക';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr മെയിൻപേജിൽ കാണാൻ വരികൾ പ്രവർത്തനക്ഷമമാക്കുക. പുനഃക്രമീകരിക്കാൻ വലിച്ചിടുക. ഇഷ്ടാനുസൃത ക്രമം Moonbase-മായി സിങ്ക് ചെയ്യുന്നു.';
+      'പുനഃക്രമീകരിക്കാൻ വലിച്ചിടുക. വരികൾ പ്രവർത്തനക്ഷമമാക്കുക അല്ലെങ്കിൽ പ്രവർത്തനരഹിതമാക്കുക. Moonfin പ്ലഗിനുമായി വരി ഓർഡർ സമന്വയം പ്രാപ്തമാക്കി.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr മെയിൻപേജിൽ കാണാൻ വരികൾ പ്രവർത്തനക്ഷമമാക്കുക. പുനഃക്രമീകരിക്കാൻ വലിച്ചിടുക. ഇഷ്ടാനുസൃത ക്രമം Moonbase-മായി സിങ്ക് ചെയ്യുന്നു.';
+      'പുനഃക്രമീകരിക്കാൻ വലിച്ചിടുക. വരികൾ പ്രവർത്തനക്ഷമമാക്കുക അല്ലെങ്കിൽ പ്രവർത്തനരഹിതമാക്കുക.';
 
   @override
-  String get enabled => 'പ്രവർത്തനക്ഷമം';
+  String get enabled => 'പ്രവർത്തനക്ഷമമാക്കി';
 
   @override
   String get hidden => 'മറച്ചിരിക്കുന്നു';
@@ -3858,7 +3851,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get imageCacheCleared => 'ചിത്ര കാഷെ മായ്ച്ചു';
 
   @override
-  String get clear => 'മായ്ക്കുക';
+  String get clear => 'ക്ലിയർ';
 
   @override
   String get browse => 'ബ്രൗസ് ചെയ്യുക';
@@ -3874,11 +3867,11 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'ഡൗൺലോഡ് ചെയ്യുന്നു · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ഇറക്കുമതി ചെയ്യുന്നു';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3886,7 +3879,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Seerr ക്രമീകരണങ്ങൾ';
+  String get seerrSettings => 'സീർ ക്രമീകരണങ്ങൾ';
 
   @override
   String get requestMore => 'കൂടുതൽ അഭ്യർത്ഥിക്കുക';
@@ -3983,7 +3976,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showMore => 'കൂടുതൽ കാണിക്കുക';
 
   @override
-  String get appearances => 'പ്രത്യക്ഷപ്പെടലുകൾ';
+  String get appearances => 'രൂപഭാവങ്ങൾ';
 
   @override
   String get crewSection => 'ക്രൂ';
@@ -4021,149 +4014,148 @@ class AppLocalizationsMl extends AppLocalizations {
   String get deletedStatus => 'ഇല്ലാതാക്കി';
 
   @override
-  String get failedStatus => 'പരാജയപ്പെട്ടു';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'പ്രോസസ് ചെയ്യുന്നു';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name പരിഷ്കരിച്ചു';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'പൂർത്തിയായി';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'ഈ ശീർഷകം ഇതിനകം അഭ്യർത്ഥിച്ചു';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'അഭ്യർത്ഥന പരിധി എത്തി';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'ഈ ശീർഷകം ബ്ലോക്ക്‌ലിസ്റ്റിലാണ്';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'അഭ്യർത്ഥിക്കാൻ സീസണുകളൊന്നും ബാക്കിയില്ല';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'ഈ അഭ്യർത്ഥന നടത്താൻ നിങ്ങൾക്ക് അനുമതിയില്ല';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'അഭ്യർത്ഥനകൾ';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'പ്രശ്നങ്ങൾ';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'ഏറ്റവും പുതിയത്';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'അവസാനം പരിഷ്കരിച്ചത്';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'പ്രശ്നങ്ങളൊന്നുമില്ല';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit സിനിമ അഭ്യർത്ഥനകളിൽ $remaining ബാക്കി';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit സീസൺ അഭ്യർത്ഥനകളിൽ $remaining ബാക്കി';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name ന്റെ ഭാഗം';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'ശേഖരം കാണുക';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'ശേഖരം അഭ്യർത്ഥിക്കുക';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total സിനിമകൾ · $available ലഭ്യമാണ്';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count സിനിമകൾ അഭ്യർത്ഥിക്കുക';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total ൽ $current അഭ്യർത്ഥിക്കുന്നു...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count സിനിമകൾ അഭ്യർത്ഥിച്ചു';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total സിനിമകളിൽ $ok എണ്ണം അഭ്യർത്ഥിച്ചു';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'എല്ലാ സിനിമകളും ഇതിനകം ലഭ്യമാണ് അല്ലെങ്കിൽ അഭ്യർത്ഥിച്ചു';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'വീഡിയോ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ഓഡിയോ';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'എന്താണ് തെറ്റ്?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'എല്ലാ എപ്പിസോഡുകളും';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'എപ്പിസോഡ്';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'ഓപ്പൺ';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'പരിഹരിച്ചു';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'പരിഹരിക്കുക';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'വീണ്ടും തുറക്കുക';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name റിപ്പോർട്ട് ചെയ്തു';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count അഭിപ്രായങ്ങൾ';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'ഒരു അഭിപ്രായം ചേർക്കുക';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'ഈ പ്രശ്നം ഇല്ലാതാക്കണോ?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'റിപ്പോർട്ട് സമർപ്പിക്കുക';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB സ്കോർ';
@@ -4220,7 +4212,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get disable => 'പ്രവർത്തനരഹിതമാക്കുക';
 
   @override
-  String get done => 'പൂർത്തിയായി';
+  String get done => 'ചെയ്തു';
 
   @override
   String get edit => 'എഡിറ്റ് ചെയ്യുക';
@@ -4235,7 +4227,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get forward => 'മുന്നോട്ട്';
 
   @override
-  String get general => 'പൊതുവായത്';
+  String get general => 'ജനറൽ';
 
   @override
   String get go => 'പോകൂ';
@@ -4325,7 +4317,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get time => 'സമയം';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ട്രിക്ക്പ്ലേ';
 
   @override
   String get uninstall => 'അൺഇൻസ്റ്റാൾ ചെയ്യുക';
@@ -4367,25 +4359,25 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminDrawerLibraries => 'ലൈബ്രറികൾ';
 
   @override
-  String get adminDrawerDisplay => 'ഡിസ്പ്ലേ';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'മെറ്റാഡാറ്റ';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO ക്രമീകരണങ്ങൾ';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ട്രാൻസ്കോഡിംഗ്';
 
   @override
-  String get adminDrawerResume => 'തുടരുക';
+  String get adminDrawerResume => 'പുനരാരംഭിക്കുക';
 
   @override
   String get adminDrawerStreaming => 'സ്ട്രീമിംഗ്';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ട്രിക്ക്പ്ലേ';
 
   @override
   String get adminDrawerDevices => 'ഉപകരണങ്ങൾ';
@@ -4589,7 +4581,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audioCodec => 'ഓഡിയോ കോഡെക്';
 
   @override
-  String get hwAccel => 'HW ആക്സൽ';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'പൂർത്തീകരണം';
@@ -4604,10 +4596,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminClearDates => 'വ്യക്തമായ തീയതികൾ';
 
   @override
-  String get adminActivitySeverityAll => 'എല്ലാ തീവ്രതകളും';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'തീയതി ശ്രേണി';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4644,23 +4636,23 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' ഉപകരണം നീക്കം ചെയ്യണോ? ഉപയോക്താവിന് ഈ ഉപകരണത്തിൽ വീണ്ടും സൈൻ ഇൻ ചെയ്യേണ്ടിവരും.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'എല്ലാ ഉപകരണങ്ങളും ഇല്ലാതാക്കുക';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count ഉപകരണങ്ങൾ നീക്കം ചെയ്യണോ? ബാധിക്കപ്പെട്ട ഉപയോക്താക്കൾക്ക് വീണ്ടും സൈൻ ഇൻ ചെയ്യേണ്ടിവരും. നിങ്ങളുടെ നിലവിലെ ഉപകരണത്തെ ഇത് ബാധിക്കില്ല.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'ഉപകരണങ്ങൾ നീക്കം ചെയ്തു';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'ചില ഉപകരണങ്ങൾ നീക്കം ചെയ്തു; $count എണ്ണം നീക്കം ചെയ്യാൻ കഴിഞ്ഞില്ല.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4778,256 +4770,244 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminMetadataCountryHint => 'ഉദാ. യുഎസ്, ഡിഇ, എഫ്ആർ';
 
   @override
-  String get adminLibraryTabPaths => 'പാതകൾ';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'ഓപ്ഷനുകൾ';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ഡൗൺലോഡറുകൾ';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'മെറ്റാഡാറ്റ സേവറുകൾ';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'സബ്ടൈറ്റിൽ ഡൗൺലോഡറുകൾ';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'വരികൾ ഡൗൺലോഡറുകൾ';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'മെറ്റാഡാറ്റ ഡൗൺലോഡറുകൾ: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ചിത്ര ഫെച്ചറുകൾ: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'ഈ സെർവർ ഈ ലൈബ്രറി തരത്തിനായി ഡൗൺലോഡറുകളൊന്നും നൽകുന്നില്ല.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'പൊതുവായത്';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'മെറ്റാഡാറ്റ';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'എംബഡഡ് വിവരം';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'സബ്ടൈറ്റിലുകൾ';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'ചിത്രങ്ങൾ';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'പരമ്പരകൾ';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'സംഗീതം';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'സിനിമകൾ';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'തത്സമയ നിരീക്ഷണം പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ഫയൽ മാറ്റങ്ങൾ കണ്ടെത്തി അവ സ്വയമേവ പ്രോസസ് ചെയ്യുക.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'ആർക്കൈവുകൾ മീഡിയ ഫയലുകളായി പരിഗണിക്കുക';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ഫോട്ടോകൾ പ്രദർശിപ്പിക്കുക';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'ആർട്ട്‌വർക്ക് മീഡിയ ഫോൾഡറുകളിൽ സംരക്ഷിക്കുക';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'സ്വയമേവയുള്ള മെറ്റാഡാറ്റ പുതുക്കൽ';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ഒരിക്കലും';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ഡിഫോൾട്ട്';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'ഡിസ്പ്ലേ';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'ലൈബ്രറി ഡിസ്പ്ലേ';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'സാധാരണ മീഡിയ ഫോൾഡറുകൾ കാണിക്കാൻ ഒരു ഫോൾഡർ കാഴ്ച പ്രദർശിപ്പിക്കുക';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'സ്പെഷ്യലുകൾ അവ സംപ്രേഷണം ചെയ്ത സീസണുകൾക്കുള്ളിൽ പ്രദർശിപ്പിക്കുക';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'സിനിമകൾ ശേഖരങ്ങളായി ഗ്രൂപ്പ് ചെയ്യുക';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'ഷോകൾ ശേഖരങ്ങളായി ഗ്രൂപ്പ് ചെയ്യുക';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'നിർദ്ദേശങ്ങളിൽ ബാഹ്യ ഉള്ളടക്കം കാണിക്കുക';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'ചേർത്ത തീയതി സ്വഭാവം';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'ചേർത്ത തീയതി ഇവിടെ നിന്ന് ഉപയോഗിക്കുക';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'ലൈബ്രറിയിലേക്ക് സ്കാൻ ചെയ്ത തീയതി';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ഫയൽ സൃഷ്ടിച്ച തീയതി';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'മെറ്റാഡാറ്റയും ചിത്രങ്ങളും';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ഇഷ്ട മെറ്റാഡാറ്റ ഭാഷ';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'അധ്യായങ്ങൾ';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'ഡമ്മി അധ്യായ ദൈർഘ്യം (സെക്കൻഡുകൾ)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'അധ്യായങ്ങളില്ലാത്ത മീഡിയയ്ക്കായി സൃഷ്ടിക്കുന്ന അധ്യായങ്ങളുടെ ദൈർഘ്യം. പ്രവർത്തനരഹിതമാക്കാൻ 0 ആയി സജ്ജമാക്കുക.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'അധ്യായ ചിത്ര റെസലൂഷൻ';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO ക്രമീകരണങ്ങൾ';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO മെറ്റാഡാറ്റ Kodi യുമായും സമാന ക്ലയന്റുകളുമായും അനുയോജ്യമാണ്. ക്രമീകരണങ്ങൾ NFO മെറ്റാഡാറ്റ സംരക്ഷിക്കുന്ന എല്ലാ ലൈബ്രറികൾക്കും ബാധകമാണ്.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ഫയലുകളിൽ വാച്ച് ഡാറ്റ സംഭരിക്കാനുള്ള ഉപയോക്താവ്';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'NFO ഫയലുകൾക്കുള്ളിൽ ചിത്ര പാതകൾ സംരക്ഷിക്കുക';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO ചിത്ര പാതകൾക്കായി പാത പകരംവയ്ക്കൽ പ്രവർത്തനക്ഷമമാക്കുക';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart ചിത്രങ്ങൾ extrathumbs ഫോൾഡറിലേക്ക് പകർത്തുക';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ഒന്നുമില്ല';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ദിവസങ്ങൾ';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'എംബഡഡ് ശീർഷകങ്ങൾ ഉപയോഗിക്കുക';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'എക്സ്ട്രാകൾക്കായി എംബഡഡ് ശീർഷകങ്ങൾ ഉപയോഗിക്കുക';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'എംബഡഡ് എപ്പിസോഡ് വിവരം ഉപയോഗിക്കുക';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'എംബഡഡ് സബ്ടൈറ്റിലുകൾ അനുവദിക്കുക';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'എല്ലാം അനുവദിക്കുക';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'ടെക്സ്റ്റ് മാത്രം';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'ചിത്രം മാത്രം';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ഒന്നുമില്ല';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'എംബഡഡ് സബ്ടൈറ്റിലുകൾ ഉണ്ടെങ്കിൽ ഡൗൺലോഡ് ഒഴിവാക്കുക';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ഓഡിയോ ട്രാക്ക് ഡൗൺലോഡ് ഭാഷയുമായി പൊരുത്തപ്പെടുന്നെങ്കിൽ ഡൗൺലോഡ് ഒഴിവാക്കുക';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'ഒരു കൃത്യമായ സബ്ടൈറ്റിൽ പൊരുത്തം ആവശ്യമാണ്';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'സബ്ടൈറ്റിലുകൾ മീഡിയ ഫോൾഡറുകളിൽ സംരക്ഷിക്കുക';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'അധ്യായ ചിത്രങ്ങൾ എക്സ്ട്രാക്റ്റ് ചെയ്യുക';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'ലൈബ്രറി സ്കാൻ സമയത്ത് അധ്യായ ചിത്രങ്ങൾ എക്സ്ട്രാക്റ്റ് ചെയ്യുക';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'trickplay ചിത്ര എക്സ്ട്രാക്ഷൻ പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'ലൈബ്രറി സ്കാൻ സമയത്ത് trickplay ചിത്രങ്ങൾ എക്സ്ട്രാക്റ്റ് ചെയ്യുക';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'trickplay ചിത്രങ്ങൾ മീഡിയ ഫോൾഡറുകളിൽ സംരക്ഷിക്കുക';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'ഒന്നിലധികം ഫോൾഡറുകളിൽ വ്യാപിച്ചുകിടക്കുന്ന പരമ്പരകൾ സ്വയമേവ ലയിപ്പിക്കുക';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'സീസൺ പൂജ്യം ഡിസ്പ്ലേ പേര്';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'ഓഡിയോ നോർമലൈസേഷനായി LUFS സ്കാൻ പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'നിലവാരമില്ലാത്ത ആർട്ടിസ്റ്റ് ടാഗ് തിരഞ്ഞെടുക്കുക';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'സിനിമകൾ സ്വയമേവ ശേഖരങ്ങളിലേക്ക് ചേർക്കുക';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'ലൈബ്രറിയുടെ പേര് ആവശ്യമാണ്';
@@ -5273,145 +5253,143 @@ class AppLocalizationsMl extends AppLocalizations {
       'എല്ലാ ചാനലുകളിലേക്കും ആക്സസ് പ്രവർത്തനക്ഷമമാക്കുക';
 
   @override
-  String get adminParentalControl => 'പേരന്റൽ കൺട്രോൾ';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'അനുവദനീയമായ പരമാവധി പേരന്റൽ റേറ്റിംഗ്';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'ഉയർന്ന റേറ്റിംഗുള്ള ഉള്ളടക്കം ഈ ഉപയോക്താവിൽ നിന്ന് മറയ്ക്കപ്പെടും.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ഒന്നുമില്ല';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'റേറ്റിംഗ് വിവരമില്ലാത്ത അല്ലെങ്കിൽ തിരിച്ചറിയാൻ കഴിയാത്ത ഇനങ്ങൾ തടയുക';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'പുസ്തകങ്ങൾ';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ചാനലുകൾ';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ലൈവ് ടിവി';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'സിനിമകൾ';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'സംഗീതം';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ട്രെയിലറുകൾ';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'ഷോകൾ';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'ആക്സസ് ഷെഡ്യൂളുകൾ';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'ചുവടെയുള്ള ഷെഡ്യൂൾ ചെയ്ത സമയങ്ങളിൽ മാത്രം ആക്സസ് അനുവദിക്കുക. ഷെഡ്യൂൾ സജ്ജീകരിക്കാത്തപ്പോൾ ദിവസം മുഴുവൻ ആക്സസ് അനുവദനീയമാണ്.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'ഷെഡ്യൂൾ ചേർക്കുക';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'ദിവസം';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'ആരംഭം';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'അവസാനം';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'എല്ലാ ദിവസവും';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'പ്രവൃത്തിദിവസം';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'വാരാന്ത്യം';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ഞായർ';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'തിങ്കൾ';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'ചൊവ്വ';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'ബുധൻ';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'വ്യാഴം';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'വെള്ളി';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'ശനി';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'അനുവദനീയമായ ടാഗുകൾ';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'ഈ ടാഗുകളുള്ള ഉള്ളടക്കം മാത്രം കാണിക്കുന്നു. എല്ലാം അനുവദിക്കാൻ ശൂന്യമായി വിടുക.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'തടഞ്ഞ ടാഗുകൾ';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'ഈ ടാഗുകളുള്ള ഉള്ളടക്കം ഈ ഉപയോക്താവിൽ നിന്ന് മറയ്ക്കപ്പെടും.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ടാഗ് ചേർക്കുക';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'പ്രവർത്തനക്ഷമമാക്കിയ ഉപകരണങ്ങൾ';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'പ്രവർത്തനക്ഷമമാക്കിയ ചാനലുകൾ';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'പ്രാമാണീകരണ ദാതാവ്';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'പാസ്‌വേഡ് പുനഃസജ്ജീകരണ ദാതാവ്';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'ലോക്ക്ഔട്ടിന് മുമ്പുള്ള പരമാവധി പരാജയപ്പെട്ട ലോഗിൻ ശ്രമങ്ങൾ';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'ഡിഫോൾട്ടിനായി 0 ആയി സജ്ജമാക്കുക, അല്ലെങ്കിൽ ലോക്ക്ഔട്ട് പ്രവർത്തനരഹിതമാക്കാൻ -1.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay ആക്സസ്';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'ഗ്രൂപ്പുകൾ സൃഷ്ടിക്കാനും ചേരാനും അനുവദിക്കുക';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'ഗ്രൂപ്പുകളിൽ ചേരാൻ അനുവദിക്കുക';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'ആക്സസ് ഇല്ല';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'ഇവിടെ നിന്ന് ഉള്ളടക്കം ഇല്ലാതാക്കാൻ അനുവദിക്കുക';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5500,26 +5478,25 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'ബാക്കപ്പ് സൃഷ്ടിക്കുക';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'ബാക്കപ്പിൽ എന്ത് ഉൾപ്പെടുത്തണമെന്ന് തിരഞ്ഞെടുക്കുക.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ഡാറ്റാബേസ്';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'എപ്പോഴും ഉൾപ്പെടുത്തിയത്';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'മെറ്റാഡാറ്റ';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'സബ്ടൈറ്റിലുകൾ';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay ചിത്രങ്ങൾ';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'ബാക്കപ്പ് സൃഷ്‌ടിക്കുന്നു...';
@@ -5956,11 +5933,11 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminThrottleBuffering => 'ത്രോട്ടിൽ ബഫറിംഗ്';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചു';
+  String get adminTrickplaySaved => 'ട്രിക്ക്പ്ലേ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചു';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'trickplay ക്രമീകരണങ്ങൾ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല';
+      'ട്രിക്ക്പ്ലേ ക്രമീകരണങ്ങൾ ലോഡ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6076,7 +6053,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminBaseUrl => 'അടിസ്ഥാന URL';
 
   @override
-  String get adminBaseUrlHint => 'ഉദാ. /jellyfin';
+  String get adminBaseUrlHint => 'ഉദാ. /ജെല്ലിഫിൻ';
 
   @override
   String get https => 'HTTPS';
@@ -6241,64 +6218,60 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminAddTuner => 'ട്യൂണർ ചേർക്കുക';
 
   @override
-  String get adminEditTuner => 'ട്യൂണർ എഡിറ്റ് ചെയ്യുക';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ട്യൂണർ';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ഫയൽ അല്ലെങ്കിൽ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ട്യൂണർ IP വിലാസം';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'ഡിസ്പ്ലേ പേര്';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'യൂസർ ഏജന്റ്';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ഒരേസമയമുള്ള കണക്ഷൻ പരിധി';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ട്യൂണർ ഒരേസമയം അനുവദിക്കുന്ന പരമാവധി സ്ട്രീമുകളുടെ എണ്ണം. അൺലിമിറ്റഡിന് 0 ആയി സജ്ജമാക്കുക.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'ഫോൾബാക്ക് പരമാവധി സ്ട്രീമിംഗ് ബിറ്റ്റേറ്റ്';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'പ്രിയപ്പെട്ട ചാനലുകൾ മാത്രം ഇറക്കുമതി ചെയ്യുക';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'ഹാർഡ്‌വെയർ ട്രാൻസ്കോഡിംഗ് അനുവദിക്കുക';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 ട്രാൻസ്കോഡിംഗ് കണ്ടെയ്നർ അനുവദിക്കുക';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'സ്ട്രീം പങ്കിടൽ അനുവദിക്കുക';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'സ്ട്രീം ലൂപ്പിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS അവഗണിക്കുക';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'നേറ്റീവ് ഫ്രെയിം റേറ്റിൽ ഇൻപുട്ട് വായിക്കുക';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ദാതാവിനെ എഡിറ്റ് ചെയ്യുക';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6307,50 +6280,50 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ഫയൽ അല്ലെങ്കിൽ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'സിനിമ പ്രിഫിക്സ്';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'സിനിമ വിഭാഗങ്ങൾ';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'ഒന്നിലധികം വിഭാഗങ്ങൾ ഒരു ലംബ ബാർ ഉപയോഗിച്ച് വേർതിരിക്കുക.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'കുട്ടികളുടെ വിഭാഗങ്ങൾ';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'വാർത്ത വിഭാഗങ്ങൾ';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'കായിക വിഭാഗങ്ങൾ';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ഉപയോക്തൃനാമം';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'പാസ്‌വേഡ്';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'രാജ്യം';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'ഒരു രാജ്യം തിരഞ്ഞെടുക്കുക';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'പോസ്റ്റൽ കോഡ്';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'ലിസ്റ്റിംഗുകൾ നേടുക';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'ലിസ്റ്റിംഗുകൾ';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'എല്ലാ ട്യൂണറുകളും പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ട്യൂണർ തരം';
@@ -6392,7 +6365,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'ഈ ട്യൂണർ തരം പുനഃസജ്ജീകരണം പിന്തുണയ്ക്കുന്നില്ല.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6415,46 +6388,43 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'സീരീസ് റെക്കോർഡിംഗ് പാത';
 
   @override
-  String get adminMovieRecordingPath => 'സിനിമ റെക്കോർഡിംഗ് പാത';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'ഗൈഡ് ഡാറ്റ ദിവസങ്ങൾ';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ഓട്ടോമാറ്റിക്';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ദിവസങ്ങൾ';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'പോസ്റ്റ്-പ്രോസസിംഗ് ആപ്ലിക്കേഷൻ പാത';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'പോസ്റ്റ്-പ്രോസസർ ആർഗ്യുമെന്റുകൾ';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'റെക്കോർഡിംഗ് NFO മെറ്റാഡാറ്റ സംരക്ഷിക്കുക';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'റെക്കോർഡിംഗ് ചിത്രങ്ങൾ സംരക്ഷിക്കുക';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'സമയക്രമം';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'റെക്കോർഡിംഗ് പാതകൾ';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'പോസ്റ്റ്-പ്രോസസിംഗ്';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'ഗൈഡ് ഡാറ്റ: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6498,14 +6468,14 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminGuideProviders => 'ഗൈഡ് ദാതാക്കൾ';
 
   @override
-  String get adminRefreshGuideData => 'ഗൈഡ് ഡാറ്റ പുതുക്കുക';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'ഗൈഡ് ഡാറ്റ പുതുക്കൽ ആരംഭിച്ചു';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'ഈ സെർവറിൽ ഗൈഡ് പുതുക്കൽ ടാസ്ക് ലഭ്യമല്ല.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'ദാതാവിനെ ചേർക്കുക';
@@ -6587,7 +6557,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminLiveTvTitle => 'ലൈവ് ടിവി അഡ്മിനിസ്ട്രേഷൻ';
 
   @override
-  String get adminApply => 'പ്രയോഗിക്കുക';
+  String get adminApply => 'അപേക്ഷിക്കുക';
 
   @override
   String get adminNotSet => 'സജ്ജമാക്കിയിട്ടില്ല';
@@ -6639,7 +6609,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'മെറ്റാഡാറ്റ എഡിറ്റർ';
 
   @override
-  String get adminMetadataIdentify => 'തിരിച്ചറിയുക';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'ടൈപ്പ് ചെയ്യുക';
@@ -6654,7 +6624,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminMetadataImages => 'ചിത്രങ്ങൾ';
 
   @override
-  String get adminMetadataFieldTitle => 'ശീർഷകം';
+  String get adminMetadataFieldTitle => 'തലക്കെട്ട്';
 
   @override
   String get adminMetadataFieldSortTitle => 'ശീർഷകം അടുക്കുക';
@@ -7055,21 +7025,19 @@ class AppLocalizationsMl extends AppLocalizations {
       'സ്പ്ലാഷ് സ്ക്രീൻ പ്രവർത്തനക്ഷമമാക്കുക';
 
   @override
-  String get adminBrandingSplashUpload => 'ചിത്രം അപ്‌ലോഡ് ചെയ്യുക';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'സ്‌പ്ലാഷ്‌സ്‌ക്രീൻ അപ്ഡേറ്റ് ചെയ്തു';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'സ്‌പ്ലാഷ്‌സ്‌ക്രീൻ അപ്‌ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'സ്‌പ്ലാഷ്‌സ്‌ക്രീൻ നീക്കം ചെയ്തു';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'ഇഷ്ടാനുസൃത സ്‌പ്ലാഷ്‌സ്‌ക്രീൻ ഇല്ല';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'ഹാർഡ്‌വെയർ ആക്സിലറേഷൻ';
@@ -7086,127 +7054,121 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഇതിനായി ഹാർഡ്‌വെയർ ഡീകോഡിംഗ് പ്രവർത്തനക്ഷമമാക്കുക:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ഉപകരണം';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'മെച്ചപ്പെടുത്തിയ NVDEC ഡീകോഡർ പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'സിസ്റ്റം നേറ്റീവ് ഹാർഡ്‌വെയർ ഡീകോഡർ തിരഞ്ഞെടുക്കുക';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'ഹാർഡ്‌വെയർ ഡീകോഡിംഗ് കളർ ഡെപ്ത്';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC ഡീകോഡിംഗ്';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 ഡീകോഡിംഗ്';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bit ഡീകോഡിംഗ്';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit ഡീകോഡിംഗ്';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'ഹാർഡ്‌വെയർ എൻകോഡിംഗ്';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC എൻകോഡിംഗ് അനുവദിക്കുക';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 എൻകോഡിംഗ് അനുവദിക്കുക';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel ലോ-പവർ H.264 എൻകോഡർ പ്രവർത്തനക്ഷമമാക്കുക';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel ലോ-പവർ HEVC എൻകോഡർ പ്രവർത്തനക്ഷമമാക്കുക';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'ടോൺ മാപ്പിംഗ്';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'ടോൺ മാപ്പിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP ടോൺ മാപ്പിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox ടോൺ മാപ്പിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'ടോൺ മാപ്പിംഗ് അൽഗോരിതം';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'ടോൺ മാപ്പിംഗ് മോഡ്';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'ടോൺ മാപ്പിംഗ് റേഞ്ച്';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'ടോൺ മാപ്പിംഗ് ഡീസാച്ചുറേഷൻ';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ടോൺ മാപ്പിംഗ് പീക്ക്';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'ടോൺ മാപ്പിംഗ് പാരാമീറ്റർ';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP ടോൺ മാപ്പിംഗ് തെളിച്ചം';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP ടോൺ മാപ്പിംഗ് കോൺട്രാസ്റ്റ്';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'പ്രീസെറ്റുകളും ഗുണനിലവാരവും';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'എൻകോഡർ പ്രീസെറ്റ്';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 എൻകോഡിംഗ് CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) എൻകോഡിംഗ് CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'ഡീഇന്റർലേസ് രീതി';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ഡീഇന്റർലേസ് ചെയ്യുമ്പോൾ ഫ്രെയിം റേറ്റ് ഇരട്ടിയാക്കുക';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ഓഡിയോ';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'ഓഡിയോ VBR എൻകോഡിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ഓഡിയോ ഡൗൺമിക്സ് ബൂസ്റ്റ്';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'സ്റ്റീരിയോ ഡൗൺമിക്സ് അൽഗോരിതം';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'പരമാവധി മക്സിംഗ് ക്യൂ വലുപ്പം';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ഓട്ടോ';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'എൻകോഡിംഗ്';
@@ -7333,7 +7295,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminTaskStop => 'നിർത്തുക';
 
   @override
-  String get adminRunningTasks => 'പ്രവർത്തിക്കുന്ന ടാസ്കുകൾ';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'ഓടുക';
@@ -7403,8 +7365,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count മണിക്കൂർ',
-      one: '1 മണിക്കൂർ',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7450,27 +7412,27 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesമി';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursമ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysദി';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'സീക്ക് പ്രിവ്യൂ തംബ്‌നെയിലുകൾക്കായി trickplay ചിത്ര സൃഷ്ടിക്കൽ കോൺഫിഗർ ചെയ്യുക.';
+      'തിരനോട്ടം ലഘുചിത്രങ്ങൾക്കായി ട്രിക്ക്പ്ലേ ഇമേജ് ജനറേഷൻ കോൺഫിഗർ ചെയ്യുക.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'പൊതു HTTPS പോർട്ട്';
@@ -7479,50 +7441,49 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'അടിസ്ഥാന URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ഉദാ. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ഉദാ. /ജെല്ലിഫിൻ';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'പബ്ലിക് HTTP പോർട്ട്';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS ആവശ്യമാണ്';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'എല്ലാ റിമോട്ട് അഭ്യർത്ഥനകളും HTTPS ലേക്ക് റീഡയറക്റ്റ് ചെയ്യുക. സെർവറിന് സാധുവായ സർട്ടിഫിക്കറ്റ് ഇല്ലെങ്കിൽ ഇതിന് ഒരു ഫലവുമില്ല.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'സർട്ടിഫിക്കറ്റ് പാസ്‌വേഡ്';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP ക്രമീകരണങ്ങൾ';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'സ്വയമേവയുള്ള പോർട്ട് മാപ്പിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN നെറ്റ്‌വർക്കുകൾ';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'ലോക്കൽ നെറ്റ്‌വർക്കിലുള്ളതായി പരിഗണിക്കുന്ന IP വിലാസങ്ങളുടെയോ CIDR സബ്‌നെറ്റുകളുടെയോ കോമ അല്ലെങ്കിൽ ലൈൻ കൊണ്ട് വേർതിരിച്ച ലിസ്റ്റ്.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'പ്രസിദ്ധീകരിച്ച സെർവർ URI-കൾ';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'ഒരു സബ്‌നെറ്റ് അല്ലെങ്കിൽ വിലാസം ഒരു പ്രസിദ്ധീകരിച്ച URL-ലേക്ക് മാപ്പ് ചെയ്യുക, ഉദാ. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'സർട്ടിഫിക്കറ്റ് പാത';
@@ -7553,11 +7514,11 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'ത്രോട്ടിൽ ബഫറിംഗ്';
 
   @override
-  String get adminPlaybackThrottleDelay => 'ത്രോട്ടിൽ കാലതാമസം (സെക്കൻഡുകൾ)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'തത്സമയ സബ്ടൈറ്റിൽ എക്സ്ട്രാക്ഷൻ അനുവദിക്കുക';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'ഏറ്റവും കുറഞ്ഞ റെസ്യൂമെ ശതമാനം';
@@ -7615,23 +7576,22 @@ class AppLocalizationsMl extends AppLocalizations {
       'മന്ദഗതിയിലുള്ള പ്രതികരണ പരിധി (മിസെ)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'സാവധാന പ്രതികരണ മുന്നറിയിപ്പുകൾ പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect പ്രവർത്തനക്ഷമമാക്കുക';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'സെർവർ';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'മെറ്റാഡാറ്റ';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'പാതകൾ';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'പ്രകടനം';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'കാഷെ പാത';
@@ -7643,7 +7603,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminGeneralServerName => 'സെർവറിൻ്റെ പേര്';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ഇഷ്ട ഡിസ്പ്ലേ ഭാഷ';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7696,8 +7656,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# പങ്കാളികൾ',
-      one: '# പങ്കാളി',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7845,8 +7805,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# വരികൾ കണ്ടെത്തി',
-      one: '# വരി കണ്ടെത്തി',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7887,21 +7847,20 @@ class AppLocalizationsMl extends AppLocalizations {
   String get offlineSavedMedia => 'സംരക്ഷിച്ച മീഡിയ';
 
   @override
-  String get offlineBannerTitle => 'നിങ്ങൾ ഓഫ്‌ലൈനാണ്';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'നിങ്ങളുടെ ഡൗൺലോഡുകൾ കാണിക്കുന്നു';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ഡൗൺലോഡുകൾ';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'നിങ്ങളുടെ സെർവറിലേക്ക് എത്താൻ കഴിയുന്നില്ല';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'അത് തിരികെ വരുന്നതുവരെ ഡൗൺലോഡുകളിൽ നിന്ന് പ്ലേ ചെയ്യുന്നു';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7975,17 +7934,17 @@ class AppLocalizationsMl extends AppLocalizations {
   String get pinForgot => 'പിൻ മറന്നോ?';
 
   @override
-  String get pinClear => 'മായ്ക്കുക';
+  String get pinClear => 'ക്ലിയർ';
 
   @override
   String get pinBackspace => 'ബാക്ക്സ്പേസ്';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect അഭ്യർത്ഥന അംഗീകരിച്ചു.';
+  String get quickConnectAuthorized => 'ദ്രുത കണക്ഷൻ അഭ്യർത്ഥന അംഗീകരിച്ചു.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect കോഡ് അസാധുവാണ് അല്ലെങ്കിൽ കാലഹരണപ്പെട്ടു.';
+      'ദ്രുത കണക്റ്റ് കോഡ് അസാധുവാണ് അല്ലെങ്കിൽ കാലഹരണപ്പെട്ടു.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7997,19 +7956,19 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'ഈ സെർവറിൽ Quick Connect പ്രവർത്തനരഹിതമാണ്.';
+      'ഈ സെർവറിൽ ദ്രുത കണക്ഷൻ പ്രവർത്തനരഹിതമാക്കിയിരിക്കുന്നു.';
 
   @override
   String get quickConnectForbidden =>
-      'നിങ്ങളുടെ അക്കൗണ്ടിന് ഈ Quick Connect അഭ്യർത്ഥന അംഗീകരിക്കാൻ കഴിയില്ല.';
+      'നിങ്ങളുടെ അക്കൗണ്ടിന് ഈ ദ്രുത കണക്ഷൻ അഭ്യർത്ഥന അംഗീകരിക്കാൻ കഴിയില്ല.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect കോഡ് കണ്ടെത്തിയില്ല. ഒരു പുതിയ കോഡ് പരീക്ഷിക്കുക.';
+      'ദ്രുത കണക്റ്റ് കോഡ് കണ്ടെത്തിയില്ല. ഒരു പുതിയ കോഡ് പരീക്ഷിക്കുക.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect പരാജയപ്പെട്ടു: $message';
+    return 'ദ്രുത കണക്ഷൻ പരാജയപ്പെട്ടു: $message';
   }
 
   @override
@@ -8242,7 +8201,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'റൊട്ടേഷൻ അനുവദിക്കുക';
 
   @override
-  String get playerTooltipPrevious => 'മുമ്പത്തേത്';
+  String get playerTooltipPrevious => 'മുമ്പത്തെ';
 
   @override
   String get playerTooltipSeekBack => 'തിരികെ അന്വേഷിക്കുക';
@@ -8268,14 +8227,13 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      '\"കാണുന്നത് തുടരുക\" എന്നതിൽ നിന്ന് മറയ്ക്കുക';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp =>
-      '\"അടുത്തത്\" എന്നതിൽ നിന്ന് മറയ്ക്കുക';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'ശേഖരത്തിലേക്ക് ചേർക്കുക';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8310,7 +8268,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'പ്ലഗിൻ സിങ്ക്, Seerr, റേറ്റിംഗുകൾ എന്നിവയും അതിലേറെയും';
+      'പ്ലഗിൻ സമന്വയം, സീർ, റേറ്റിംഗുകൾ എന്നിവയും അതിലേറെയും';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8329,15 +8287,14 @@ class AppLocalizationsMl extends AppLocalizations {
   String get settingsAlphabetical => 'അക്ഷരമാലാക്രമം';
 
   @override
-  String get settingsConnectionSection => 'കണക്ഷൻ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'സ്വയം-സൈൻ ചെയ്ത സർട്ടിഫിക്കറ്റുകൾ അനുവദിക്കുക';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'സ്വയം-സൈൻ ചെയ്ത അല്ലെങ്കിൽ പ്രൈവറ്റ്-CA TLS സർട്ടിഫിക്കറ്റുകൾ ഉപയോഗിക്കുന്ന സെർവറുകളെ വിശ്വസിക്കുക. നിങ്ങൾ നിയന്ത്രിക്കുന്ന സെർവറുകൾക്ക് മാത്രം പ്രവർത്തനക്ഷമമാക്കുക. ഇത് എല്ലാ കണക്ഷനുകൾക്കുമുള്ള സർട്ടിഫിക്കറ്റ് മൂല്യനിർണ്ണയം പ്രവർത്തനരഹിതമാക്കുന്നു.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'സ്വകാര്യതയും സുരക്ഷയും';
@@ -8353,11 +8310,11 @@ class AppLocalizationsMl extends AppLocalizations {
       'തീം ആക്‌സൻ്റുകൾ, ബാക്ക്‌ഡ്രോപ്പുകൾ, കണ്ട സൂചകങ്ങൾ, തീം സംഗീതം';
 
   @override
-  String get settingsDetailsScreen => 'വിശദാംശ സ്ക്രീൻ';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'ശൈലി, പശ്ചാത്തല ബ്ലർ, ടാബ് സ്വഭാവം';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'ഹോം പേജ്';
@@ -8395,11 +8352,11 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'നാവിഗേഷൻ ബാറിൽ Seerr ബട്ടൺ കാണിക്കുക';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'മുകളിലെ നാവിഗേഷൻ ബാറിൽ ടെക്സ്റ്റ് ലേബലുകൾ എപ്പോഴും കാണിക്കുക';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8420,7 +8377,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'അധിക റേറ്റിംഗ് ഉറവിടങ്ങൾ, Seerr അഭ്യർത്ഥനകൾ, സിങ്ക് ചെയ്ത മുൻഗണനകൾ എന്നിവയുൾപ്പെടെയുള്ള സെർവർ-സൈഡ് സംയോജനങ്ങൾക്ക് Moonbase ശക്തി പകരുന്നു.';
+      'Moonbase അധിക റേറ്റിംഗ് ഉറവിടങ്ങൾ, സീർ അഭ്യർത്ഥനകൾ, സമന്വയിപ്പിച്ച മുൻഗണനകൾ എന്നിവ ഉൾപ്പെടെയുള്ള സെർവർ-സൈഡ് സംയോജനങ്ങൾക്ക് ശക്തി നൽകുന്നു.';
 
   @override
   String get settingsOfflineDownloads => 'ഓഫ്‌ലൈൻ ഡൗൺലോഡുകൾ';
@@ -8469,7 +8426,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'ഡെവലപ്പർക്ക് ഒരു കോഫി സംഭാവന ചെയ്യുക';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'നിയമപരമായ';
@@ -8503,8 +8460,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ലൈസൻസ് അറിയിപ്പുകൾ',
-      one: '# ലൈസൻസ് അറിയിപ്പ്',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8554,16 +8511,16 @@ class AppLocalizationsMl extends AppLocalizations {
       'ആമുഖങ്ങളും ഔട്ട്റോകളും ഒഴിവാക്കണോ?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'മീഡിയ സെഗ്‌മെന്റ് കൗണ്ട്ഡൗൺ';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'പ്രോഗ്രസ് ബാർ';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ടൈമർ';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ഒന്നുമില്ല';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'പ്രോംപ്റ്റ് ഉപയോക്താവ്';
@@ -8796,7 +8753,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'അടുത്തിടെ പുറത്തിറങ്ങിയ $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8829,11 +8786,11 @@ class AppLocalizationsMl extends AppLocalizations {
       'ടണൽ ചെയ്യാത്ത പ്ലേബാക്ക് നിർബന്ധിക്കുക. ടണലിംഗ് ഓഡിയോ/വീഡിയോ നിർത്തലുള്ള ഉപകരണങ്ങളിൽ ഉപയോഗപ്രദമാണ്.';
 
   @override
-  String get enableTunnelingTitle => 'ടണലിംഗ് പ്രവർത്തനക്ഷമമാക്കുക';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'വിപുലം. ഓഡിയോയും വീഡിയോയും ഒരു കപ്പിൾഡ് ഹാർഡ്‌വെയർ പാതയിലൂടെ റൂട്ട് ചെയ്യുന്നു. ചില ഉപകരണങ്ങളിൽ ഓഡിയോ/വീഡിയോ ഡ്രോപ്പ്‌ഔട്ടുകൾക്ക് കാരണമാകുന്നതിനാൽ ഡിഫോൾട്ടായി ഓഫാണ്.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8860,15 +8817,14 @@ class AppLocalizationsMl extends AppLocalizations {
       'സബ്‌ടൈറ്റിൽ ട്രാക്കിൽ ഉൾച്ചേർത്ത ഫോണ്ട് സൈസ് സൂചനകൾ പ്രയോഗിക്കുക. നിങ്ങളുടെ ശൈലി മുൻഗണനകളിൽ നിന്ന് സബ്‌ടൈറ്റിൽ സൈസ് ഉപയോഗിക്കുന്നത് പ്രവർത്തനരഹിതമാക്കുക.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'മീഡിയ വിശദാംശങ്ങൾ കാണിക്കുക';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'ലൈബ്രറി പേജുകളുടെ മുകളിൽ തിരഞ്ഞെടുത്ത ഇനത്തിന്റെ വിശദാംശങ്ങൾ കാണിക്കുക.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'ബ്രൗസ് ചെയ്യുമ്പോൾ ബാക്ക്‌ഡ്രോപ്പുകൾ മറയ്ക്കണോ?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'വിശദമായ ഉപതലക്കെട്ടുകൾ ഉപയോഗിക്കുക';
@@ -8886,38 +8842,37 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'തീം സ്റ്റോർ';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'കമ്മ്യൂണിറ്റി തീമുകൾ ബ്രൗസ് ചെയ്ത് സംരക്ഷിക്കുക';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'നിങ്ങളുടെ മറ്റ് സംരക്ഷിച്ച തീമുകൾ പോലെ ഉപയോഗിക്കാൻ ഒരു തീം സംരക്ഷിക്കുക.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ഇപ്പോൾ തീമുകളൊന്നും ലഭ്യമല്ല.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'തീം സ്റ്റോർ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'സംരക്ഷിക്കുക';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'സംരക്ഷിച്ച് പ്രയോഗിക്കുക';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'സംരക്ഷിച്ചു';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'ഈ തീം ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" സംരക്ഷിച്ചു.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8976,21 +8931,21 @@ class AppLocalizationsMl extends AppLocalizations {
   String get homeRowsSection => 'ഹോം വരികൾ';
 
   @override
-  String get homeRowDisplay => 'ഹോം വരി ഡിസ്പ്ലേ';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'ഹോം വരി വിഭാഗങ്ങൾ';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'ഹോം വരി ടോഗിളുകൾ';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'ലൈബ്രറി അധിഷ്ഠിത ഹോം വരി വിഭാഗങ്ങൾ പ്രവർത്തനക്ഷമമാക്കുകയോ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്യുക';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'ഹോം വിഭാഗങ്ങളിൽ വരികൾ പ്രദർശിപ്പിക്കാൻ ഇനിപ്പറയുന്ന ടോഗിളുകൾ പ്രവർത്തനക്ഷമമാക്കുക.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'വരികളുടെ തരം';
@@ -9049,56 +9004,55 @@ class AppLocalizationsMl extends AppLocalizations {
       'സിനിമകൾ, പരമ്പരകൾ, അല്ലെങ്കിൽ രണ്ടും വിഭാഗങ്ങളുടെ വരികളിൽ കാണിക്കുക.';
 
   @override
-  String get displayPlaylistsRows => 'പ്ലേലിസ്റ്റ് വരികൾ പ്രദർശിപ്പിക്കുക';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'ഹോം വിഭാഗങ്ങളിൽ പ്ലേലിസ്റ്റ് വരികൾ കാണിക്കുക.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'പ്ലേലിസ്റ്റ് വരി അടുക്കൽ';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'പ്ലേലിസ്റ്റ് വരികൾ ചേർത്ത തീയതി, റിലീസ് തീയതി, അക്ഷരമാലാക്രമം എന്നിവയും അതിലേറെയും അനുസരിച്ച് അടുക്കുക.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ഓഡിയോ വരികൾ പ്രദർശിപ്പിക്കുക';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'ഹോം വിഭാഗങ്ങളിൽ ഓഡിയോ വരികൾ കാണിക്കുക.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ഓഡിയോ വരികളുടെ അടുക്കൽ';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ഓഡിയോ വരികൾ ചേർത്ത തീയതി, റിലീസ് തീയതി, അക്ഷരമാലാക്രമം എന്നിവയും അതിലേറെയും അനുസരിച്ച് അടുക്കുക.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ഓഡിയോ പ്ലേലിസ്റ്റുകൾ';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'രൂപഭാവം';
 
   @override
-  String get layout => 'ലേഔട്ട്';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'തീം';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'കീബോർഡ്';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'ബട്ടണുകൾ';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'റെൻഡറിംഗ്';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV കോൺഫിഗറേഷൻ';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'കാർഡ് വലിപ്പം';
@@ -9108,7 +9062,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'ലോംഗ്-പ്രസ് പ്ലേ ഓപ്ഷൻ പ്രവർത്തനക്ഷമമാക്കാൻ ബാഹ്യ പ്ലേയർ സജ്ജമാക്കുക';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9372,10 +9326,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get guestAppearances => 'അതിഥി വേഷങ്ങൾ';
 
   @override
-  String get appearancesSeerr => 'പ്രത്യക്ഷപ്പെടലുകൾ (Seerr)';
+  String get appearancesSeerr => 'രൂപഭാവങ്ങൾ (സീർ)';
 
   @override
-  String get crewContributionsSeerr => 'ക്രൂ സംഭാവനകൾ (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'ഗ്രൂപ്പിനൊപ്പം കാണുക';
@@ -9461,8 +9415,8 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ലൈബ്രറികൾ',
-      one: '1 ലൈബ്രറി',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9553,7 +9507,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get mixedMoviesAndShows => 'മിക്സഡ് സിനിമകളും ഷോകളും';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'ഇൻ്റൽ ദ്രുത സമന്വയം';
 
   @override
   String get rockchipMpp => 'റോക്ക്ചിപ്പ് എംപിപി';
@@ -9621,13 +9575,13 @@ class AppLocalizationsMl extends AppLocalizations {
   String get loadingShuffle => 'ഷഫിൾ ലോഡുചെയ്യുന്നു...';
 
   @override
-  String get libraryShuffleLabel => 'ലൈബ്രറി ഷഫിൾ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'റാൻഡം ഷഫിൾ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'വിഭാഗ ഷഫിൾ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'യാന്ത്രിക HDR സ്വിച്ചിംഗ്';
@@ -9640,222 +9594,222 @@ class AppLocalizationsMl extends AppLocalizations {
   String get whenFullscreen => 'ഫുൾസ്ക്രീൻ ആയിരിക്കുമ്പോൾ';
 
   @override
-  String get changeArtwork => 'ആർട്ട്‌വർക്ക് മാറ്റുക';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'കാണുന്നില്ല';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'ട്രാൻസ്കോഡിംഗ് പരിധികൾ';
 
   @override
-  String get clearAllArtworkButton => 'എല്ലാ ആർട്ട്‌വർക്കും മായ്ക്കണോ?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'ഡൗൺലോഡ് ചെയ്ത എല്ലാ ആർട്ട്‌വർക്കും മായ്ക്കണമെന്ന് ഉറപ്പാണോ?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'മായ്ക്കൽ സ്ഥിരീകരിക്കുക';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'ഈ $itemType മായ്ക്കണമെന്ന് ഉറപ്പാണോ?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'അപ്‌ലോഡ് ചെയ്യണോ?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'റെസലൂഷൻ: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'ഇന്റർഫേസ് ഭാഷയിൽ മാത്രം ആർട്ട്‌വർക്ക് കാണിക്കുക';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'എല്ലാം മായ്ക്കൽ സ്ഥിരീകരിക്കുക';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'ചിത്രം വിജയകരമായി അപ്‌ലോഡ് ചെയ്തു!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'ചിത്രം അപ്‌ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ചിത്രം സജ്ജമാക്കാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ചിത്രം ഇല്ലാതാക്കാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'എല്ലാ ആർട്ട്‌വർക്കും മായ്ക്കാൻ കഴിഞ്ഞില്ല: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'അതെ';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'പോസ്റ്റർ';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'ബാക്ക്‌ഡ്രോപ്പുകൾ';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'ബാനർ';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'ലോഗോ';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'തംബ്‌നെയിൽ';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'ആർട്ട്';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ഡിസ്ക് ആർട്ട്';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'സ്ക്രീൻഷോട്ട്';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'ബോക്സ് കവർ';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'ബോക്സ് പിൻ കവർ';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'മെനു ആർട്ട്';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'പോസ്റ്റർ';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ബാക്ക്‌ഡ്രോപ്പ്';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'ബാനർ';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'ലോഗോ';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'തംബ്‌നെയിൽ';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ആർട്ട്';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ഡിസ്ക് ആർട്ട്';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'സ്ക്രീൻഷോട്ട്';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'ബോക്സ് കവർ';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'ബോക്സ് പിൻ കവർ';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'മെനു ആർട്ട്';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'എല്ലാം';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'ഉയർന്നത് (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'ഇടത്തരം (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'കുറഞ്ഞത് (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'ഉറവിടങ്ങൾ';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'അധ്യായങ്ങൾ';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'ബുക്ക്മാർക്കുകൾ';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'കുറിപ്പുകൾ';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'ക്യൂ';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ടൈംലൈൻ';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ടൈംലൈൻ ശൂന്യമാണ്';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'മുഴുവൻ പുസ്തകം';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'കേന്ദ്രീകൃത ടൈംലൈൻ';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ബുക്ക്മാർക്കുകൾ എക്സ്പോർട്ട് ചെയ്യുക';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'കുറിപ്പുകൾ എക്സ്പോർട്ട് ചെയ്യുക';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'എല്ലാം എക്സ്പോർട്ട് ചെയ്യുക';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path ലേക്ക് എക്സ്പോർട്ട് ചെയ്തു';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'എക്സ്പോർട്ട് പരാജയപ്പെട്ടു: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'വരികൾ';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'ബുക്ക്മാർക്ക് ചേർക്കുക';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'കുറിപ്പ് ചേർക്കുക';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'കുറിപ്പ് എഡിറ്റ് ചെയ്യുക';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'ഈ നിമിഷത്തിനായി ഒരു കുറിപ്പ് എഴുതുക';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'സ്ലീപ്പ് ടൈമർ';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ഓഫ്';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'അധ്യായത്തിന്റെ അവസാനം';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'ഇഷ്ടാനുസൃതം';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining ബാക്കി';
+    return '$remaining left';
   }
 
   @override
@@ -9863,58 +9817,58 @@ class AppLocalizationsMl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count മിനി',
-      one: '1 മിനി',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'പ്ലേബാക്ക് വേഗത';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'ബാക്കി';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'കഴിഞ്ഞത്';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$secondsസെ പിന്നോട്ട്';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$secondsസെ മുന്നോട്ട്';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'മുൻ അധ്യായം';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'അടുത്ത അധ്യായം';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total ൽ അധ്യായം $current';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'അധ്യായങ്ങളൊന്നുമില്ല';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'ഇതുവരെ ബുക്ക്മാർക്കുകളൊന്നുമില്ല';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'ഇതുവരെ കുറിപ്പുകളൊന്നുമില്ല';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position ൽ ബുക്ക്മാർക്ക് ചേർത്തു';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x ലേക്ക് പുനഃസജ്ജമാക്കുക';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9922,256 +9876,249 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'സംരക്ഷിക്കുക';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'റദ്ദാക്കുക';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'ഇല്ലാതാക്കുക';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'സബ്ടൈറ്റിൽ മുൻഗണനകൾ';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'സബ്ടൈറ്റിൽ മോഡുകൾ, ഡിഫോൾട്ട് ഭാഷകൾ, രൂപഭാവം, റെൻഡറിംഗ് ഓപ്ഷനുകൾ എന്നിവ മാറ്റുക.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'സബ്ടൈറ്റിൽ റെൻഡറിംഗ്';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'ഡിസ്പ്ലേ ഓപ്ഷനുകൾ';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'റിലീസ് തീയതി (ആരോഹണം)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'റിലീസ് തീയതി (അവരോഹണം)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'സംഭാവനകൾ ഗ്രൂപ്പ് ചെയ്യുക';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'ഒന്നിലധികം റോളുകൾ ഗ്രൂപ്പ് ചെയ്യുക';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'ലൈബ്രറി റൈറ്റ് ആക്സസ് മുന്നറിയിപ്പ്';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'ഇത് എങ്ങനെ പരിഹരിക്കാം:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. സെർവറിലെ നിങ്ങളുടെ മീഡിയ ലൈബ്രറി ഫോൾഡറുകൾക്കായി Jellyfin സേവന ഉപയോക്താവിന് (ഉദാ. jellyfin അല്ലെങ്കിൽ Docker PUID/PGID) റൈറ്റ് അനുമതികൾ നൽകുക.\n\n2. അല്ലെങ്കിൽ, നിങ്ങളുടെ Jellyfin ഡാഷ്ബോർഡ് -> Libraries ലേക്ക് പോയി, ഈ ലൈബ്രറി എഡിറ്റ് ചെയ്യുക, Jellyfin ന്റെ ആന്തരിക ഡാറ്റാബേസിൽ ആർട്ട്‌വർക്ക് സംഭരിക്കാൻ \'Save artwork into media folders\' പ്രവർത്തനരഹിതമാക്കുക.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'ഒഴിവാക്കുക';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'നിങ്ങളുടെ \'$libraryName\' ലൈബ്രറി ആർട്ട്‌വർക്ക് നേരിട്ട് മീഡിയ ഫോൾഡറുകളിൽ സംരക്ഷിക്കാൻ കോൺഫിഗർ ചെയ്തിരിക്കുന്നു (\'Save artwork into media folders\' പ്രവർത്തനക്ഷമമാണ്). എന്നിരുന്നാലും, Jellyfin റൈറ്റ് ആക്സസ് പരീക്ഷിച്ചു, ഈ ഡയറക്ടറിയിലേക്ക് ഫയലുകൾ എഴുതാൻ അനുമതിയില്ല:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin ആർട്ട്‌വർക്ക് അപ്ഡേറ്റ് ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടതായി തോന്നുന്നു. നിങ്ങളുടെ ലൈബ്രറി ആർട്ട്‌വർക്ക് നേരിട്ട് മീഡിയ ഫോൾഡറുകളിൽ സംരക്ഷിക്കാൻ കോൺഫിഗർ ചെയ്തിരിക്കുന്നു (\'Save artwork into media folders\' പ്രവർത്തനക്ഷമമാണ്). Jellyfin സെർവർ പ്രോസസിന് നിങ്ങളുടെ മീഡിയ ഡയറക്ടറികളിലേക്ക് ഫയലുകൾ എഴുതാൻ അനുമതിയില്ലാത്തപ്പോൾ ഈ പിശക് സാധാരണയായി സംഭവിക്കുന്നു.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'ബാഹ്യ ലിസ്റ്റുകൾ';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'വീണ്ടും പ്ലേ ചെയ്യുക';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ഫയൽ വിവരം';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'വലുപ്പം: $size  •  ഫോർമാറ്റ്: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'എല്ലാ ($count) ഓഡിയോ ട്രാക്കുകളും കാണിക്കുക';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'എല്ലാ ($count) സബ്ടൈറ്റിൽ ട്രാക്കുകളും കാണിക്കുക';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'ഡയറക്റ്റ് പ്ലേ കഴിവ് പരിശോധിക്കുന്നു...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'ഡയറക്റ്റ് പ്ലേ കഴിവ്: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'ഫോഴ്സ്ഡ്';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'കണ്ടെയ്നർ ഫോർമാറ്റ് പ്ലേയർ പിന്തുണയ്ക്കുന്നില്ല.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'വീഡിയോ കോഡെക് പിന്തുണയ്ക്കുന്നില്ല.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'ഓഡിയോ കോഡെക് പിന്തുണയ്ക്കുന്നില്ല.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'സബ്ടൈറ്റിൽ ഫോർമാറ്റ് പിന്തുണയ്ക്കുന്നില്ല (ബേണിംഗ് ആവശ്യമാണ്).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ഓഡിയോ പ്രൊഫൈൽ പിന്തുണയ്ക്കുന്നില്ല.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'വീഡിയോ പ്രൊഫൈൽ പിന്തുണയ്ക്കുന്നില്ല.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'വീഡിയോ ലെവൽ പിന്തുണയ്ക്കുന്നില്ല.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'ഈ ഉപകരണം വീഡിയോ റെസലൂഷൻ പിന്തുണയ്ക്കുന്നില്ല.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'വീഡിയോ ബിറ്റ് ഡെപ്ത് പിന്തുണയ്ക്കുന്നില്ല.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'വീഡിയോ ഫ്രെയിംറേറ്റ് പിന്തുണയ്ക്കുന്നില്ല.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ഫയൽ ബിറ്റ്റേറ്റ് പ്ലേയർ സ്ട്രീമിംഗ് പരിധി കവിയുന്നു.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'വീഡിയോ ബിറ്റ്റേറ്റ് സ്ട്രീമിംഗ് പരിധി കവിയുന്നു.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ഓഡിയോ ബിറ്റ്റേറ്റ് സ്ട്രീമിംഗ് പരിധി കവിയുന്നു.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ഓഡിയോ ചാനലുകളുടെ എണ്ണം പിന്തുണയ്ക്കുന്നില്ല.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'അക്ഷരമാലാക്രമം';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'റിലീസ് ക്രമം (ആരോഹണം)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'റിലീസ് ക്രമം (അവരോഹണം)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'ഇഷ്ടാനുസൃതം (വലിച്ചിടുക)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'പ്ലേലിസ്റ്റ് അടുക്കൽ ഓപ്ഷനുകൾ';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'അടുക്കൽ പുനഃസജ്ജമാക്കുക';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode വീണ്ടും കാണുക';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'പ്ലേലിസ്റ്റ് വീണ്ടും കാണുക';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'സബ്ടൈറ്റിലുകളൊന്നും കണ്ടെത്തിയില്ല.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'അഡ്മിൻ നിയന്ത്രണങ്ങൾ';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'റെൻഡറിംഗ് എഞ്ചിൻ (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'സുഗമമായ ആനിമേഷനുകൾക്കും കുറഞ്ഞ സ്റ്റട്ടറിനുമായുള്ള Flutter-ന്റെ ആധുനിക GPU റെൻഡററാണ് Impeller. ചില TV ബോക്സുകളിലും പഴയ GPU-കളിലും ഇത് ഗ്ലിച്ചുകൾക്കോ കറുത്ത വീഡിയോയ്ക്കോ കാരണമായേക്കാം; അവ കാണുകയാണെങ്കിൽ ഇത് ഓഫ് ചെയ്യുക. ഓട്ടോമാറ്റിക് നിങ്ങളുടെ ഉപകരണത്തിനുള്ള മികച്ച ഡിഫോൾട്ട് തിരഞ്ഞെടുക്കുന്നു. പ്രയോഗിക്കാൻ Moonfin പുനരാരംഭിക്കുക.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ഓട്ടോമാറ്റിക്';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ഓൺ';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ഓഫ്';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'പുനരാരംഭിക്കൽ ആവശ്യമാണ്';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'റെൻഡറിംഗ് എഞ്ചിൻ മാറ്റാൻ Moonfin പുനരാരംഭിക്കേണ്ടതുണ്ട്. ഇപ്പോൾ ആപ്പ് അടയ്ക്കുക, തുടർന്ന് പ്രയോഗിക്കാൻ അത് വീണ്ടും തുറക്കുക.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ഇപ്പോൾ ആപ്പ് അടയ്ക്കുക';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'ലൈബ്രറി പുതുക്കുക';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'എല്ലാ ലൈബ്രറികളും പുതുക്കുക';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'ചേർത്ത തീയതി (പഴയത് ആദ്യം)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'ചേർത്ത തീയതി (പുതിയത് ആദ്യം)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'അക്ഷരമാലാക്രമം (A മുതൽ Z വരെ)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'അക്ഷരമാലാക്രമം (Z മുതൽ A വരെ)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'സെർവർ അനലിറ്റിക്സ് ലോഡ് ചെയ്യുന്നു... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'സോഴ്സുമായി പൊരുത്തപ്പെടുത്തുക';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb ടോപ്പ് 250 സിനിമകൾ';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb ടോപ്പ് 250 ടിവി ഷോകൾ';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb ഏറ്റവും ജനപ്രിയ സിനിമകൾ';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb ഏറ്റവും ജനപ്രിയ ടിവി ഷോകൾ';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'IMDb ഏറ്റവും കുറഞ്ഞ റേറ്റിംഗുള്ള സിനിമകൾ';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb ഏറ്റവും ഉയർന്ന റേറ്റിംഗുള്ള ഇംഗ്ലീഷ് സിനിമകൾ';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -9,22 +9,22 @@ class AppLocalizationsMn extends AppLocalizations {
   AppLocalizationsMn([String locale = 'mn']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Сарны фин';
 
   @override
-  String get accountPreferences => 'БҮРТГЭЛИЙН ТОХИРГОО';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Интерфейсийн хэл';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Системийн үндсэн';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Нэвтрэх';
 
   @override
-  String get empty => 'Хоосон';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Түргэн холболт';
 
   @override
   String get password => 'Нууц үг';
@@ -113,7 +113,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get cancel => 'Цуцлах';
 
   @override
-  String get remove => 'Хасах';
+  String get remove => 'Устгах';
 
   @override
   String get connectToServer => 'Сервертэй холбогдоно уу';
@@ -141,62 +141,62 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAppearanceTheme => 'Апп-ын сэдэв';
 
   @override
-  String get detailScreenStyle => 'Дэлгэрэнгүй дэлгэцийн хэв маяг';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Сонгодог нь Moonfin-ий анхны төвлөрсөн байрлал. Орчин үеийн нь дэлгэцэд зохицдог кино маягийн байрлал.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Сонгодог';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Орчин үеийн';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Дэлгэсэн табууд';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Табуудыг үзэж байхад агуулгыг нь автоматаар харуулна. Унтраавал таб бүрийг гараар нээж хаана.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Техникийн дэлгэрэнгүйг харуулах уу?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Кодек, нягтрал, урсгалын мэдээллийг баннерын хураангуйд харуулна';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Зөвлөмжийн систем';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends дотоод сангийн алгоритм эсвэл онлайн TMDb-ийн ижил төстэй байдлын хэмжүүрийг ашиглана. Тэмдэглэл: Онлайн зөвлөмжид Seerr холболт шаардлагатай.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-ийн ижил төстэй байдал';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Насны ангиллын хязгаар тавих уу?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Moonfin Recommends-ийн саналыг сонгосон медиагийн насны ангиллаар хязгаарлана';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Интерфейсийн хэв маяг';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Автомат нь таны төхөөрөмжид тохирно. Тодорхой хэлбэрийг албадахыг хүсвэл Apple эсвэл Material-ыг сонгоно уу.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автомат';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsMn extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Шилэн эффектийн чанар';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Авто нь энэ төхөөрөмжид тохирох шилэн эффектийг сонгоно. Бүрэн нь жинхэнэ бүдгэрүүлэлтийг албадана; Багасгасан нь GPU-ийн хүчийг хэмнэх хөнгөн шил ашиглана.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Авто';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Бүрэн';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Багасгасан';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Програмыг дахин эхлүүлэхгүйгээр Moonfin болон Neon Pulse хооронд сэлгэнэ үү';
 
   @override
-  String get customThemeTitle => 'Захиалгат загвар';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Захиалгат загвар нь Moonfin даяарх харагдах байдлыг өөрчилнө. Өөрийн хэв маягт тохирох нэгийг сонгоно уу.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Системийн гарыг илүүд үздэг';
@@ -239,7 +239,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Текст оруулахдаа төхөөрөмжийнхөө оруулах аргыг өгөгдмөлөөр ашиглана уу';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Сарны фин';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsMn extends AppLocalizations {
       'Нил ягаан өнгийн туяа, хөх өнгийн текст, илүү хүчтэй хром тодосгогч бүхий Synthwave загвар';
 
   @override
-  String get themeGlass => 'Шил';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Хөвөгч градиент дэвсгэр, бүрхэг гадаргуу, Apple-ийн цэнхэр өргөлттэй шингэн шилэн хэв маяг';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit баатар';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Бүдүүн өнгөний палитр, дөрвөлжин хүрээ, хатуу сүүдэр, пиксел фонттой ретро пиксел-арт хэв маяг';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -327,35 +327,35 @@ class AppLocalizationsMn extends AppLocalizations {
   String get exit => 'Гарах';
 
   @override
-  String get gameMenu => 'Цэс';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Түр зогссон';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Төлөв хадгалах';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Тоглоомууд';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Төлөв ачаалах';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Хурдан урагшлуулах';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Эмуляторын тохиргоо';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Энэ цөмд тохируулах сонголт байхгүй.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Цэс нээхийн тулд удаан дарна уу';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Энэ төхөөрөмж дээр тоглоом тоглуулахыг хараахан дэмжээгүй байна.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Нүүр хуудасны мөрийг ачаалж чадсангүй';
@@ -383,7 +383,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get noItemsFound => 'Ямар ч зүйл олдсонгүй';
 
   @override
-  String get home => 'Нүүр';
+  String get home => 'Гэр';
 
   @override
   String get browseAll => 'Бүгдийг үзэх';
@@ -415,7 +415,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get noLibrariesFound => 'Номын сан олдсонгүй';
 
   @override
-  String get library => 'Медиа сан';
+  String get library => 'Номын сан';
 
   @override
   String get displaySettings => 'Дэлгэцийн тохиргоо';
@@ -554,7 +554,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Discover дээр ямар сэдвийн хангамжийг харуулахыг сонгоно уу.';
 
   @override
-  String get apply => 'Хэрэглэх';
+  String get apply => 'Өргөдөл гаргах';
 
   @override
   String get openLink => 'Холбоосыг нээх';
@@ -603,7 +603,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get listen => 'Сонсооч';
 
   @override
-  String get resume => 'Үргэлжлүүлэх';
+  String get resume => 'Үргэлжлэл';
 
   @override
   String get failedToLoadLibrary => 'Номын санг ачаалж чадсангүй';
@@ -710,7 +710,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get browseByGenre => 'Төрөлөөр нь үзэх';
 
   @override
-  String get discover => 'Танилцах';
+  String get discover => 'Discover';
 
   @override
   String get trendingTitlesOpenLibrary =>
@@ -765,43 +765,43 @@ class AppLocalizationsMn extends AppLocalizations {
   String get books => 'Номууд';
 
   @override
-  String get latestBooks => 'Шинэ номууд';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Шинэ аудио номууд';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ном',
-      one: '1 ном',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Ном';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудио ном';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% уншсан';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time үлдсэн';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Унших';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Сонсох';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Зохиогч';
@@ -878,8 +878,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудио ном',
-      one: '1 аудио ном',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -915,7 +915,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get nextUp => 'Дараагийн';
 
   @override
-  String get seasons => 'Улирлууд';
+  String get seasons => 'Улирал';
 
   @override
   String get chapters => 'Бүлгүүд';
@@ -982,8 +982,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Улирал',
-      one: '1 Улирал',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -994,40 +994,40 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get items => 'Зүйлс';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Нэмэлтүүд';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Хөшигний ард';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Хасагдсан үзэгдлүүд';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Богино баримтат';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Ярилцлага';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Үзэгдлүүд';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Богино кино';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Трейлерүүд';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time үлдсэн';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time-ийн дараа дуусна';
+    return 'Ends in $time';
   }
 
   @override
@@ -1045,7 +1045,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get play => 'Тоглуулах';
+  String get play => 'Тогло';
 
   @override
   String get startOver => 'Дахин эхлүүлэх';
@@ -1069,10 +1069,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get version => 'Хувилбар';
 
   @override
-  String get cast => 'Дамжуулах';
+  String get cast => 'Жүжигчин';
 
   @override
-  String get trailer => 'Трейлер';
+  String get trailer => 'Чиргүүл';
 
   @override
   String get finished => 'Дууслаа';
@@ -1263,10 +1263,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get director => 'ЗАХИРАЛ';
 
   @override
-  String get directors => 'НАЙРУУЛАГЧИД';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ЗОХИОЛЧ';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'ЗОХИОЛЧИД';
@@ -1304,8 +1304,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count дуу',
-      one: '1 дуу',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1315,8 +1315,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count бүлэг',
-      one: '1 бүлэг',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1343,16 +1343,16 @@ class AppLocalizationsMn extends AppLocalizations {
   String get readMore => 'Дэлгэрэнгүй унших';
 
   @override
-  String get shuffle => 'Холих';
+  String get shuffle => 'Холимог';
 
   @override
-  String get shuffleAllMusic => 'Бүх хөгжмийг холих';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Утсан дээрээ Moonfin-д нэвтэрнэ үү';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Таны сервертэй холбогдож чадсангүй';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1364,7 +1364,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count суваг';
+    return '${count}ch';
   }
 
   @override
@@ -1464,7 +1464,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '$number-р дуу';
+    return 'Track $number';
   }
 
   @override
@@ -1511,12 +1511,12 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$valueмс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$valueмс';
+    return '+${value}ms';
   }
 
   @override
@@ -1550,7 +1550,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get transcodeReasons => 'Код хувиргах шалтгаанууд';
 
   @override
-  String get player => 'Тоглуулагч';
+  String get player => 'Тоглогч';
 
   @override
   String get container => 'Контейнер';
@@ -1568,13 +1568,13 @@ class AppLocalizationsMn extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'Кодек';
+  String get codec => 'Codec';
 
   @override
   String get videoBitrate => 'Видео битийн хурд';
 
   @override
-  String get track => 'Трек';
+  String get track => 'Зам';
 
   @override
   String get channels => 'Сувгууд';
@@ -1789,22 +1789,22 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Дараах: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesм үлдсэн';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursц үлдсэн';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursц $minutesм үлдсэн';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1827,7 +1827,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get favoriteChannel => 'Дуртай суваг';
 
   @override
-  String get record => 'Бичих';
+  String get record => 'Бичлэг';
 
   @override
   String get cancelRecordingAction => 'Бичлэгийг цуцлах';
@@ -1842,7 +1842,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get unableToCreateRecording => 'Бичлэг үүсгэх боломжгүй';
 
   @override
-  String get watch => 'Үзэх';
+  String get watch => 'үзэх';
 
   @override
   String get close => 'Хаах';
@@ -1929,7 +1929,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr бүртгэлийн төрөл';
+  String get seerrAccountType => 'Үзмэрч дансны төрөл';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2054,8 +2054,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count анги',
-      one: '1 анги',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2282,7 +2282,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Дэлгэрэнгүй хуудас, нүүр хуудасны эгнээ, дууны хэмжээ';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2297,11 +2297,11 @@ class AppLocalizationsMn extends AppLocalizations {
       'Үндсэн дэлгэцийг үзэх үед тоглуулаарай';
 
   @override
-  String get loopThemeMusic => 'Сэдвийн хөгжмийг давтах';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Нэг удаа тоглуулахын оронд дууг давтана';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur =>
@@ -2325,23 +2325,23 @@ class AppLocalizationsMn extends AppLocalizations {
   String get playerZoomMode => 'Тоглогчийн томруулах горим';
 
   @override
-  String get settingsScrollWheelAction => 'Хулганы гүйлгэх дугуй';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Тоглуулж байх үед видеон дээр хулганы дугуйг гүйлгэхэд юу хийхийг сонгоно уу.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Унтраах';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Гүйлгэх (урагш / хойш)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Дууны хэмжээ';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Дууны хэмжээ';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Тохиромжтой';
@@ -2395,37 +2395,37 @@ class AppLocalizationsMn extends AppLocalizations {
   String get defaultAudioLanguage => 'Өгөгдмөл аудио хэл';
 
   @override
-  String get fallbackAudioLanguage => 'Нөөц аудио хэл';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Үндсэн аудио замыг эрхэмлэх';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Орчуулсан дубляжаас илүү эх аудио замыг эрхэмлэнэ.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Аудио тайлбарын замыг эрхэмлэх';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Энгийн замаас илүү аудио тайлбарын замыг эрхэмлэнэ.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Хөрвүүлэлт (Аудио)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Шууд урсгал (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Хөрвүүлэлт (Битрэйт эсвэл Нягтрал)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Хөрвүүлэлт (Видео ба Аудио)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Хөрвүүлэлт (Видео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Автомат (Серверийн өгөгдмөл)';
@@ -2506,7 +2506,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Аудиог хэрхэн задлахыг сонгоно уу. AVR дамжуулалт нь Dolby/DTS-ийн түүхий урсгалыг таны хүлээн авагч руу шууд илгээнэ; Авто эсвэл Буулгах нь дотооддоо задална.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR дамжуулалт';
@@ -2516,14 +2516,13 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Эх урсгалыг шууд тоглуулах буюу дамжуулах боломжгүй үед олон сувгийн аудиог хөрвүүлэх зорилтот форматыг сонгоно уу.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Автоматаар илрүүлэх\n(Зөвлөмжтэй)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Үндсэн)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2532,51 +2531,50 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Алдагдалгүй)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Зөвхөн стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Үр ашигтай)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Алдагдалгүй)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Аудио сувгийн дээд хязгаар';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Аудио тохируулгынхаа сувгийн дээд хязгаарыг тохируулна уу. Энэ хязгаараас хэтэрсэн олон сувгийн урсгалыг буулгах буюу хөрвүүлнэ.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Автоматаар илрүүлэх\n(Тоног төхөөрөмжийн үндсэн)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 Моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Орчны дуу';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Квадрафоник';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Орчны дуу';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Орчны дуу';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Орчны дуу';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Орчны дуу';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Дамжуулах (Дэвшилтэт)';
@@ -2595,7 +2593,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Атмос) нэвтрүүлэх';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core дамжуулалт';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
   String get settingsAudioDtsHdPassthrough => 'DTS-HD MA дамжуулалт';
@@ -2604,7 +2602,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAudioTrueHdPassthrough => 'TrueHD дамжуулалт';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos дамжуулалт';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2657,11 +2655,11 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Илтгэгч';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Чихэвч';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count суваг PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2746,7 +2744,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueс';
+    return '${value}s';
   }
 
   @override
@@ -2838,45 +2836,45 @@ class AppLocalizationsMn extends AppLocalizations {
       'Хадмал орчуулгын харагдах байдлыг өөрчлөх';
 
   @override
-  String get subtitleMode => 'Хадмалын горим';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Тэмдэглэгдсэн';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Үргэлж';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Гадаад';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Албадсан';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Медиа файлын мета өгөгдөлд \"default\" эсвэл \"forced\" гэж тэмдэглэсэн замыг тоглуулна.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Видео эхлэх бүрд хадмалыг автоматаар ачаалж харуулна.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Үндсэн аудио зам гадаад хэл дээр байвал хадмалыг автоматаар асаана.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Зөвхөн forced мета тэмдэгтэй хадмалыг ачаална.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Хадмалыг автоматаар ачаалахыг бүрэн унтраана.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Нөөц хадмалын хэл';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Хадмалын урсгал';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3080,10 +3078,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showLibrariesInToolbar => 'Хэрэгслийн самбарт номын санг харуулах';
 
   @override
-  String get navbarAlwaysExpanded => 'Навигацийн самбарын шошгыг үргэлж дэлгэх';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr товчийг харуулах';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar-ийн тунгалаг байдал';
@@ -3158,19 +3156,18 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showFolderBrowsingOption => 'Фолдер үзэх сонголтыг харуулах';
 
   @override
-  String get groupItemsIntoCollections => 'Зүйлсийг цуглуулгад бүлэглэх';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Сан үзэж байхад цуглуулгад хамаарах зүйлсийг нуух';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Сан бүлэглэх тухай мэдэгдэл';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Энэ тохиргоог ашиглахын тулд Jellyfin эсвэл Emby сервер дээрх сангийнхаа Дэлгэцийн тохиргоонд \"Кинонуудыг цуглуулгад бүлэглэх\" болон/эсвэл \"Цувралуудыг цуглуулгад бүлэглэх\" гэсэн сангийн тохиргоог идэвхжүүлсэн эсэхийг шалгана уу.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Номын сангийн харагдах байдал';
@@ -3204,7 +3201,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get mediaBar => 'Медиа самбар';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Хэвлэл мэдээллийн эх сурвалж';
@@ -3230,7 +3227,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Төрөл бүрийн медиа самбарын хэв маягаас сонгох эсвэл медиа мөрийг унтраа';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Сарны фин';
 
   @override
   String get mediaBarModeMakd => 'МакД';
@@ -3283,11 +3280,10 @@ class AppLocalizationsMn extends AppLocalizations {
       '3 секундын дараа медиа талбарт трейлерүүдийг автоматаар тоглуулах';
 
   @override
-  String get trailerAudio => 'Трейлерийн дуу';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Медиа самбар дахь трейлерийн дууг идэвхжүүлэх';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Ангийг урьдчилан үзэх';
@@ -3329,7 +3325,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get resumeAudio => 'Аудио үргэлжлүүлэх';
 
   @override
-  String get resumeBooks => 'Үргэлжлүүлэн унших';
+  String get resumeBooks => 'Resume Books';
 
   @override
   String get activeRecordings => 'Идэвхтэй бичлэгүүд';
@@ -3365,11 +3361,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get combineBothRows => 'Хоёр мөрийг нэг гэрийн хэсэг болгон нэгтгэнэ';
 
   @override
-  String get fullScreenRows => 'Дэлгэсэн нүүр эгнээ';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Нэг дэлгэцэд нүүр хуудасны 1 эгнээ харуулна';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Мөр бүрийн зургийн төрөл';
@@ -3384,7 +3379,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get lastUser => 'Сүүлийн хэрэглэгч';
 
   @override
-  String get currentUser => 'Одоогийн хэрэглэгч';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Үргэлж баталгаажуулах';
@@ -3493,10 +3488,10 @@ class AppLocalizationsMn extends AppLocalizations {
       'Дэлгэц амраах үед цагийг харуулах';
 
   @override
-  String get clockModeStatic => 'Тогтмол';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Үсрэх';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Шүүмжлэгчид)';
@@ -3568,7 +3563,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Аппликешн дээр харуулсан үнэлгээний эх сурвалжийг идэвхжүүлж, дахин эрэмбэлээрэй';
 
   @override
-  String get pluginLabel => 'Moonbase залгаас';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin илэрсэн';
@@ -3640,7 +3635,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get networks => 'Сүлжээ';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-ийн танилцах эгнээ';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
@@ -3665,27 +3660,28 @@ class AppLocalizationsMn extends AppLocalizations {
       'Үр дүнд нь насанд хүрэгчдэд зориулсан контентыг нуу';
 
   @override
-  String get seerrNotificationsSection => 'Мэдэгдэл';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Шинэ хүсэлтийн мэдэгдэл';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Хэн нэгэн хүсэлт илгээхэд надад мэдэгдэнэ';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Хүсэлтийн шинэчлэл';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Зөвшөөрсөн, татгалзсан, санд нэмэгдсэн';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Асуудлын шинэчлэл';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Шинэ асуудал, хариу, шийдвэрлэлт';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3693,18 +3689,18 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr-ийн танилцах хуудас';
+  String get discoverRows => 'Мөрүүдийг нээх';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr-ийн үндсэн хуудсанд харуулах эгнээг идэвхжүүлнэ. Чирж эрэмбийг өөрчилнө. Захиалгат эрэмбэ Moonbase-тэй синк болно.';
+      'Дахин эрэмбэлэхийн тулд чирнэ үү. Мөрүүдийг идэвхжүүлэх эсвэл идэвхгүй болгох. Идэвхжүүлсэн эгнээний дарааллыг Moonfin залгаастай синк хийнэ.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr-ийн үндсэн хуудсанд харуулах эгнээг идэвхжүүлнэ. Чирж эрэмбийг өөрчилнө. Захиалгат эрэмбэ Moonbase-тэй синк болно.';
+      'Дахин эрэмбэлэхийн тулд чирнэ үү. Мөрүүдийг идэвхжүүлэх эсвэл идэвхгүй болгох.';
 
   @override
-  String get enabled => 'Идэвхтэй';
+  String get enabled => 'Идэвхжүүлсэн';
 
   @override
   String get hidden => 'Нуугдсан';
@@ -3840,7 +3836,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get imageCacheCleared => 'Зургийн кэшийг цэвэрлэлээ';
 
   @override
-  String get clear => 'Цэвэрлэх';
+  String get clear => 'Тодорхой';
 
   @override
   String get browse => 'Үзэх';
@@ -3856,11 +3852,11 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Татаж байна · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Импортлож байна';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3965,7 +3961,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showMore => 'Илүү харуулах';
 
   @override
-  String get appearances => 'Оролцоо';
+  String get appearances => 'Гадаад төрх';
 
   @override
   String get crewSection => 'Экипаж';
@@ -4003,148 +3999,148 @@ class AppLocalizationsMn extends AppLocalizations {
   String get deletedStatus => 'Устгасан';
 
   @override
-  String get failedStatus => 'Амжилтгүй';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Боловсруулж байна';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name өөрчилсөн';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Дууссан';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate =>
-      'Энэ гарчигт аль хэдийн хүсэлт гаргасан байна';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Хүсэлтийн хязгаарт хүрсэн';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Энэ гарчиг хар жагсаалтад байна';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Хүсэлт гаргах улирал үлдээгүй';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Танд энэ хүсэлтийг гаргах эрх байхгүй';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Хүсэлтүүд';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Асуудлууд';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Хамгийн шинэ';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Сүүлд өөрчилсөн';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Асуудал байхгүй';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit киноны хүсэлтээс $remaining үлдсэн';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit улирлын хүсэлтээс $remaining үлдсэн';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name-ийн нэг хэсэг';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Цуглуулгыг үзэх';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Цуглуулгыг хүсэх';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total кино · $available боломжтой';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count кино хүсэх';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total-аас $current дахийг хүсэж байна...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count кино хүслээ';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total киноноос $ok-ийг хүслээ';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Бүх кино аль хэдийн боломжтой эсвэл хүссэн байна';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Асуудал мэдэгдэх';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Видео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Аудио';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Юу буруу байна?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Бүх анги';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Анги';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Нээлттэй';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Шийдэгдсэн';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Шийдвэрлэх';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Дахин нээх';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name мэдэгдсэн';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count сэтгэгдэл';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Сэтгэгдэл нэмэх';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Энэ асуудлыг устгах уу?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Мэдэгдэл илгээх';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB оноо';
@@ -4168,7 +4164,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get originalLanguageLabel => 'Жинхэнэ хэл';
 
   @override
-  String get seasonsLabel => 'Улирлууд';
+  String get seasonsLabel => 'Улирал';
 
   @override
   String get episodesLabel => 'Ангиуд';
@@ -4201,10 +4197,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get disable => 'Идэвхгүй болгох';
 
   @override
-  String get done => 'Болсон';
+  String get done => 'Дууслаа';
 
   @override
-  String get edit => 'Засах';
+  String get edit => 'Засварлах';
 
   @override
   String get encoding => 'Кодлох';
@@ -4213,10 +4209,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get error => 'Алдаа';
 
   @override
-  String get forward => 'Урагш';
+  String get forward => 'Урагшаа';
 
   @override
-  String get general => 'Ерөнхий';
+  String get general => 'Генерал';
 
   @override
   String get go => 'Яв';
@@ -4237,7 +4233,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get networking => 'Сүлжээ';
 
   @override
-  String get next => 'Дараагийн';
+  String get next => 'Дараа нь';
 
   @override
   String get path => 'Зам';
@@ -4297,7 +4293,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Зогсоох';
+  String get stop => 'Зогс';
 
   @override
   String get streaming => 'Дамжуулж байна';
@@ -4306,7 +4302,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get time => 'Цаг хугацаа';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Трик тоглоом';
 
   @override
   String get uninstall => 'Устгах';
@@ -4345,28 +4341,28 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminDrawerUsers => 'Хэрэглэгчид';
 
   @override
-  String get adminDrawerLibraries => 'Медиа сангууд';
+  String get adminDrawerLibraries => 'Номын сангууд';
 
   @override
-  String get adminDrawerDisplay => 'Дэлгэц';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Мета өгөгдөл';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO тохиргоо';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Код хувиргах';
 
   @override
-  String get adminDrawerResume => 'Үргэлжлүүлэх';
+  String get adminDrawerResume => 'Үргэлжлэл';
 
   @override
   String get adminDrawerStreaming => 'Дамжуулж байна';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Трик тоглоом';
 
   @override
   String get adminDrawerDevices => 'Төхөөрөмжүүд';
@@ -4390,7 +4386,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminDrawerScheduledTasks => 'Төлөвлөсөн ажлууд';
 
   @override
-  String get adminDrawerPlugins => 'Залгаасууд';
+  String get adminDrawerPlugins => 'Plugins';
 
   @override
   String get adminDrawerRepositories => 'Хадгалах газрууд';
@@ -4457,7 +4453,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get analyticsContentRatings => 'Агуулгын үнэлгээ';
 
   @override
-  String get analyticsRuntimeBuckets => 'Үргэлжлэх хугацааны бүлгүүд';
+  String get analyticsRuntimeBuckets => 'Runtime Buckets';
 
   @override
   String get analyticsFileFormats => 'Файлын форматууд';
@@ -4537,10 +4533,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get sessionRewind => 'Ухраах';
 
   @override
-  String get sessionForward => 'Урагш';
+  String get sessionForward => 'Урагшаа';
 
   @override
-  String get sessionNext => 'Дараагийн';
+  String get sessionNext => 'Дараа нь';
 
   @override
   String get sessionVolumeDown => 'Боть –';
@@ -4555,7 +4551,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get nowPlaying => 'Одоо тоглож байна';
 
   @override
-  String get volume => 'Дууны хэмжээ';
+  String get volume => 'Эзлэхүүн';
 
   @override
   String get actions => 'Үйлдлүүд';
@@ -4567,7 +4563,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audioCodec => 'Аудио кодлогч';
 
   @override
-  String get hwAccel => 'Техник хурдасгалт';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Дуусгах';
@@ -4582,10 +4578,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminClearDates => 'Огноог арилгах';
 
   @override
-  String get adminActivitySeverityAll => 'Бүх түвшин';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Огнооны хязгаар';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4622,23 +4618,23 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' төхөөрөмжийг устгах уу? Хэрэглэгч энэ төхөөрөмж дээр дахин нэвтрэх шаардлагатай болно.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Бүх төхөөрөмжийг устгах';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count төхөөрөмжийг устгах уу? Холбогдох хэрэглэгчид дахин нэвтрэх шаардлагатай болно. Таны одоогийн төхөөрөмжид нөлөөлөхгүй.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Төхөөрөмжүүдийг устгалаа';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Зарим төхөөрөмжийг устгалаа; $count-ийг устгаж чадсангүй.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4753,248 +4749,244 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminMetadataCountryHint => 'жишээ нь АНУ, DE, ФР';
 
   @override
-  String get adminLibraryTabPaths => 'Замууд';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Сонголтууд';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Татагчид';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Мета өгөгдөл хадгалагчид';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Хадмал татагчид';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Дууны үг татагчид';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Мета өгөгдөл татагчид: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Зураг татагчид: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Энэ сервер нь сангийн энэ төрөлд татагч санал болгохгүй байна.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Ерөнхий';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Мета өгөгдөл';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Суулгагдсан мэдээлэл';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Хадмал';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Зургууд';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Цуврал';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Хөгжим';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Кино';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Бодит цагийн хяналтыг идэвхжүүлэх';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Файлын өөрчлөлтийг илрүүлж автоматаар боловсруулна.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Архивыг медиа файл гэж үзэх';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Гэрэл зургийг харуулах';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Зургийг медиа хавтсанд хадгалах';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Мета өгөгдлийн автомат шинэчлэл';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Хэзээ ч үгүй';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Үндсэн';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Дэлгэц';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Сангийн дэлгэц';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Энгийн медиа хавтсыг харуулах хавтасны харагдацыг гаргах';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Тусгай ангиудыг гарсан улиралд нь харуулах';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Кинонуудыг цуглуулгад бүлэглэх';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Цувралуудыг цуглуулгад бүлэглэх';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Саналд гадаад контентыг харуулах';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Нэмсэн огнооны үйлдэл';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Нэмсэн огноог эндээс авах';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Санд сканнердсан огноо';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Файл үүсгэсэн огноо';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Мета өгөгдөл ба зураг';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Мета өгөгдлийн сонгосон хэл';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Бүлгүүд';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Түр бүлгийн үргэлжлэх хугацаа (секунд)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Бүлэггүй медиад үүсгэх бүлгийн урт. Унтраахын тулд 0 болгоно уу.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Бүлгийн зургийн нягтрал';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO тохиргоо';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO мета өгөгдөл нь Kodi болон түүнтэй төстэй клиентүүдтэй нийцнэ. Тохиргоо нь NFO мета өгөгдөл хадгалдаг бүх санд үйлчилнэ.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO файлд үзсэн өгөгдлийг нь хадгалах хэрэглэгч';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Зургийн замыг NFO файлд хадгалах';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO зургийн замд зам орлуулахыг идэвхжүүлэх';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart зургийг extrathumbs хавтсанд хуулах';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Байхгүй';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days хоног';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Суулгагдсан гарчгийг ашиглах';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Нэмэлтэд суулгагдсан гарчгийг ашиглах';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Суулгагдсан ангийн мэдээллийг ашиглах';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Суулгагдсан хадмалыг зөвшөөрөх';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Бүгдийг зөвшөөрөх';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Зөвхөн текст';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Зөвхөн зураг';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Байхгүй';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Суулгагдсан хадмал байвал татахыг алгасах';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Аудио зам татах хэлтэй таарвал татахыг алгасах';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Хадмал яг таарахыг шаардах';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Хадмалыг медиа хавтсанд хадгалах';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Бүлгийн зургийг задлах';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Сан сканнердах үед бүлгийн зургийг задлах';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay зураг задлахыг идэвхжүүлэх';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Сан сканнердах үед Trickplay зургийг задлах';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay зургийг медиа хавтсанд хадгалах';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Олон хавтсанд тархсан цувралыг автоматаар нэгтгэх';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Тэг улирлын харагдах нэр';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Аудио нормчлолын LUFS сканыг идэвхжүүлэх';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Стандарт бус уран бүтээлчийн шошгыг эрхэмлэх';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Кинонуудыг цуглуулгад автоматаар нэмэх';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Номын сангийн нэр шаардлагатай';
@@ -5235,143 +5227,143 @@ class AppLocalizationsMn extends AppLocalizations {
       'Бүх суваг руу нэвтрэх эрхийг идэвхжүүлнэ';
 
   @override
-  String get adminParentalControl => 'Эцэг эхийн хяналт';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Зөвшөөрөх насны ангиллын дээд хязгаар';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Үүнээс өндөр ангилалтай контентыг энэ хэрэглэгчээс нуух болно.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Байхгүй';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Ангиллын мэдээлэлгүй эсвэл танигдаагүй зүйлсийг хориглох';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Номууд';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Сувгууд';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Шууд ТВ';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Кино';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Хөгжим';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трейлерүүд';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Цуврал';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Хандалтын хуваарь';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Зөвхөн доорх хуваарийн цагт хандалтыг зөвшөөрнө. Хуваарь тохируулаагүй бол өдөржин хандах боломжтой.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Хуваарь нэмэх';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Өдөр';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Эхлэх';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Дуусах';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Өдөр бүр';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Ажлын өдөр';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Амралтын өдөр';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Ням';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Даваа';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Мягмар';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Лхагва';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Пүрэв';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Баасан';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Бямба';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Зөвшөөрсөн шошго';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Зөвхөн эдгээр шошготой контентыг харуулна. Бүгдийг зөвшөөрөхийн тулд хоосон орхино уу.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Хориглосон шошго';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Эдгээр шошготой контентыг энэ хэрэглэгчээс нууна.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Шошго нэмэх';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Идэвхжүүлсэн төхөөрөмж';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Идэвхжүүлсэн суваг';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Баталгаажуулалтын үйлчилгээ үзүүлэгч';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Нууц үг сэргээх үйлчилгээ үзүүлэгч';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Түгжихээс өмнөх амжилтгүй нэвтрэлтийн дээд хязгаар';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Үндсэн утгад 0, түгжээг унтраахад -1 гэж тохируулна уу.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay хандалт';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'Бүлэг үүсгэх, нэгдэхийг зөвшөөрөх';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Бүлэгт нэгдэхийг зөвшөөрөх';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Хандалтгүй';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Контент устгахыг эндээс зөвшөөрөх';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5459,25 +5451,25 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Нөөцлөлт үүсгэх';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Нөөцлөлтөд юу оруулахаа сонгоно уу.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Өгөгдлийн сан';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Үргэлж багтана';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Мета өгөгдөл';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Хадмал';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay зураг';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Нөөцлөлт үүсгэж байна...';
@@ -5906,7 +5898,8 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminTrickplaySaved => 'Trickplay тохиргоог хадгалсан';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay тохиргоог ачаалж чадсангүй';
+  String get adminTrickplayLoadFailed =>
+      'Трик тоглох тохиргоог ачаалж чадсангүй';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6020,7 +6013,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminBaseUrl => 'Үндсэн URL';
 
   @override
-  String get adminBaseUrlHint => 'жишээ нь /jellyfin';
+  String get adminBaseUrlHint => 'жишээ нь /желлифин';
 
   @override
   String get https => 'HTTPS';
@@ -6183,61 +6176,60 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminAddTuner => 'Таалагч нэмнэ үү';
 
   @override
-  String get adminEditTuner => 'Тюнер засах';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U тюнер';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл эсвэл URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Тюнерийн IP хаяг';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Ойлгомжтой нэр';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Зэрэг холболтын хязгаар';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Тюнерийн зэрэг зөвшөөрөх урсгалын дээд тоо. Хязгааргүй бол 0 гэж тохируулна уу.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Нөөц дамжуулалтын дээд битрэйт';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Зөвхөн дуртай сувгийг импортлох';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Техник хангамжийн хөрвүүлэлтийг зөвшөөрөх';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 хөрвүүлэлтийн савыг зөвшөөрөх';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Урсгал хуваалцахыг зөвшөөрөх';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Урсгалыг давтахыг идэвхжүүлэх';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS-ийг үл хэрэгсэх';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Оролтыг үндсэн кадрын давтамжаар унших';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Үйлчилгээ үзүүлэгч засах';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6246,50 +6238,50 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл эсвэл URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Киноны угтвар';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Киноны ангилал';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Олон ангиллыг босоо зураасаар тусгаарлана уу.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Хүүхдийн ангилал';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Мэдээний ангилал';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Спортын ангилал';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Хэрэглэгчийн нэр';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Нууц үг';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Улс';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Улс сонгоно уу';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Шуудангийн код';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Жагсаалт авах';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Жагсаалт';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Бүх тюнерийг идэвхжүүлэх';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тохируулагчийн төрөл';
@@ -6318,7 +6310,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Тюнер устгаж чадсангүй: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6332,7 +6324,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Энэ төрлийн тюнер дахин тохируулахыг дэмждэггүй.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6355,45 +6347,43 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Цуврал бичлэг хийх зам';
 
   @override
-  String get adminMovieRecordingPath => 'Кино бичлэгийн зам';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Хөтөлбөрийн өгөгдлийн хоног';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автомат';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days хоног';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Дараах боловсруулалтын програмын зам';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Дараах боловсруулагчийн аргумент';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Бичлэгийн NFO мета өгөгдлийг хадгалах';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Бичлэгийн зургийг хадгалах';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Цаг тохируулга';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Бичлэгийн замууд';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Дараах боловсруулалт';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Хөтөлбөрийн өгөгдөл: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6434,15 +6424,14 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminGuideProviders => 'Хөтөч үйлчилгээ үзүүлэгчид';
 
   @override
-  String get adminRefreshGuideData => 'Хөтөлбөрийн өгөгдлийг шинэчлэх';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Хөтөлбөрийн өгөгдлийн шинэчлэл эхэллээ';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Энэ сервер дээр хөтөлбөр шинэчлэх ажил боломжгүй байна.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Үйлчилгээ үзүүлэгч нэмэх';
@@ -6525,7 +6514,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminLiveTvTitle => 'Шууд ТВ-ийн удирдлага';
 
   @override
-  String get adminApply => 'Хэрэглэх';
+  String get adminApply => 'Өргөдөл гаргах';
 
   @override
   String get adminNotSet => 'Тохируулаагүй';
@@ -6577,7 +6566,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Мета өгөгдөл засварлагч';
 
   @override
-  String get adminMetadataIdentify => 'Таних';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Төрөл';
@@ -6861,7 +6850,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Хасах';
+  String get adminReposRemove => 'Устгах';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6990,20 +6979,19 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Нээлтийн дэлгэцийг идэвхжүүлэх';
 
   @override
-  String get adminBrandingSplashUpload => 'Зураг байршуулах';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Эхлэлийн дэлгэцийг шинэчиллээ';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Эхлэлийн дэлгэцийг байршуулж чадсангүй';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Эхлэлийн дэлгэцийг устгалаа';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Захиалгат эхлэлийн дэлгэц байхгүй';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Техник хангамжийн хурдатгал';
@@ -7020,123 +7008,121 @@ class AppLocalizationsMn extends AppLocalizations {
       'Техник хангамжийн код тайлахыг идэвхжүүлэх:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV төхөөрөмж';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Сайжруулсан NVDEC задлагчийг идэвхжүүлэх';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Системийн уугуул техник задлагчийг эрхэмлэх';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Техник задлалтын өнгөний гүн';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-бит HEVC задлалт';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-бит VP9 задлалт';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-бит задлалт';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-бит задлалт';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Техник кодчилол';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC кодчилолыг зөвшөөрөх';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 кодчилолыг зөвшөөрөх';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel-ийн бага чадлын H.264 кодлогчийг идэвхжүүлэх';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel-ийн бага чадлын HEVC кодлогчийг идэвхжүүлэх';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тон зураглал';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Тон зураглалыг идэвхжүүлэх';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP тон зураглалыг идэвхжүүлэх';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox тон зураглалыг идэвхжүүлэх';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Тон зураглалын алгоритм';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Тон зураглалын горим';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Тон зураглалын хүрээ';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Тон зураглалын өнгө сулралт';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Тон зураглалын оргил';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Тон зураглалын параметр';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP тон зураглалын гэрэлтэлт';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP тон зураглалын тодрол';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Урьдчилсан тохиргоо ба чанар';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Кодлогчийн урьдчилсан тохиргоо';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 кодчилолын CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) кодчилолын CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Деинтерлэйс арга';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Деинтерлэйс хийхэд кадрын давтамжийг хоёр дахин нэмэгдүүлэх';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Аудио';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Аудио VBR кодчилолыг идэвхжүүлэх';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Аудио буулгалтын өсгөлт';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Стерео буулгалтын алгоритм';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Муксинг дарааллын дээд хэмжээ';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Авто';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодлох';
@@ -7258,10 +7244,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminTaskNeverRun => 'Хэзээ ч гүйхгүй';
 
   @override
-  String get adminTaskStop => 'Зогсоох';
+  String get adminTaskStop => 'Зогс';
 
   @override
-  String get adminRunningTasks => 'Ажиллаж буй ажлууд';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Гүй';
@@ -7331,8 +7317,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count цаг',
-      one: '1 цаг',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7378,17 +7364,17 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesм';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursц';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysө';
+    return '${days}d';
   }
 
   @override
@@ -7398,7 +7384,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'Гүйлгэх урьдчилсан харагдацын зурагт зориулсан Trickplay зураг үүсгэлтийг тохируулна.';
+      'Урьдчилан үзэх өнгөц зургийг хайхын тулд трик тоглох дүрс үүсгэх тохиргоог хийнэ үү.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Нийтийн HTTPS порт';
@@ -7407,50 +7393,49 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Үндсэн URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'жишээ нь /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'жишээ нь /желлифин';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Нийтийн HTTP порт';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS шаардах';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Алсын бүх хүсэлтийг HTTPS руу чиглүүлнэ. Серверт хүчинтэй гэрчилгээ байхгүй бол нөлөөгүй.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Гэрчилгээний нууц үг';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP тохиргоо';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4-ийг идэвхжүүлэх';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6-г идэвхжүүлэх';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Автомат порт зураглалыг идэвхжүүлэх';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN сүлжээ';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Дотоод сүлжээнд байна гэж үзэх IP хаяг эсвэл CIDR дэд сүлжээний жагсаалт, таслал эсвэл мөрөөр тусгаарлана.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Нийтэлсэн серверийн URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Дэд сүлжээ эсвэл хаягийг нийтэлсэн URL-д холбоно, жишээ нь all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Гэрчилгээний зам';
@@ -7480,11 +7465,11 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Тохируулагч буфер';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Хязгаарлалтын саатал (секунд)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Хадмалыг шууд задлахыг зөвшөөрөх';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Анкетийн хамгийн бага хувь';
@@ -7541,23 +7526,22 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Удаан хариу өгөх босго (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Удаан хариултын сануулгыг идэвхжүүлэх';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect-ийг идэвхжүүлэх';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Мета өгөгдөл';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Замууд';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Гүйцэтгэл';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Кэш зам';
@@ -7569,13 +7553,13 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminGeneralServerName => 'Серверийн нэр';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Сонгосон харуулах хэл';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Тохиргоог ачаалж чадсангүй';
 
   @override
-  String get adminDiscover => 'Танилцах';
+  String get adminDiscover => 'Discover';
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
@@ -7591,7 +7575,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get folders => 'Хавтас';
 
   @override
-  String get libraries => 'Медиа сангууд';
+  String get libraries => 'Номын сангууд';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7621,8 +7605,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# оролцогч',
-      one: '# оролцогч',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7769,8 +7753,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# эгнээ олдлоо',
-      one: '# эгнээ олдлоо',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7811,21 +7795,20 @@ class AppLocalizationsMn extends AppLocalizations {
   String get offlineSavedMedia => 'Хадгалсан медиа';
 
   @override
-  String get offlineBannerTitle => 'Та офлайн байна';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Таны татсан зүйлсийг харуулж байна';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Татсан зүйлс';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Таны сервертэй холбогдож чадсангүй';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Сэргэх хүртэл татсан зүйлсээс тоглуулж байна';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7899,41 +7882,41 @@ class AppLocalizationsMn extends AppLocalizations {
   String get pinForgot => 'ПИН кодоо мартсан уу?';
 
   @override
-  String get pinClear => 'Цэвэрлэх';
+  String get pinClear => 'Тодорхой';
 
   @override
-  String get pinBackspace => 'Устгах';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect хүсэлтийг зөвшөөрлөө.';
+  String get quickConnectAuthorized => 'Түргэн холболтын хүсэлтийг зөвшөөрсөн.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect код буруу эсвэл хугацаа нь дууссан байна.';
+      'Түргэн холболтын код хүчингүй эсвэл хугацаа нь дууссан.';
 
   @override
   String get quickConnectNotSupported =>
-      'Энэ сервер дээр Quick Connect дэмжигдэхгүй.';
+      'Түргэн холболтыг энэ сервер дээр дэмждэггүй.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect кодыг зөвшөөрч чадсангүй.';
+      'Түргэн холболтын кодыг зөвшөөрч чадсангүй.';
 
   @override
   String get quickConnectDisabled =>
-      'Энэ сервер дээр Quick Connect идэвхгүй байна.';
+      'Түргэн холболтыг энэ сервер дээр идэвхгүй болгосон.';
 
   @override
   String get quickConnectForbidden =>
-      'Таны бүртгэл энэ Quick Connect хүсэлтийг зөвшөөрөх боломжгүй.';
+      'Таны бүртгэл энэ Түргэн холболтын хүсэлтийг зөвшөөрөх боломжгүй.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect код олдсонгүй. Шинэ код оролдоно уу.';
+      'Түргэн холболтын код олдсонгүй. Шинэ код оруулж үзнэ үү.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect амжилтгүй боллоо: $message';
+    return 'Түргэн холболт амжилтгүй болсон: $message';
   }
 
   @override
@@ -8038,7 +8021,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get shuffleSelectGenre => 'Төрөл зүйл сонгоно уу';
 
   @override
-  String get shuffleLibrary => 'Медиа сан';
+  String get shuffleLibrary => 'Номын сан';
 
   @override
   String get shuffleGenre => 'Төрөл';
@@ -8099,7 +8082,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Тоглуулахыг түр зогсоосон. Та үзэж байгаа хэвээр байна уу?';
 
   @override
-  String get stillWatchingStop => 'Зогсоох';
+  String get stillWatchingStop => 'Зогс';
 
   @override
   String get stillWatchingContinue => 'Үргэлжлүүлэх';
@@ -8183,13 +8166,14 @@ class AppLocalizationsMn extends AppLocalizations {
   String get contextMenuGoToSeries => 'Цуврал руу оч';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Үргэлжлүүлэн үзэхээс нуух';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Дараагийн хэсгээс нуух';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Цуглуулгад нэмэх';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8243,15 +8227,14 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsAlphabetical => 'Цагаан толгойн дарааллаар';
 
   @override
-  String get settingsConnectionSection => 'ХОЛБОЛТ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Өөрөө гарын үсэг зурсан гэрчилгээг зөвшөөрөх';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Өөрөө гарын үсэг зурсан эсвэл хувийн CA-ийн TLS гэрчилгээ хэрэглэдэг серверт итгэнэ. Зөвхөн өөрийн хянадаг серверт идэвхжүүлнэ үү. Энэ нь бүх холболтын гэрчилгээний шалгалтыг унтраана.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'НУУЦЛАЛ & АЮУЛГҮЙ БАЙДАЛ';
@@ -8267,11 +8250,11 @@ class AppLocalizationsMn extends AppLocalizations {
       'Сэдвийн өргөлт, арын дэвсгэр, үзсэн үзүүлэлт, сэдэвт хөгжим';
 
   @override
-  String get settingsDetailsScreen => 'Дэлгэрэнгүй дэлгэц';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Хэв маяг, дэвсгэрийн бүдгэрэлт, табын үйлдэл';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Нүүр хуудас';
@@ -8309,11 +8292,11 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Навигацийн самбарт Seerr товчийг харуулах';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Дээд навигацийн самбарт текст шошгыг үргэлж харуулах';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8382,7 +8365,8 @@ class AppLocalizationsMn extends AppLocalizations {
   String get settingsSupportMoonfin => 'Дэмжлэг Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Хөгжүүлэгчид кофе хандивлах';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ХУУЛЬ ЗҮЙН';
@@ -8416,8 +8400,8 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лицензийн мэдэгдэл',
-      one: '# лицензийн мэдэгдэл',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8467,16 +8451,16 @@ class AppLocalizationsMn extends AppLocalizations {
       'Танилцуулга болон гадуурх хэсгийг алгасах уу?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Медиа сегментийн тоолол';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Явцын мөр';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Байхгүй';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Шуурхай хэрэглэгч';
@@ -8610,7 +8594,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8705,7 +8689,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Саяхан гарсан $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8738,11 +8722,11 @@ class AppLocalizationsMn extends AppLocalizations {
       'Хонгилгүй тоглуулахыг албадах. Аудио/видео тасалдалтай төхөөрөмжүүдэд хэрэгтэй.';
 
   @override
-  String get enableTunnelingTitle => 'Туннелийг идэвхжүүлэх';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Дэвшилтэт. Аудио, видеог хосолсон техник хангамжийн замаар дамжуулна. Зарим төхөөрөмж дээр аудио/видео тасалдал үүсгэдэг тул үндсэндээ унтраалттай.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8769,14 +8753,14 @@ class AppLocalizationsMn extends AppLocalizations {
       'Хадмал орчуулгад суулгасан үсгийн хэмжээтэй зөвлөмжийг ашиглана уу. Загварын сонголтоос хадмал орчуулгын хэмжээг ашиглахыг идэвхгүй болго.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Медиагийн дэлгэрэнгүйг харуулах';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Сангийн хуудасны дээд хэсэгт сонгосон зүйлийн дэлгэрэнгүйг харуулна.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Үзэж байхад дэвсгэр зургийг нуух уу?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Нарийвчилсан дэд гарчгийг ашиглана уу';
@@ -8794,37 +8778,37 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Загварын дэлгүүр';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Нийгэмлэгийн загваруудыг үзэж хадгална';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Загварыг хадгалснаар бусад хадгалсан загварынхаа адил ашиглана.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Одоогоор боломжтой загвар байхгүй байна.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Загварын дэлгүүрийг ачаалж чадсангүй. Холболтоо шалгаад дахин оролдоно уу.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Хадгалах';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Хадгалж хэрэглэх';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Хадгалсан';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Энэ загварыг ачаалж чадсангүй.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\"-ийг хадгаллаа.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8882,21 +8866,21 @@ class AppLocalizationsMn extends AppLocalizations {
   String get homeRowsSection => 'Нүүр хуудас';
 
   @override
-  String get homeRowDisplay => 'Нүүр эгнээний харагдац';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Нүүр эгнээний хэсгүүд';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Нүүр эгнээний унтраалга';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Сан дээр суурилсан нүүр эгнээний ангиллыг идэвхжүүлэх эсвэл унтраах';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Нүүр хэсгүүдэд эгнээг харуулахын тулд дараах унтраалгыг идэвхжүүлнэ үү.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Мөрийн төрөл';
@@ -8955,56 +8939,55 @@ class AppLocalizationsMn extends AppLocalizations {
       'Төрөл бүрийн мөрөнд Кино, Цуврал эсвэл хоёуланг нь харуул.';
 
   @override
-  String get displayPlaylistsRows => 'Тоглуулах жагсаалтын эгнээг харуулах';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Нүүр хэсгүүдэд тоглуулах жагсаалтын эгнээг харуулна.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Тоглуулах жагсаалтын эгнээний эрэмбэ';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Тоглуулах жагсаалтын эгнээг нэмсэн огноо, гарсан огноо, цагаан толгойн дараалал болон бусад байдлаар эрэмбэлнэ.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Аудио эгнээг харуулах';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Нүүр хэсгүүдэд аудио эгнээг харуулна.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Аудио эгнээний эрэмбэ';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Аудио эгнээг нэмсэн огноо, гарсан огноо, цагаан толгойн дараалал болон бусад байдлаар эрэмбэлнэ.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудио тоглуулах жагсаалт';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Харагдах байдал';
+  String get appearance => 'Гадаад төрх';
 
   @override
-  String get layout => 'Байрлал';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Загвар';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Гар';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Товчнууд';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Дүрслэл';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV тохиргоо';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Картын хэмжээ';
@@ -9014,7 +8997,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Удаан дарж тоглуулах сонголтыг идэвхжүүлэхийн тулд гадаад тоглуулагч тохируулна уу';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9119,345 +9102,342 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin хөтчийн түвшний хүсэлтийн алдаа илрүүллээ. Энэ нь ихэвчлэн медиа сервер дээр CORS эсвэл preflight толгой дутуугаас үүсдэг.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Зорилтот URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Дэлгэрэнгүй: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'Одоогийн ажиллах орчин';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Схем';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Залгаасын горим';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC скан';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Албадсан серверийн URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Үндсэн серверийн URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'Илрүүлэлтийн прокси URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'тохируулаагүй';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Холимог контент';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Энэ хуудсыг HTTPS-ээр ачаалсан боловч тохируулсан нэг буюу хэд хэдэн URL нь HTTP байна. Хөтчүүд HTTPS хуудсыг HTTP API дуудахыг хориглодог.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Засвар: медиа сервер эсвэл прокси цэгээ HTTPS-ээр нийлүүлнэ үү, эсвэл Moonfin-ийг зөвхөн итгэмжлэгдсэн дотоод сүлжээнд HTTP-ээр ачаална уу.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Одоогийн ажиллах тохиргооноос холимог контентын илэрхий тохиргоо илрээгүй.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS шалгах жагсаалт';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin-д хөтчийн origin-ыг зөвшөөрнө үү.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers-д Authorization, X-Emby-Authorization, X-Emby-Token-ыг оруулна уу.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Дамжуулалт болон гүйлгэх үйлдэлд Content-Range, Accept-Ranges-ыг ил гаргана уу.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight хүсэлтэд 204 буцаана уу.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Толгойн жишээ хэсэг (nginx маягийн)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Тэмдэглэл';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Энэ оношилгооны хуудас нь вэб хувилбарт зориулагдсан. Хэрэв та үүнийг өөр платформ дээр харж байгаа бол эдгээр шалгалт хамаарахгүй байж болно.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Сервер сонголт руу буцах';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Бүх хэрэглэгчийг гаргах';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Микрофоны зөвшөөрлийг бүрмөсөн татгалзсан байна. Системийн тохиргооноос идэвхжүүлнэ үү.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Дуут хайлтад микрофоны зөвшөөрөл шаардлагатай.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Ойлгосонгүй. Дахин оролдоно уу.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Яриа илрээгүй.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Микрофоны алдаа.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Дуут хайлтад интернэт шаардлагатай.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Дуут үйлчилгээ завгүй байна. Дахин оролдоно уу.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Микрофоны зөвшөөрлийг бүрмөсөн татгалзсан байна.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Микрофоны зөвшөөрлийг татгалзсан байна.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Энэ төхөөрөмж дээр яриа таних боломжгүй.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS-ийн гаралт сонгогчийг нээх';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Энэ төхөөрөмж дээр AirPlay гаралт сонгогч боломжгүй.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Видеонууд';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Нэвтрүүлгүүд';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Дуунууд';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Зургийн цомог';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Гэрэл зураг';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Хүмүүс';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Саяхан гарсан ангиуд';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Дахин үзэх';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Зочны оролцоо';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Оролцоо (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Багийн оролцоо (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Бүлгээр үзэх';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Алдаанууд';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Сануулгууд';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Диск';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Хөтчөөр нээх';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Энэ платформ дээр суулгагдсан хөтөч боломжгүй.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Серверийг дахин эхлүүлэхдээ итгэлтэй байна уу?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Серверийг унтраахдаа итгэлтэй байна уу? Та үүнийг гараар дахин эхлүүлэх шаардлагатай болно.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Дотоод';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Сул';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Хэрэглэгч олдсонгүй';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Таны хайлтад тохирох хэрэглэгч алга';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Төхөөрөмж олдсонгүй';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Одоогийн шүүлтүүрт тохирох төхөөрөмж алга';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Нууц үг тохируулсан';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Нууц үг тохируулаагүй';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Алсын хандалт';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Зөвхөн дотоод';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Медиа аналитикийг ачаалж чадсангүй';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Бүх медиа сангийн нэгдсэн аналитик.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Шилдэг уран бүтээлчид';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Шилдэг зохиолчид';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Шилдэг оролцогчид';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Сан',
-      one: '1 Сан',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Энэ сонголтод индексжүүлсэн медиагийн нийлбэр хараахан байхгүй байна.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Сангийн дэлгэрэнгүй';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Сангийн задаргаа';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Боломжтой сан байхгүй байна.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Серверийн удирдлага';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Өгөгдөл';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Зургийн кэш';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Кэш';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Логууд';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Мета өгөгдөл';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Хөрвүүлэлт';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Энэ сервер серверийн зам буцаасангүй.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% ашигласан';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Хэрэглэгчийн үйл ажиллагаа';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Системийн үйл явдал';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Анхаарал шаардлагатай';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Сервер';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Тоглуулалт';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Төхөөрөмжүүд';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Дэвшилтэт';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Залгаасууд';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Шууд ТВ';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Гэрийн видео';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Холимог контент';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Гэрийн видео ба гэрэл зураг';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Холимог кино ба цуврал';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9469,298 +9449,299 @@ class AppLocalizationsMn extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Бичлэг олдсонгүй';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension архиваас зургийн хуудас олдсонгүй.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Суулгагдсан дүрслэгч алдаа гаргалаа ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB дүрслэгч алдаа гаргалаа ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Уншигчид дотоод файл алга: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri-аас номын өгөгдөл нээх үед HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => 'Уншиж болох номын цэг байхгүй';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Дэмжигдээгүй комик архивын формат: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Энэ платформ дээр CBR задлах залгаас боломжгүй.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '.cbr архивыг задалж чадсангүй.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Энэ платформ дээр CB7 задлалт боломжгүй.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Энэ платформ дээр CB7 задлах залгаас боломжгүй.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Төрлийн самбарыг хаах';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Холимогийг ачаалж байна...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'САНГИЙН ХОЛИМОГ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'САНАМСАРГҮЙ ХОЛИМОГ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ТӨРЛИЙН ХОЛИМОГ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Автомат HDR шилжилт';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR видео тоглуулахад HDR-ийг автоматаар идэвхжүүлж, гарахад дэлгэцийн горимыг сэргээнэ.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Бүрэн дэлгэцэд байхад';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Зургийг солих';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Дутуу';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Хөрвүүлэлтийн хязгаар';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Бүх зургийг цэвэрлэх үү?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Татсан бүх зургийг цэвэрлэхдээ итгэлтэй байна уу?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Цэвэрлэхийг баталгаажуулах';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Энэ $itemType-ийг цэвэрлэхдээ итгэлтэй байна уу?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Байршуулах уу?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Нягтрал: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Зөвхөн интерфейсийн хэл дээрх зургийг харуулах';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Бүгдийг цэвэрлэхийг баталгаажуулах';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Зургийг амжилттай байршууллаа!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Зураг байршуулж чадсангүй: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Зураг тохируулж чадсангүй: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Зураг устгаж чадсангүй: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Бүх зургийг цэвэрлэж чадсангүй: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Тийм';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Дэвсгэр зураг';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Баннер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Лого';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Товч зураг';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Арт';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Дискний арт';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Дэлгэцийн зураг';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Хайрцгийн нүүр';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Хайрцгийн ар тал';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Цэсний арт';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'дэвсгэр зураг';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'баннер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'лого';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'товч зураг';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'арт';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'дискний арт';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'дэлгэцийн зураг';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'хайрцгийн нүүр';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'хайрцгийн ар тал';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'цэсний арт';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Бүгд';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Өндөр (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Дунд (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Бага (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Эх сурвалж';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Бүлгүүд';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Хавчуургууд';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Тэмдэглэл';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Дараалал';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Цагийн шугам';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Цагийн шугам хоосон байна';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Бүтэн ном';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Төвлөрсөн цагийн шугам';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Хавчуургыг экспортлох';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Тэмдэглэлийг экспортлох';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Бүгдийг экспортлох';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path руу экспортлолоо';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Экспорт амжилтгүй боллоо: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Дууны үг';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Хавчуурга нэмэх';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Тэмдэглэл нэмэх';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Тэмдэглэл засах';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Энэ агшинд тэмдэглэл бичих';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Унтах таймер';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Унтраах';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Бүлгийн төгсгөл';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Захиалгат';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining үлдсэн';
+    return '$remaining left';
   }
 
   @override
@@ -9768,58 +9749,58 @@ class AppLocalizationsMn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Тоглуулах хурд';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Үлдсэн';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Өнгөрсөн';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$secondsс ухраах';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$secondsс урагшлуулах';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Өмнөх бүлэг';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Дараагийн бүлэг';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total-аас $current-р бүлэг';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Бүлэг байхгүй';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Одоогоор хавчуурга байхгүй';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Одоогоор тэмдэглэл байхгүй';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position-д хавчуурга нэмлээ';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x болгож сэргээх';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9827,248 +9808,249 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Хадгалах';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Цуцлах';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Устгах';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Хадмалын тохиргоо';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Хадмалын горим, үндсэн хэл, харагдах байдал, дүрслэлийн сонголтыг өөрчилнө.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Хадмалын дүрслэл';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Харуулах сонголтууд';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Гарсан огноо (өсөхөөр)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Гарсан огноо (буурахаар)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Оролцоог бүлэглэх';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Олон дүрийг бүлэглэх';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'Санд бичих эрхийн сануулга';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Үүнийг хэрхэн засах вэ:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Сервер дээрх медиа сангийнхаа хавтсуудад Jellyfin үйлчилгээний хэрэглэгчид (жишээ нь jellyfin эсвэл Docker PUID/PGID) бичих эрх олгоно уу.\n\n2. Эсвэл Jellyfin-ий Хяналтын самбар -> Сангууд руу орж, энэ санг засаад, зургийг Jellyfin-ий дотоод өгөгдлийн санд хадгалахын тулд \'Зургийг медиа хавтсанд хадгалах\' тохиргоог унтраана уу.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Хаах';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Таны \'$libraryName\' сан нь зургийг медиа хавтсанд шууд хадгалахаар тохируулагдсан байна (\'Зургийг медиа хавтсанд хадгалах\' идэвхтэй). Гэвч Jellyfin бичих эрхийг шалгасан бөгөөд энэ хавтсанд файл бичих зөвшөөрөлгүй байна:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin зургийг шинэчилж чадаагүй бололтой. Таны сан нь зургийг медиа хавтсанд шууд хадгалахаар тохируулагдсан байна (\'Зургийг медиа хавтсанд хадгалах\' идэвхтэй). Энэ алдаа нь ихэвчлэн Jellyfin серверийн процесс таны медиа хавтсанд файл бичих зөвшөөрөлгүй үед гардаг.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Гадаад жагсаалт';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Дахин тоглуулах';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Файлын мэдээлэл';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Хэмжээ: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Бүх ($count) аудио замыг харуулах';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Бүх ($count) хадмал замыг харуулах';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Шууд тоглуулах боломжийг шалгаж байна...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Шууд тоглуулах боломж: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Албадсан';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Тоглуулагч савны форматыг дэмждэггүй.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видео кодек дэмжигдэхгүй.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудио кодек дэмжигдэхгүй.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Хадмалын формат дэмжигдэхгүй (шатаах шаардлагатай).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Аудио профайл дэмжигдэхгүй.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Видео профайл дэмжигдэхгүй.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Видео түвшин дэмжигдэхгүй.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Энэ төхөөрөмж видеоны нягтралыг дэмждэггүй.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Видеоны битийн гүн дэмжигдэхгүй.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Видеоны кадрын давтамж дэмжигдэхгүй.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Файлын битрэйт тоглуулагчийн дамжуулалтын хязгаараас хэтэрсэн.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Видеоны битрэйт дамжуулалтын хязгаараас хэтэрсэн.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Аудионы битрэйт дамжуулалтын хязгаараас хэтэрсэн.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Аудио сувгийн тоо дэмжигдэхгүй.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Цагаан толгойн дарааллаар';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Гарсан дараалал (өсөхөөр)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Гарсан дараалал (буурахаар)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Захиалгат (чирж буулгах)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Тоглуулах жагсаалтын эрэмбийн сонголт';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Эрэмбийг сэргээх';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode-г дахин үзэх';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Тоглуулах жагсаалтыг дахин үзэх';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Хадмал олдсонгүй.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Админы удирдлага';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Дүрслэлийн хөдөлгүүр (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller бол илүү жигд хөдөлгөөн, бага доголдолтой байхад зориулсан Flutter-ийн орчин үеийн GPU дүрслэгч юм. Зарим ТВ хайрцаг болон хуучин GPU дээр гажилт эсвэл хар дэлгэц үүсгэж болзошгүй; тийм зүйл харвал Унтраах болгоно уу. Автомат нь таны төхөөрөмжид тохирох үндсэн утгыг сонгоно. Хэрэглэхийн тулд Moonfin-ийг дахин эхлүүлнэ үү.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автомат';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Асаах';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Унтраах';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Дахин эхлүүлэх шаардлагатай';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Дүрслэлийн хөдөлгүүрийг солихын тулд Moonfin дахин эхлэх шаардлагатай. Аппыг одоо хаагаад дахин нээж хэрэглэнэ үү.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Аппыг одоо хаах';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Санг шинэчлэх';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Бүх санг шинэчлэх';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Нэмсэн огноо (хуучнаас)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Нэмсэн огноо (шинээс)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Цагаан толгойн дараалал (А-аас Я)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Цагаан толгойн дараалал (Я-гаас А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Серверийн аналитикийг ачаалж байна... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Эх сурвалжтай тааруулах';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb-ийн шилдэг 250 кино';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb-ийн шилдэг 250 ТВ цуврал';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb-ийн хамгийн алдартай кино';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb-ийн хамгийн алдартай ТВ цуврал';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb-ийн хамгийн бага үнэлгээтэй кино';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb-ийн шилдэг үнэлгээтэй англи кино';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -12,27 +12,27 @@ class AppLocalizationsNb extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'KONTOINNSTILLINGER';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Grensesnittspråk';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Systemstandard';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Logg på';
 
   @override
-  String get empty => 'Tom';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Kobler til $serverName';
+    return 'Kobler til  $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Hurtigtilkobling';
 
   @override
   String get password => 'Passord';
@@ -61,12 +61,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect er utilgjengelig: $detail';
+    return 'QuickConnect utilgjengelig: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect er utilgjengelig ($status): $detail';
+    return 'QuickConnect utilgjengelig ($status): $detail';
   }
 
   @override
@@ -106,11 +106,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Vil du fjerne «$serverName» fra serverne dine?';
+    return 'Fjern \"$serverName\" fra din server?';
   }
 
   @override
-  String get cancel => 'Kansellere';
+  String get cancel => 'Kanseller';
 
   @override
   String get remove => 'Fjern';
@@ -122,7 +122,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get serverAddress => 'Serveradresse';
 
   @override
-  String get serverAddressHint => 'https://din-server.example.com';
+  String get serverAddressHint => 'https://din-server.eksempel.no';
 
   @override
   String get connect => 'Koble til';
@@ -141,62 +141,62 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsAppearanceTheme => 'App-tema';
 
   @override
-  String get detailScreenStyle => 'Stil for detaljskjerm';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassisk er den opprinnelige, midtstilte Moonfin-layouten. Moderne er en responsiv, filmatisk layout.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassisk';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderne';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Utvidede faner';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Vis faneinnhold automatisk mens du blar gjennom faner. Slå av for å åpne og lukke hver fane manuelt.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Vis tekniske detaljer?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Vis informasjon om kodek, oppløsning og strøm i bannersammendraget';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Anbefalingssystem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Bruk den lokale bibliotekalgoritmen Moonfin anbefaler, eller TMDb-likhetsmålinger på nett. Merk: Anbefalinger på nett krever Seerr-integrasjon.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin anbefaler';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-likhet';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Begrens etter aldersgrense?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Begrens forslag fra Moonfin anbefaler etter aldersgrensen til det aktuelle innholdet';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Grensesnittstil';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatisk følger enheten din. Velg Apple eller Material for å tvinge fram et bestemt utseende.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatisk';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,11 +205,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glasskvalitet';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto velger den beste glasseffekten for denne enheten. Full tvinger fram ekte uskarphet, mens Redusert bruker et lett glass som sparer GPU-strøm.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
@@ -218,25 +218,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Redusert';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Bytt mellom Moonfin og Neon Pulse uten å starte appen på nytt';
 
   @override
-  String get customThemeTitle => 'Egendefinert tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Egendefinerte temaer endrer visuelle elementer i hele Moonfin. Velg et av disse alternativene som passer din stil.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Foretrekk systemtastatur';
+  String get keyboardPreferSystemIme => 'Foretrekk system tastatur';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Bruk enhetens inndatametode som standard for tekstinnskriving';
+      'Bruk din enhets inntastings metode som standard for tekst';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -246,7 +246,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Nåværende Moonfin-utseende du alle har blitt glad i';
 
   @override
-  String get themeNeonPulse => 'Neonpuls';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle =>
@@ -257,14 +257,14 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Flytende glass-styling med drivende gradientbakgrunn, frostede flater og Apple-blå aksentfarge';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pikselkunst-styling med grov palett, blokkete kanter, harde slagskygger og pikselfont';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Kan ikke koble til $target';
+    return 'Tilkobling til  $target feilet';
   }
 
   @override
@@ -324,39 +324,38 @@ class AppLocalizationsNb extends AppLocalizations {
   String get exitAppConfirmation => 'Er du sikker på at du vil avslutte?';
 
   @override
-  String get exit => 'Gå';
+  String get exit => 'Avslutt';
 
   @override
-  String get gameMenu => 'Meny';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Satt på pause';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Lagre tilstand';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Spill';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Last inn tilstand';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Spol framover';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulatorinnstillinger';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Denne kjernen har ingen justerbare alternativer.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Hold inne for å åpne menyen';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spillavspilling støttes ikke på denne enheten ennå.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Ingen hjemmerader kunne lastes';
@@ -366,22 +365,22 @@ class AppLocalizationsNb extends AppLocalizations {
       'Prøv å oppdatere eller redusere aktive hjemmeseksjoner.';
 
   @override
-  String get retryHomeRows => 'Prøv Hjem-rader på nytt';
+  String get retryHomeRows => 'Prøv Hjemrader på nytt';
 
   @override
-  String get guide => 'Guide';
+  String get guide => 'TV-Guide';
 
   @override
   String get recordings => 'Opptak';
 
   @override
-  String get schedule => 'Rute';
+  String get schedule => 'Sendeskjema';
 
   @override
-  String get series => 'Serier';
+  String get series => 'Serie';
 
   @override
-  String get noItemsFound => 'Ingen varer funnet';
+  String get noItemsFound => 'Ingen elementer funnet';
 
   @override
   String get home => 'Hjem';
@@ -427,7 +426,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Kunne ikke laste inn mappen: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -435,7 +434,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count elementer';
+    return '$count items';
   }
 
   @override
@@ -452,7 +451,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count elementer';
+    return '$count Items';
   }
 
   @override
@@ -483,7 +482,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get small => 'Liten';
 
   @override
-  String get medium => 'Middels';
+  String get medium => 'Medium';
 
   @override
   String get large => 'Stor';
@@ -493,7 +492,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Sjangere';
+    return '$name — Genres';
   }
 
   @override
@@ -506,7 +505,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get albumArtists => 'Albumartister';
 
   @override
-  String get artists => 'Artister';
+  String get artists => 'Kunstnere';
 
   @override
   String get bookmarks => 'Bokmerker';
@@ -532,17 +531,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count min siden';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count t siden';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count d siden';
+    return '${count}d ago';
   }
 
   @override
@@ -553,7 +552,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Velg hvilke emnestrømmer som skal vises i Discover.';
 
   @override
-  String get apply => 'Bruk';
+  String get apply => 'Søke';
 
   @override
   String get openLink => 'Åpne Link';
@@ -577,7 +576,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count titler';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +602,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get listen => 'Lytte';
 
   @override
-  String get resume => 'Fortsett';
+  String get resume => 'Gjenoppta';
 
   @override
   String get failedToLoadLibrary => 'Kunne ikke laste inn biblioteket';
@@ -662,17 +661,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count forfattere';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count sjangere';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent % fullført';
+    return '$percent% completed';
   }
 
   @override
@@ -689,7 +688,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titler organisert for lesing først.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -726,7 +725,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Fant ingen $label';
+    return 'No $label found';
   }
 
   @override
@@ -745,7 +744,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get readStatus => 'Lese';
 
   @override
-  String get watched => 'Sett';
+  String get watched => 'Så på';
 
   @override
   String get unread => 'Ulest';
@@ -763,43 +762,43 @@ class AppLocalizationsNb extends AppLocalizations {
   String get books => 'Bøker';
 
   @override
-  String get latestBooks => 'Nyeste bøker';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Nyeste lydbøker';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bøker',
-      one: '1 bok',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Bok';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Lydbok';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent % lest';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time igjen';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Les';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Lytt';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Forfatter';
@@ -837,12 +836,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count deler';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Først utgitt $year';
+    return 'First published $year';
   }
 
   @override
@@ -857,7 +856,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count bøker';
+    return '$count books';
   }
 
   @override
@@ -869,7 +868,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count forfattere';
+    return '$count Authors';
   }
 
   @override
@@ -877,8 +876,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count lydbøker',
-      one: '1 lydbok',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -896,13 +895,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get delete => 'Slett';
 
   @override
-  String get save => 'Lagre';
+  String get save => 'Spare';
 
   @override
   String get moreLikeThis => 'Mer som dette';
 
   @override
-  String get castAndCrew => 'Skuespillere og team';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Samling';
@@ -914,7 +913,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get nextUp => 'Neste opp';
 
   @override
-  String get seasons => 'Sesonger';
+  String get seasons => 'Årstider';
 
   @override
   String get chapters => 'Kapitler';
@@ -926,7 +925,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get movies => 'Filmer';
 
   @override
-  String get musicVideos => 'Musikkvideoer';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Annen';
@@ -945,7 +944,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Plate $number';
+    return 'Disc $number';
   }
 
   @override
@@ -971,7 +970,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Utgitt $year';
+    return 'Published $year';
   }
 
   @override
@@ -982,52 +981,52 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sesonger',
-      one: '1 sesong',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Slutter kl. $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Elementer';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ekstramateriale';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Bak kulissene';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Slettede scener';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjuer';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scener';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kortfilmer';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailere';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time igjen';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Slutter om $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1041,11 +1040,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Fortsett fra $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Spill av';
+  String get play => 'Spille';
 
   @override
   String get startOver => 'Start på nytt';
@@ -1072,7 +1071,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get cast => 'Cast';
 
   @override
-  String get trailer => 'Trailer';
+  String get trailer => 'Tilhenger';
 
   @override
   String get finished => 'Ferdig';
@@ -1140,7 +1139,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Vil du slette nedlastede spor for «$title»?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1155,17 +1154,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Ingen $itemLabel lastet inn';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Laster ned $title ($count elementer)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Er du sikker på at du vil slette «$name» fra serveren? Denne handlingen kan ikke angres.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1176,7 +1175,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Bokformatet støttes ikke: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1202,7 +1201,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Undertekst lastet ned og valgt: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1211,7 +1210,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Fant ingen eksterne undertekster for $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1219,7 +1218,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Versjon $number';
+    return 'Version $number';
   }
 
   @override
@@ -1239,7 +1238,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Laster ned $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Vil du slette lokale filer for $typeLabel?\n\nDette frigjør lagringsplass. Du kan laste dem ned igjen senere.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1263,25 +1262,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get director => 'DIREKTØR';
 
   @override
-  String get directors => 'REGISSØRER';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'MANUSFORFATTER';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'MANUSFORFATTERE';
+  String get writers => 'FORRETTER';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count til';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count episoder';
+    return '$count Episodes';
   }
 
   @override
@@ -1296,7 +1295,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String chapterNumber(int number) {
-    return 'Kapittel $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1304,8 +1303,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count spor',
-      one: '1 spor',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1315,25 +1314,25 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapitler',
-      one: '1 kapittel',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Født $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Død $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Alder $age';
+    return 'Age $age';
   }
 
   @override
@@ -1343,20 +1342,20 @@ class AppLocalizationsNb extends AppLocalizations {
   String get readMore => 'Les mer';
 
   @override
-  String get shuffle => 'Tilfeldig';
+  String get shuffle => 'Bland';
 
   @override
-  String get shuffleAllMusic => 'Spill all musikk i tilfeldig rekkefølge';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Logg på Moonfin på telefonen';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Får ikke kontakt med serveren';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count nedlastinger';
+    return '$count downloads';
   }
 
   @override
@@ -1375,32 +1374,32 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Ekstern undertekst $action krever Jellyfin-tillatelsen for undertekstadministrasjon for denne brukeren.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Dette elementet ble ikke funnet på serveren for ekstern undertekst $action.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Ekstern undertekst $action mislyktes: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Ekstern undertekst $action mislyktes (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Kunne ikke $action eksterne undertekster.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'alle nedlastede episoder for «$name»';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1430,17 +1429,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label-handlingen mislyktes: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Kunne ikke angi cast-volum: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label-kontroller';
+    return '$label Controls';
   }
 
   @override
@@ -1457,7 +1456,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Stopp $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1465,7 +1464,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Spor $number';
+    return 'Track $number';
   }
 
   @override
@@ -1475,14 +1474,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get castingToGoogleCast => 'Caster til Google Cast';
 
   @override
-  String get castingViaAirPlay => 'Caster via AirPlay';
+  String get castingViaAirPlay => 'Casting via AirPlay';
 
   @override
-  String get castingViaDlna => 'Caster via DLNA';
+  String get castingViaDlna => 'Casting via DLNA';
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sekunder';
+    return '$seconds seconds';
   }
 
   @override
@@ -1512,12 +1511,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1551,7 +1550,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get transcodeReasons => 'Årsaker til omkoding';
 
   @override
-  String get player => 'Avspiller';
+  String get player => 'Spiller';
 
   @override
   String get container => 'Container';
@@ -1569,7 +1568,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'Kodek';
+  String get codec => 'Codec';
 
   @override
   String get videoBitrate => 'Video bitrate';
@@ -1584,7 +1583,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audioBitrate => 'Lydbithastighet';
 
   @override
-  String get sampleRate => 'Samplingsfrekvens';
+  String get sampleRate => 'Sample Rate';
 
   @override
   String get format => 'Format';
@@ -1597,12 +1596,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Øktfeil for $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Kunne ikke laste inn bokdetaljer: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1611,7 +1610,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Dette formatet (.$extension) kan ikke vises i appen ennå.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1623,17 +1622,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Kunne ikke åpne leseren i appen: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Bokmerket er allerede lagret ved $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Bokmerke lagt til: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1646,7 +1645,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Side $number';
+    return 'Page $number';
   }
 
   @override
@@ -1662,7 +1661,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String percentRead(String percent) {
-    return '$percent % lest';
+    return '$percent% read';
   }
 
   @override
@@ -1685,7 +1684,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Tilbakestill zoom (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1708,7 +1707,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Kunne ikke oppdatere lesestatus: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1740,7 +1739,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Denne plattformen kan ikke kjøre den innebygde dokumentmotoren for $extension-filer.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1779,7 +1778,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Kunne ikke laste inn guiden: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1790,22 +1789,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Neste: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min igjen';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours t igjen';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours t $minutes min igjen';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1828,29 +1827,29 @@ class AppLocalizationsNb extends AppLocalizations {
   String get favoriteChannel => 'Favoritt kanal';
 
   @override
-  String get record => 'Ta opp';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Avbryt opptak';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Programmet er satt opp for opptak';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Opptaket er avbrutt';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Kan ikke opprette opptak';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Se på';
+  String get watch => 'Klokke';
 
   @override
-  String get close => 'Lukk';
+  String get close => 'Lukke';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Kunne ikke spille av $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1876,11 +1875,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Vil du avbryte det planlagte opptaket av «$name»?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Nei';
+  String get no => 'Ingen';
 
   @override
   String get yesCancel => 'Ja, avbryt';
@@ -1902,7 +1901,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Vil du stoppe opptaket av «$name»?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1916,12 +1915,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Ingen resultater for «$query»';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Søket mislyktes: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1962,12 +1961,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Vil du fjerne «$name» og filene?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count spor';
+    return '$count tracks';
   }
 
   @override
@@ -1978,16 +1977,16 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Kunne ikke laste inn albumet: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Fant ingen nedlastede spor for $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'Sesong';
+  String get season => 'Årstid';
 
   @override
   String get errorLoadingEpisodes => 'Feil ved innlasting av episoder';
@@ -2000,7 +1999,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Vil du fjerne «$name»?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2029,7 +2028,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sesong $number';
+    return 'Season $number';
   }
 
   @override
@@ -2045,7 +2044,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Vil du slette alle nedlastede episoder i $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2053,7 +2052,7 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episoder',
+      other: '$count episodes',
       one: '1 episode',
     );
     return '$_temp0';
@@ -2089,7 +2088,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Vil du slette $count nedlastede elementer?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2103,7 +2102,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'av grensen på $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2187,7 +2186,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count alternativer';
+    return '$count options';
   }
 
   @override
@@ -2280,11 +2279,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get themeMusicVolume => 'Temamusikkvolum';
 
   @override
-  String get themeMusicSettingsSubtitle => 'Detaljsider, hjem-rader og volum';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
-    return '$value %';
+    return '$value%';
   }
 
   @override
@@ -2295,18 +2295,18 @@ class AppLocalizationsNb extends AppLocalizations {
       'Spill når du surfer på startskjermen';
 
   @override
-  String get loopThemeMusic => 'Gjenta temamusikk';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Gjenta sporet i stedet for å spille det én gang';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detaljer Bakgrunnsuskarphet';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2322,23 +2322,23 @@ class AppLocalizationsNb extends AppLocalizations {
   String get playerZoomMode => 'Spillerzoommodus';
 
   @override
-  String get settingsScrollWheelAction => 'Musehjul';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Velg hva rulling med musehjulet over videoen gjør under avspilling.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Av';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Spol (fram / tilbake)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Volum';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Volum';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Passe';
@@ -2353,7 +2353,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get refreshRateSwitching => 'Bytte av oppdateringsfrekvens';
 
   @override
-  String get disabled => 'Deaktivert';
+  String get disabled => 'Funksjonshemmet';
 
   @override
   String get scaleOnTv => 'Skala på TV';
@@ -2392,37 +2392,37 @@ class AppLocalizationsNb extends AppLocalizations {
   String get defaultAudioLanguage => 'Standard lydspråk';
 
   @override
-  String get fallbackAudioLanguage => 'Reservespråk for lyd';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Foretrekk standard lydspor';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Foretrekk originalt lydspor framfor lokalisert dubbing.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Foretrekk synstolkingsspor';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Foretrekk synstolkingsspor framfor vanlige spor.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Omkoding (lyd)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Direktestrøm (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Omkoding (bitrate eller oppløsning)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Omkoding (video og lyd)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Omkoding (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (serverstandard)';
@@ -2499,27 +2499,27 @@ class AppLocalizationsNb extends AppLocalizations {
       'Aktiver TrueHD-lyd (fungerer kanskje ikke på alle plattformer)';
 
   @override
-  String get settingsAudioOutputMode => 'Lydutgangsmodus';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Velg hvordan lyd dekodes. AVR Passthrough sender rå Dolby-/DTS-strømmer til receiveren, mens Auto eller Nedmiks dekoder lokalt.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Reservekodek for lyd';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Velg målformatet for omkoding av flerkanalslyd når kildestrømmen ikke kan spilles direkte eller sendes gjennom.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Oppdag automatisk\n(anbefalt)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(standard)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2528,27 +2528,26 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(tapsfri)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(kun stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(effektiv)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(tapsfri)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maks antall lydkanaler';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Angi maksimalt antall kanaler i lydoppsettet ditt. Flerkanalsstrømmer som overskrider denne grensen, blir nedmikset eller omkodet.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Oppdag automatisk\n(maskinvarestandard)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2560,7 +2559,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvadrofonisk';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2575,67 +2574,67 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (avansert)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Kodek-passthrough';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Aktiver bare formater som AVR-en eller HDMI-mottakeren din støtter.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3-passthrough';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos)-passthrough';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core-passthrough';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA-passthrough';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD-passthrough';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos-passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Send Dolby Digital Plus (EAC3) som bitstrøm til ekstern dekoder.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Send Dolby Atmos over EAC3 (JOC) som bitstrøm til ekstern dekoder.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Send DTS-HD MA (inkludert DTS Core) som bitstrøm til ekstern dekoder.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Send Dolby TrueHD med Atmos-metadata som bitstrøm til ekstern dekoder.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Oppdagede lydfunksjoner';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Ingen øyeblikksbilde av kjøretidsfunksjoner er tilgjengelig ennå.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Rute';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekoding';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD-lydrute';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2650,10 +2649,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Høyttaler';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Hodetelefoner';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2661,39 +2660,39 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostikk';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Videonivå';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Videoområde';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Undertekstkodek';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Tillatte lydkodeker';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS-lydkodeker';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4-lydkodeker';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif-passthrough';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktiv lydrute';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'HD-lydstøtte for ruten';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nattmodus';
@@ -2726,10 +2725,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Kan forbedre ytelsen, men kan forårsake avspillingsproblemer på enkelte enheter.';
 
   @override
-  String get nextUpAndQueuing => 'Neste opp og kø';
+  String get nextUpAndQueuing => 'Next Up & Queuing';
 
   @override
-  String get nextUpDisplay => 'Visning av Neste opp';
+  String get nextUpDisplay => 'Next Up Display';
 
   @override
   String get extended => 'Utvidet';
@@ -2742,7 +2741,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2756,7 +2755,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Etter $episodes episoder / $hours t';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2797,7 +2796,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get selectMpvConf => 'Velg mpv.conf';
 
   @override
-  String get pathToMpvConf => '/bane/til/mpv.conf';
+  String get pathToMpvConf => '/path/to/mpv.conf';
 
   @override
   String get subtitleStyleDescription =>
@@ -2832,45 +2831,45 @@ class AppLocalizationsNb extends AppLocalizations {
       'Tilpass undertekstens utseende';
 
   @override
-  String get subtitleMode => 'Undertekstmodus';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Flagget';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Alltid';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Fremmedspråk';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Tvunget';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Spiller spor som internt er merket som «default» eller «forced» i mediefilens metadata.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Laster inn og viser undertekster automatisk hver gang en video starter.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Slår automatisk på undertekster hvis standard lydspor er på et fremmed språk.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Laster bare inn undertekster som er eksplisitt merket med forced-flagget.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Deaktiverer automatisk innlasting av undertekster helt.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Reservespråk for undertekster';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Undertekststrøm';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2886,7 +2885,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get directPlayPgsSubtitles => 'Direkte spill PGS undertekster';
 
   @override
-  String get assSsaDirectPlay => 'ASS/SSA-direkteavspilling';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles => 'Direkte spill ASS/SSA undertekster';
@@ -2929,17 +2928,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Lastet inn profilinnstillinger for $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Kunne ikke laste inn profilinnstillinger for $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Synkroniserte lokale innstillinger til $profile-profilen.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3074,10 +3073,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showLibrariesInToolbar => 'Vis biblioteker i verktøylinjen';
 
   @override
-  String get navbarAlwaysExpanded => 'Vis alltid etiketter i navigasjonslinjen';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Vis Seerr-knapp';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar opasitet';
@@ -3152,19 +3151,18 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showFolderBrowsingOption => 'Vis alternativ for mappelesing';
 
   @override
-  String get groupItemsIntoCollections => 'Grupper elementer i samlinger';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Skjul bibliotekelementer som tilhører en samling, når du blar i bibliotekene';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Merknad om bibliotekgruppering';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'For å bruke denne innstillingen må du sørge for at bibliotekinnstillingene «Group movies into collections» og/eller «Group shows into collections» er aktivert under bibliotekets visningsinnstillinger på Jellyfin- eller Emby-serveren.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliotekets synlighet';
@@ -3193,7 +3191,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count valgt';
+    return '$count selected';
   }
 
   @override
@@ -3223,7 +3221,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Velg mellom ulike mediefeltstiler, eller slå av mediefeltet';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Månefinne';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3276,10 +3274,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Spill av trailere automatisk i mediefeltet etter 3 sekunder';
 
   @override
-  String get trailerAudio => 'Trailerlyd';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Aktiver lyd for trailere i Media Bar';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Forhåndsvisning av episode';
@@ -3357,11 +3355,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Kombiner begge radene til en enkelt hjemmeseksjon';
 
   @override
-  String get fullScreenRows => 'Utvidede hjem-rader';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Begrens hjem-rader til én rad per skjerm';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Bildetype per rad';
@@ -3376,7 +3373,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get lastUser => 'Siste bruker';
 
   @override
-  String get currentUser => 'Gjeldende bruker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentiser alltid';
@@ -3481,10 +3478,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get displayClockDuringScreensaver => 'Vis klokke under skjermsparer';
 
   @override
-  String get clockModeStatic => 'Statisk';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Sprettende';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Råtne tomater (kritikere)';
@@ -3556,7 +3553,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Aktiver og omorganiser vurderingskildene som vises i hele appen';
 
   @override
-  String get pluginLabel => 'Moonbase-plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin oppdaget';
@@ -3574,14 +3571,14 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersjon: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
   String get availableServices => 'Tilgjengelige tjenester';
 
   @override
-  String get serverPluginSync => 'Synkronisering av servertillegg';
+  String get serverPluginSync => 'Server Plugin Sync';
 
   @override
   String get syncSettingsWithPlugin =>
@@ -3613,7 +3610,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get upcomingMovies => 'Kommende filmer';
 
   @override
-  String get studios => 'Studioer';
+  String get studios => 'Studios';
 
   @override
   String get popularSeries => 'Populær serie';
@@ -3628,7 +3625,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get networks => 'Nettverk';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-oppdagelsesrader';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Tilbakestill rader til standardverdier';
@@ -3651,43 +3648,44 @@ class AppLocalizationsNb extends AppLocalizations {
   String get hideAdultContent => 'Skjul voksent innhold i resultater';
 
   @override
-  String get seerrNotificationsSection => 'Varsler';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Varsler om nye forespørsler';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Varsle meg når noen sender inn en forespørsel';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Oppdateringer om forespørsler';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Godkjent, avslått og lagt til i biblioteket ditt';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Oppdateringer om saker';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nye saker, svar og løsninger';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Logget inn som: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr-oppdagelsesside';
+  String get discoverRows => 'Oppdag rader';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktiver radene du vil se på Seerr-hovedsiden. Dra for å endre rekkefølge. Egendefinert rekkefølge synkroniseres med Moonbase.';
+      'Dra for å omorganisere. Aktiver eller deaktiver rader. Aktivert radrekkefølge synkroniseres med Moonfin-plugin.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktiver radene du vil se på Seerr-hovedsiden. Dra for å endre rekkefølge. Egendefinert rekkefølge synkroniseres med Moonbase.';
+      'Dra for å omorganisere. Aktiver eller deaktiver rader.';
 
   @override
   String get enabled => 'Aktivert';
@@ -3700,7 +3698,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Versjon $version';
+    return 'Version $version';
   }
 
   @override
@@ -3749,7 +3747,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Oppdatering tilgjengelig: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3761,7 +3759,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version er tilgjengelig';
+    return 'v$version Available';
   }
 
   @override
@@ -3824,7 +3822,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get imageCacheCleared => 'Bildebufferen er tømt';
 
   @override
-  String get clear => 'Tøm';
+  String get clear => 'Klar';
 
   @override
   String get browse => 'Bla gjennom';
@@ -3840,15 +3838,15 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Laster ned · $percent %';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importerer';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count elementer';
+    return '$count Items';
   }
 
   @override
@@ -3868,7 +3866,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Forespurt av $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3885,12 +3883,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Vil du avbryte forespørselen for «$title»?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Vil du avbryte $count forespørsler for «$title»?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3905,12 +3903,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Budsjett: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Inntekter: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3920,7 +3918,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Be om $type';
+    return 'Request $type';
   }
 
   @override
@@ -3956,7 +3954,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'alder $age';
+    return 'age $age';
   }
 
   @override
@@ -3987,148 +3985,148 @@ class AppLocalizationsNb extends AppLocalizations {
   String get deletedStatus => 'Slettet';
 
   @override
-  String get failedStatus => 'Mislyktes';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Behandles';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Endret av $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Fullført';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Denne tittelen er allerede forespurt';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Forespørselsgrensen er nådd';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Denne tittelen er blokkert';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Ingen sesonger igjen å be om';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Du har ikke tillatelse til å sende denne forespørselen';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Forespørsler';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Saker';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nyeste';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Sist endret';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Ingen saker';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining av $limit filmforespørsler igjen';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining av $limit sesongforespørsler igjen';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Del av $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vis samling';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Be om samling';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmer · $available tilgjengelige';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Be om $count filmer';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Ber om $current av $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count filmer forespurt';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok av $total filmer forespurt';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alle filmer er allerede tilgjengelige eller forespurt';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Rapporter sak';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Lyd';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Hva er galt?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alle episoder';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Åpen';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Løst';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Løs';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Gjenåpne';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Rapportert av $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommentarer';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Legg til en kommentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Vil du slette denne saken?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Send inn rapport';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-poengsum';
@@ -4152,7 +4150,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get originalLanguageLabel => 'Originalspråk';
 
   @override
-  String get seasonsLabel => 'Sesonger';
+  String get seasonsLabel => 'Årstider';
 
   @override
   String get episodesLabel => 'Episoder';
@@ -4161,13 +4159,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get access => 'Adgang';
 
   @override
-  String get add => 'Legg til';
+  String get add => 'Legge til';
 
   @override
   String get address => 'Adresse';
 
   @override
-  String get analytics => 'Analyse';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalog';
@@ -4188,7 +4186,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get done => 'Ferdig';
 
   @override
-  String get edit => 'Rediger';
+  String get edit => 'Redigere';
 
   @override
   String get encoding => 'Koding';
@@ -4197,10 +4195,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get error => 'Feil';
 
   @override
-  String get forward => 'Fremover';
+  String get forward => 'Framover';
 
   @override
-  String get general => 'Generelt';
+  String get general => 'General';
 
   @override
   String get go => 'Gå';
@@ -4281,16 +4279,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get status => 'Status';
 
   @override
-  String get stop => 'Stopp';
+  String get stop => 'Stoppe';
 
   @override
-  String get streaming => 'Strømming';
+  String get streaming => 'Streaming';
 
   @override
   String get time => 'Tid';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Triksing';
 
   @override
   String get uninstall => 'Avinstaller';
@@ -4308,7 +4306,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get unmute => 'Slå på lyden';
 
   @override
-  String get mute => 'Demp';
+  String get mute => 'Stum';
 
   @override
   String get branding => 'Merkevarebygging';
@@ -4317,7 +4315,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminDrawerDashboard => 'Dashbord';
 
   @override
-  String get adminDrawerAnalytics => 'Analyse';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Innstillinger';
@@ -4332,25 +4330,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteker';
 
   @override
-  String get adminDrawerDisplay => 'Visning';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-innstillinger';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Omkoding';
 
   @override
-  String get adminDrawerResume => 'Fortsett';
+  String get adminDrawerResume => 'Gjenoppta';
 
   @override
-  String get adminDrawerStreaming => 'Strømming';
+  String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Triksing';
 
   @override
   String get adminDrawerDevices => 'Enheter';
@@ -4374,7 +4372,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminDrawerScheduledTasks => 'Planlagte oppgaver';
 
   @override
-  String get adminDrawerPlugins => 'Tillegg';
+  String get adminDrawerPlugins => 'Plugins';
 
   @override
   String get adminDrawerRepositories => 'Lagre';
@@ -4401,22 +4399,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Tilgjengelige tilleggsoppdateringer: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Tillegg som krever omstart: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Mislykkede planlagte oppgaver: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Nylige advarsler/feil: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4475,7 +4473,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Feil: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4502,7 +4500,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Kommandoen mislyktes: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4521,7 +4519,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get sessionRewind => 'Spole';
 
   @override
-  String get sessionForward => 'Fremover';
+  String get sessionForward => 'Framover';
 
   @override
   String get sessionNext => 'Neste';
@@ -4551,7 +4549,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audioCodec => 'Lydkodek';
 
   @override
-  String get hwAccel => 'HW-akselerasjon';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Fullføring';
@@ -4566,14 +4564,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminClearDates => 'Klare datoer';
 
   @override
-  String get adminActivitySeverityAll => 'Alle alvorlighetsgrader';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datoområde';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Kunne ikke laste inn aktivitetsloggen: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4590,7 +4588,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Kunne ikke oppdatere enheten: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4601,28 +4599,28 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Kunne ikke slette enheten: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Vil du fjerne enheten «$name»? Brukeren må logge på igjen på denne enheten.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Slett alle enheter';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Vil du fjerne $count enheter? Berørte brukere må logge på igjen. Din nåværende enhet påvirkes ikke.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Enhetene er fjernet';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Noen enheter ble fjernet, men $count kunne ikke fjernes.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4651,7 +4649,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Kunne ikke starte skanningen: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4662,12 +4660,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Biblioteket er omdøpt til «$name»';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Kunne ikke gi nytt navn: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4675,17 +4673,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Biblioteket «$name» er slettet';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Kunne ikke slette biblioteket: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Kunne ikke legge til banen: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4693,12 +4691,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Vil du fjerne «$path» fra dette biblioteket?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Kunne ikke fjerne banen: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4706,7 +4704,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Kunne ikke lagre alternativene: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4737,255 +4735,251 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminMetadataCountryHint => 'f.eks. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Baner';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Alternativer';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Nedlastere';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadatalagrere';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Undertekstnedlastere';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Sangtekstnedlastere';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadatanedlastere: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Bildehentere: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Denne serveren tilbyr ingen nedlastere for denne bibliotektypen.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Generelt';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Innebygd informasjon';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Undertekster';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Bilder';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serier';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musikk';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmer';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktiver sanntidsovervåking';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Oppdag filendringer og behandle dem automatisk.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Behandle arkiver som mediefiler';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Vis bilder';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Lagre bildemateriell i mediemappene';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatisk oppdatering av metadata';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Aldri';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Standard';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visning';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotekvisning';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Vis en mappevisning for å vise vanlige mediemapper';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Vis spesialepisoder i sesongene de ble sendt i';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupper filmer i samlinger';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupper serier i samlinger';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'Vis eksternt innhold i forslag';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Virkemåte for lagt til-dato';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Bruk lagt til-dato fra';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Datoen filen ble skannet inn i biblioteket';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datoen filen ble opprettet';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata og bilder';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Foretrukket metadataspråk';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitler';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Varighet for genererte kapitler (sekunder)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Lengden på kapitler som genereres for medier uten kapitler. Sett til 0 for å deaktivere.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Oppløsning for kapittelbilder';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-innstillinger';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metadata er kompatible med Kodi og lignende klienter. Innstillingene gjelder alle biblioteker som lagrer NFO-metadata.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Bruker det skal lagres visningsdata for i NFO-filer';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Lagre bildebaner i NFO-filer';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktiver baneerstatning for NFO-bildebaner';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopier extrafanart-bilder til en extrathumbs-mappe';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ingen';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dager';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Bruk innebygde titler';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Bruk innebygde titler for ekstramateriale';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'Bruk innebygd episodeinformasjon';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Tillat innebygde undertekster';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Tillat alle';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Kun tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Kun bilde';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ingen';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Hopp over nedlasting hvis innebygde undertekster finnes';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Hopp over nedlasting hvis lydsporet samsvarer med nedlastingsspråket';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Krev perfekt undertekstsamsvar';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Lagre undertekster i mediemappene';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Trekk ut kapittelbilder';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Trekk ut kapittelbilder under bibliotekskanningen';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktiver uttrekking av trickplay-bilder';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Trekk ut trickplay-bilder under bibliotekskanningen';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Lagre trickplay-bilder i mediemappene';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Slå automatisk sammen serier som er spredt over flere mapper';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Visningsnavn for sesong null';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Aktiver LUFS-skanning for lydnormalisering';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Foretrekk ikke-standard artisttagg';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Legg filmer automatisk til i samlinger';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Biblioteknavn er obligatorisk';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Kunne ikke opprette biblioteket: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5012,27 +5006,27 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Vil du deaktivere $name? Brukeren vil ikke kunne logge på.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Vil du aktivere $name? Brukeren vil kunne logge på igjen.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Brukeren «$name» er deaktivert';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Brukeren «$name» er aktivert';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Kunne ikke oppdatere brukerpolicyen: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5049,7 +5043,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Kunne ikke opprette brukeren: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5069,7 +5063,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Kunne ikke lagre: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5080,7 +5074,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Mislyktes: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5213,145 +5207,143 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktiver tilgang til alle kanaler';
 
   @override
-  String get adminParentalControl => 'Foreldrekontroll';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Maksimal tillatt aldersgrense';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Innhold med høyere aldersgrense skjules for denne brukeren.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ingen';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokker elementer uten eller med ukjent aldersgrense';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Bøker';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanaler';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Direktesendt TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmer';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musikk';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailere';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serier';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Tilgangstidsplaner';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Tillat tilgang bare i tidsrommene nedenfor. Tilgang er tillatt hele døgnet når ingen tidsplan er angitt.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Legg til tidsplan';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dag';
+  String get adminScheduleDay => 'Day';
 
   @override
   String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Slutt';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Hver dag';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Ukedag';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Helg';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Søndag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Mandag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Tirsdag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Onsdag';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Torsdag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Fredag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Lørdag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tillatte tagger';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Bare innhold med disse taggene vises. La stå tomt for å tillate alt.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokkerte tagger';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Innhold med disse taggene skjules for denne brukeren.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Legg til tagg';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Aktiverte enheter';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Aktiverte kanaler';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Autentiseringsleverandør';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Leverandør for tilbakestilling av passord';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksimalt antall mislykkede påloggingsforsøk før utestenging';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Sett til 0 for standardverdien, eller -1 for å deaktivere utestenging.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-tilgang';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Tillat å opprette og bli med i grupper';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Tillat å bli med i grupper';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Ingen tilgang';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Tillat sletting av innhold fra';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5359,22 +5351,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Serveren returnerte HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Er du sikker på at du vil slette $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Brukeren «$name» er slettet';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Kunne ikke slette brukeren: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5395,7 +5387,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Kunne ikke opprette nøkkelen: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5406,7 +5398,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Vil du oppheve nøkkelen for $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5414,7 +5406,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Kunne ikke oppheve nøkkelen: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5434,30 +5426,29 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nOpprettet: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Opprett sikkerhetskopi';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Velg hva som skal inkluderes i sikkerhetskopien.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
   String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Alltid inkludert';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Undertekster';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-bilder';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Oppretter sikkerhetskopi...';
@@ -5467,7 +5458,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Kunne ikke opprette sikkerhetskopien: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5480,7 +5471,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Kunne ikke laste inn manifestet: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5491,7 +5482,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Kunne ikke gjenopprette sikkerhetskopien: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5523,17 +5514,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Lagret til $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Kunne ikke lagre filen: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Kunne ikke laste inn $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5544,7 +5535,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Kunne ikke laste inn oppgavene: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5556,17 +5547,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Kunne ikke starte oppgaven: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Kunne ikke stoppe oppgaven: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Kunne ikke laste inn oppgaven: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5574,12 +5565,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Kunne ikke fjerne utløseren: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Kunne ikke legge til utløseren: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5595,7 +5586,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminNoTriggers => 'Ingen utløsere er konfigurert';
 
   @override
-  String get adminTriggerType => 'Utløsertype';
+  String get adminTriggerType => 'Trigger Type';
 
   @override
   String get adminTimeLimit => 'Tidsbegrensning (valgfritt)';
@@ -5605,7 +5596,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours time(r)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5616,7 +5607,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Kunne ikke slå tillegget av/på: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5624,27 +5615,27 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Er du sikker på at du vil avinstallere «$name»?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Kunne ikke avinstallere tillegget: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Kunne ikke installere pakken: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Kunne ikke installere oppdateringen: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Kunne ikke laste inn tilleggene: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5656,12 +5647,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Installer oppdatering (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Kunne ikke laste inn katalogen: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5683,17 +5674,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '«$name» fjernes etter at serveren startes på nytt';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Kunne ikke avinstallere: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Oppdaterer «$name» til v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5702,7 +5693,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Kunne ikke laste inn tillegget: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5710,7 +5701,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versjon $version';
+    return 'Version $version';
   }
 
   @override
@@ -5730,24 +5721,24 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Er du sikker på at du vil fjerne «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Kunne ikke lagre repositoriene: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Kunne ikke laste inn repositoriene: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
   String get adminRepositoryNameHint => 'f.eks. Jellyfin Stall';
 
   @override
-  String get adminRepositoryUrl => 'Repositorie-URL';
+  String get adminRepositoryUrl => 'Repository URL';
 
   @override
   String get adminAddEntry => 'Legg til oppføring';
@@ -5757,12 +5748,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Kan ikke laste inn tilleggsinnstillingene: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Kunne ikke åpne $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6001,7 +5992,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminPublicHttpsPort => 'Offentlig HTTPS-port';
 
   @override
-  String get adminBaseUrl => 'Base-URL';
+  String get adminBaseUrl => 'Base URL';
 
   @override
   String get adminBaseUrlHint => 'f.eks. /jellyfin';
@@ -6044,12 +6035,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Kunne ikke laste inn metadata: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Kunne ikke lagre metadata: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6070,7 +6061,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Kunne ikke oppdatere metadata: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6084,7 +6075,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Eksternt søk mislyktes: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6098,7 +6089,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Kunne ikke oppdatere innholdstypen: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6113,12 +6104,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType-bildet er oppdatert';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Kunne ikke laste ned bildet: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6129,27 +6120,27 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType-bildet er lastet opp';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Kunne ikke laste opp bildet: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Slett $imageType-bildet';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType-bildet er slettet';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Kunne ikke slette bildet: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6160,67 +6151,67 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Søk etter tunere mislyktes: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Legg til tuner';
 
   @override
-  String get adminEditTuner => 'Rediger tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fil eller URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Tunerens IP-adresse';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Visningsnavn';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Brukeragent';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Grense for samtidige tilkoblinger';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Maksimalt antall strømmer tuneren tillater samtidig. Sett til 0 for ubegrenset.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Reserve for maks strømmebitrate';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importer bare favorittkanaler';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Tillat maskinvareomkoding';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Tillat fMP4-omkodingscontainer';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Tillat strømdeling';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Aktiver strømsløyfe';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorer DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Les inndata med opprinnelig bildefrekvens';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Rediger leverandør';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6229,60 +6220,60 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fil eller URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmprefiks';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmkategorier';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Skill flere kategorier med en loddrett strek.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Barnekategorier';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nyhetskategorier';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportskategorier';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Brukernavn';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Passord';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Velg et land';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postnummer';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Hent oppføringer';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Oppføringer';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktiver alle tunere';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
-  String get adminTunerType => 'Tunertype';
+  String get adminTunerType => 'Tuner Type';
 
   @override
   String get adminTunerAdded => 'Tuner lagt til';
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Kunne ikke legge til tuneren: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6296,12 +6287,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Kunne ikke legge til leverandøren: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Kunne ikke fjerne tuneren: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6309,16 +6300,16 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Kunne ikke tilbakestille tuneren: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Denne tunertypen støtter ikke tilbakestilling.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Kunne ikke fjerne leverandøren: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6337,43 +6328,43 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serieopptaksbane';
 
   @override
-  String get adminMovieRecordingPath => 'Bane for filmopptak';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Antall dager med guidedata';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatisk';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dager';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Bane til etterbehandlingsprogram';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumenter for etterbehandler';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Lagre NFO-metadata for opptak';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Lagre bilder for opptak';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tidsstyring';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Opptaksbaner';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Etterbehandling';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Guidedata: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6381,7 +6372,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Kunne ikke lagre innstillingene: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6398,7 +6389,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Kunne ikke oppdatere tilordningene: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6415,14 +6406,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminGuideProviders => 'Veiledningsleverandører';
 
   @override
-  String get adminRefreshGuideData => 'Oppdater guidedata';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Oppdatering av guidedata er startet';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Oppgaven for oppdatering av guiden er ikke tilgjengelig på denne serveren.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Legg til leverandør';
@@ -6433,26 +6424,26 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Opptaksbane: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Seriebane: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Tid før start: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Tid etter slutt: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Tunersøk';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Kanalkartlegginger';
@@ -6481,7 +6472,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Vil du gjenopprette sikkerhetskopien $name nå?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6505,7 +6496,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminLiveTvTitle => 'Direkte TV-administrasjon';
 
   @override
-  String get adminApply => 'Bruk';
+  String get adminApply => 'Søke';
 
   @override
   String get adminNotSet => 'Ikke satt';
@@ -6527,27 +6518,27 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes min siden';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours t siden';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days d siden';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Kunne ikke laste inn $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count treff';
+    return '$count matches';
   }
 
   @override
@@ -6557,7 +6548,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadataredigerer';
 
   @override
-  String get adminMetadataIdentify => 'Identifiser';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Type';
@@ -6599,7 +6590,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminMetadataFieldCriticRating => 'Kritikervurdering';
 
   @override
-  String get adminMetadataFieldTagline => 'Slagord';
+  String get adminMetadataFieldTagline => 'Tagline';
 
   @override
   String get adminMetadataFieldOverview => 'Oversikt';
@@ -6611,7 +6602,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminMetadataTags => 'Tagger';
 
   @override
-  String get adminMetadataStudios => 'Studioer';
+  String get adminMetadataStudios => 'Studios';
 
   @override
   String get adminMetadataPeople => 'Mennesker';
@@ -6657,22 +6648,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType-bildet er oppdatert';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType-bildet er lastet opp';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType-bildet er slettet';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Kunne ikke laste ned bildet: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6681,12 +6672,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Kunne ikke laste opp bildet: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Slett $imageType-bildet';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6695,12 +6686,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Kunne ikke slette bildet: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Velg $imageType-bilde';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6733,7 +6724,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Oppdatering tilgjengelig: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6756,7 +6747,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Installer oppdatering (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6768,7 +6759,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '«$name» installeres...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6788,7 +6779,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name-innstillinger';
+    return '$name Settings';
   }
 
   @override
@@ -6828,7 +6819,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Kunne ikke laste inn repositoriene: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6836,15 +6827,15 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Er du sikker på at du vil fjerne «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Fjern';
+  String get adminReposRemove => 'Fjerne';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Kunne ikke lagre repositoriene: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6864,7 +6855,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminReposAddTitle => 'Legg til arkiv';
 
   @override
-  String get adminReposUrl => 'Repositorie-URL';
+  String get adminReposUrl => 'Repository URL';
 
   @override
   String get adminReposNameHint => 'f.eks. Jellyfin Stall';
@@ -6971,20 +6962,19 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktiver velkomstskjerm';
 
   @override
-  String get adminBrandingSplashUpload => 'Last opp bilde';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Velkomstskjermen er oppdatert';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Kunne ikke laste opp velkomstskjermen';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Velkomstskjermen er fjernet';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Ingen egendefinert velkomstskjerm';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Maskinvareakselerasjon';
@@ -6999,120 +6989,118 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Aktiver maskinvaredekoding for:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-enhet';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Aktiver forbedret NVDEC-dekoder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Foretrekk systemets egen maskinvaredekoder';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Fargedybde for maskinvaredekoding';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bits HEVC-dekoding';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bits VP9-dekoding';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bits dekoding';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bits dekoding';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Maskinvarekoding';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Tillat HEVC-koding';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Tillat AV1-koding';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktiver Intels lavenergi-H.264-koder';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktiver Intels lavenergi-HEVC-koder';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktiver tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Aktiver VPP tone mapping';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktiver VideoToolbox tone mapping';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritme for tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modus for tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Område for tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Avmetning for tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Topp for tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter for tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Lysstyrke for VPP tone mapping';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast for VPP tone mapping';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Forhåndsinnstillinger og kvalitet';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Forhåndsinnstilling for koder';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF for H.264-koding';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF for H.265-koding (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Deinterlace-metode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Doble bildefrekvensen ved deinterlacing';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Lyd';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktiver VBR-koding for lyd';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Forsterkning ved nedmiksing av lyd';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritme for stereonedmiksing';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Maks størrelse på muxekøen';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7130,7 +7118,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminPlaybackFallbackFontPath => 'Reserve skriftbane';
 
   @override
-  String get adminPlaybackStreaming => 'Strømming';
+  String get adminPlaybackStreaming => 'Streaming';
 
   @override
   String get adminResumeVideo => 'Video';
@@ -7235,10 +7223,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminTaskNeverRun => 'Aldri løp';
 
   @override
-  String get adminTaskStop => 'Stopp';
+  String get adminTaskStop => 'Stoppe';
 
   @override
-  String get adminRunningTasks => 'Oppgaver som kjører';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Løp';
@@ -7260,17 +7248,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Daglig kl. $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Hver $day kl. $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Hver $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7308,8 +7296,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count timer',
-      one: '1 time',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7337,17 +7325,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days d siden';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours t siden';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes min siden';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7355,22 +7343,22 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours t';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
@@ -7381,7 +7369,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminNetworkingPublicHttpsPort => 'Offentlig HTTPS-port';
 
   @override
-  String get adminNetworkingBaseUrl => 'Base-URL';
+  String get adminNetworkingBaseUrl => 'Base URL';
 
   @override
   String get adminNetworkingBaseUrlHint => 'f.eks. /jellyfin';
@@ -7390,44 +7378,43 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Offentlig HTTP-port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Krev HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Omdiriger alle eksterne forespørsler til HTTPS. Har ingen effekt hvis serveren ikke har et gyldig sertifikat.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Sertifikatpassord';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-innstillinger';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktiver IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktiver IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Aktiver automatisk porttilordning';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-nettverk';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Komma- eller linjeseparert liste over IP-adresser eller CIDR-subnett som behandles som en del av det lokale nettverket.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publiserte server-URI-er';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Tilordne et subnett eller en adresse til en publisert URL, f.eks. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Sertifikatbane';
@@ -7457,12 +7444,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Gassbuffring';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Forsinkelse for struping (sekunder)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Tillat uttrekking av undertekster underveis';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minste CV-prosent';
@@ -7511,18 +7497,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Kunne ikke oppdatere innholdstypen: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Langsom responsterskel (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktiver advarsler om trege svar';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktiver Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7531,10 +7516,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Baner';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Ytelse';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Bufferbane';
@@ -7546,7 +7531,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminGeneralServerName => 'Servernavn';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Foretrukket visningsspråk';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Kunne ikke laste inn innstillingene';
@@ -7556,12 +7541,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Kunne ikke oppdatere tilordningene: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Tidsgrense: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7598,8 +7583,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# deltakere',
-      one: '# deltaker',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7642,7 +7627,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Element $index';
+    return 'Item $index';
   }
 
   @override
@@ -7690,12 +7675,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName ble med i SyncPlay-gruppen';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName forlot SyncPlay-gruppen';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7707,7 +7692,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Synkroniserer avspilling til $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7745,8 +7730,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rader oppdaget',
-      one: '# rad oppdaget',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7787,20 +7772,20 @@ class AppLocalizationsNb extends AppLocalizations {
   String get offlineSavedMedia => 'Lagrede medier';
 
   @override
-  String get offlineBannerTitle => 'Du er frakoblet';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Viser nedlastingene dine';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Nedlastinger';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Får ikke kontakt med serveren';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Spiller av fra nedlastinger til den er tilbake';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7816,12 +7801,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Cast-kontrollen mislyktes: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind-kontroller';
+    return '$kind Controls';
   }
 
   @override
@@ -7832,7 +7817,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Stopp $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7856,12 +7841,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Angi en $length-sifret PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Angi din $length-sifrede PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7874,42 +7859,41 @@ class AppLocalizationsNb extends AppLocalizations {
   String get pinForgot => 'Glemt PIN-koden?';
 
   @override
-  String get pinClear => 'Tøm';
+  String get pinClear => 'Klar';
 
   @override
   String get pinBackspace => 'Tilbake';
 
   @override
-  String get quickConnectAuthorized =>
-      'Quick Connect-forespørselen er autorisert.';
+  String get quickConnectAuthorized => 'Hurtigkoblingsforespørsel autorisert.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect-koden er ugyldig eller utløpt.';
+      'Hurtigkoblingskoden er ugyldig eller utløpt.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect støttes ikke på denne serveren.';
+      'Hurtigkobling støttes ikke på denne serveren.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Kunne ikke autorisere Quick Connect-koden.';
+      'Kunne ikke autorisere hurtigkoblingskoden.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect er deaktivert på denne serveren.';
+      'Hurtigkobling er deaktivert på denne serveren.';
 
   @override
   String get quickConnectForbidden =>
-      'Kontoen din kan ikke godkjenne denne Quick Connect-forespørselen.';
+      'Kontoen din kan ikke godkjenne denne hurtigkoblingsforespørselen.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect-koden ble ikke funnet. Prøv en ny kode.';
+      'Hurtigkoblingskoden ble ikke funnet. Prøv en ny kode.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect mislyktes: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7920,7 +7904,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Kommandoen mislyktes: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7949,7 +7933,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Kunne ikke starte casting: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7995,7 +7979,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Laster ned $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8076,14 +8060,14 @@ class AppLocalizationsNb extends AppLocalizations {
       'Avspillingen er satt på pause. Ser du fortsatt på?';
 
   @override
-  String get stillWatchingStop => 'Stopp';
+  String get stillWatchingStop => 'Stoppe';
 
   @override
   String get stillWatchingContinue => 'Fortsette';
 
   @override
   String skipSegment(String segment) {
-    return 'Hopp over $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8094,12 +8078,12 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Laster ned $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Laster ned $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8136,7 +8120,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Tillat rotasjon';
 
   @override
-  String get playerTooltipPrevious => 'Forrige';
+  String get playerTooltipPrevious => 'Tidligere';
 
   @override
   String get playerTooltipSeekBack => 'Søk tilbake';
@@ -8160,13 +8144,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get contextMenuGoToSeries => 'Gå til serien';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Skjul fra Fortsett å se';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Skjul fra Neste opp';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Legg til i samling';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8220,14 +8205,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetisk';
 
   @override
-  String get settingsConnectionSection => 'TILKOBLING';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Tillat selvsignerte sertifikater';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Stol på servere som bruker selvsignerte TLS-sertifikater eller sertifikater fra en privat CA. Aktiver bare for servere du selv kontrollerer. Dette deaktiverer sertifikatvalidering for alle tilkoblinger.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PERSONVERN OG SIKKERHET';
@@ -8243,11 +8228,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Temaaksenter, bakgrunner, sett-indikatorer og temamusikk';
 
   @override
-  String get settingsDetailsScreen => 'Detaljskjerm';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, bakgrunnsuskarphet og fanevirkemåte';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Hjemmeside';
@@ -8285,11 +8270,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Vis Seerr-knappen i navigasjonslinjen';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vis alltid tekstetiketter i den øverste navigasjonslinjen';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8336,7 +8321,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Maksimalt antall elementer å laste ned samtidig.';
 
   @override
-  String get settingsAppInfo => 'APPINFO';
+  String get settingsAppInfo => 'APP INFO';
 
   @override
   String get settingsReportAnIssue => 'Rapporter et problem';
@@ -8357,7 +8342,8 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsSupportMoonfin => 'Støtt Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Spander en kaffe på utvikleren';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'LOVLIG';
@@ -8391,8 +8377,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# lisensmerknader',
-      one: '# lisensmerknad',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8442,16 +8428,16 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vil du hoppe over introer og outroer?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Nedtelling for mediesegment';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Fremdriftslinje';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Tidtaker';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ingen';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Spør bruker';
@@ -8475,7 +8461,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Hvordan video skal skaleres for å passe til skjermen.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv => 'Avspillingsmotor (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8485,13 +8471,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (anbefalt)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (eldre)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (eldre)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (anbefalt)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Reserve';
@@ -8681,755 +8667,749 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nylig utgitt i $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Spill av neste episode automatisk';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Spill av neste episode automatisk når den er tilgjengelig.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Hopp over stillhet';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Hopp automatisk over stille lydsegmenter når strømmen støtter det.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Tillat eksterne lydeffekter';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'La equalizer- og effektapper (f.eks. Wavelet) koble seg til Media3-avspillingsøkter.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Deaktiver tunnelering';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Tving avspilling uten tunnelering. Nyttig på enheter med lyd-/videobrudd ved tunnelering.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Aktiver tunnelering';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avansert. Ruter lyd og video gjennom en koblet maskinvarebane. Av som standard fordi det gir lyd-/videobrudd på enkelte enheter.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Tilordne Dolby Vision-profil 7 til HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Spill av Dolby Vision profil 7-strømmer som HDR10-kompatibel HEVC på enheter uten DV-støtte.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Bruk innebygde undertekststiler';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Bruk farger, skrifter og plassering som er innebygd i undertekstsporet. Deaktiver for å bruke dine egne stilinnstillinger i stedet.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Bruk innebygde skriftstørrelser for undertekster';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Bruk hint om skriftstørrelse som er innebygd i undertekstsporet. Deaktiver for å bruke undertekststørrelsen fra stilinnstillingene dine.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Vis mediedetaljer';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Vis detaljer om det valgte elementet øverst på bibliotekssidene.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Skjul bakgrunnsbilder mens du blar?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Bruk detaljerte underoverskrifter';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Vis en detaljert eller minimal underrad på bibliotekssidene.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle =>
-      'Vil du slette det lagrede temaet?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Vil du fjerne «$themeName» fra bufferen på denne enheten?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Temabutikk';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Bla gjennom og lagre temaer fra fellesskapet';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Lagre et tema for å bruke det som de andre lagrede temaene dine.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Ingen temaer er tilgjengelige akkurat nå.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Kunne ikke laste inn Temabutikken. Sjekk tilkoblingen og prøv igjen.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Lagre';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Lagre og bruk';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Lagret';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Dette temaet kunne ikke lastes inn.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Lagret «$themeName».';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Slettet «$themeName» fra denne enheten.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Kunne ikke slette «$themeName».';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Lagrede temaer';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Dette er temaer som er lastet ned fra Moonfin-tillegget for den gjeldende serveren. Sletting fjerner bare denne lokale kopien.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Fant ingen lagrede temaer for denne serveren.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Aktiv nå';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Slett lagret tema';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Administrer nedlastede tilleggstemaer på denne enheten';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Temaredigering';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Åpne temaredigering for Moonfin i nettleseren';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Startskjerm';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Bunnlinje';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klassisk';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderne';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Hjem-rader';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Visning av hjem-rader';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Hjem-radseksjoner';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Brytere for hjem-rader';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Aktiver eller deaktiver bibliotekbaserte kategorier for hjem-rader';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktiver bryterne nedenfor for å vise radene i Hjem-seksjonene.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klassisk beholder bildetype og infooverlegg per rad. Moderne bruker rader fra portrett til bakgrunnsbilde.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Vis favorittrader';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Vis rader med favorittfilmer, -serier og andre favoritter i Hjem-seksjonene.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortering av favorittrader';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sorter favorittrader etter lagt til-dato, utgivelsesdato, alfabetisk og mer.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Vis samlingsrader';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Vis samlingsrader i Hjem-seksjonene.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortering av samlingsrader';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sorter samlingsrader etter lagt til-dato, utgivelsesdato, alfabetisk og mer.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Vis sjangerrader';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'Vis sjangerrader i Hjem-seksjonene.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortering av sjangerrader';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sorter sjangerrader etter lagt til-dato, utgivelsesdato, alfabetisk og mer.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementer i sjangerrader';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Vis filmer, serier eller begge deler i sjangerrader.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Vis spillelisterader';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Vis spillelisterader i Hjem-seksjonene.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortering av spillelisterader';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sorter spillelisterader etter lagt til-dato, utgivelsesdato, alfabetisk og mer.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Vis lydrader';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'Vis lydrader i Hjem-seksjonene.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortering av lydrader';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sorter lydrader etter lagt til-dato, utgivelsesdato, alfabetisk og mer.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Lydspillelister';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Utseende';
+  String get appearance => 'Appearance';
 
   @override
   String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastatur';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Knapper';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Gjengivelse';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-konfigurasjon';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Ekstern spillerapp';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Angi en ekstern spiller for å aktivere avspilling ved langt trykk';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Vis appvelgeren når avspillingen starter.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Laster inn installerte spillere...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Tilkobling';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Mål for lydomkoding';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Støttes på denne enheten';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Støttes ikke på denne enheten';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD)-passthrough';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Send DTS:X (DTS UHD) som bitstrøm til ekstern dekoder.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD med Atmos (JOC)-passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Virkemåte for mediespiller';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Avspillingsforbedringer';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Alltid på.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Erstatt Hopp over outro med Neste opp-visning';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Vis Neste opp-overlegget i stedet for Hopp over outro-knappen.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Spillerruting';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Foretrekk programvaredekodere';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Bruk FFmpeg (lyd) og libgav1 (AV1) før maskinvaredekodere. Deaktiver hvis HDMI-lydpassthrough slutter å virke.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Åpne videoavspilling i den valgte eksterne appen på Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatisk køing';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Foretrekk SDH-undertekster';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Prioriter SDH-/CC-undertekstspor ved automatisk valg.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Nettdiagnostikk';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin nettdiagnostikk';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Bruk denne siden til å diagnostisere tilkoblingsproblemer i nettleseren (CORS, blandet innhold og oppdagelsesinnstillinger).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Oppdaget feil med blandet innhold';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Oppdaget CORS-/preflight-feil';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin oppdaget en HTTPS-side som prøver å kalle en HTTP-server-URL. Nettlesere blokkerer denne forespørselen før den når serveren din.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin oppdaget en forespørselsfeil på nettlesernivå som vanligvis skyldes manglende CORS- eller preflight-hoder på medieserveren.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Mål-URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detalj: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Gjeldende kjøretidskontekst';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Protokoll';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Tilleggsmodus';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC-skanning';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Tvunget server-URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Standard server-URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL for oppdagelsesproxy';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'ikke konfigurert';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Blandet innhold';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Denne siden lastes over HTTPS, men én eller flere konfigurerte URL-er bruker HTTP. Nettlesere blokkerer HTTPS-sider fra å kalle HTTP-API-er.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Løsning: server medieserveren eller proxy-endepunktet via HTTPS, eller last Moonfin over HTTP bare på klarerte lokale nettverk.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Ingen åpenbar konfigurasjon med blandet innhold ble oppdaget ut fra gjeldende kjøretidsinnstillinger.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS-sjekkliste';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Tillat nettleserens origin i Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Inkluder Authorization, X-Emby-Authorization og X-Emby-Token i Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Eksponer Content-Range og Accept-Ranges for strømming og spoling.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Returner 204 på OPTIONS-preflight-forespørsler.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Eksempel på header-utdrag (nginx-stil)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Merk';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Denne diagnostikkruten er ment for nettbygg. Hvis du ser dette på en annen plattform, gjelder kanskje ikke disse kontrollene.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Tilbake til servervalg';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Logg av alle brukere';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Mikrofontillatelsen er permanent avslått. Aktiver den i systeminnstillingene.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Mikrofontillatelse kreves for talesøk.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Fikk ikke med meg det. Prøv igjen.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Ingen tale ble oppdaget.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Mikrofonfeil.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Talesøk krever internett.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => 'Taletjenesten er opptatt. Prøv igjen.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Mikrofontillatelsen er permanent avslått.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Mikrofontillatelsen er avslått.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Talegjenkjenning er ikke tilgjengelig på denne enheten.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Åpne iOS-rutevelgeren';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay-rutevelgeren er ikke tilgjengelig på denne enheten.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videoer';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programmer';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Sanger';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Fotoalbum';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Bilder';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Personer';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Nylig utgitte episoder';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Se igjen';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Gjesteopptredener';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Opptredener (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Bidrag fra teamet (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Se med gruppe';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Feil';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Advarsler';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Åpne i nettleser';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Innebygd nettleser er ikke tilgjengelig på denne plattformen.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Er du sikker på at du vil starte serveren på nytt?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Er du sikker på at du vil slå av serveren? Du må starte den manuelt igjen.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Intern';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inaktiv';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Fant ingen brukere';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Ingen brukere samsvarer med søket';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Fant ingen enheter';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Ingen enheter samsvarer med gjeldende filtre';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Passord angitt';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Ingen passord konfigurert';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Ekstern tilgang';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Kun lokalt';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Kunne ikke laste inn medieanalysen';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Samlet analyse på tvers av alle mediebiblioteker.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Toppartister';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Toppforfattere';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Toppbidragsytere';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count biblioteker',
-      one: '1 bibliotek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Ingen indekserte medietotaler er tilgjengelige for dette utvalget ennå.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Bibliotekdetaljer';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Bibliotekfordeling';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'Ingen biblioteker er tilgjengelige.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Serveradministrasjon';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
   String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Bildebuffer';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Buffer';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Logger';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Omkoding';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Denne serveren returnerte ingen serverbaner.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent % brukt';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Brukeraktivitet';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Systemhendelser';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Krever oppmerksomhet';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Avspilling';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Enheter';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avansert';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Tillegg';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Direktesendt TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Hjemmevideoer';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Blandet innhold';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Hjemmevideoer og bilder';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Blandede filmer og serier';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9441,150 +9421,150 @@ class AppLocalizationsNb extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Fant ingen opptak';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Fant ingen bildesider i .$extension-arkivet.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Innebygd gjengiver mislyktes ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB-gjengiver mislyktes ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Mangler lokal fil for leseren: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status ved åpning av bokdata fra $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Ingen lesbart bokendepunkt er tilgjengelig';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Tegneseriearkivformatet støttes ikke: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Tillegget for CBR-utpakking er ikke tilgjengelig på denne plattformen.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Kunne ikke pakke ut .cbr-arkivet.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7-utpakking er ikke tilgjengelig på denne plattformen.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Tillegget for CB7-utpakking er ikke tilgjengelig på denne plattformen.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Lukk sjangerpanelet';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Laster inn tilfeldig rekkefølge...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'TILFELDIG FRA BIBLIOTEK';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'TILFELDIG UTVALG';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'TILFELDIG FRA SJANGRE';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatisk HDR-bytte';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Aktiver HDR automatisk ved avspilling av HDR-video, og gjenopprett visningsmodus ved avslutning.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Ved fullskjerm';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Endre bildemateriell';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Mangler';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Omkodingsgrenser';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Vil du fjerne alt bildemateriell?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Er du sikker på at du vil fjerne alt nedlastet bildemateriell?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Bekreft fjerning';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Er du sikker på at du vil fjerne følgende: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Vil du laste opp?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Oppløsning: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Vis bare bildemateriell på grensesnittspråket';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Bekreft fjerning av alt';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Bildet ble lastet opp!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Kunne ikke laste opp bildet: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Kunne ikke angi bildet: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Kunne ikke slette bildet: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kunne ikke fjerne alt bildemateriell: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Bakgrunnsbilder';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9593,31 +9573,31 @@ class AppLocalizationsNb extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatyrbilde';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafikk';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Plategrafikk';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Skjermbilde';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Boksomslag';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Boksomslag bak';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menygrafikk';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'bakgrunnsbilde';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9626,114 +9606,114 @@ class AppLocalizationsNb extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatyrbilde';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafikk';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'plategrafikk';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'skjermbilde';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'boksomslag';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'boksomslag bak';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menygrafikk';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alle';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Høy (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Middels (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Lav (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Kilder';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitler';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Bokmerker';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notater';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Kø';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Tidslinje';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Tidslinjen er tom';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Hele boken';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokusert tidslinje';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksporter bokmerker';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksporter notater';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksporter alt';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Eksportert til $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksporten mislyktes: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Sangtekster';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Legg til bokmerke';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Legg til notat';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Rediger notat';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Skriv et notat for dette øyeblikket';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Sovetidtaker';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Av';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Slutten av kapitlet';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Egendefinert';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining igjen';
+    return '$remaining left';
   }
 
   @override
@@ -9748,51 +9728,51 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Avspillingshastighet';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Gjenstår';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Forløpt';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Tilbake $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Fram $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Forrige kapittel';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Neste kapittel';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapittel $current av $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Ingen kapitler';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Ingen bokmerker ennå';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Ingen notater ennå';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Bokmerke lagt til ved $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Tilbakestill til 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9800,248 +9780,249 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Lagre';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Avbryt';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Slett';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Undertekstinnstillinger';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Endre undertekstmoduser, standardspråk, utseende og gjengivelsesalternativer.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Undertekstgjengivelse';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Visningsalternativer';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Utgivelsesdato (stigende)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Utgivelsesdato (synkende)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupper bidrag';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupper flere roller';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Advarsel om skrivetilgang til biblioteket';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Slik løser du dette:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Gi skrivetillatelser til Jellyfin-tjenestebrukeren (f.eks. jellyfin eller Docker PUID/PGID) for mediebibliotekmappene på serveren.\n\n2. Eller gå til Jellyfin-dashbordet -> Biblioteker, rediger dette biblioteket og deaktiver «Save artwork into media folders» for å lagre bildemateriell i Jellyfins interne database.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Lukk';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Biblioteket «$libraryName» er konfigurert til å lagre bildemateriell direkte i mediemappene («Save artwork into media folders» er aktivert). Jellyfin har imidlertid testet skrivetilgangen og har ikke tillatelse til å skrive filer til denne katalogen:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Det ser ut til at Jellyfin ikke klarte å oppdatere bildematerialet. Biblioteket ditt er konfigurert til å lagre bildemateriell direkte i mediemappene («Save artwork into media folders» er aktivert). Denne feilen oppstår vanligvis når Jellyfin-serverprosessen ikke har tillatelse til å skrive filer til mediekatalogene dine.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Eksterne lister';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Spill av på nytt';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Filinformasjon';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Størrelse: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Vis alle ($count) lydspor';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Vis alle ($count) undertekstspor';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Kontrollerer Direct Play-kapasitet...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play-kapasitet: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Tvunget';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Containerformatet støttes ikke av spilleren.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Videokodeken støttes ikke.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Lydkodeken støttes ikke.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Undertekstformatet støttes ikke (må brennes inn).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Lydprofilen støttes ikke.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Videoprofilen støttes ikke.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Videonivået støttes ikke.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Videooppløsningen støttes ikke av denne enheten.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Videoens bitdybde støttes ikke.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Videoens bildefrekvens støttes ikke.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Filens bitrate overskrider spillerens strømmegrense.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Videoens bitrate overskrider strømmegrensen.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Lydens bitrate overskrider strømmegrensen.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Antall lydkanaler støttes ikke.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetisk';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Utgivelsesrekkefølge (stigende)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Utgivelsesrekkefølge (synkende)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Egendefinert (dra og slipp)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Sorteringsalternativer for spilleliste';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Tilbakestill sortering';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Se S$season:E$episode på nytt';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Se spillelisten på nytt';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Fant ingen undertekster.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Adminkontroller';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Gjengivelsesmotor (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller er Flutters moderne GPU-gjengiver som gir jevnere animasjoner og mindre hakking. På enkelte TV-bokser og eldre GPU-er kan den forårsake feil eller svart video – slå den av hvis du opplever det. Automatisk velger den beste standardinnstillingen for enheten din. Start Moonfin på nytt for å ta i bruk endringen.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatisk';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'På';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Av';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Omstart kreves';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin må startes på nytt for å endre gjengivelsesmotoren. Lukk appen nå, og åpne den igjen for å ta i bruk endringen.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Lukk appen nå';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Oppdater bibliotek';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Oppdater alle biblioteker';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Lagt til (eldste først)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Lagt til (nyeste først)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetisk (A til Å)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetisk (Å til A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Laster inn serveranalyse... $percentage %';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Samme som kilden';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb topp 250 filmer';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb topp 250 TV-serier';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb mest populære filmer';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb mest populære TV-serier';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb lavest rangerte filmer';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb topprangerte engelske filmer';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -12,27 +12,27 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'ACCOUNTVOORKEUREN';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Interfacetaal';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Systeemstandaard';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Inloggen';
 
   @override
-  String get empty => 'Leeg';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Verbinden met $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Snel verbinden';
 
   @override
   String get password => 'Wachtwoord';
@@ -61,12 +61,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect niet beschikbaar: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect niet beschikbaar ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -107,7 +107,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '\"$serverName\" uit uw servers verwijderen?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -142,62 +142,62 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsAppearanceTheme => 'App-thema';
 
   @override
-  String get detailScreenStyle => 'Stijl van detailscherm';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassiek is de oorspronkelijke gecentreerde moonfin-lay-out. Modern is een responsieve, filmische lay-out.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassiek';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Uitgeklapte tabbladen';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Toon tabbladinhoud automatisch tijdens het bladeren. Zet dit uit om elk tabblad handmatig te openen en te sluiten.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Technische details tonen?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Toon codec-, resolutie- en streaminformatie in de bannersamenvatting';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Aanbevelingssysteem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Gebruik het lokale bibliotheekalgoritme van Moonfin Recommends of de online gelijkeniswaarden van TMDb. Let op: online aanbevelingen vereisen Seerr-integratie.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-gelijkenis';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Leeftijdsclassificatielimiet toepassen?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Beperk suggesties van Moonfin Recommends op basis van de leeftijdsclassificatie van de betreffende media';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Interfacestijl';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatisch past zich aan uw apparaat aan. Kies Apple of Material om een vaste look af te dwingen.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatisch';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,38 +206,38 @@ class AppLocalizationsNl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glaskwaliteit';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto kiest het beste glaseffect voor dit apparaat. Volledig dwingt echte vervaging af; Beperkt gebruikt een lichtgewicht glas dat GPU-vermogen bespaart.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Volledig';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Beperkt';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Schakel tussen Moonfin en Neon Pulse zonder de app opnieuw te starten';
 
   @override
-  String get customThemeTitle => 'Aangepast thema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Aangepaste thema\'s veranderen visuele elementen in heel Moonfin. Kies een van deze opties die bij uw stijl past.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Voorkeur voor systeemtoetsenbord';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Gebruik standaard de invoermethode van uw apparaat voor tekstinvoer';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -258,14 +258,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid glass-styling met een zwevende gradiëntachtergrond, matglazen oppervlakken en een Apple-blauw accent';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixelart-styling met een stevig palet, blokkerige randen, harde slagschaduwen en een pixellettertype';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -315,7 +315,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Kan geen verbinding maken met $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -331,32 +331,32 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Gepauzeerd';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Status opslaan';
+  String get gameSaveState => 'Save state';
 
   @override
   String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Status laden';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Vooruitspoelen';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulatorinstellingen';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Deze core heeft geen aanpasbare opties.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Houd ingedrukt om het menu te openen';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Games afspelen wordt op dit apparaat nog niet ondersteund.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Er konden geen thuisrijen worden geladen';
@@ -378,13 +378,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get schedule => 'Schema';
 
   @override
-  String get series => 'Series';
+  String get series => 'Serie';
 
   @override
   String get noItemsFound => 'Geen artikelen gevonden';
 
   @override
-  String get home => 'Home';
+  String get home => 'Thuis';
 
   @override
   String get browseAll => 'Blader door alles';
@@ -429,7 +429,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Kan map niet laden: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -534,17 +534,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '${count}m geleden';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '${count}u geleden';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '${count}d geleden';
+    return '${count}d ago';
   }
 
   @override
@@ -579,7 +579,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count titels';
+    return '$count titles';
   }
 
   @override
@@ -666,7 +666,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count auteurs';
+    return '$count authors';
   }
 
   @override
@@ -676,7 +676,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% voltooid';
+    return '$percent% completed';
   }
 
   @override
@@ -693,7 +693,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titels, geordend om lezend te bladeren.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -730,7 +730,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Geen $label gevonden';
+    return 'No $label found';
   }
 
   @override
@@ -767,43 +767,43 @@ class AppLocalizationsNl extends AppLocalizations {
   String get books => 'Boeken';
 
   @override
-  String get latestBooks => 'Nieuwste boeken';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Nieuwste audioboeken';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count boeken',
-      one: '1 boek',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Boek';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audioboek';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% gelezen';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Nog $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lezen';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Luisteren';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Auteur';
@@ -841,12 +841,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count secties';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Eerste uitgave $year';
+    return 'First published $year';
   }
 
   @override
@@ -861,7 +861,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count boeken';
+    return '$count books';
   }
 
   @override
@@ -872,7 +872,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Auteurs';
+    return '$count Authors';
   }
 
   @override
@@ -880,8 +880,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audioboeken',
-      one: '1 audioboek',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -929,7 +929,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get movies => 'Films';
 
   @override
-  String get musicVideos => 'Videoclips';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Ander';
@@ -948,7 +948,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Schijf $number';
+    return 'Disc $number';
   }
 
   @override
@@ -974,7 +974,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Uitgegeven in $year';
+    return 'Published $year';
   }
 
   @override
@@ -985,28 +985,28 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Seizoenen',
-      one: '1 Seizoen',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Eindigt om $time';
+    return 'Ends at $time';
   }
 
   @override
   String get items => 'Items';
 
   @override
-  String get extras => 'Extra\'s';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Achter de schermen';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Verwijderde scènes';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
@@ -1015,22 +1015,22 @@ class AppLocalizationsNl extends AppLocalizations {
   String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scènes';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Korte films';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'Nog $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Eindigt over $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1044,7 +1044,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Hervatten vanaf $position';
+    return 'Resume from $position';
   }
 
   @override
@@ -1072,7 +1072,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get version => 'Versie';
 
   @override
-  String get cast => 'Casten';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Trailer';
@@ -1143,7 +1143,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Gedownloade tracks voor \"$title\" verwijderen?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1158,17 +1158,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Geen $itemLabel geladen';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title downloaden ($count items)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Weet u zeker dat u \"$name\" van de server wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1179,7 +1179,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Niet-ondersteund boekformaat: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1207,7 +1207,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Ondertitel gedownload en geselecteerd: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1216,7 +1216,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Geen externe ondertitels gevonden voor $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1224,7 +1224,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Versie $number';
+    return 'Version $number';
   }
 
   @override
@@ -1245,7 +1245,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name downloaden ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1253,7 +1253,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Lokale bestanden voor $typeLabel verwijderen?\n\nDit maakt opslagruimte vrij. U kunt ze later opnieuw downloaden.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1269,25 +1269,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String get director => 'DIRECTEUR';
 
   @override
-  String get directors => 'REGISSEURS';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCHRIJVER';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARISTEN';
+  String get writers => 'SCHRIJVERS';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count meer';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count Afleveringen';
+    return '$count Episodes';
   }
 
   @override
@@ -1297,12 +1297,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Aflevering $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Hoofdstuk $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1321,25 +1321,25 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hoofdstukken',
-      one: '1 hoofdstuk',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Geboren $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Overleden $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Leeftijd $age';
+    return 'Age $age';
   }
 
   @override
@@ -1352,13 +1352,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shuffle => 'Willekeurig';
 
   @override
-  String get shuffleAllMusic => 'Alle muziek willekeurig afspelen';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Meld u aan bij Moonfin op uw telefoon';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Kan uw server niet bereiken';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1370,7 +1370,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1381,32 +1381,32 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Voor $action van externe ondertitels is de Jellyfin-machtiging voor ondertitelbeheer vereist voor deze gebruiker.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Dit item kon niet op de server worden gevonden voor $action van externe ondertitels.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '$action van externe ondertitels mislukt: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '$action van externe ondertitels mislukt (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Kan externe ondertitels niet $action.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'alle gedownloade afleveringen van \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1438,17 +1438,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Actie $label mislukt: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Kan castvolume niet instellen: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label-bediening';
+    return '$label Controls';
   }
 
   @override
@@ -1458,14 +1458,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get unavailable => 'Niet beschikbaar';
 
   @override
-  String get pause => 'Pauzeren';
+  String get pause => 'Pauze';
 
   @override
   String get syncPosition => 'Synchroniseer positie';
 
   @override
   String stopCast(String label) {
-    return '$label stoppen';
+    return 'Stop $label';
   }
 
   @override
@@ -1490,7 +1490,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds seconden';
+    return '$seconds seconds';
   }
 
   @override
@@ -1532,7 +1532,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get subtitleDelay => 'Ondertitelvertraging';
 
   @override
-  String get reset => 'Resetten';
+  String get reset => 'Opnieuw instellen';
 
   @override
   String get unknown => 'Onbekend';
@@ -1583,7 +1583,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoBitrate => 'Video-bitsnelheid';
 
   @override
-  String get track => 'Track';
+  String get track => 'Spoor';
 
   @override
   String get channels => 'Kanalen';
@@ -1605,12 +1605,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Fout in $protocol-sessie';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Kan boekgegevens niet laden: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1619,7 +1619,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Dit formaat (.$extension) kan nog niet in de app worden weergegeven.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1631,17 +1631,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Kan de ingebouwde lezer niet openen: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Er is al een bladwijzer opgeslagen bij $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Bladwijzer toegevoegd: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1653,7 +1653,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Pagina $number';
+    return 'Page $number';
   }
 
   @override
@@ -1664,12 +1664,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Formaat: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% gelezen';
+    return '$percent% read';
   }
 
   @override
@@ -1693,7 +1693,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Zoom herstellen (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1716,7 +1716,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Kan leesstatus niet bijwerken: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1748,7 +1748,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Dit platform kan de ingesloten documentengine voor $extension-bestanden niet uitvoeren.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1787,7 +1787,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Kan gids niet laden: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1798,22 +1798,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Straks: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Nog ${minutes}m';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Nog ${hours}u';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Nog ${hours}u ${minutes}m';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1836,29 +1836,29 @@ class AppLocalizationsNl extends AppLocalizations {
   String get favoriteChannel => 'Favoriete kanaal';
 
   @override
-  String get record => 'Opnemen';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Opname annuleren';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Programma wordt opgenomen';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Opname geannuleerd';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Kan opname niet aanmaken';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Kijken';
+  String get watch => 'Bekijken';
 
   @override
   String get close => 'Sluiten';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Kan $name niet afspelen';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1884,7 +1884,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Geplande opname van \"$name\" annuleren?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1910,7 +1910,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Opname van \"$name\" stoppen?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1925,12 +1925,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Geen resultaten voor \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Zoeken mislukt: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1971,7 +1971,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" en de bijbehorende bestanden verwijderen?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
@@ -1987,12 +1987,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Kan album niet laden: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Geen gedownloade tracks gevonden voor $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2009,7 +2009,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" verwijderen?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2019,12 +2019,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'S$season A$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Aflevering $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2038,7 +2038,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Seizoen $number';
+    return 'Season $number';
   }
 
   @override
@@ -2054,7 +2054,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Alle gedownloade afleveringen in $season verwijderen?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2062,8 +2062,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count afleveringen',
-      one: '1 aflevering',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2098,7 +2098,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '$count gedownloade items verwijderen?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2112,7 +2112,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'van $limit limiet';
+    return 'of $limit limit';
   }
 
   @override
@@ -2195,7 +2195,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count opties';
+    return '$count options';
   }
 
   @override
@@ -2290,7 +2290,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detailpagina\'s, startrijen en volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2305,11 +2305,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Speel af tijdens het bladeren door het startscherm';
 
   @override
-  String get loopThemeMusic => 'Themamuziek herhalen';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Herhaal de track in plaats van hem één keer af te spelen';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Details Achtergrondvervaging';
@@ -2333,17 +2333,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get playerZoomMode => 'Spelerzoommodus';
 
   @override
-  String get settingsScrollWheelAction => 'Muiswiel';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Kies wat er tijdens het afspelen gebeurt als u met het muiswiel over de video scrolt.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Uit';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Spoelen (vooruit / terug)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2364,7 +2364,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get refreshRateSwitching => 'Wisselen van vernieuwingsfrequentie';
 
   @override
-  String get disabled => 'Uitgeschakeld';
+  String get disabled => 'Gehandicapt';
 
   @override
   String get scaleOnTv => 'Schaal op tv';
@@ -2403,37 +2403,37 @@ class AppLocalizationsNl extends AppLocalizations {
   String get defaultAudioLanguage => 'Standaard audiotaal';
 
   @override
-  String get fallbackAudioLanguage => 'Terugvaltaal voor audio';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Voorkeur voor standaard audiotrack';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Geef de voorkeur aan de originele audiotrack boven de nagesynchroniseerde versie.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Voorkeur voor audiodescriptietracks';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Geef de voorkeur aan audiodescriptietracks boven normale tracks.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcoderen (audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
   String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcoderen (bitsnelheid of resolutie)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcoderen (video en audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcoderen (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatisch (serverstandaard)';
@@ -2463,7 +2463,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get korean => 'Koreaans';
 
   @override
-  String get chinese => 'Chinees';
+  String get chinese => 'Chinese';
 
   @override
   String get russian => 'Russisch';
@@ -2510,28 +2510,27 @@ class AppLocalizationsNl extends AppLocalizations {
       'Schakel TrueHD-audio in (werkt mogelijk niet op alle platforms)';
 
   @override
-  String get settingsAudioOutputMode => 'Audio-uitvoermodus';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Kies hoe audio wordt gedecodeerd. AVR Passthrough stuurt onbewerkte Dolby/DTS-streams naar uw receiver; Auto of Downmix decodeert lokaal.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Terugvalcodec voor audio';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Selecteer het doelformaat waarnaar meerkanaalsaudio wordt getranscodeerd wanneer de bronstream niet direct kan worden afgespeeld of doorgegeven.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automatisch detecteren\n(Aanbevolen)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Standaard)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2540,27 +2539,26 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Verliesvrij)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Alleen stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficiënt)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Verliesvrij)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max. audiokanalen';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Stel het maximale aantal kanalen van uw audio-opstelling in. Meerkanaalsstreams die deze limiet overschrijden worden gedownmixt of getranscodeerd.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automatisch detecteren\n(Hardwarestandaard)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2572,7 +2570,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrafonisch';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2587,68 +2585,67 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (geavanceerd)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Codec-passthrough';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Schakel alleen formaten in die uw AVR of HDMI-apparaat ondersteunt.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3-passthrough';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos)-passthrough';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core-passthrough';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA-passthrough';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD-passthrough';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos-passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) als bitstream naar een externe decoder sturen.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Dolby Atmos via EAC3 (JOC) als bitstream naar een externe decoder sturen.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (inclusief DTS-core) als bitstream naar een externe decoder sturen.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Dolby TrueHD met Atmos-metagegevens als bitstream naar een externe decoder sturen.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Gedetecteerde audiomogelijkheden';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Nog geen momentopname van runtimemogelijkheden beschikbaar.';
+      'No runtime capability snapshot available yet.';
 
   @override
   String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Decoderen';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD-audioroute';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2663,50 +2660,50 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Luidspreker';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Koptelefoon';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostiek';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Videoniveau';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Videobereik';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Ondertitelcodec';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Toegestane audiocodecs';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS-audiocodecs';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4-audiocodecs';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Actieve audioroute';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'HD-audio-ondersteuning van route';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nachtmodus';
@@ -2770,7 +2767,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Na $episodes afleveringen / $hours u';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2846,45 +2843,45 @@ class AppLocalizationsNl extends AppLocalizations {
       'Pas de weergave van ondertitels aan';
 
   @override
-  String get subtitleMode => 'Ondertitelmodus';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Gemarkeerd';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Altijd';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Anderstalig';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Geforceerd';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Speelt tracks af die in de metagegevens van het mediabestand intern zijn gemarkeerd als \"default\" of \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Laadt en toont automatisch ondertitels telkens wanneer een video start.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Schakelt ondertitels automatisch in als de standaard audiotrack in een vreemde taal is.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Laadt alleen ondertitels die expliciet zijn gemarkeerd met de forced-metagegevensvlag.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Schakelt het automatisch laden van ondertitels volledig uit.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Terugvaltaal voor ondertitels';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Ondertitelstream';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2944,17 +2941,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Profielinstellingen van $profile geladen.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Kan profielinstellingen van $profile niet laden.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Lokale instellingen gesynchroniseerd met profiel $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3090,10 +3087,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Bibliotheken weergeven in de werkbalk';
 
   @override
-  String get navbarAlwaysExpanded => 'Navigatiebalklabels altijd uitklappen';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr-knop tonen';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navigatiebalkdekking';
@@ -3168,19 +3165,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Toon de mapzoekoptie';
 
   @override
-  String get groupItemsIntoCollections => 'Items groeperen in collecties';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Verberg bibliotheekitems die bij een collectie horen tijdens het bladeren door bibliotheken';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Melding over bibliotheekgroepering';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Om deze instelling te gebruiken, moet u ervoor zorgen dat de bibliotheekinstellingen \"Group movies into collections\" en/of \"Group shows into collections\" zijn ingeschakeld onder de weergave-instellingen van uw bibliotheek op uw Jellyfin- of Emby-server.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Zichtbaarheid van de bibliotheek';
@@ -3209,7 +3205,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count geselecteerd';
+    return '$count selected';
   }
 
   @override
@@ -3292,11 +3288,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Trailers worden na 3 seconden automatisch afgespeeld in de mediabalk';
 
   @override
-  String get trailerAudio => 'Traileraudio';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Audio inschakelen voor trailers in de mediabalk';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Aflevering voorbeeld';
@@ -3373,11 +3368,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get combineBothRows => 'Combineer beide rijen tot één woongedeelte';
 
   @override
-  String get fullScreenRows => 'Uitgeklapte startrijen';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Beperk startrijen tot 1 rij per scherm';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Per rij afbeeldingstype';
@@ -3392,7 +3386,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get lastUser => 'Laatste gebruiker';
 
   @override
-  String get currentUser => 'Huidige gebruiker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Altijd authenticeren';
@@ -3500,10 +3494,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Klok weergeven tijdens screensaver';
 
   @override
-  String get clockModeStatic => 'Statisch';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Stuiterend';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (critici)';
@@ -3576,7 +3570,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Schakel de beoordelingsbronnen in die in de app worden weergegeven en herschik ze';
 
   @override
-  String get pluginLabel => 'Moonbase-plug-in';
+  String get pluginLabel => 'Plug-in';
 
   @override
   String get pluginDetected => 'Plug-in gedetecteerd';
@@ -3594,7 +3588,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersie: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3648,7 +3642,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get networks => 'Netwerken';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-ontdekkingsrijen';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Zet rijen terug naar de standaardwaarden';
@@ -3672,44 +3666,44 @@ class AppLocalizationsNl extends AppLocalizations {
       'Inhoud voor volwassenen verbergen in de resultaten';
 
   @override
-  String get seerrNotificationsSection => 'Meldingen';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Meldingen voor nieuwe verzoeken';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Waarschuw mij wanneer iemand een verzoek indient';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Verzoekupdates';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Goedgekeurd, afgewezen en toegevoegd aan uw bibliotheek';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Probleemupdates';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nieuwe problemen, reacties en oplossingen';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Ingelogd als: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr-ontdekkingspagina';
+  String get discoverRows => 'Ontdek rijen';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Schakel de rijen in die je op de hoofdpagina van Seerr wilt zien. Sleep om de volgorde te wijzigen. De aangepaste volgorde wordt gesynchroniseerd met Moonbase.';
+      'Sleep om de volgorde te wijzigen. Rijen in- of uitschakelen. Synchronisatie van rijvolgorde ingeschakeld met de Moonfin-plug-in.';
 
   @override
   String get discoverRowsDescription =>
-      'Schakel de rijen in die je op de hoofdpagina van Seerr wilt zien. Sleep om de volgorde te wijzigen. De aangepaste volgorde wordt gesynchroniseerd met Moonbase.';
+      'Sleep om de volgorde te wijzigen. Rijen in- of uitschakelen.';
 
   @override
   String get enabled => 'Ingeschakeld';
@@ -3722,7 +3716,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Versie $version';
+    return 'Version $version';
   }
 
   @override
@@ -3772,7 +3766,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Update beschikbaar: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3784,7 +3778,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version beschikbaar';
+    return 'v$version Available';
   }
 
   @override
@@ -3848,7 +3842,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get imageCacheCleared => 'Afbeeldingscache gewist';
 
   @override
-  String get clear => 'Wissen';
+  String get clear => 'Duidelijk';
 
   @override
   String get browse => 'Blader';
@@ -3864,11 +3858,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Downloaden · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importeren';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3892,7 +3886,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Aangevraagd door $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3909,12 +3903,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Verzoek voor \"$title\" annuleren?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '$count verzoeken voor \"$title\" annuleren?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3934,7 +3928,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String revenueAmount(String amount) {
-    return 'Opbrengst: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3944,7 +3938,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type aanvragen';
+    return 'Request $type';
   }
 
   @override
@@ -3979,7 +3973,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'leeftijd $age';
+    return 'age $age';
   }
 
   @override
@@ -4010,102 +4004,102 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deletedStatus => 'Verwijderd';
 
   @override
-  String get failedStatus => 'Mislukt';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Wordt verwerkt';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Gewijzigd door $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Voltooid';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Deze titel is al aangevraagd';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Verzoeklimiet bereikt';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Deze titel staat op de blokkeerlijst';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Geen seizoenen meer om aan te vragen';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'U hebt geen toestemming om dit verzoek te doen';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Verzoeken';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemen';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nieuwste';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Laatst gewijzigd';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Geen problemen';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Nog $remaining van $limit filmverzoeken over';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Nog $remaining van $limit seizoensverzoeken over';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Onderdeel van $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Collectie bekijken';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Collectie aanvragen';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total films · $available beschikbaar';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count films aanvragen';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$current van $total aanvragen...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count films aangevraagd';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok van $total films aangevraagd';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alle films zijn al beschikbaar of aangevraagd';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Probleem melden';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4114,44 +4108,44 @@ class AppLocalizationsNl extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Wat is er mis?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alle afleveringen';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Aflevering';
+  String get episode => 'Episode';
 
   @override
   String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Opgelost';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Oplossen';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Heropenen';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Gemeld door $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count reacties';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Een reactie toevoegen';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Dit probleem verwijderen?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Melding verzenden';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-score';
@@ -4268,7 +4262,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get refresh => 'Vernieuwen';
 
   @override
-  String get remote => 'Afstandsbediening';
+  String get remote => 'Op afstand';
 
   @override
   String get rename => 'Hernoemen';
@@ -4304,7 +4298,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get status => 'Status';
 
   @override
-  String get stop => 'Stoppen';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Streamen';
@@ -4313,7 +4307,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get time => 'Tijd';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trucspel';
 
   @override
   String get uninstall => 'Verwijderen';
@@ -4322,7 +4316,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get up => 'Omhoog';
 
   @override
-  String get update => 'Bijwerken';
+  String get update => 'Update';
 
   @override
   String get upload => 'Uploaden';
@@ -4355,13 +4349,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotheken';
 
   @override
-  String get adminDrawerDisplay => 'Weergave';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metagegevens';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-instellingen';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcoderen';
@@ -4373,7 +4367,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminDrawerStreaming => 'Streamen';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trucspel';
 
   @override
   String get adminDrawerDevices => 'Apparaten';
@@ -4424,22 +4418,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Beschikbare plug-in-updates: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Plug-ins die opnieuw opstarten vereisen: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Mislukte geplande taken: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Recente waarschuwings-/foutmeldingen: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4498,7 +4492,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Fout: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4526,7 +4520,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Opdracht mislukt: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4575,7 +4569,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audioCodec => 'Audiocodec';
 
   @override
-  String get hwAccel => 'HW-versnelling';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Voltooiing';
@@ -4590,14 +4584,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminClearDates => 'Duidelijke data';
 
   @override
-  String get adminActivitySeverityAll => 'Alle ernstniveaus';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datumbereik';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Kan activiteitenlogboek niet laden: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4614,7 +4608,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Kan apparaat niet bijwerken: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4625,28 +4619,28 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Kan apparaat niet verwijderen: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Apparaat \'$name\' verwijderen? De gebruiker moet zich op dit apparaat opnieuw aanmelden.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Alle apparaten verwijderen';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count apparaten verwijderen? Betrokken gebruikers moeten zich opnieuw aanmelden. Uw huidige apparaat wordt niet beïnvloed.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Apparaten verwijderd';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Enkele apparaten verwijderd; $count konden niet worden verwijderd.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4675,7 +4669,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Kan scan niet starten: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4686,12 +4680,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Bibliotheek hernoemd naar \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Hernoemen mislukt: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4699,17 +4693,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Bibliotheek \"$name\" verwijderd';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Kan bibliotheek niet verwijderen: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Kan pad niet toevoegen: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4717,12 +4711,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '\"$path\" uit deze bibliotheek verwijderen?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Kan pad niet verwijderen: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4730,7 +4724,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Kan opties niet opslaan: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4761,263 +4755,251 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminMetadataCountryHint => 'bijv. VS, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Paden';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opties';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
   String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metagegevensbewaarders';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Ondertiteldownloaders';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Songtekstdownloaders';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metagegevensdownloaders: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Afbeeldingsophalers: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Deze server biedt geen downloaders voor dit bibliotheektype.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Algemeen';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metagegevens';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Ingesloten informatie';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Ondertitels';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Afbeeldingen';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
   String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muziek';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Films';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Realtimemonitoring inschakelen';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detecteer bestandswijzigingen en verwerk ze automatisch.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Archieven behandelen als mediabestanden';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Foto\'s weergeven';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Afbeeldingen opslaan in mediamappen';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Metagegevens automatisch vernieuwen';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nooit';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Standaard';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Weergave';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Bibliotheekweergave';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Een mapweergave tonen voor gewone mediamappen';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Specials tonen binnen het seizoen waarin ze zijn uitgezonden';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Films groeperen in collecties';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Series groeperen in collecties';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Externe inhoud tonen bij suggesties';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Gedrag van datum toegevoegd';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Datum toegevoegd overnemen van';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Datum waarop het in de bibliotheek is gescand';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum waarop het bestand is aangemaakt';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metagegevens en afbeeldingen';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Voorkeurstaal voor metadata';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Hoofdstukken';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Duur van tijdelijke hoofdstukken (seconden)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Lengte van hoofdstukken die worden gegenereerd voor media zonder hoofdstukken. Stel in op 0 om uit te schakelen.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolutie van hoofdstukafbeeldingen';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-instellingen';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metagegevens zijn compatibel met Kodi en vergelijkbare clients. Instellingen gelden voor alle bibliotheken die NFO-metagegevens opslaan.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Gebruiker van wie kijkgegevens in NFO-bestanden worden opgeslagen';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Afbeeldingspaden opslaan in NFO-bestanden';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Padvervanging inschakelen voor NFO-afbeeldingspaden';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart-afbeeldingen kopiëren naar een extrathumbs-map';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Geen';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dagen';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Ingesloten titels gebruiken';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Ingesloten titels gebruiken voor extra\'s';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Ingesloten afleveringsinformatie gebruiken';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Ingesloten ondertitels toestaan';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Alles toestaan';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Alleen tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Alleen afbeeldingen';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Geen';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Download overslaan als er ingesloten ondertitels aanwezig zijn';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Download overslaan als de audiotrack overeenkomt met de downloadtaal';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Een perfecte ondertitelovereenkomst vereisen';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Ondertitels opslaan in mediamappen';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'Hoofdstukafbeeldingen extraheren';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Hoofdstukafbeeldingen extraheren tijdens de bibliotheekscan';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Extractie van trickplay-afbeeldingen inschakelen';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Trickplay-afbeeldingen extraheren tijdens de bibliotheekscan';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay-afbeeldingen opslaan in mediamappen';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Series die over meerdere mappen zijn verspreid automatisch samenvoegen';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Weergavenaam voor seizoen nul';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'LUFS-scan inschakelen voor audionormalisatie';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Voorkeur voor niet-standaard artiesten-tag';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Films automatisch aan collecties toevoegen';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Bibliotheeknaam is vereist';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Kan bibliotheek niet aanmaken: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5044,27 +5026,27 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name uitschakelen? Deze gebruiker kan zich dan niet meer aanmelden.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name inschakelen? Deze gebruiker kan zich dan weer aanmelden.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Gebruiker \"$name\" uitgeschakeld';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Gebruiker \"$name\" ingeschakeld';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Kan gebruikersbeleid niet bijwerken: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5081,7 +5063,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Kan gebruiker niet aanmaken: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5102,7 +5084,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Opslaan mislukt: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5113,7 +5095,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Mislukt: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5249,145 +5231,143 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminEnableAllChannels => 'Schakel toegang tot alle kanalen in';
 
   @override
-  String get adminParentalControl => 'Ouderlijk toezicht';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Maximaal toegestane leeftijdsclassificatie';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Inhoud met een hogere classificatie wordt voor deze gebruiker verborgen.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Geen';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Items zonder of met onbekende classificatie blokkeren';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Boeken';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanalen';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
   String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Films';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muziek';
+  String get adminUnratedMusic => 'Music';
 
   @override
   String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Series';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Toegangsschema\'s';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Sta alleen toegang toe tijdens de onderstaande geplande tijden. Als er geen schema is ingesteld, is toegang de hele dag toegestaan.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Schema toevoegen';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dag';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Begin';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Einde';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Elke dag';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Doordeweeks';
+  String get adminDayWeekday => 'Weekday';
 
   @override
   String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Zondag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Maandag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Dinsdag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Woensdag';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Donderdag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Vrijdag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Zaterdag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Toegestane tags';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Alleen inhoud met deze tags wordt getoond. Laat leeg om alles toe te staan.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Geblokkeerde tags';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Inhoud met deze tags wordt voor deze gebruiker verborgen.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Tag toevoegen';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Ingeschakelde apparaten';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Ingeschakelde kanalen';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Authenticatieprovider';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Provider voor wachtwoordherstel';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maximumaantal mislukte aanmeldpogingen vóór blokkering';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Stel in op 0 voor de standaardwaarde, of op -1 om blokkering uit te schakelen.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-toegang';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Groepen aanmaken en eraan deelnemen toestaan';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Deelnemen aan groepen toestaan';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Geen toegang';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Inhoud verwijderen toestaan uit';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5395,22 +5375,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Server gaf HTTP $status terug';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Weet u zeker dat u $name wilt verwijderen?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Gebruiker \"$name\" verwijderd';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Kan gebruiker niet verwijderen: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5431,7 +5411,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Kan sleutel niet aanmaken: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5442,7 +5422,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Sleutel voor $name intrekken?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5450,7 +5430,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Kan sleutel niet intrekken: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5470,29 +5450,29 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nAangemaakt: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Back-up maken';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Kies wat u in de back-up wilt opnemen.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
   String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Altijd opgenomen';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metagegevens';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Ondertitels';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-afbeeldingen';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Back-up maken...';
@@ -5502,7 +5482,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Kan back-up niet maken: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5515,7 +5495,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Kan manifest niet laden: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5526,7 +5506,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Kan back-up niet herstellen: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5558,17 +5538,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Opgeslagen in $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Kan bestand niet opslaan: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Kan $fileName niet laden';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5579,7 +5559,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Kan taken niet laden: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5591,17 +5571,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Kan taak niet starten: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Kan taak niet stoppen: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Kan taak niet laden: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5609,12 +5589,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Kan trigger niet verwijderen: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Kan trigger niet toevoegen: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5640,7 +5620,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours uur';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5651,7 +5631,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Kan plug-in niet in-/uitschakelen: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5659,27 +5639,27 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Weet u zeker dat u \"$name\" wilt verwijderen?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Kan plug-in niet verwijderen: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Kan pakket niet installeren: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Kan update niet installeren: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Kan plug-ins niet laden: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5691,12 +5671,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Update installeren (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Kan catalogus niet laden: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5718,17 +5698,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" wordt verwijderd nadat de server opnieuw is opgestart';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Verwijderen mislukt: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" bijwerken naar v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5737,7 +5717,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Kan plug-in niet laden: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5745,7 +5725,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versie $version';
+    return 'Version $version';
   }
 
   @override
@@ -5765,17 +5745,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Weet u zeker dat u \"$name\" wilt verwijderen?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Kan repository\'s niet opslaan: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Kan repository\'s niet laden: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5792,12 +5772,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Kan plug-in-instellingen niet laden: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Kan $uri niet openen';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6036,7 +6016,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminBaseUrl => 'Basis-URL';
 
   @override
-  String get adminBaseUrlHint => 'bijv. /jellyfin';
+  String get adminBaseUrlHint => 'bijv. /kwallen';
 
   @override
   String get https => 'HTTPS';
@@ -6076,12 +6056,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Kan metagegevens niet laden: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Kan metagegevens niet opslaan: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6102,7 +6082,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Kan metagegevens niet vernieuwen: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6116,7 +6096,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Extern zoeken mislukt: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6130,7 +6110,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Kan inhoudstype niet bijwerken: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6145,12 +6125,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Afbeelding $imageType bijgewerkt';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Kan afbeelding niet downloaden: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6163,27 +6143,27 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Afbeelding $imageType geüpload';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Kan afbeelding niet uploaden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Afbeelding $imageType verwijderen';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Afbeelding $imageType verwijderd';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Kan afbeelding niet verwijderen: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6194,70 +6174,67 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Zoeken naar tuners mislukt: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Tuner toevoegen';
 
   @override
-  String get adminEditTuner => 'Tuner bewerken';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Bestand of URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-adres van tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Weergavenaam';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limiet voor gelijktijdige verbindingen';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Het maximale aantal streams dat de tuner tegelijk toestaat. Stel in op 0 voor onbeperkt.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Maximale streaming-bitsnelheid als terugval';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Alleen favoriete kanalen importeren';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Hardwaretranscodering toestaan';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4-transcodeercontainer toestaan';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Streams delen toestaan';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Herhalen van streams inschakelen';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS negeren';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Invoer lezen op de oorspronkelijke framerate';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Provider bewerken';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6266,50 +6243,50 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Bestand of URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmvoorvoegsel';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmcategorieën';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Scheid meerdere categorieën met een verticale streep.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kindercategorieën';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nieuwscategorieën';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportcategorieën';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Gebruikersnaam';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Wachtwoord';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selecteer een land';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postcode';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Overzichten ophalen';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Overzichten';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Alle tuners inschakelen';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tunertype';
@@ -6319,7 +6296,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Kan tuner niet toevoegen: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6333,12 +6310,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Kan provider niet toevoegen: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Kan tuner niet verwijderen: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6346,16 +6323,16 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Kan tuner niet resetten: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Dit tunertype ondersteunt resetten niet.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Kan provider niet verwijderen: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6374,43 +6351,43 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serie-opnamepad';
 
   @override
-  String get adminMovieRecordingPath => 'Opnamepad voor films';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Dagen gidsgegevens';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatisch';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dagen';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Pad naar nabewerkingsprogramma';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumenten voor nabewerking';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'NFO-metagegevens van opname opslaan';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Opnameafbeeldingen opslaan';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
   String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Opnamepaden';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Nabewerking';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Gidsgegevens: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6418,7 +6395,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Kan instellingen niet opslaan: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6435,7 +6412,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Kan toewijzingen niet bijwerken: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6451,14 +6428,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminGuideProviders => 'Gids aanbieders';
 
   @override
-  String get adminRefreshGuideData => 'Gidsgegevens vernieuwen';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Vernieuwen van gidsgegevens gestart';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'De taak voor het vernieuwen van de gids is niet beschikbaar op deze server.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Aanbieder toevoegen';
@@ -6469,22 +6446,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Opnamepad: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Seriepad: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Marge vooraf: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Marge achteraf: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6517,7 +6494,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Back-up $name nu herstellen?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6547,7 +6524,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminNotSet => 'Niet ingesteld';
 
   @override
-  String get adminReset => 'Resetten';
+  String get adminReset => 'Opnieuw instellen';
 
   @override
   String get adminLogsTitle => 'Serverlogboeken';
@@ -6578,12 +6555,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Kan $fileName niet laden';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count overeenkomsten';
+    return '$count matches';
   }
 
   @override
@@ -6593,7 +6570,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metagegevenseditor';
 
   @override
-  String get adminMetadataIdentify => 'Identificeren';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Type';
@@ -6693,22 +6670,22 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Afbeelding $imageType bijgewerkt';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Afbeelding $imageType geüpload';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Afbeelding $imageType verwijderd';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Kan afbeelding niet downloaden: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6717,12 +6694,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Kan afbeelding niet uploaden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Afbeelding $imageType verwijderen';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6731,19 +6708,19 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Kan afbeelding niet verwijderen: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Afbeelding $imageType kiezen';
+    return 'Choose $imageType image';
   }
 
   @override
   String get adminMetadataUpload => 'Uploaden';
 
   @override
-  String get adminMetadataUpdate => 'Bijwerken';
+  String get adminMetadataUpdate => 'Update';
 
   @override
   String get adminMetadataRemoteImage => 'Afbeelding op afstand';
@@ -6769,7 +6746,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Update beschikbaar: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6794,7 +6771,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Update installeren (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6806,7 +6783,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" wordt geïnstalleerd...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6826,7 +6803,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Instellingen voor $name';
+    return '$name Settings';
   }
 
   @override
@@ -6866,7 +6843,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Kan repository\'s niet laden: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6874,7 +6851,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Weet u zeker dat u \"$name\" wilt verwijderen?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6882,7 +6859,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Kan repository\'s niet opslaan: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7009,20 +6986,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Schakel het splash-scherm in';
 
   @override
-  String get adminBrandingSplashUpload => 'Afbeelding uploaden';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Splashscreen bijgewerkt';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Kan splashscreen niet uploaden';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Splashscreen verwijderd';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Geen aangepast splashscreen';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardwareversnelling';
@@ -7038,123 +7014,118 @@ class AppLocalizationsNl extends AppLocalizations {
       'Schakel hardwaredecodering in voor:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-apparaat';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Verbeterde NVDEC-decoder inschakelen';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Voorkeur voor de eigen hardwaredecoder van het systeem';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Kleurdiepte voor hardwaredecodering';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bits HEVC-decodering';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bits VP9-decodering';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bits decodering';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-bits decodering';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardwarecodering';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC-codering toestaan';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1-codering toestaan';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel low-power H.264-encoder inschakelen';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel low-power HEVC-encoder inschakelen';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Tone mapping inschakelen';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP-tone mapping inschakelen';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox-tone mapping inschakelen';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping-algoritme';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Tone mapping-modus';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Tone mapping-bereik';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Tone mapping-desaturatie';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Tone mapping-piek';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Tone mapping-parameter';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP-tone mapping-helderheid';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP-tone mapping-contrast';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Presets en kwaliteit';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Encoder-preset';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF voor H.264-codering';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF voor H.265 (HEVC)-codering';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Deïnterlacemethode';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'De framerate verdubbelen bij deïnterlacen';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'VBR-audiocodering inschakelen';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Versterking bij audiodownmix';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritme voor stereodownmix';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maximale grootte van de muxing-wachtrij';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7276,10 +7247,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminTaskNeverRun => 'Nooit rennen';
 
   @override
-  String get adminTaskStop => 'Stoppen';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Lopende taken';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Uitvoeren';
@@ -7301,17 +7272,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Dagelijks om $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Elke $day om $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Elke $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7349,8 +7320,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count uur',
-      one: '1 uur',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7378,17 +7349,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '${days}d geleden';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '${hours}u geleden';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '${minutes}m geleden';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7401,7 +7372,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '${hours}u';
+    return '${hours}h';
   }
 
   @override
@@ -7411,7 +7382,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day-$month';
+    return '$month/$day';
   }
 
   @override
@@ -7425,50 +7396,49 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Basis-URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'bijv. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'bijv. /kwallen';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Openbare HTTP-poort';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS vereisen';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Leid alle externe verzoeken om naar HTTPS. Dit heeft geen effect als de server geen geldig certificaat heeft.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Certificaatwachtwoord';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-instellingen';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 inschakelen';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 inschakelen';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Automatische poorttoewijzing inschakelen';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-netwerken';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Lijst met IP-adressen of CIDR-subnetten, gescheiden door komma\'s of regels, die als lokaal netwerk worden beschouwd.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Gepubliceerde server-URI\'s';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Wijs een subnet of adres toe aan een gepubliceerde URL, bijv. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Certificaatpad';
@@ -7498,11 +7468,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Gaspedaalbuffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Throttlevertraging (seconden)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Ondertitels direct extraheren toestaan';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimaal CV-percentage';
@@ -7551,7 +7521,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Kan inhoudstype niet bijwerken: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7559,23 +7529,22 @@ class AppLocalizationsNl extends AppLocalizations {
       'Drempel voor langzame respons (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Waarschuwingen voor trage reacties inschakelen';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect inschakelen';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metagegevens';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Paden';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Prestaties';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cache-pad';
@@ -7587,7 +7556,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminGeneralServerName => 'Servernaam';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Voorkeurstaal voor weergave';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Kan instellingen niet laden';
@@ -7597,12 +7566,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Kan toewijzingen niet bijwerken: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Tijdslimiet: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7639,8 +7608,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# deelnemers',
-      one: '# deelnemer',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7732,12 +7701,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName is lid geworden van de SyncPlay-groep';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName heeft de SyncPlay-groep verlaten';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7749,7 +7718,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Afspelen synchroniseren met $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7789,8 +7758,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rijen gevonden',
-      one: '# rij gevonden',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7831,20 +7800,20 @@ class AppLocalizationsNl extends AppLocalizations {
   String get offlineSavedMedia => 'Opgeslagen media';
 
   @override
-  String get offlineBannerTitle => 'U bent offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Uw downloads worden getoond';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
   String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Kan uw server niet bereiken';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Afspelen vanuit downloads tot hij weer bereikbaar is';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7860,12 +7829,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Cast-bediening mislukt: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind-bediening';
+    return '$kind Controls';
   }
 
   @override
@@ -7876,7 +7845,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind stoppen';
+    return 'Stop $kind';
   }
 
   @override
@@ -7900,12 +7869,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Voer een pincode van $length cijfers in';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Voer uw pincode van $length cijfers in';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7918,7 +7887,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pinForgot => 'Pincode vergeten?';
 
   @override
-  String get pinClear => 'Wissen';
+  String get pinClear => 'Duidelijk';
 
   @override
   String get pinBackspace => 'Backspace';
@@ -7952,7 +7921,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect mislukt: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7963,7 +7932,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Opdracht mislukt: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7993,7 +7962,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Kan casten niet starten: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8039,7 +8008,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name downloaden...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8121,14 +8090,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Het afspelen is gepauzeerd. Kijk je nog steeds?';
 
   @override
-  String get stillWatchingStop => 'Stoppen';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Doorgaan';
 
   @override
   String skipSegment(String segment) {
-    return '$segment overslaan';
+    return 'Skip $segment';
   }
 
   @override
@@ -8139,12 +8108,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$current/$total downloaden — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName downloaden';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8181,7 +8150,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Rotatie toestaan';
 
   @override
-  String get playerTooltipPrevious => 'Vorige';
+  String get playerTooltipPrevious => 'Vorig';
 
   @override
   String get playerTooltipSeekBack => 'Zoek terug';
@@ -8206,13 +8175,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Verbergen uit Ga door met kijken';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Verbergen uit Volgende omhoog';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Toevoegen aan collectie';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'Open het serverbeheerpaneel';
@@ -8265,15 +8234,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetisch';
 
   @override
-  String get settingsConnectionSection => 'VERBINDING';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Zelfondertekende certificaten toestaan';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Vertrouw servers die zelfondertekende of privé-CA-TLS-certificaten gebruiken. Schakel dit alleen in voor servers die u zelf beheert. Hiermee wordt certificaatvalidatie voor alle verbindingen uitgeschakeld.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACY & VEILIGHEID';
@@ -8289,11 +8257,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Thema-accenten, achtergronden, bekeken indicatoren en themamuziek';
 
   @override
-  String get settingsDetailsScreen => 'Detailscherm';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stijl, achtergrondvervaging en tabbladgedrag';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Startpagina';
@@ -8331,11 +8299,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Toon de Seerr-knop in de navigatiebalk';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Toon altijd tekstlabels in de bovenste navigatiebalk';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8403,7 +8371,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Doneer een kop koffie aan de ontwikkelaar';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'JURIDISCH';
@@ -8437,8 +8405,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licentiemeldingen',
-      one: '# licentiemelding',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8487,16 +8455,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intro\'s en Outro\'s overslaan?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Aftellen bij mediasegmenten';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Voortgangsbalk';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Geen';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Vraag gebruiker';
@@ -8530,13 +8498,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (aanbevolen)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (verouderd)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (verouderd)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (aanbevolen)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision-terugval';
@@ -8729,758 +8697,749 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Onlangs uitgebracht: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Volgende aflevering automatisch afspelen';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Speel automatisch de volgende aflevering af wanneer die beschikbaar is.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Stilte overslaan';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Sla automatisch stille audiofragmenten over wanneer de stream dit ondersteunt.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Externe audio-effecten toestaan';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Sta equalizer- en effect-apps (bijv. Wavelet) toe om te koppelen aan Media3-afspeelsessies.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Tunneling uitschakelen';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Forceer afspelen zonder tunneling. Handig op apparaten met audio-/videohaperingen bij tunneling.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Tunneling inschakelen';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Geavanceerd. Stuurt audio en video via een gekoppeld hardwarepad. Staat standaard uit omdat het op sommige apparaten audio-/video-uitval veroorzaakt.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision-profiel 7 toewijzen aan HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Speel Dolby Vision profiel 7-streams af als HDR10-compatibele HEVC op apparaten zonder Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Ingesloten ondertitelstijlen gebruiken';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Pas kleuren, lettertypen en positionering toe die in de ondertiteltrack zijn ingesloten. Schakel dit uit om in plaats daarvan uw eigen ondertitelstijlvoorkeuren te gebruiken.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Ingesloten lettergroottes voor ondertitels gebruiken';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Pas de lettergrootte-hints toe die in de ondertiteltrack zijn ingesloten. Schakel dit uit om de ondertitelgrootte uit uw stijlvoorkeuren te gebruiken.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mediadetails tonen';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Toon details van het geselecteerde item bovenaan bibliotheekpagina\'s.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Achtergronden verbergen tijdens bladeren?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Gedetailleerde subkoppen gebruiken';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Toon een gedetailleerde of minimale subrij op bibliotheekpagina\'s.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Opgeslagen thema verwijderen?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '\"$themeName\" uit de cache van dit apparaat verwijderen?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Themawinkel';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Blader door community-thema\'s en sla ze op';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Sla een thema op om het net als uw andere opgeslagen thema\'s te gebruiken.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Er zijn momenteel geen thema\'s beschikbaar.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Kan de Themawinkel niet laden. Controleer uw verbinding en probeer het opnieuw.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Opslaan';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Opslaan en toepassen';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Opgeslagen';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Dit thema kon niet worden geladen.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" opgeslagen.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" van dit apparaat verwijderd.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Kan \"$themeName\" niet verwijderen.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Opgeslagen thema\'s';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Dit zijn thema\'s die voor de huidige server zijn gedownload van de Moonfin-plug-in. Verwijderen wist alleen deze lokale kopie.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Er zijn geen opgeslagen thema\'s gevonden voor deze server.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Momenteel actief';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Opgeslagen thema verwijderen';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Beheer gedownloade plug-in-thema\'s op dit apparaat';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Thema-editor';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Open de Moonfin Thema-editor in uw browser';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Startscherm';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Onderste balk';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klassiek';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Startrijen';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Weergave van startrijen';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Secties van startrijen';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Startrijschakelaars';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Schakel bibliotheekcategorieën voor startrijen in of uit';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Schakel de volgende opties in om de rijen in Home-secties weer te geven.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klassiek behoudt per rij het afbeeldingstype en de info-overlay. Modern gebruikt rijen die van portret naar achtergrond lopen.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Favorietenrijen weergeven';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Toon Favoriete films, series en andere favorietenrijen in Home-secties.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortering van favorietenrijen';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sorteer favorietenrijen op datum toegevoegd, releasedatum, alfabetisch en meer.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Collectierijen weergeven';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Toon Collectie-rijen in Home-secties.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortering van collectierijen';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sorteer collectierijen op datum toegevoegd, releasedatum, alfabetisch en meer.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Genrerijen weergeven';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'Toon Genre-rijen in Home-secties.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortering van genrerijen';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sorteer genrerijen op datum toegevoegd, releasedatum, alfabetisch en meer.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Items in genrerijen';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Toon films, series of beide in genrerijen.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Afspeellijstrijen weergeven';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Toon Afspeellijst-rijen in Home-secties.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortering van afspeellijstrijen';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sorteer afspeellijstrijen op datum toegevoegd, releasedatum, alfabetisch en meer.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Audiorijen weergeven';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'Toon Audio-rijen in Home-secties.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortering van audiorijen';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sorteer audiorijen op datum toegevoegd, releasedatum, alfabetisch en meer.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Audio-afspeellijsten';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Weergave';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Lay-out';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Thema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Toetsenbord';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Knoppen';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-configuratie';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Externe speler-app';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Stel een externe speler in om de afspeeloptie bij lang indrukken te activeren';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Toon de app-kiezer wanneer het afspelen start.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Geïnstalleerde spelers laden...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Verbinding';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Doelformaat voor audiotranscodering';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Ondersteund op dit apparaat';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Niet ondersteund op dit apparaat';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD)-passthrough';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) als bitstream naar een externe decoder sturen.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD met Atmos (JOC)-passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Gedrag van mediaspeler';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Afspeelverbeteringen';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Altijd aan.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Aftiteling overslaan vervangen door Volgende omhoog';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Toon de overlay Volgende omhoog in plaats van de knop Aftiteling overslaan.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Spelerroutering';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Voorkeur voor softwaredecoders';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Gebruik FFmpeg (audio) en libgav1 (AV1) vóór hardwaredecoders. Schakel dit uit als HDMI-audiopassthrough niet werkt.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Open het afspelen van video\'s in de door u gekozen externe app op Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatisch in de wachtrij plaatsen';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Voorkeur voor SDH-ondertitels';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Geef bij automatische selectie voorrang aan SDH-/CC-ondertiteltracks.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Webdiagnostiek';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin-webdiagnostiek';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Gebruik deze pagina om verbindingsproblemen in de browser te onderzoeken (CORS, gemengde inhoud en detectie-instellingen).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Fout door gemengde inhoud gedetecteerd';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS-/preflight-fout gedetecteerd';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin heeft gedetecteerd dat een HTTPS-pagina een HTTP-server-URL probeert aan te roepen. Browsers blokkeren dit verzoek voordat het uw server bereikt.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin heeft een verzoekfout op browserniveau gedetecteerd die meestal wordt veroorzaakt door ontbrekende CORS- of preflight-headers op de mediaserver.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Doel-URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Details: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'Huidige runtimecontext';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Plug-in-modus';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC-scan';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Afgedwongen server-URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Standaard server-URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL van detectieproxy';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'niet geconfigureerd';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Gemengde inhoud';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Deze pagina wordt via HTTPS geladen, maar een of meer geconfigureerde URL\'s zijn HTTP. Browsers blokkeren HTTPS-pagina\'s die HTTP-API\'s aanroepen.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Oplossing: bied uw mediaserver of proxy-eindpunt via HTTPS aan, of laad Moonfin alleen via HTTP op vertrouwde lokale netwerken.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Geen duidelijke configuratie met gemengde inhoud gevonden in de huidige runtime-instellingen.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS-checklist';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Sta de browser-origin toe in Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Neem Authorization, X-Emby-Authorization en X-Emby-Token op in Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Stel Content-Range en Accept-Ranges beschikbaar voor streaming en zoekgedrag.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Geef 204 terug op OPTIONS-preflightverzoeken.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Voorbeeld van een headerfragment (nginx-stijl)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Let op';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Deze diagnostiekroute is bedoeld voor webbuilds. Als u dit op een ander platform ziet, zijn deze controles mogelijk niet van toepassing.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Terug naar serverselectie';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Alle gebruikers afmelden';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Microfoontoestemming is permanent geweigerd. Schakel deze in bij de systeeminstellingen.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Microfoontoestemming is vereist voor zoeken met spraak.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Niet verstaan. Probeer het opnieuw.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Geen spraak gedetecteerd.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Microfoonfout.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Zoeken met spraak vereist internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'De spraakservice is bezet. Probeer het opnieuw.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Microfoontoestemming is permanent geweigerd.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Microfoontoestemming is geweigerd.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Spraakherkenning is niet beschikbaar op dit apparaat.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS-routekiezer openen';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'De AirPlay-routekiezer is niet beschikbaar op dit apparaat.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Video\'s';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programma\'s';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Nummers';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Fotoalbums';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Foto\'s';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Personen';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Onlangs uitgebrachte afleveringen';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Opnieuw kijken';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Gastoptredens';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Optredens (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Bijdragen van de crew (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Samen met groep kijken';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Fouten';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Waarschuwingen';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Schijf';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Openen in browser';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'De ingebouwde browser is niet beschikbaar op dit platform.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Weet u zeker dat u de server opnieuw wilt opstarten?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Weet u zeker dat u de server wilt afsluiten? U moet hem dan handmatig opnieuw opstarten.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Intern';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inactief';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Geen gebruikers gevonden';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Er zijn geen gebruikers die overeenkomen met uw zoekopdracht';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Geen apparaten gevonden';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Er zijn geen apparaten die overeenkomen met de huidige filters';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Wachtwoord ingesteld';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Geen wachtwoord ingesteld';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Externe toegang';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Alleen lokaal';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => 'Kan media-analyses niet laden';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Gecombineerde analyses van alle mediabibliotheken.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Topartiesten';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Topauteurs';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Topbijdragers';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotheken',
-      one: '1 Bibliotheek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Er zijn nog geen totalen van geïndexeerde media beschikbaar voor deze selectie.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Bibliotheekdetails';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Bibliotheekoverzicht';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'Er zijn geen bibliotheken beschikbaar.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Serverbeheer';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Gegevens';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Afbeeldingscache';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Logboeken';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metagegevens';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcodering';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Deze server heeft geen serverpaden teruggegeven.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% gebruikt';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Gebruikersactiviteit';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Systeemgebeurtenissen';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Vereist aandacht';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Afspelen';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Apparaten';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Geavanceerd';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Plug-ins';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
   String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Thuisvideo\'s';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Gemengde inhoud';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Thuisvideo\'s en foto\'s';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Gemengde films en series';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9492,151 +9451,150 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Geen opnames gevonden';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Geen afbeeldingspagina\'s gevonden in het .$extension-archief.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Ingesloten renderer mislukt ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB-renderer mislukt ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Lokaal bestand voor de lezer ontbreekt: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status bij het openen van boekgegevens van $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Geen leesbaar boekeindpunt beschikbaar';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Niet-ondersteund striparchiefformaat: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'De plug-in voor CBR-extractie is niet beschikbaar op dit platform.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Kan het .cbr-archief niet uitpakken.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7-extractie is niet beschikbaar op dit platform.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'De plug-in voor CB7-extractie is niet beschikbaar op dit platform.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Genrepaneel sluiten';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Willekeurige selectie laden...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'WILLEKEURIG UIT BIBLIOTHEEK';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'VOLLEDIG WILLEKEURIG';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'WILLEKEURIG UIT GENRES';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatisch schakelen naar HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Schakel HDR automatisch in bij het afspelen van HDR-video en herstel de weergavemodus bij het afsluiten.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'In volledig scherm';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Afbeelding wijzigen';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Ontbreekt';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Transcodeerlimieten';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Alle afbeeldingen wissen?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Weet u zeker dat u alle gedownloade afbeeldingen wilt wissen?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Wissen bevestigen';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Weet u zeker dat u deze $itemType wilt wissen?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Uploaden?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolutie: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Alleen afbeeldingen in de interfacetaal tonen';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Alles wissen bevestigen';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Afbeelding is geüpload!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Kan afbeelding niet uploaden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Kan afbeelding niet instellen: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Kan afbeelding niet verwijderen: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kan niet alle afbeeldingen wissen: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Achtergronden';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9645,31 +9603,31 @@ class AppLocalizationsNl extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatuur';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Illustratie';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Schijfillustratie';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Schermafbeelding';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Voorkant doos';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Achterkant doos';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menu-illustratie';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'achtergrond';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9678,114 +9636,114 @@ class AppLocalizationsNl extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatuur';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'illustratie';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'schijfillustratie';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'schermafbeelding';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'voorkant van de doos';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'achterkant van de doos';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menu-illustratie';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alle';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Hoog (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Gemiddeld (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Laag (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Bronnen';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Hoofdstukken';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Bladwijzers';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notities';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Wachtrij';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Tijdlijn';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'De tijdlijn is leeg';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Hele boek';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Gerichte tijdlijn';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Bladwijzers exporteren';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Notities exporteren';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Alles exporteren';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Geëxporteerd naar $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Exporteren mislukt: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Songteksten';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Bladwijzer toevoegen';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Notitie toevoegen';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Notitie bewerken';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Schrijf een notitie voor dit moment';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Slaaptimer';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Uit';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Einde van hoofdstuk';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Aangepast';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Nog $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9800,51 +9758,51 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Afspeelsnelheid';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Resterend';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Verstreken';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '${seconds}s terug';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '${seconds}s vooruit';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Vorig hoofdstuk';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Volgend hoofdstuk';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Hoofdstuk $current van $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Geen hoofdstukken';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Nog geen bladwijzers';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Nog geen notities';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Bladwijzer toegevoegd bij $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Terugzetten naar 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9852,253 +9810,249 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Opslaan';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Annuleren';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Verwijderen';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Ondertitelvoorkeuren';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Wijzig ondertitelmodi, standaardtalen, weergave en renderopties.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Ondertitelweergave';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Weergaveopties';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Releasedatum (oplopend)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Releasedatum (aflopend)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Bijdragen groeperen';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Meerdere rollen groeperen';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Waarschuwing over schrijftoegang tot bibliotheek';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Zo lost u dit op:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Geef de Jellyfin-servicegebruiker (bijv. jellyfin of Docker PUID/PGID) schrijfrechten voor de mappen van uw mediabibliotheek op de server.\n\n2. Of ga naar uw Jellyfin-dashboard -> Bibliotheken, bewerk deze bibliotheek en schakel \'Save artwork into media folders\' uit om afbeeldingen op te slaan in de interne database van Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Sluiten';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Uw bibliotheek \'$libraryName\' is ingesteld om afbeeldingen rechtstreeks in de mediamappen op te slaan (\'Save artwork into media folders\' staat aan). Jellyfin heeft de schrijftoegang echter getest en heeft geen toestemming om bestanden naar deze map te schrijven:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Het lijkt erop dat Jellyfin de afbeelding niet heeft kunnen bijwerken. Uw bibliotheek is ingesteld om afbeeldingen rechtstreeks in de mediamappen op te slaan (\'Save artwork into media folders\' staat aan). Deze fout treedt meestal op wanneer het Jellyfin-serverproces geen toestemming heeft om bestanden naar uw mediamappen te schrijven.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Externe lijsten';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Opnieuw afspelen';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Bestandsinformatie';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Grootte: $size  •  Formaat: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Alle ($count) audiotracks tonen';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Alle ($count) ondertiteltracks tonen';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Direct Play-mogelijkheid controleren...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Direct Play-mogelijkheid: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Geforceerd';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Het containerformaat wordt niet ondersteund door de speler.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'De videocodec wordt niet ondersteund.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'De audiocodec wordt niet ondersteund.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Het ondertitelformaat wordt niet ondersteund (moet worden ingebrand).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Het audioprofiel wordt niet ondersteund.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Het videoprofiel wordt niet ondersteund.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Het videoniveau wordt niet ondersteund.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'De videoresolutie wordt niet ondersteund door dit apparaat.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'De videobitdiepte wordt niet ondersteund.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'De videoframerate wordt niet ondersteund.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'De bitsnelheid van het bestand overschrijdt de streaminglimiet van de speler.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'De videobitsnelheid overschrijdt de streaminglimiet.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'De audiobitsnelheid overschrijdt de streaminglimiet.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Het aantal audiokanalen wordt niet ondersteund.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetisch';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Releasevolgorde (oplopend)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Releasevolgorde (aflopend)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Aangepast (slepen en neerzetten)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Sorteeropties voor afspeellijst';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Sortering herstellen';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:A$episode opnieuw kijken';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Afspeellijst opnieuw kijken';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Geen ondertitels gevonden.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Beheerdersopties';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Rendering-engine (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller is de moderne GPU-renderer van Flutter voor vloeiendere animaties en minder haperingen. Op sommige tv-boxen en oudere GPU\'s kan dit glitches of zwarte video veroorzaken; zet het dan Uit. Automatisch kiest de beste standaardinstelling voor uw apparaat. Start Moonfin opnieuw op om de wijziging toe te passen.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatisch';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Aan';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Uit';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Opnieuw opstarten vereist';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin moet opnieuw worden opgestart om de rendering-engine te wijzigen. Sluit de app nu en open hem daarna opnieuw om de wijziging toe te passen.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'App nu sluiten';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Bibliotheek vernieuwen';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Alle bibliotheken vernieuwen';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Datum toegevoegd (oudste eerst)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Datum toegevoegd (nieuwste eerst)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetisch (A tot Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetisch (Z tot A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Serveranalyses laden... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Gelijk aan bron';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 films';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 series';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb populairste films';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb populairste series';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb laagst beoordeelde films';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb best beoordeelde Engelstalige films';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -9,30 +9,30 @@ class AppLocalizationsPa extends AppLocalizations {
   AppLocalizationsPa([String locale = 'pa']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'ਮੂਨਫਿਨ';
 
   @override
-  String get accountPreferences => 'ਖਾਤਾ ਤਰਜੀਹਾਂ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ਇੰਟਰਫੇਸ ਭਾਸ਼ਾ';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'ਸਿਸਟਮ ਡਿਫਾਲਟ';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'ਸਾਈਨ - ਇਨ';
 
   @override
-  String get empty => 'ਖਾਲੀ';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName ਨਾਲ ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'ਤੇਜ਼ ਕਨੈਕਟ';
 
   @override
   String get password => 'ਪਾਸਵਰਡ';
@@ -61,12 +61,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ਉਪਲਬਧ ਨਹੀਂ: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ਉਪਲਬਧ ਨਹੀਂ ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin ਸੰਸਕਰਣ $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'ਆਪਣੇ ਸਰਵਰਾਂ ਵਿੱਚੋਂ \"$serverName\" ਹਟਾਉਣਾ ਹੈ?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsAppearanceTheme => 'ਐਪ ਥੀਮ';
 
   @override
-  String get detailScreenStyle => 'ਵੇਰਵਾ ਸਕ੍ਰੀਨ ਸ਼ੈਲੀ';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'ਕਲਾਸਿਕ ਅਸਲ ਕੇਂਦਰਿਤ Moonfin ਲੇਆਉਟ ਹੈ। ਮਾਡਰਨ ਇੱਕ ਜਵਾਬਦੇਹ ਸਿਨੇਮੈਟਿਕ ਲੇਆਉਟ ਹੈ।';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'ਕਲਾਸਿਕ';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'ਮਾਡਰਨ';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'ਵਿਸਤ੍ਰਿਤ ਟੈਬਾਂ';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ਟੈਬਾਂ ਬ੍ਰਾਊਜ਼ ਕਰਦੇ ਸਮੇਂ ਟੈਬ ਸਮੱਗਰੀ ਆਪਣੇ-ਆਪ ਦਿਖਾਓ। ਹਰ ਟੈਬ ਨੂੰ ਹੱਥੀਂ ਖੋਲ੍ਹਣ ਅਤੇ ਬੰਦ ਕਰਨ ਲਈ ਬੰਦ ਕਰੋ।';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'ਤਕਨੀਕੀ ਵੇਰਵੇ ਦਿਖਾਉਣੇ ਹਨ?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'ਬੈਨਰ ਸੰਖੇਪ ਵਿੱਚ ਕੋਡੇਕ, ਰੈਜ਼ੋਲਿਊਸ਼ਨ ਅਤੇ ਸਟ੍ਰੀਮ ਜਾਣਕਾਰੀ ਦਿਖਾਓ';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'ਸਿਫਾਰਸ਼ ਸਿਸਟਮ';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends ਲੋਕਲ-ਲਾਇਬ੍ਰੇਰੀ ਐਲਗੋਰਿਦਮ ਜਾਂ ਆਨਲਾਈਨ TMDb ਦੇ ਸਮਾਨਤਾ ਮੈਟ੍ਰਿਕਸ ਵਰਤੋ। ਨੋਟ: ਆਨਲਾਈਨ ਸਿਫਾਰਸ਼ਾਂ ਲਈ Seerr ਏਕੀਕਰਨ ਦੀ ਲੋੜ ਹੈ।';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb ਸਮਾਨਤਾ';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'ਮਾਪਾ ਰੇਟਿੰਗ ਸੀਮਾ ਲਾਗੂ ਕਰਨੀ ਹੈ?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'ਟਾਰਗੇਟ ਮੀਡੀਆ ਦੀ ਮਾਪਾ ਰੇਟਿੰਗ ਅਨੁਸਾਰ Moonfin Recommends ਸੁਝਾਅ ਸੀਮਿਤ ਕਰੋ';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'ਇੰਟਰਫੇਸ ਸ਼ੈਲੀ';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ਆਟੋਮੈਟਿਕ ਤੁਹਾਡੇ ਡਿਵਾਈਸ ਨਾਲ ਮੇਲ ਖਾਂਦਾ ਹੈ। ਕੋਈ ਦਿੱਖ ਲਾਗੂ ਕਰਨ ਲਈ Apple ਜਾਂ Material ਚੁਣੋ।';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ਆਟੋਮੈਟਿਕ';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsPa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'ਗਲਾਸ ਗੁਣਵੱਤਾ';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ਆਟੋ ਇਸ ਡਿਵਾਈਸ ਲਈ ਸਭ ਤੋਂ ਵਧੀਆ ਗਲਾਸ ਪ੍ਰਭਾਵ ਚੁਣਦਾ ਹੈ। ਫੁੱਲ ਅਸਲ ਧੁੰਦਲਾਪਣ ਲਾਗੂ ਕਰਦਾ ਹੈ; ਘਟਾਇਆ ਹੋਇਆ ਇੱਕ ਹਲਕਾ ਗਲਾਸ ਵਰਤਦਾ ਹੈ ਜੋ GPU ਊਰਜਾ ਬਚਾਉਂਦਾ ਹੈ।';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ਆਟੋ';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'ਫੁੱਲ';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'ਘਟਾਇਆ';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'ਐਪ ਨੂੰ ਰੀਸਟਾਰਟ ਕੀਤੇ ਬਿਨਾਂ Moonfin ਅਤੇ Neon Pulse ਵਿਚਕਾਰ ਸਵਿਚ ਕਰੋ';
 
   @override
-  String get customThemeTitle => 'ਕਸਟਮ ਥੀਮ';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ਕਸਟਮ ਥੀਮ Moonfin ਵਿੱਚ ਦ੍ਰਿਸ਼ ਤੱਤ ਬਦਲਦੇ ਹਨ। ਆਪਣੀ ਸ਼ੈਲੀ ਦੇ ਅਨੁਕੂਲ ਇਹਨਾਂ ਵਿੱਚੋਂ ਇੱਕ ਵਿਕਲਪ ਚੁਣੋ।';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'ਸਿਸਟਮ ਕੀਬੋਰਡ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'ਟੈਕਸਟ ਦਾਖਲ ਕਰਨ ਲਈ ਡਿਫਾਲਟ ਰੂਪ ਵਿੱਚ ਆਪਣੇ ਡਿਵਾਈਸ ਦੀ ਇਨਪੁੱਟ ਵਿਧੀ ਵਰਤੋ';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'ਮੂਨਫਿਨ';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਮੈਜੈਂਟਾ ਗਲੋ, ਸਿਆਨ ਟੈਕਸਟ, ਅਤੇ ਮਜ਼ਬੂਤ ​​ਕ੍ਰੋਮ ਕੰਟ੍ਰਾਸਟ ਦੇ ਨਾਲ ਸਿੰਥਵੇਵ ਸਟਾਈਲਿੰਗ';
 
   @override
-  String get themeGlass => 'ਗਲਾਸ';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'ਇੱਕ ਵਹਿੰਦੇ ਗ੍ਰੇਡੀਐਂਟ ਪਿਛੋਕੜ, ਧੁੰਦਲੀਆਂ ਸਤਹਾਂ ਅਤੇ Apple-ਨੀਲੇ ਲਹਿਜੇ ਨਾਲ ਲਿਕੁਇਡ-ਗਲਾਸ ਸ਼ੈਲੀ';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit ਹੀਰੋ';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'ਮੋਟੇ ਪੈਲੇਟ, ਬਲਾਕੀ ਕਿਨਾਰਿਆਂ, ਸਖ਼ਤ ਪਰਛਾਵੇਂ ਅਤੇ ਪਿਕਸਲ ਫੌਂਟ ਨਾਲ ਰੈਟਰੋ ਪਿਕਸਲ-ਆਰਟ ਸ਼ੈਲੀ';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +313,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,36 +327,35 @@ class AppLocalizationsPa extends AppLocalizations {
   String get exit => 'ਨਿਕਾਸ';
 
   @override
-  String get gameMenu => 'ਮੀਨੂ';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'ਰੋਕਿਆ ਗਿਆ';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'ਸਟੇਟ ਸੇਵ ਕਰੋ';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ਖੇਡਾਂ';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'ਸਟੇਟ ਲੋਡ ਕਰੋ';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'ਤੇਜ਼-ਅੱਗੇ';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'ਐਮੂਲੇਟਰ ਸੈਟਿੰਗਾਂ';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'ਇਸ ਕੋਰ ਦੇ ਕੋਈ ਵਿਵਸਥਿਤ ਹੋਣ ਯੋਗ ਵਿਕਲਪ ਨਹੀਂ ਹਨ।';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'ਮੀਨੂ ਖੋਲ੍ਹਣ ਲਈ ਦਬਾ ਕੇ ਰੱਖੋ';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਗੇਮ ਪਲੇਬੈਕ ਅਜੇ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ਕੋਈ ਘਰੇਲੂ ਕਤਾਰਾਂ ਨੂੰ ਲੋਡ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ';
@@ -372,19 +371,19 @@ class AppLocalizationsPa extends AppLocalizations {
   String get guide => 'ਗਾਈਡ';
 
   @override
-  String get recordings => 'ਰਿਕਾਰਡਿੰਗਾਂ';
+  String get recordings => 'ਰਿਕਾਰਡਿੰਗਜ਼';
 
   @override
   String get schedule => 'ਤਹਿ';
 
   @override
-  String get series => 'ਸੀਰੀਜ਼';
+  String get series => 'ਲੜੀ';
 
   @override
   String get noItemsFound => 'ਕੋਈ ਆਈਟਮਾਂ ਨਹੀਂ ਮਿਲੀਆਂ';
 
   @override
-  String get home => 'ਹੋਮ';
+  String get home => 'ਘਰ';
 
   @override
   String get browseAll => 'ਸਭ ਬ੍ਰਾਊਜ਼ ਕਰੋ';
@@ -428,7 +427,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'ਫੋਲਡਰ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count ਆਈਟਮਾਂ';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count ਆਈਟਮਾਂ';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ਸ਼ੈਲੀਆਂ';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +532,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$countਮਿੰਟ ਪਹਿਲਾਂ';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$countਘੰਟੇ ਪਹਿਲਾਂ';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$countਦਿਨ ਪਹਿਲਾਂ';
+    return '${count}d ago';
   }
 
   @override
@@ -577,7 +576,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count ਸਿਰਲੇਖ';
+    return '$count titles';
   }
 
   @override
@@ -602,7 +601,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get listen => 'ਸੁਣੋ';
 
   @override
-  String get resume => 'ਜਾਰੀ ਰੱਖੋ';
+  String get resume => 'ਮੁੜ ਸ਼ੁਰੂ ਕਰੋ';
 
   @override
   String get failedToLoadLibrary => 'ਲਾਇਬ੍ਰੇਰੀ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
@@ -664,17 +663,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count ਲੇਖਕ';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count ਸ਼ੈਲੀਆਂ';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% ਪੂਰਾ ਹੋਇਆ';
+    return '$percent% completed';
   }
 
   @override
@@ -691,11 +690,11 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'ਪੜ੍ਹਨ-ਪਹਿਲਾਂ ਬ੍ਰਾਊਜ਼ਿੰਗ ਲਈ ਵਿਵਸਥਿਤ $count ਸਿਰਲੇਖ।';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => 'ਟਾਈਟਲ';
+  String get titles => 'ਸਿਰਲੇਖ';
 
   @override
   String get allTitles => 'ਸਾਰੇ ਸਿਰਲੇਖ';
@@ -728,7 +727,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'ਕੋਈ $label ਨਹੀਂ ਮਿਲੇ';
+    return 'No $label found';
   }
 
   @override
@@ -747,13 +746,13 @@ class AppLocalizationsPa extends AppLocalizations {
   String get readStatus => 'ਪੜ੍ਹੋ';
 
   @override
-  String get watched => 'ਦੇਖੇ ਹੋਏ';
+  String get watched => 'ਦੇਖਿਆ';
 
   @override
   String get unread => 'ਨਾ ਪੜ੍ਹਿਆ';
 
   @override
-  String get unwatched => 'ਅਣਦੇਖੇ';
+  String get unwatched => 'ਅਣਦੇਖਿਆ';
 
   @override
   String get seriesStatus => 'ਸੀਰੀਜ਼ ਸਥਿਤੀ';
@@ -765,43 +764,43 @@ class AppLocalizationsPa extends AppLocalizations {
   String get books => 'ਕਿਤਾਬਾਂ';
 
   @override
-  String get latestBooks => 'ਨਵੀਨਤਮ ਕਿਤਾਬਾਂ';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'ਨਵੀਨਤਮ ਆਡੀਓਬੁੱਕਸ';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਕਿਤਾਬਾਂ',
-      one: '1 ਕਿਤਾਬ',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'ਕਿਤਾਬ';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ਆਡੀਓਬੁੱਕ';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% ਪੜ੍ਹੀ';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time ਬਾਕੀ';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'ਪੜ੍ਹੋ';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'ਸੁਣੋ';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'ਲੇਖਕ';
@@ -839,12 +838,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count ਭਾਗ';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'ਪਹਿਲੀ ਵਾਰ ਪ੍ਰਕਾਸ਼ਿਤ $year';
+    return 'First published $year';
   }
 
   @override
@@ -859,7 +858,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count ਕਿਤਾਬਾਂ';
+    return '$count books';
   }
 
   @override
@@ -870,7 +869,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count ਲੇਖਕ';
+    return '$count Authors';
   }
 
   @override
@@ -878,8 +877,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਆਡੀਓਬੁੱਕਸ',
-      one: '1 ਆਡੀਓਬੁੱਕ',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -915,7 +914,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get nextUp => 'ਅਗਲਾ ਉੱਪਰ';
 
   @override
-  String get seasons => 'ਸੀਜ਼ਨ';
+  String get seasons => 'ਰੁੱਤਾਂ';
 
   @override
   String get chapters => 'ਅਧਿਆਏ';
@@ -927,7 +926,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get movies => 'ਫਿਲਮਾਂ';
 
   @override
-  String get musicVideos => 'ਸੰਗੀਤ ਵੀਡੀਓ';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'ਹੋਰ';
@@ -946,7 +945,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'ਡਿਸਕ $number';
+    return 'Disc $number';
   }
 
   @override
@@ -971,7 +970,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'ਪ੍ਰਕਾਸ਼ਿਤ $year';
+    return 'Published $year';
   }
 
   @override
@@ -982,52 +981,52 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਸੀਜ਼ਨ',
-      one: '1 ਸੀਜ਼ਨ',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time \'ਤੇ ਖਤਮ ਹੁੰਦਾ ਹੈ';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'ਆਈਟਮਾਂ';
+  String get items => 'Items';
 
   @override
-  String get extras => 'ਵਾਧੂ';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'ਪਰਦੇ ਪਿੱਛੇ';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ਹਟਾਏ ਗਏ ਦ੍ਰਿਸ਼';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ਫੀਚਰੈੱਟ';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'ਇੰਟਰਵਿਊ';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'ਦ੍ਰਿਸ਼';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'ਸ਼ਾਰਟਸ';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ਟ੍ਰੇਲਰ';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time ਬਾਕੀ';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time ਵਿੱਚ ਖਤਮ ਹੁੰਦਾ ਹੈ';
+    return 'Ends in $time';
   }
 
   @override
@@ -1041,11 +1040,11 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position ਤੋਂ ਮੁੜ ਸ਼ੁਰੂ ਕਰੋ';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'ਚਲਾਓ';
+  String get play => 'ਖੇਡੋ';
 
   @override
   String get startOver => 'ਸ਼ੁਰੂ ਕਰੋ';
@@ -1069,7 +1068,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get version => 'ਸੰਸਕਰਣ';
 
   @override
-  String get cast => 'ਕਾਸਟ ਕਰੋ';
+  String get cast => 'ਕਾਸਟ';
 
   @override
   String get trailer => 'ਟ੍ਰੇਲਰ';
@@ -1139,7 +1138,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" ਲਈ ਡਾਊਨਲੋਡ ਕੀਤੇ ਟਰੈਕ ਮਿਟਾਉਣੇ ਹਨ?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1154,17 +1153,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'ਕੋਈ $itemLabel ਲੋਡ ਨਹੀਂ ਹੋਏ';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ ($count ਆਈਟਮਾਂ)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ \"$name\" ਨੂੰ ਸਰਵਰ ਤੋਂ ਮਿਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ? ਇਹ ਕਾਰਵਾਈ ਵਾਪਸ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1175,7 +1174,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'ਅਸਮਰਥਿਤ ਕਿਤਾਬ ਫਾਰਮੈਟ: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1202,7 +1201,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'ਉਪਸਿਰਲੇਖ ਡਾਊਨਲੋਡ ਕੀਤਾ ਅਤੇ ਚੁਣਿਆ ਗਿਆ: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1211,7 +1210,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language ਲਈ ਕੋਈ ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ ਨਹੀਂ ਮਿਲੇ।';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1219,7 +1218,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'ਸੰਸਕਰਣ $number';
+    return 'Version $number';
   }
 
   @override
@@ -1239,7 +1238,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel ਲਈ ਲੋਕਲ ਫਾਈਲਾਂ ਮਿਟਾਉਣੀਆਂ ਹਨ?\n\nਇਸ ਨਾਲ ਸਟੋਰੇਜ ਥਾਂ ਖਾਲੀ ਹੋਵੇਗੀ। ਤੁਸੀਂ ਬਾਅਦ ਵਿੱਚ ਮੁੜ-ਡਾਊਨਲੋਡ ਕਰ ਸਕਦੇ ਹੋ।';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1264,10 +1263,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get director => 'ਡਾਇਰੈਕਟਰ';
 
   @override
-  String get directors => 'ਡਾਇਰੈਕਟਰ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ਲੇਖਕ';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'ਲੇਖਕ';
@@ -1277,12 +1276,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    return '+$count ਹੋਰ';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count ਐਪੀਸੋਡ';
+    return '$count Episodes';
   }
 
   @override
@@ -1292,12 +1291,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'ਐਪੀਸੋਡ $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'ਅਧਿਆਏ $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1305,8 +1304,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਟਰੈਕ',
-      one: '1 ਟਰੈਕ',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1316,25 +1315,25 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਅਧਿਆਏ',
-      one: '1 ਅਧਿਆਏ',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'ਜਨਮ $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'ਮੌਤ $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'ਉਮਰ $age';
+    return 'Age $age';
   }
 
   @override
@@ -1347,17 +1346,17 @@ class AppLocalizationsPa extends AppLocalizations {
   String get shuffle => 'ਸ਼ਫਲ';
 
   @override
-  String get shuffleAllMusic => 'ਸਾਰਾ ਸੰਗੀਤ ਸ਼ਫਲ ਕਰੋ';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'ਆਪਣੇ ਫੋਨ \'ਤੇ Moonfin ਵਿੱਚ ਸਾਈਨ ਇਨ ਕਰੋ';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'ਤੁਹਾਡੇ ਸਰਵਰ ਤੱਕ ਪਹੁੰਚ ਨਹੀਂ ਹੋ ਸਕਦੀ';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count ਡਾਊਨਲੋਡ';
+    return '$count downloads';
   }
 
   @override
@@ -1376,32 +1375,32 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ $action ਲਈ ਇਸ ਯੂਜ਼ਰ ਵਾਸਤੇ Jellyfin ਉਪਸਿਰਲੇਖ ਪ੍ਰਬੰਧਨ ਅਨੁਮਤੀ ਦੀ ਲੋੜ ਹੈ।';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ $action ਲਈ ਇਹ ਆਈਟਮ ਸਰਵਰ \'ਤੇ ਨਹੀਂ ਮਿਲ ਸਕੀ।';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ $action ਅਸਫਲ: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ $action ਅਸਫਲ (HTTP $status)।';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'ਰਿਮੋਟ ਉਪਸਿਰਲੇਖ $action ਕਰਨ ਵਿੱਚ ਅਸਫਲ।';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" ਲਈ ਸਾਰੇ ਡਾਊਨਲੋਡ ਕੀਤੇ ਐਪੀਸੋਡ';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1431,17 +1430,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label ਕਾਰਵਾਈ ਅਸਫਲ: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'ਕਾਸਟ ਵਾਲੀਅਮ ਸੈੱਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label ਕੰਟਰੋਲ';
+    return '$label Controls';
   }
 
   @override
@@ -1458,7 +1457,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$label ਰੋਕੋ';
+    return 'Stop $label';
   }
 
   @override
@@ -1466,7 +1465,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ਟਰੈਕ $number';
+    return 'Track $number';
   }
 
   @override
@@ -1483,7 +1482,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds ਸਕਿੰਟ';
+    return '$seconds seconds';
   }
 
   @override
@@ -1525,7 +1524,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get subtitleDelay => 'ਉਪਸਿਰਲੇਖ ਦੇਰੀ';
 
   @override
-  String get reset => 'ਰੀਸੈੱਟ ਕਰੋ';
+  String get reset => 'ਰੀਸੈਟ ਕਰੋ';
 
   @override
   String get unknown => 'ਅਗਿਆਤ';
@@ -1552,7 +1551,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get transcodeReasons => 'ਟ੍ਰਾਂਸਕੋਡ ਕਾਰਨ';
 
   @override
-  String get player => 'ਪਲੇਅਰ';
+  String get player => 'ਖਿਡਾਰੀ';
 
   @override
   String get container => 'ਕੰਟੇਨਰ';
@@ -1598,12 +1597,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol ਸੈਸ਼ਨ ਗਲਤੀ';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'ਕਿਤਾਬ ਵੇਰਵੇ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1612,7 +1611,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'ਇਹ ਫਾਰਮੈਟ (.$extension) ਅਜੇ ਐਪ ਵਿੱਚ ਰੈਂਡਰ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ।';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1624,17 +1623,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'ਐਪ ਵਿੱਚ ਰੀਡਰ ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label \'ਤੇ ਬੁੱਕਮਾਰਕ ਪਹਿਲਾਂ ਹੀ ਸੇਵ ਹੈ।';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'ਬੁੱਕਮਾਰਕ ਸ਼ਾਮਲ ਕੀਤਾ: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1646,7 +1645,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'ਪੰਨਾ $number';
+    return 'Page $number';
   }
 
   @override
@@ -1657,12 +1656,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'ਫਾਰਮੈਟ: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% ਪੜ੍ਹੀ';
+    return '$percent% read';
   }
 
   @override
@@ -1685,7 +1684,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'ਜ਼ੂਮ ਰੀਸੈਟ ਕਰੋ (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1708,7 +1707,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'ਪੜ੍ਹਨ ਸਥਿਤੀ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1740,7 +1739,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'ਇਹ ਪਲੇਟਫਾਰਮ $extension ਫਾਈਲਾਂ ਲਈ ਏਮਬੈੱਡਡ ਦਸਤਾਵੇਜ਼ ਇੰਜਣ ਹੋਸਟ ਨਹੀਂ ਕਰ ਸਕਦਾ।';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1779,7 +1778,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'ਗਾਈਡ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1790,22 +1789,22 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'ਅਗਲਾ: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesਮਿੰਟ ਬਾਕੀ';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursਘੰਟੇ ਬਾਕੀ';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursਘੰਟੇ $minutesਮਿੰਟ ਬਾਕੀ';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1828,19 +1827,19 @@ class AppLocalizationsPa extends AppLocalizations {
   String get favoriteChannel => 'ਮਨਪਸੰਦ ਚੈਨਲ';
 
   @override
-  String get record => 'ਰਿਕਾਰਡ ਕਰੋ';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'ਰਿਕਾਰਡਿੰਗ ਰੱਦ ਕਰੋ';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'ਪ੍ਰੋਗਰਾਮ ਰਿਕਾਰਡ ਕਰਨ ਲਈ ਸੈੱਟ ਕੀਤਾ ਗਿਆ';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'ਰਿਕਾਰਡਿੰਗ ਰੱਦ ਕੀਤੀ ਗਈ';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'ਰਿਕਾਰਡਿੰਗ ਬਣਾਈ ਨਹੀਂ ਜਾ ਸਕੀ';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'ਦੇਖੋ';
@@ -1850,7 +1849,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name ਚਲਾਉਣ ਵਿੱਚ ਅਸਫਲ';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1876,11 +1875,11 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" ਦੀ ਨਿਰਧਾਰਿਤ ਰਿਕਾਰਡਿੰਗ ਰੱਦ ਕਰਨੀ ਹੈ?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'ਨਹੀਂ';
+  String get no => 'ਨੰ';
 
   @override
   String get yesCancel => 'ਹਾਂ, ਰੱਦ ਕਰੋ';
@@ -1904,7 +1903,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" ਦੀ ਰਿਕਾਰਡਿੰਗ ਰੋਕਣੀ ਹੈ?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1919,12 +1918,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" ਲਈ ਕੋਈ ਨਤੀਜੇ ਨਹੀਂ';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'ਖੋਜ ਅਸਫਲ: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1965,12 +1964,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" ਅਤੇ ਇਸ ਦੀਆਂ ਫਾਈਲਾਂ ਹਟਾਉਣੀਆਂ ਹਨ?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ਟਰੈਕ';
+    return '$count tracks';
   }
 
   @override
@@ -1981,12 +1980,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ਐਲਬਮ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name ਲਈ ਕੋਈ ਡਾਊਨਲੋਡ ਕੀਤੇ ਟਰੈਕ ਨਹੀਂ ਮਿਲੇ।';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2003,12 +2002,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" ਹਟਾਉਣਾ ਹੈ?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes ਮਿੰਟ';
+    return '$minutes min';
   }
 
   @override
@@ -2018,7 +2017,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'ਐਪੀਸੋਡ $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2032,7 +2031,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'ਸੀਜ਼ਨ $number';
+    return 'Season $number';
   }
 
   @override
@@ -2048,7 +2047,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season ਵਿੱਚ ਸਾਰੇ ਡਾਊਨਲੋਡ ਕੀਤੇ ਐਪੀਸੋਡ ਮਿਟਾਉਣੇ ਹਨ?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2056,8 +2055,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਐਪੀਸੋਡ',
-      one: '1 ਐਪੀਸੋਡ',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2092,7 +2091,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '$count ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਆਈਟਮਾਂ ਮਿਟਾਉਣੀਆਂ ਹਨ?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2106,7 +2105,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit ਸੀਮਾ ਵਿੱਚੋਂ';
+    return 'of $limit limit';
   }
 
   @override
@@ -2188,7 +2187,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count ਵਿਕਲਪ';
+    return '$count options';
   }
 
   @override
@@ -2279,7 +2278,8 @@ class AppLocalizationsPa extends AppLocalizations {
   String get themeMusicVolume => 'ਥੀਮ ਸੰਗੀਤ ਵਾਲੀਅਮ';
 
   @override
-  String get themeMusicSettingsSubtitle => 'ਵੇਰਵਾ ਪੰਨੇ, ਹੋਮ ਕਤਾਰਾਂ ਅਤੇ ਵਾਲੀਅਮ';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2293,10 +2293,11 @@ class AppLocalizationsPa extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'ਹੋਮ ਸਕ੍ਰੀਨ ਬ੍ਰਾਊਜ਼ ਕਰਨ ਵੇਲੇ ਚਲਾਓ';
 
   @override
-  String get loopThemeMusic => 'ਥੀਮ ਸੰਗੀਤ ਲੂਪ ਕਰੋ';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'ਟਰੈਕ ਨੂੰ ਇੱਕ ਵਾਰ ਚਲਾਉਣ ਦੀ ਬਜਾਏ ਦੁਹਰਾਓ';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'ਵੇਰਵੇ ਬੈਕਗ੍ਰਾਊਂਡ ਬਲਰ';
@@ -2319,23 +2320,23 @@ class AppLocalizationsPa extends AppLocalizations {
   String get playerZoomMode => 'ਪਲੇਅਰ ਜ਼ੂਮ ਮੋਡ';
 
   @override
-  String get settingsScrollWheelAction => 'ਮਾਊਸ ਸਕ੍ਰੋਲ ਵ੍ਹੀਲ';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'ਪਲੇਬੈਕ ਦੌਰਾਨ ਵੀਡੀਓ ਉੱਤੇ ਮਾਊਸ ਵ੍ਹੀਲ ਸਕ੍ਰੋਲ ਕਰਨ ਨਾਲ ਕੀ ਹੋਵੇ ਚੁਣੋ।';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ਬੰਦ';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'ਸੀਕ (ਅੱਗੇ / ਪਿੱਛੇ)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ਵਾਲੀਅਮ';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ਵਾਲੀਅਮ';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'ਫਿੱਟ';
@@ -2350,7 +2351,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get refreshRateSwitching => 'ਰਿਫ੍ਰੈਸ਼ ਰੇਟ ਸਵਿਚ ਕਰਨਾ';
 
   @override
-  String get disabled => 'ਅਸਮਰੱਥ';
+  String get disabled => 'ਅਯੋਗ';
 
   @override
   String get scaleOnTv => 'ਟੀਵੀ \'ਤੇ ਸਕੇਲ';
@@ -2389,37 +2390,37 @@ class AppLocalizationsPa extends AppLocalizations {
   String get defaultAudioLanguage => 'ਡਿਫੌਲਟ ਆਡੀਓ ਭਾਸ਼ਾ';
 
   @override
-  String get fallbackAudioLanguage => 'ਬੈਕਅੱਪ ਆਡੀਓ ਭਾਸ਼ਾ';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'ਡਿਫਾਲਟ ਆਡੀਓ ਟਰੈਕ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'ਸਥਾਨਕ ਡੱਬ ਦੀ ਬਜਾਏ ਮੂਲ ਆਡੀਓ ਟਰੈਕ ਨੂੰ ਤਰਜੀਹ ਦਿਓ।';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ਆਡੀਓ ਵਰਣਨ ਟਰੈਕਾਂ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'ਆਮ ਟਰੈਕਾਂ ਦੀ ਬਜਾਏ ਆਡੀਓ ਵਰਣਨ ਟਰੈਕਾਂ ਨੂੰ ਤਰਜੀਹ ਦਿਓ।';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ਟ੍ਰਾਂਸਕੋਡਿੰਗ (ਆਡੀਓ)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'ਡਾਇਰੈਕਟ ਸਟ੍ਰੀਮ (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ਟ੍ਰਾਂਸਕੋਡਿੰਗ (ਬਿੱਟਰੇਟ ਜਾਂ ਰੈਜ਼ੋਲਿਊਸ਼ਨ)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ਟ੍ਰਾਂਸਕੋਡਿੰਗ (ਵੀਡੀਓ ਅਤੇ ਆਡੀਓ)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ਟ੍ਰਾਂਸਕੋਡਿੰਗ (ਵੀਡੀਓ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ਆਟੋ (ਸਰਵਰ ਡਿਫੌਲਟ)';
@@ -2496,27 +2497,27 @@ class AppLocalizationsPa extends AppLocalizations {
       'TrueHD ਆਡੀਓ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ (ਸ਼ਾਇਦ ਸਾਰੇ ਪਲੇਟਫਾਰਮਾਂ \'ਤੇ ਕੰਮ ਨਾ ਕਰੇ)';
 
   @override
-  String get settingsAudioOutputMode => 'ਆਡੀਓ ਆਉਟਪੁੱਟ ਮੋਡ';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ਚੁਣੋ ਕਿ ਆਡੀਓ ਕਿਵੇਂ ਡੀਕੋਡ ਹੋਵੇ। AVR ਪਾਸਥਰੂ ਕੱਚੀਆਂ Dolby/DTS ਸਟ੍ਰੀਮਾਂ ਤੁਹਾਡੇ ਰਿਸੀਵਰ ਨੂੰ ਭੇਜਦਾ ਹੈ; ਆਟੋ ਜਾਂ ਡਾਊਨਮਿਕਸ ਸਥਾਨਕ ਤੌਰ \'ਤੇ ਡੀਕੋਡ ਕਰਦਾ ਹੈ।';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR ਪਾਸਥਰੂ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'ਆਡੀਓ ਬੈਕਅੱਪ ਕੋਡੇਕ';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'ਜਦੋਂ ਸਰੋਤ ਸਟ੍ਰੀਮ ਸਿੱਧੀ-ਚਲਾਈ ਜਾਂ ਪਾਸ ਨਹੀਂ ਹੋ ਸਕਦੀ, ਤਾਂ ਮਲਟੀ-ਚੈਨਲ ਆਡੀਓ ਟ੍ਰਾਂਸਕੋਡ ਕਰਨ ਲਈ ਟਾਰਗੇਟ ਫਾਰਮੈਟ ਚੁਣੋ।';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'ਆਟੋ ਖੋਜ\n(ਸਿਫਾਰਸ਼ੀ)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ਡਿਫਾਲਟ)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2525,113 +2526,113 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ਨੁਕਸਾਨ-ਰਹਿਤ)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ਸਿਰਫ ਸਟੀਰੀਓ)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ਕੁਸ਼ਲ)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ਨੁਕਸਾਨ-ਰਹਿਤ)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'ਵੱਧ ਤੋਂ ਵੱਧ ਆਡੀਓ ਚੈਨਲ';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'ਆਪਣੇ ਆਡੀਓ ਸੈੱਟਅੱਪ ਦੇ ਵੱਧ ਤੋਂ ਵੱਧ ਚੈਨਲ ਸੰਰਚਿਤ ਕਰੋ। ਇਸ ਸੀਮਾ ਤੋਂ ਵੱਧ ਮਲਟੀ-ਚੈਨਲ ਸਟ੍ਰੀਮਾਂ ਡਾਊਨਮਿਕਸ ਜਾਂ ਟ੍ਰਾਂਸਕੋਡ ਹੋਣਗੀਆਂ।';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'ਆਟੋ ਖੋਜ\n(ਹਾਰਡਵੇਅਰ ਡਿਫਾਲਟ)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 ਮੋਨੋ';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ਸਟੀਰੀਓ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 ਸਰਾਊਂਡ';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 ਕਵਾਡ੍ਰਾਫੋਨਿਕ';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 ਸਰਾਊਂਡ';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 ਸਰਾਊਂਡ';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 ਸਰਾਊਂਡ';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 ਸਰਾਊਂਡ';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'ਪਾਸਥਰੂ (ਉੱਨਤ)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'ਕੋਡੇਕ ਪਾਸਥਰੂ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'ਸਿਰਫ ਉਹ ਫਾਰਮੈਟ ਸਮਰੱਥ ਕਰੋ ਜੋ ਤੁਹਾਡਾ AVR ਜਾਂ HDMI ਸਿੰਕ ਸਮਰਥਨ ਕਰਦਾ ਹੈ।';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 ਪਾਸਥਰੂ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) ਪਾਸਥਰੂ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core ਪਾਸਥਰੂ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA ਪਾਸਥਰੂ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD ਪਾਸਥਰੂ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos ਪਾਸਥਰੂ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) ਬਾਹਰੀ ਡੀਕੋਡਰ ਨੂੰ ਬਿੱਟਸਟ੍ਰੀਮ ਕਰੋ।';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) ਉੱਤੇ Dolby Atmos ਬਾਹਰੀ ਡੀਕੋਡਰ ਨੂੰ ਬਿੱਟਸਟ੍ਰੀਮ ਕਰੋ।';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS core ਸਮੇਤ) ਬਾਹਰੀ ਡੀਕੋਡਰ ਨੂੰ ਬਿੱਟਸਟ੍ਰੀਮ ਕਰੋ।';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos ਮੈਟਾਡਾਟਾ ਨਾਲ Dolby TrueHD ਬਾਹਰੀ ਡੀਕੋਡਰ ਨੂੰ ਬਿੱਟਸਟ੍ਰੀਮ ਕਰੋ।';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'ਖੋਜੀਆਂ ਗਈਆਂ ਆਡੀਓ ਸਮਰੱਥਾਵਾਂ';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'ਅਜੇ ਕੋਈ ਰਨਟਾਈਮ ਸਮਰੱਥਾ ਸਨੈਪਸ਼ਾਟ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'ਰੂਟ';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'ਡੀਕੋਡ';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'ਪਾਸਥਰੂ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ਆਡੀਓ ਰੂਟ';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2646,10 +2647,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'ਸਪੀਕਰ';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'ਹੈੱਡਫੋਨ';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2657,37 +2658,39 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'ਡਾਇਗਨੌਸਟਿਕਸ';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'ਵੀਡੀਓ ਪੱਧਰ';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'ਵੀਡੀਓ ਰੇਂਜ';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'ਉਪਸਿਰਲੇਖ ਕੋਡੇਕ';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => 'ਮਨਜ਼ੂਰ ਆਡੀਓ ਕੋਡੇਕ';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ਆਡੀਓ ਕੋਡੇਕ';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ਆਡੀਓ ਕੋਡੇਕ';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif ਪਾਸਥਰੂ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'ਸਰਗਰਮ ਆਡੀਓ ਰੂਟ';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
-  String get settingsAudioDiagnosticsRouteHdAudioSupport => 'ਰੂਟ HD ਆਡੀਓ ਸਮਰਥਨ';
+  String get settingsAudioDiagnosticsRouteHdAudioSupport =>
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'ਨਾਈਟ ਮੋਡ';
@@ -2736,7 +2739,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueਸ';
+    return '${value}s';
   }
 
   @override
@@ -2750,7 +2753,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes ਐਪੀਸੋਡ / $hoursਘੰਟੇ ਬਾਅਦ';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2826,45 +2829,45 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਉਪਸਿਰਲੇਖ ਦਿੱਖ ਨੂੰ ਅਨੁਕੂਲਿਤ ਕਰੋ';
 
   @override
-  String get subtitleMode => 'ਉਪਸਿਰਲੇਖ ਮੋਡ';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ਫਲੈਗ ਕੀਤੇ';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'ਹਮੇਸ਼ਾ';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'ਵਿਦੇਸ਼ੀ';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'ਲਾਜ਼ਮੀ';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'ਮੀਡੀਆ ਫਾਈਲ ਦੇ ਮੈਟਾਡਾਟਾ ਵਿੱਚ \"default\" ਜਾਂ \"forced\" ਵਜੋਂ ਅੰਦਰੂਨੀ ਤੌਰ \'ਤੇ ਫਲੈਗ ਕੀਤੇ ਟਰੈਕ ਚਲਾਉਂਦਾ ਹੈ।';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'ਹਰ ਵਾਰ ਵੀਡੀਓ ਸ਼ੁਰੂ ਹੋਣ \'ਤੇ ਆਪਣੇ-ਆਪ ਉਪਸਿਰਲੇਖ ਲੋਡ ਕਰਕੇ ਦਿਖਾਉਂਦਾ ਹੈ।';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'ਜੇ ਡਿਫਾਲਟ ਆਡੀਓ ਟਰੈਕ ਵਿਦੇਸ਼ੀ ਭਾਸ਼ਾ ਵਿੱਚ ਹੈ ਤਾਂ ਆਪਣੇ-ਆਪ ਉਪਸਿਰਲੇਖ ਚਾਲੂ ਕਰਦਾ ਹੈ।';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'ਸਿਰਫ forced ਮੈਟਾਡਾਟਾ ਫਲੈਗ ਨਾਲ ਸਪੱਸ਼ਟ ਤੌਰ \'ਤੇ ਟੈਗ ਕੀਤੇ ਉਪਸਿਰਲੇਖ ਲੋਡ ਕਰਦਾ ਹੈ।';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'ਆਪਣੇ-ਆਪ ਉਪਸਿਰਲੇਖ ਲੋਡਿੰਗ ਪੂਰੀ ਤਰ੍ਹਾਂ ਅਯੋਗ ਕਰਦਾ ਹੈ।';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ਬੈਕਅੱਪ ਉਪਸਿਰਲੇਖ ਭਾਸ਼ਾ';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'ਉਪਸਿਰਲੇਖ ਸਟ੍ਰੀਮ';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2923,17 +2926,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile ਪ੍ਰੋਫਾਈਲ ਸੈਟਿੰਗਾਂ ਲੋਡ ਕੀਤੀਆਂ।';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile ਪ੍ਰੋਫਾਈਲ ਸੈਟਿੰਗਾਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ।';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'ਲੋਕਲ ਸੈਟਿੰਗਾਂ $profile ਪ੍ਰੋਫਾਈਲ ਨਾਲ ਸਿੰਕ ਕੀਤੀਆਂ।';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3069,10 +3072,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showLibrariesInToolbar => 'ਟੂਲਬਾਰ ਵਿੱਚ ਲਾਇਬ੍ਰੇਰੀਆਂ ਦਿਖਾਓ';
 
   @override
-  String get navbarAlwaysExpanded => 'ਨੈਵਬਾਰ ਲੇਬਲ ਹਮੇਸ਼ਾ ਵਿਸਤ੍ਰਿਤ ਕਰੋ';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr ਬਟਨ ਦਿਖਾਓ';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'ਨਵਬਾਰ ਧੁੰਦਲਾਪਨ';
@@ -3147,18 +3150,18 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showFolderBrowsingOption => 'ਫੋਲਡਰ ਬ੍ਰਾਊਜ਼ਿੰਗ ਵਿਕਲਪ ਦਿਖਾਓ';
 
   @override
-  String get groupItemsIntoCollections => 'ਆਈਟਮਾਂ ਨੂੰ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸਮੂਹ ਕਰੋ';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ਲਾਇਬ੍ਰੇਰੀਆਂ ਬ੍ਰਾਊਜ਼ ਕਰਦੇ ਸਮੇਂ ਸੰਗ੍ਰਹਿ ਨਾਲ ਜੁੜੀਆਂ ਲਾਇਬ੍ਰੇਰੀ ਆਈਟਮਾਂ ਲੁਕਾਓ';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'ਲਾਇਬ੍ਰੇਰੀ ਸਮੂਹੀਕਰਨ ਸੂਚਨਾ';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'ਇਸ ਸੈਟਿੰਗ ਨੂੰ ਵਰਤਣ ਲਈ, ਕਿਰਪਾ ਕਰਕੇ ਯਕੀਨੀ ਬਣਾਓ ਕਿ ਤੁਹਾਡੇ Jellyfin ਜਾਂ Emby ਸਰਵਰ \'ਤੇ ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ ਦੀਆਂ Display ਸੈਟਿੰਗਾਂ ਹੇਠ \"Group movies into collections\" ਅਤੇ/ਜਾਂ \"Group shows into collections\" ਲਾਇਬ੍ਰੇਰੀ ਸੈਟਿੰਗਾਂ ਸਮਰੱਥ ਹਨ।';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'ਲਾਇਬ੍ਰੇਰੀ ਦਰਿਸ਼ਗੋਚਰਤਾ';
@@ -3187,7 +3190,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count ਚੁਣੇ ਗਏ';
+    return '$count selected';
   }
 
   @override
@@ -3217,7 +3220,7 @@ class AppLocalizationsPa extends AppLocalizations {
       'Moonfin, MakD ਵਿੱਚੋਂ ਚੁਣੋ, ਜਾਂ ਮੀਡੀਆ ਬਾਰ ਨੂੰ ਬੰਦ ਕਰੋ';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'ਮੂਨਫਿਨ';
 
   @override
   String get mediaBarModeMakd => 'ਮਾਕਡੀ';
@@ -3269,10 +3272,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get autoPlayTrailers => '3 ਸਕਿੰਟਾਂ ਬਾਅਦ ਮੀਡੀਆ ਬਾਰ ਵਿੱਚ ਆਟੋ-ਪਲੇ ਟ੍ਰੇਲਰ';
 
   @override
-  String get trailerAudio => 'ਟ੍ਰੇਲਰ ਆਡੀਓ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'ਮੀਡੀਆ ਬਾਰ ਵਿੱਚ ਟ੍ਰੇਲਰਾਂ ਲਈ ਆਡੀਓ ਸਮਰੱਥ ਕਰੋ';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'ਐਪੀਸੋਡ ਪੂਰਵ-ਝਲਕ';
@@ -3350,11 +3353,10 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਦੋਵਾਂ ਕਤਾਰਾਂ ਨੂੰ ਇੱਕ ਸਿੰਗਲ ਹੋਮ ਸੈਕਸ਼ਨ ਵਿੱਚ ਜੋੜੋ';
 
   @override
-  String get fullScreenRows => 'ਵਿਸਤ੍ਰਿਤ ਹੋਮ ਕਤਾਰਾਂ';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'ਹੋਮ ਕਤਾਰਾਂ ਨੂੰ ਪ੍ਰਤੀ ਸਕ੍ਰੀਨ 1 ਕਤਾਰ ਤੱਕ ਸੀਮਿਤ ਕਰੋ';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ਪ੍ਰਤੀ ਕਤਾਰ ਚਿੱਤਰ ਦੀ ਕਿਸਮ';
@@ -3369,7 +3371,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get lastUser => 'ਆਖਰੀ ਉਪਭੋਗਤਾ';
 
   @override
-  String get currentUser => 'ਮੌਜੂਦਾ ਯੂਜ਼ਰ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ਹਮੇਸ਼ਾ ਪ੍ਰਮਾਣਿਤ ਕਰੋ';
@@ -3446,7 +3448,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes ਮਿੰਟ';
+    return '$minutes min';
   }
 
   @override
@@ -3476,10 +3478,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get displayClockDuringScreensaver => 'ਸਕ੍ਰੀਨਸੇਵਰ ਦੌਰਾਨ ਘੜੀ ਡਿਸਪਲੇ ਕਰੋ';
 
   @override
-  String get clockModeStatic => 'ਸਥਿਰ';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'ਉਛਲਦਾ';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'ਸੜੇ ਹੋਏ ਟਮਾਟਰ (ਆਲੋਚਕ)';
@@ -3488,7 +3490,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get rottenTomatoesAudience => 'ਸੜੇ ਹੋਏ ਟਮਾਟਰ (ਦਰਸ਼ਕ)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'ਆਈ.ਐਮ.ਡੀ.ਬੀ';
 
   @override
   String get tmdb => 'TMDB';
@@ -3500,7 +3502,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get metacriticUser => 'ਮੈਟਾਕ੍ਰਿਟਿਕ (ਉਪਭੋਗਤਾ)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ਟ੍ਰੈਕਟ';
 
   @override
   String get letterboxd => 'ਲੈਟਰਬਾਕਸਡੀ';
@@ -3549,7 +3551,7 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਪੂਰੇ ਐਪ ਵਿੱਚ ਦਰਸਾਏ ਗਏ ਰੇਟਿੰਗ ਸਰੋਤਾਂ ਨੂੰ ਸਮਰੱਥ ਅਤੇ ਮੁੜ ਕ੍ਰਮਬੱਧ ਕਰੋ';
 
   @override
-  String get pluginLabel => 'Moonbase ਪਲੱਗਇਨ';
+  String get pluginLabel => 'ਪਲੱਗਇਨ';
 
   @override
   String get pluginDetected => 'ਪਲੱਗਇਨ ਖੋਜਿਆ ਗਿਆ';
@@ -3567,7 +3569,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nਸੰਸਕਰਣ: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3620,7 +3622,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get networks => 'ਨੈੱਟਵਰਕ';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr ਖੋਜ ਕਤਾਰਾਂ';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'ਕਤਾਰਾਂ ਨੂੰ ਪੂਰਵ-ਨਿਰਧਾਰਤ \'ਤੇ ਰੀਸੈਟ ਕਰੋ';
@@ -3643,46 +3645,47 @@ class AppLocalizationsPa extends AppLocalizations {
   String get hideAdultContent => 'ਨਤੀਜਿਆਂ ਵਿੱਚ ਬਾਲਗ ਸਮੱਗਰੀ ਨੂੰ ਲੁਕਾਓ';
 
   @override
-  String get seerrNotificationsSection => 'ਸੂਚਨਾਵਾਂ';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'ਨਵੀਂ ਬੇਨਤੀ ਸੂਚਨਾਵਾਂ';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'ਜਦੋਂ ਕੋਈ ਬੇਨਤੀ ਭੇਜੇ ਤਾਂ ਮੈਨੂੰ ਸੁਚੇਤ ਕਰੋ';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'ਬੇਨਤੀ ਅੱਪਡੇਟ';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'ਮਨਜ਼ੂਰ, ਅਸਵੀਕਾਰ ਅਤੇ ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ ਵਿੱਚ ਸ਼ਾਮਲ ਕੀਤਾ';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'ਮੁੱਦਾ ਅੱਪਡੇਟ';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'ਨਵੇਂ ਮੁੱਦੇ, ਜਵਾਬ ਅਤੇ ਹੱਲ';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'ਇਸ ਵਜੋਂ ਲੌਗ ਇਨ: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr ਖੋਜ ਪੰਨਾ';
+  String get discoverRows => 'ਕਤਾਰਾਂ ਦੀ ਖੋਜ ਕਰੋ';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr ਮੇਨਪੇਜ \'ਤੇ ਦੇਖਣ ਲਈ ਕਤਾਰਾਂ ਸਮਰੱਥ ਕਰੋ। ਮੁੜ-ਕ੍ਰਮਬੱਧ ਕਰਨ ਲਈ ਖਿੱਚੋ। ਕਸਟਮ ਕ੍ਰਮ Moonbase ਨਾਲ ਸਿੰਕ ਹੁੰਦਾ ਹੈ।';
+      'ਮੁੜ ਕ੍ਰਮਬੱਧ ਕਰਨ ਲਈ ਘਸੀਟੋ। ਕਤਾਰਾਂ ਨੂੰ ਸਮਰੱਥ ਜਾਂ ਅਯੋਗ ਕਰੋ। ਸਮਰੱਥ ਕਤਾਰ ਆਰਡਰ Moonfin ਪਲੱਗਇਨ ਨਾਲ ਸਿੰਕ ਕਰਦਾ ਹੈ।';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr ਮੇਨਪੇਜ \'ਤੇ ਦੇਖਣ ਲਈ ਕਤਾਰਾਂ ਸਮਰੱਥ ਕਰੋ। ਮੁੜ-ਕ੍ਰਮਬੱਧ ਕਰਨ ਲਈ ਖਿੱਚੋ। ਕਸਟਮ ਕ੍ਰਮ Moonbase ਨਾਲ ਸਿੰਕ ਹੁੰਦਾ ਹੈ।';
+      'ਮੁੜ ਕ੍ਰਮਬੱਧ ਕਰਨ ਲਈ ਘਸੀਟੋ। ਕਤਾਰਾਂ ਨੂੰ ਸਮਰੱਥ ਜਾਂ ਅਯੋਗ ਕਰੋ।';
 
   @override
-  String get enabled => 'ਸਮਰੱਥ';
+  String get enabled => 'ਸਮਰਥਿਤ';
 
   @override
   String get hidden => 'ਲੁਕਿਆ ਹੋਇਆ';
@@ -3692,7 +3695,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'ਸੰਸਕਰਣ $version';
+    return 'Version $version';
   }
 
   @override
@@ -3742,7 +3745,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'ਅੱਪਡੇਟ ਉਪਲਬਧ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3753,7 +3756,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version ਉਪਲਬਧ';
+    return 'v$version Available';
   }
 
   @override
@@ -3816,7 +3819,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get imageCacheCleared => 'ਚਿੱਤਰ ਕੈਸ਼ ਸਾਫ਼ ਕੀਤਾ';
 
   @override
-  String get clear => 'ਸਾਫ਼ ਕਰੋ';
+  String get clear => 'ਸਾਫ਼';
 
   @override
   String get browse => 'ਬ੍ਰਾਊਜ਼ ਕਰੋ';
@@ -3832,19 +3835,19 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ਆਯਾਤ ਹੋ ਰਿਹਾ';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count ਆਈਟਮਾਂ';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr ਸੈਟਿੰਗਾਂ';
+  String get seerrSettings => 'ਸੀਰਰ ਸੈਟਿੰਗਾਂ';
 
   @override
   String get requestMore => 'ਹੋਰ ਬੇਨਤੀ ਕਰੋ';
@@ -3860,7 +3863,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name ਦੁਆਰਾ ਬੇਨਤੀ ਕੀਤੀ';
+    return 'Requested by $name';
   }
 
   @override
@@ -3877,12 +3880,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" ਲਈ ਬੇਨਤੀ ਰੱਦ ਕਰਨੀ ਹੈ?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" ਲਈ $count ਬੇਨਤੀਆਂ ਰੱਦ ਕਰਨੀਆਂ ਹਨ?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3897,12 +3900,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'ਬਜਟ: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'ਆਮਦਨ: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3912,7 +3915,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type ਦੀ ਬੇਨਤੀ ਕਰੋ';
+    return 'Request $type';
   }
 
   @override
@@ -3941,14 +3944,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showMore => 'ਹੋਰ ਦਿਖਾਓ';
 
   @override
-  String get appearances => 'ਪੇਸ਼ਕਾਰੀਆਂ';
+  String get appearances => 'ਦਿੱਖ';
 
   @override
   String get crewSection => 'ਚਾਲਕ ਦਲ';
 
   @override
   String ageValue(int age) {
-    return 'ਉਮਰ $age';
+    return 'age $age';
   }
 
   @override
@@ -3979,147 +3982,148 @@ class AppLocalizationsPa extends AppLocalizations {
   String get deletedStatus => 'ਮਿਟਾਇਆ ਗਿਆ';
 
   @override
-  String get failedStatus => 'ਅਸਫਲ';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'ਪ੍ਰੋਸੈਸਿੰਗ';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name ਦੁਆਰਾ ਸੋਧਿਆ';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'ਪੂਰਾ ਹੋਇਆ';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'ਇਸ ਸਿਰਲੇਖ ਦੀ ਪਹਿਲਾਂ ਹੀ ਬੇਨਤੀ ਕੀਤੀ ਗਈ ਸੀ';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'ਬੇਨਤੀ ਸੀਮਾ ਪੂਰੀ ਹੋ ਗਈ';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'ਇਹ ਸਿਰਲੇਖ ਬਲਾਕਸੂਚੀ ਵਿੱਚ ਹੈ';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'ਬੇਨਤੀ ਕਰਨ ਲਈ ਕੋਈ ਸੀਜ਼ਨ ਬਾਕੀ ਨਹੀਂ';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'ਤੁਹਾਨੂੰ ਇਹ ਬੇਨਤੀ ਕਰਨ ਦੀ ਅਨੁਮਤੀ ਨਹੀਂ ਹੈ';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'ਬੇਨਤੀਆਂ';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'ਮੁੱਦੇ';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'ਨਵੀਨਤਮ';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'ਆਖਰੀ ਵਾਰ ਸੋਧਿਆ';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'ਕੋਈ ਮੁੱਦੇ ਨਹੀਂ';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit ਫਿਲਮ ਬੇਨਤੀਆਂ ਵਿੱਚੋਂ $remaining ਬਾਕੀ';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit ਸੀਜ਼ਨ ਬੇਨਤੀਆਂ ਵਿੱਚੋਂ $remaining ਬਾਕੀ';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name ਦਾ ਹਿੱਸਾ';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'ਸੰਗ੍ਰਹਿ ਦੇਖੋ';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'ਸੰਗ੍ਰਹਿ ਦੀ ਬੇਨਤੀ ਕਰੋ';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total ਫਿਲਮਾਂ · $available ਉਪਲਬਧ';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count ਫਿਲਮਾਂ ਦੀ ਬੇਨਤੀ ਕਰੋ';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total ਵਿੱਚੋਂ $current ਦੀ ਬੇਨਤੀ ਹੋ ਰਹੀ ਹੈ...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count ਫਿਲਮਾਂ ਦੀ ਬੇਨਤੀ ਕੀਤੀ';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total ਵਿੱਚੋਂ $ok ਫਿਲਮਾਂ ਦੀ ਬੇਨਤੀ ਕੀਤੀ';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'ਸਾਰੀਆਂ ਫਿਲਮਾਂ ਪਹਿਲਾਂ ਹੀ ਉਪਲਬਧ ਹਨ ਜਾਂ ਬੇਨਤੀ ਕੀਤੀਆਂ ਗਈਆਂ ਹਨ';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'ਮੁੱਦਾ ਰਿਪੋਰਟ ਕਰੋ';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'ਵੀਡੀਓ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ਆਡੀਓ';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'ਕੀ ਗਲਤ ਹੈ?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'ਸਾਰੇ ਐਪੀਸੋਡ';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'ਐਪੀਸੋਡ';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'ਖੁੱਲ੍ਹਾ';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'ਹੱਲ ਕੀਤਾ';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'ਹੱਲ ਕਰੋ';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'ਮੁੜ ਖੋਲ੍ਹੋ';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name ਦੁਆਰਾ ਰਿਪੋਰਟ ਕੀਤਾ';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count ਟਿੱਪਣੀਆਂ';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'ਇੱਕ ਟਿੱਪਣੀ ਸ਼ਾਮਲ ਕਰੋ';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'ਇਹ ਮੁੱਦਾ ਮਿਟਾਉਣਾ ਹੈ?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'ਰਿਪੋਰਟ ਭੇਜੋ';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB ਸਕੋਰ';
@@ -4143,7 +4147,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get originalLanguageLabel => 'ਮੂਲ ਭਾਸ਼ਾ';
 
   @override
-  String get seasonsLabel => 'ਸੀਜ਼ਨ';
+  String get seasonsLabel => 'ਰੁੱਤਾਂ';
 
   @override
   String get episodesLabel => 'ਐਪੀਸੋਡ';
@@ -4179,7 +4183,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get done => 'ਹੋ ਗਿਆ';
 
   @override
-  String get edit => 'ਸੋਧੋ';
+  String get edit => 'ਸੰਪਾਦਿਤ ਕਰੋ';
 
   @override
   String get encoding => 'ਏਨਕੋਡਿੰਗ';
@@ -4191,7 +4195,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get forward => 'ਅੱਗੇ';
 
   @override
-  String get general => 'ਆਮ';
+  String get general => 'ਜਨਰਲ';
 
   @override
   String get go => 'ਜਾਓ';
@@ -4254,7 +4258,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get run => 'ਚਲਾਓ';
 
   @override
-  String get search => 'ਖੋਜੋ';
+  String get search => 'ਖੋਜ';
 
   @override
   String get select => 'ਚੁਣੋ';
@@ -4272,7 +4276,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get status => 'ਸਥਿਤੀ';
 
   @override
-  String get stop => 'ਰੋਕੋ';
+  String get stop => 'ਰੂਕੋ';
 
   @override
   String get streaming => 'ਸਟ੍ਰੀਮਿੰਗ';
@@ -4281,7 +4285,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get time => 'ਸਮਾਂ';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ਟ੍ਰਿਕਪਲੇ';
 
   @override
   String get uninstall => 'ਅਣਇੰਸਟੌਲ ਕਰੋ';
@@ -4299,7 +4303,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get unmute => 'ਅਣਮਿਊਟ ਕਰੋ';
 
   @override
-  String get mute => 'ਮਿਊਟ ਕਰੋ';
+  String get mute => 'ਚੁੱਪ';
 
   @override
   String get branding => 'ਬ੍ਰਾਂਡਿੰਗ';
@@ -4323,25 +4327,25 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminDrawerLibraries => 'ਲਾਇਬ੍ਰੇਰੀਆਂ';
 
   @override
-  String get adminDrawerDisplay => 'ਡਿਸਪਲੇ';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'ਮੈਟਾਡਾਟਾ';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO ਸੈਟਿੰਗਾਂ';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ਟ੍ਰਾਂਸਕੋਡਿੰਗ';
 
   @override
-  String get adminDrawerResume => 'ਜਾਰੀ ਰੱਖੋ';
+  String get adminDrawerResume => 'ਮੁੜ ਸ਼ੁਰੂ ਕਰੋ';
 
   @override
   String get adminDrawerStreaming => 'ਸਟ੍ਰੀਮਿੰਗ';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ਟ੍ਰਿਕਪਲੇ';
 
   @override
   String get adminDrawerDevices => 'ਡਿਵਾਈਸਾਂ';
@@ -4391,22 +4395,22 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'ਪਲੱਗਇਨ ਅੱਪਡੇਟ ਉਪਲਬਧ: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'ਮੁੜ-ਚਾਲੂ ਦੀ ਲੋੜ ਵਾਲੇ ਪਲੱਗਇਨ: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'ਅਸਫਲ ਨਿਰਧਾਰਿਤ ਕਾਰਜ: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'ਹਾਲੀਆ ਚੇਤਾਵਨੀ/ਗਲਤੀ ਐਂਟਰੀਆਂ: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4465,7 +4469,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'ਗਲਤੀ: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4492,7 +4496,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'ਕਮਾਂਡ ਅਸਫਲ: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4556,14 +4560,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminClearDates => 'ਤਾਰੀਖਾਂ ਨੂੰ ਸਾਫ਼ ਕਰੋ';
 
   @override
-  String get adminActivitySeverityAll => 'ਸਾਰੀਆਂ ਗੰਭੀਰਤਾਵਾਂ';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'ਮਿਤੀ ਰੇਂਜ';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'ਗਤੀਵਿਧੀ ਲੌਗ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4580,7 +4584,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'ਡਿਵਾਈਸ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4591,28 +4595,28 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'ਡਿਵਾਈਸ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'ਡਿਵਾਈਸ \'$name\' ਹਟਾਉਣਾ ਹੈ? ਯੂਜ਼ਰ ਨੂੰ ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਮੁੜ ਸਾਈਨ ਇਨ ਕਰਨਾ ਪਵੇਗਾ।';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'ਸਾਰੇ ਡਿਵਾਈਸ ਮਿਟਾਓ';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count ਡਿਵਾਈਸ ਹਟਾਉਣੇ ਹਨ? ਪ੍ਰਭਾਵਿਤ ਯੂਜ਼ਰਾਂ ਨੂੰ ਮੁੜ ਸਾਈਨ ਇਨ ਕਰਨਾ ਪਵੇਗਾ। ਤੁਹਾਡਾ ਮੌਜੂਦਾ ਡਿਵਾਈਸ ਪ੍ਰਭਾਵਿਤ ਨਹੀਂ ਹੁੰਦਾ।';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'ਡਿਵਾਈਸ ਹਟਾਏ ਗਏ';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'ਕੁਝ ਡਿਵਾਈਸ ਹਟਾਏ ਗਏ; $count ਨੂੰ ਹਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4641,7 +4645,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'ਸਕੈਨ ਸ਼ੁਰੂ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4652,12 +4656,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'ਲਾਇਬ੍ਰੇਰੀ ਦਾ ਨਾਮ \"$name\" ਰੱਖਿਆ ਗਿਆ';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'ਨਾਮ ਬਦਲਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4665,17 +4669,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'ਲਾਇਬ੍ਰੇਰੀ \"$name\" ਮਿਟਾਈ ਗਈ';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'ਲਾਇਬ੍ਰੇਰੀ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'ਪਾਥ ਸ਼ਾਮਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4683,12 +4687,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'ਇਸ ਲਾਇਬ੍ਰੇਰੀ ਵਿੱਚੋਂ \"$path\" ਹਟਾਉਣਾ ਹੈ?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'ਪਾਥ ਹਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4696,7 +4700,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'ਵਿਕਲਪ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4727,251 +4731,251 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminMetadataCountryHint => 'ਜਿਵੇਂ ਕਿ US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'ਪਾਥ';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'ਵਿਕਲਪ';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ਡਾਊਨਲੋਡਰ';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'ਮੈਟਾਡਾਟਾ ਸੇਵਰ';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'ਉਪਸਿਰਲੇਖ ਡਾਊਨਲੋਡਰ';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'ਬੋਲ ਡਾਊਨਲੋਡਰ';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'ਮੈਟਾਡਾਟਾ ਡਾਊਨਲੋਡਰ: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ਚਿੱਤਰ ਫੈਚਰ: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'ਇਹ ਸਰਵਰ ਇਸ ਲਾਇਬ੍ਰੇਰੀ ਕਿਸਮ ਲਈ ਕੋਈ ਡਾਊਨਲੋਡਰ ਪੇਸ਼ ਨਹੀਂ ਕਰਦਾ।';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'ਆਮ';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'ਮੈਟਾਡਾਟਾ';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'ਏਮਬੈੱਡਡ ਜਾਣਕਾਰੀ';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'ਉਪਸਿਰਲੇਖ';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'ਚਿੱਤਰ';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'ਸੀਰੀਜ਼';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'ਸੰਗੀਤ';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'ਫਿਲਮਾਂ';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'ਰੀਅਲ-ਟਾਈਮ ਨਿਗਰਾਨੀ ਸਮਰੱਥ ਕਰੋ';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ਫਾਈਲ ਬਦਲਾਵਾਂ ਦਾ ਪਤਾ ਲਗਾ ਕੇ ਉਹਨਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਪ੍ਰੋਸੈਸ ਕਰੋ।';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'ਆਰਕਾਈਵਾਂ ਨੂੰ ਮੀਡੀਆ ਫਾਈਲਾਂ ਵਜੋਂ ਸਮਝੋ';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ਫੋਟੋ ਦਿਖਾਓ';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'ਆਰਟਵਰਕ ਮੀਡੀਆ ਫੋਲਡਰਾਂ ਵਿੱਚ ਸੇਵ ਕਰੋ';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'ਆਟੋਮੈਟਿਕ ਮੈਟਾਡਾਟਾ ਤਾਜ਼ਾ ਕਰਨਾ';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ਕਦੇ ਨਹੀਂ';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ਡਿਫਾਲਟ';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'ਡਿਸਪਲੇ';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'ਲਾਇਬ੍ਰੇਰੀ ਡਿਸਪਲੇ';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'ਸਾਦੇ ਮੀਡੀਆ ਫੋਲਡਰ ਦਿਖਾਉਣ ਲਈ ਇੱਕ ਫੋਲਡਰ ਦ੍ਰਿਸ਼ ਦਿਖਾਓ';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'ਵਿਸ਼ੇਸ਼ ਨੂੰ ਉਹਨਾਂ ਸੀਜ਼ਨਾਂ ਵਿੱਚ ਦਿਖਾਓ ਜਿਨ੍ਹਾਂ ਵਿੱਚ ਉਹ ਪ੍ਰਸਾਰਿਤ ਹੋਏ';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'ਫਿਲਮਾਂ ਨੂੰ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸਮੂਹ ਕਰੋ';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'ਸ਼ੋਅ ਨੂੰ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸਮੂਹ ਕਰੋ';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'ਸੁਝਾਵਾਂ ਵਿੱਚ ਬਾਹਰੀ ਸਮੱਗਰੀ ਦਿਖਾਓ';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ ਦਾ ਵਿਹਾਰ';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ ਇੱਥੋਂ ਵਰਤੋ';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'ਲਾਇਬ੍ਰੇਰੀ ਵਿੱਚ ਸਕੈਨ ਕੀਤੀ ਮਿਤੀ';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ਫਾਈਲ ਬਣਾਏ ਜਾਣ ਦੀ ਮਿਤੀ';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'ਮੈਟਾਡਾਟਾ ਅਤੇ ਚਿੱਤਰ';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ਤਰਜੀਹੀ ਮੈਟਾਡਾਟਾ ਭਾਸ਼ਾ';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'ਅਧਿਆਏ';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ਡਮੀ ਅਧਿਆਏ ਮਿਆਦ (ਸਕਿੰਟ)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'ਉਸ ਮੀਡੀਆ ਲਈ ਬਣਾਏ ਗਏ ਅਧਿਆਵਾਂ ਦੀ ਲੰਬਾਈ ਜਿਸ ਦੇ ਕੋਈ ਨਹੀਂ ਹਨ। ਅਯੋਗ ਕਰਨ ਲਈ 0 \'ਤੇ ਸੈੱਟ ਕਰੋ।';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'ਅਧਿਆਏ ਚਿੱਤਰ ਰੈਜ਼ੋਲਿਊਸ਼ਨ';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO ਸੈਟਿੰਗਾਂ';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO ਮੈਟਾਡਾਟਾ Kodi ਅਤੇ ਸਮਾਨ ਕਲਾਇੰਟਾਂ ਨਾਲ ਅਨੁਕੂਲ ਹੈ। ਸੈਟਿੰਗਾਂ ਉਹਨਾਂ ਸਾਰੀਆਂ ਲਾਇਬ੍ਰੇਰੀਆਂ \'ਤੇ ਲਾਗੂ ਹੁੰਦੀਆਂ ਹਨ ਜੋ NFO ਮੈਟਾਡਾਟਾ ਸੇਵ ਕਰਦੀਆਂ ਹਨ।';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ਫਾਈਲਾਂ ਵਿੱਚ ਦੇਖਣ ਡੇਟਾ ਸਟੋਰ ਕਰਨ ਵਾਲਾ ਯੂਜ਼ਰ';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO ਫਾਈਲਾਂ ਵਿੱਚ ਚਿੱਤਰ ਪਾਥ ਸੇਵ ਕਰੋ';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO ਚਿੱਤਰ ਪਾਥਾਂ ਲਈ ਪਾਥ ਬਦਲੀ ਸਮਰੱਥ ਕਰੋ';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart ਚਿੱਤਰਾਂ ਨੂੰ extrathumbs ਫੋਲਡਰ ਵਿੱਚ ਕਾਪੀ ਕਰੋ';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ਕੋਈ ਨਹੀਂ';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ਦਿਨ';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'ਏਮਬੈੱਡਡ ਸਿਰਲੇਖ ਵਰਤੋ';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => 'ਵਾਧੂ ਲਈ ਏਮਬੈੱਡਡ ਸਿਰਲੇਖ ਵਰਤੋ';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'ਏਮਬੈੱਡਡ ਐਪੀਸੋਡ ਜਾਣਕਾਰੀ ਵਰਤੋ';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'ਏਮਬੈੱਡਡ ਉਪਸਿਰਲੇਖ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'ਸਭ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'ਸਿਰਫ ਟੈਕਸਟ';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'ਸਿਰਫ ਚਿੱਤਰ';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ਕੋਈ ਨਹੀਂ';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'ਜੇ ਏਮਬੈੱਡਡ ਉਪਸਿਰਲੇਖ ਮੌਜੂਦ ਹਨ ਤਾਂ ਡਾਊਨਲੋਡ ਛੱਡੋ';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ਜੇ ਆਡੀਓ ਟਰੈਕ ਡਾਊਨਲੋਡ ਭਾਸ਼ਾ ਨਾਲ ਮੇਲ ਖਾਂਦਾ ਹੈ ਤਾਂ ਡਾਊਨਲੋਡ ਛੱਡੋ';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'ਸੰਪੂਰਨ ਉਪਸਿਰਲੇਖ ਮੇਲ ਦੀ ਲੋੜ ਹੈ';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'ਉਪਸਿਰਲੇਖ ਮੀਡੀਆ ਫੋਲਡਰਾਂ ਵਿੱਚ ਸੇਵ ਕਰੋ';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'ਅਧਿਆਏ ਚਿੱਤਰ ਕੱਢੋ';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'ਲਾਇਬ੍ਰੇਰੀ ਸਕੈਨ ਦੌਰਾਨ ਅਧਿਆਏ ਚਿੱਤਰ ਕੱਢੋ';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Trickplay ਚਿੱਤਰ ਕੱਢਣਾ ਸਮਰੱਥ ਕਰੋ';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'ਲਾਇਬ੍ਰੇਰੀ ਸਕੈਨ ਦੌਰਾਨ Trickplay ਚਿੱਤਰ ਕੱਢੋ';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay ਚਿੱਤਰ ਮੀਡੀਆ ਫੋਲਡਰਾਂ ਵਿੱਚ ਸੇਵ ਕਰੋ';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'ਕਈ ਫੋਲਡਰਾਂ ਵਿੱਚ ਫੈਲੀਆਂ ਲੜੀਆਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਮਿਲਾਓ';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'ਸੀਜ਼ਨ ਜ਼ੀਰੋ ਡਿਸਪਲੇ ਨਾਮ';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'ਆਡੀਓ ਸਧਾਰਨੀਕਰਨ ਲਈ LUFS ਸਕੈਨ ਸਮਰੱਥ ਕਰੋ';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'ਗੈਰ-ਮਿਆਰੀ ਕਲਾਕਾਰ ਟੈਗ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'ਫਿਲਮਾਂ ਨੂੰ ਆਪਣੇ-ਆਪ ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'ਲਾਇਬ੍ਰੇਰੀ ਦਾ ਨਾਮ ਲੋੜੀਂਦਾ ਹੈ';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'ਲਾਇਬ੍ਰੇਰੀ ਬਣਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4998,27 +5002,27 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name ਨੂੰ ਅਯੋਗ ਕਰਨਾ ਹੈ? ਉਹ ਸਾਈਨ ਇਨ ਨਹੀਂ ਕਰ ਸਕਣਗੇ।';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name ਨੂੰ ਯੋਗ ਕਰਨਾ ਹੈ? ਉਹ ਮੁੜ ਸਾਈਨ ਇਨ ਕਰ ਸਕਣਗੇ।';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'ਯੂਜ਼ਰ \"$name\" ਅਯੋਗ ਕੀਤਾ';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'ਯੂਜ਼ਰ \"$name\" ਯੋਗ ਕੀਤਾ';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'ਯੂਜ਼ਰ ਨੀਤੀ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5035,7 +5039,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'ਯੂਜ਼ਰ ਬਣਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5056,7 +5060,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5067,7 +5071,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'ਅਸਫਲ: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5204,144 +5208,143 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminEnableAllChannels => 'ਸਾਰੇ ਚੈਨਲਾਂ ਤੱਕ ਪਹੁੰਚ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ';
 
   @override
-  String get adminParentalControl => 'ਮਾਪਾ ਕੰਟਰੋਲ';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'ਵੱਧ ਤੋਂ ਵੱਧ ਮਨਜ਼ੂਰ ਮਾਪਾ ਰੇਟਿੰਗ';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'ਉੱਚੀ ਰੇਟਿੰਗ ਵਾਲੀ ਸਮੱਗਰੀ ਇਸ ਯੂਜ਼ਰ ਤੋਂ ਲੁਕਾਈ ਜਾਵੇਗੀ।';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ਕੋਈ ਨਹੀਂ';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'ਬਿਨਾਂ ਜਾਂ ਅਣਪਛਾਤੀ ਰੇਟਿੰਗ ਜਾਣਕਾਰੀ ਵਾਲੀਆਂ ਆਈਟਮਾਂ ਬਲਾਕ ਕਰੋ';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'ਕਿਤਾਬਾਂ';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ਚੈਨਲ';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ਲਾਈਵ ਟੀਵੀ';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'ਫਿਲਮਾਂ';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'ਸੰਗੀਤ';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ਟ੍ਰੇਲਰ';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'ਸ਼ੋਅ';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'ਪਹੁੰਚ ਸਮਾਂ-ਸਾਰਣੀਆਂ';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'ਸਿਰਫ ਹੇਠਾਂ ਦਿੱਤੇ ਨਿਰਧਾਰਿਤ ਸਮਿਆਂ ਦੌਰਾਨ ਪਹੁੰਚ ਦੀ ਆਗਿਆ ਦਿਓ। ਜਦੋਂ ਕੋਈ ਸਮਾਂ-ਸਾਰਣੀ ਸੈੱਟ ਨਹੀਂ ਹੁੰਦੀ ਤਾਂ ਸਾਰਾ ਦਿਨ ਪਹੁੰਚ ਦੀ ਆਗਿਆ ਹੁੰਦੀ ਹੈ।';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'ਸਮਾਂ-ਸਾਰਣੀ ਸ਼ਾਮਲ ਕਰੋ';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'ਦਿਨ';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'ਸ਼ੁਰੂ';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'ਅੰਤ';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'ਹਰ ਦਿਨ';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'ਹਫ਼ਤੇ ਦਾ ਦਿਨ';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'ਹਫ਼ਤੇ ਦਾ ਅੰਤ';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ਐਤਵਾਰ';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'ਸੋਮਵਾਰ';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'ਮੰਗਲਵਾਰ';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'ਬੁੱਧਵਾਰ';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'ਵੀਰਵਾਰ';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'ਸ਼ੁੱਕਰਵਾਰ';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'ਸ਼ਨਿੱਚਰਵਾਰ';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'ਮਨਜ਼ੂਰ ਟੈਗ';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'ਸਿਰਫ ਇਹਨਾਂ ਟੈਗਾਂ ਵਾਲੀ ਸਮੱਗਰੀ ਦਿਖਾਈ ਜਾਂਦੀ ਹੈ। ਸਭ ਦੀ ਆਗਿਆ ਦੇਣ ਲਈ ਖਾਲੀ ਛੱਡੋ।';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'ਬਲਾਕ ਕੀਤੇ ਟੈਗ';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'ਇਹਨਾਂ ਟੈਗਾਂ ਵਾਲੀ ਸਮੱਗਰੀ ਇਸ ਯੂਜ਼ਰ ਤੋਂ ਲੁਕਾਈ ਜਾਂਦੀ ਹੈ।';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ਟੈਗ ਸ਼ਾਮਲ ਕਰੋ';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'ਯੋਗ ਡਿਵਾਈਸ';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'ਯੋਗ ਚੈਨਲ';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ਪ੍ਰਮਾਣੀਕਰਨ ਪ੍ਰਦਾਤਾ';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'ਪਾਸਵਰਡ ਰੀਸੈਟ ਪ੍ਰਦਾਤਾ';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'ਲਾਕਆਉਟ ਤੋਂ ਪਹਿਲਾਂ ਵੱਧ ਤੋਂ ਵੱਧ ਅਸਫਲ ਲੌਗਇਨ ਕੋਸ਼ਿਸ਼ਾਂ';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'ਡਿਫਾਲਟ ਲਈ 0, ਜਾਂ ਲਾਕਆਉਟ ਅਯੋਗ ਕਰਨ ਲਈ -1 \'ਤੇ ਸੈੱਟ ਕਰੋ।';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay ਪਹੁੰਚ';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'ਸਮੂਹ ਬਣਾਉਣ ਅਤੇ ਸ਼ਾਮਲ ਹੋਣ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'ਸਮੂਹਾਂ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਣ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'ਕੋਈ ਪਹੁੰਚ ਨਹੀਂ';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'ਇੱਥੋਂ ਸਮੱਗਰੀ ਮਿਟਾਉਣ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5349,22 +5352,22 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'ਸਰਵਰ ਨੇ HTTP $status ਵਾਪਸ ਕੀਤਾ';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ $name ਨੂੰ ਮਿਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'ਯੂਜ਼ਰ \"$name\" ਮਿਟਾਇਆ';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'ਯੂਜ਼ਰ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5385,7 +5388,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'ਕੁੰਜੀ ਬਣਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5396,7 +5399,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name ਲਈ ਕੁੰਜੀ ਰੱਦ ਕਰਨੀ ਹੈ?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5404,7 +5407,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'ਕੁੰਜੀ ਰੱਦ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5424,29 +5427,29 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'ਟੋਕਨ: $token\\nਬਣਾਇਆ: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'ਬੈਕਅੱਪ ਬਣਾਓ';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'ਬੈਕਅੱਪ ਵਿੱਚ ਕੀ ਸ਼ਾਮਲ ਕਰਨਾ ਹੈ ਚੁਣੋ।';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ਡਾਟਾਬੇਸ';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'ਹਮੇਸ਼ਾ ਸ਼ਾਮਲ';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'ਮੈਟਾਡਾਟਾ';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'ਉਪਸਿਰਲੇਖ';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay ਚਿੱਤਰ';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'ਬੈਕਅੱਪ ਬਣਾਇਆ ਜਾ ਰਿਹਾ ਹੈ...';
@@ -5456,7 +5459,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'ਬੈਕਅੱਪ ਬਣਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5464,12 +5467,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'ਮੈਨੀਫੈਸਟ: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'ਮੈਨੀਫੈਸਟ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5480,7 +5483,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'ਬੈਕਅੱਪ ਬਹਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5512,17 +5515,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path ਵਿੱਚ ਸੇਵ ਕੀਤਾ';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ਫਾਈਲ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5533,7 +5536,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'ਕਾਰਜ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5545,17 +5548,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'ਕਾਰਜ ਸ਼ੁਰੂ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'ਕਾਰਜ ਰੋਕਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'ਕਾਰਜ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5563,12 +5566,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'ਟ੍ਰਿਗਰ ਹਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'ਟ੍ਰਿਗਰ ਸ਼ਾਮਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5594,7 +5597,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ਘੰਟੇ';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5605,7 +5608,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'ਪਲੱਗਇਨ ਟੌਗਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5613,27 +5616,27 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ \"$name\" ਨੂੰ ਅਣਇੰਸਟਾਲ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'ਪਲੱਗਇਨ ਅਣਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'ਅੱਪਡੇਟ ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'ਪਲੱਗਇਨ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5645,12 +5648,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'ਅੱਪਡੇਟ ਇੰਸਟਾਲ ਕਰੋ (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'ਕੈਟਾਲਾਗ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5672,17 +5675,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" ਸਰਵਰ ਮੁੜ-ਚਾਲੂ ਹੋਣ ਤੋਂ ਬਾਅਦ ਹਟਾਇਆ ਜਾਵੇਗਾ';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'ਅਣਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" ਨੂੰ v$version \'ਤੇ ਅੱਪਡੇਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5691,7 +5694,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'ਪਲੱਗਇਨ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5699,7 +5702,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'ਸੰਸਕਰਣ $version';
+    return 'Version $version';
   }
 
   @override
@@ -5719,17 +5722,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ \"$name\" ਨੂੰ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'ਰਿਪੋਜ਼ਟਰੀਆਂ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'ਰਿਪੋਜ਼ਟਰੀਆਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5746,12 +5749,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'ਪਲੱਗਇਨ ਸੈਟਿੰਗਾਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਮਰੱਥ: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri ਨਹੀਂ ਖੋਲ੍ਹਿਆ ਜਾ ਸਕਿਆ';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5869,10 +5872,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminThrottleBuffering => 'ਥ੍ਰੋਟਲ ਬਫਰਿੰਗ';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay ਸੈਟਿੰਗਾਂ ਸੇਵ ਕੀਤੀਆਂ';
+  String get adminTrickplaySaved => 'ਟ੍ਰਿਕਪਲੇ ਸੈਟਿੰਗਾਂ ਸੁਰੱਖਿਅਤ ਕੀਤੀਆਂ ਗਈਆਂ';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay ਸੈਟਿੰਗਾਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
+  String get adminTrickplayLoadFailed => 'ਟ੍ਰਿਕਪਲੇ ਸੈਟਿੰਗਾਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -5985,7 +5988,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminBaseUrl => 'ਬੇਸ URL';
 
   @override
-  String get adminBaseUrlHint => 'ਜਿਵੇਂ /jellyfin';
+  String get adminBaseUrlHint => 'ਜਿਵੇਂ ਕਿ /ਜੈਲੀਫਿਨ';
 
   @override
   String get https => 'HTTPS';
@@ -6025,12 +6028,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'ਮੈਟਾਡਾਟਾ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'ਮੈਟਾਡਾਟਾ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6051,7 +6054,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'ਮੈਟਾਡਾਟਾ ਤਾਜ਼ਾ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6065,7 +6068,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'ਰਿਮੋਟ ਖੋਜ ਅਸਫਲ: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6079,7 +6082,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'ਸਮੱਗਰੀ ਕਿਸਮ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6094,12 +6097,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਅੱਪਡੇਟ ਕੀਤਾ';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'ਚਿੱਤਰ ਡਾਊਨਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6110,27 +6113,27 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਅੱਪਲੋਡ ਕੀਤਾ';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਮਿਟਾਓ';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਮਿਟਾਇਆ';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'ਚਿੱਤਰ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6141,69 +6144,67 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'ਟਿਊਨਰ ਖੋਜ ਅਸਫਲ: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'ਟਿਊਨਰ ਸ਼ਾਮਲ ਕਰੋ';
 
   @override
-  String get adminEditTuner => 'ਟਿਊਨਰ ਸੰਪਾਦਿਤ ਕਰੋ';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ਟਿਊਨਰ';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ਫਾਈਲ ਜਾਂ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ਟਿਊਨਰ IP ਪਤਾ';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'ਪਛਾਣ ਨਾਮ';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'ਯੂਜ਼ਰ ਏਜੰਟ';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ਇੱਕੋ ਸਮੇਂ ਕਨੈਕਸ਼ਨ ਸੀਮਾ';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ਟਿਊਨਰ ਇੱਕੋ ਵਾਰ ਜਿੰਨੀਆਂ ਸਟ੍ਰੀਮਾਂ ਦੀ ਆਗਿਆ ਦਿੰਦਾ ਹੈ ਉਹਨਾਂ ਦੀ ਵੱਧ ਤੋਂ ਵੱਧ ਗਿਣਤੀ। ਅਸੀਮਿਤ ਲਈ 0 \'ਤੇ ਸੈੱਟ ਕਰੋ।';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'ਬੈਕਅੱਪ ਵੱਧ ਤੋਂ ਵੱਧ ਸਟ੍ਰੀਮਿੰਗ ਬਿੱਟਰੇਟ';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'ਸਿਰਫ ਮਨਪਸੰਦ ਚੈਨਲ ਆਯਾਤ ਕਰੋ';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'ਹਾਰਡਵੇਅਰ ਟ੍ਰਾਂਸਕੋਡਿੰਗ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 ਟ੍ਰਾਂਸਕੋਡਿੰਗ ਕੰਟੇਨਰ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ਸਟ੍ਰੀਮ ਸਾਂਝਾਕਰਨ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ਸਟ੍ਰੀਮ ਲੂਪਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS ਨੂੰ ਨਜ਼ਰਅੰਦਾਜ਼ ਕਰੋ';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'ਇਨਪੁੱਟ ਨੂੰ ਮੂਲ ਫ੍ਰੇਮ ਰੇਟ \'ਤੇ ਪੜ੍ਹੋ';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ਪ੍ਰਦਾਤਾ ਸੰਪਾਦਿਤ ਕਰੋ';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6212,50 +6213,50 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ਫਾਈਲ ਜਾਂ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'ਫਿਲਮ ਅਗੇਤਰ';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'ਫਿਲਮ ਸ਼੍ਰੇਣੀਆਂ';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'ਕਈ ਸ਼੍ਰੇਣੀਆਂ ਨੂੰ ਲੰਬਕਾਰੀ ਲਾਈਨ ਨਾਲ ਵੱਖ ਕਰੋ।';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'ਬੱਚਿਆਂ ਦੀਆਂ ਸ਼੍ਰੇਣੀਆਂ';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'ਖ਼ਬਰਾਂ ਦੀਆਂ ਸ਼੍ਰੇਣੀਆਂ';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'ਖੇਡ ਸ਼੍ਰੇਣੀਆਂ';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ਯੂਜ਼ਰਨੇਮ';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'ਪਾਸਵਰਡ';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'ਦੇਸ਼';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'ਇੱਕ ਦੇਸ਼ ਚੁਣੋ';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'ਡਾਕ ਕੋਡ';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'ਸੂਚੀਆਂ ਪ੍ਰਾਪਤ ਕਰੋ';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'ਸੂਚੀਆਂ';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'ਸਾਰੇ ਟਿਊਨਰ ਸਮਰੱਥ ਕਰੋ';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ਟਿਊਨਰ ਦੀ ਕਿਸਮ';
@@ -6265,7 +6266,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'ਟਿਊਨਰ ਸ਼ਾਮਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6279,12 +6280,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'ਪ੍ਰਦਾਤਾ ਸ਼ਾਮਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'ਟਿਊਨਰ ਹਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6292,16 +6293,16 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'ਟਿਊਨਰ ਰੀਸੈਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'ਇਹ ਟਿਊਨਰ ਕਿਸਮ ਰੀਸੈਟ ਕਰਨ ਦਾ ਸਮਰਥਨ ਨਹੀਂ ਕਰਦੀ।';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'ਪ੍ਰਦਾਤਾ ਹਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6320,43 +6321,43 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'ਸੀਰੀਜ਼ ਰਿਕਾਰਡਿੰਗ ਮਾਰਗ';
 
   @override
-  String get adminMovieRecordingPath => 'ਫਿਲਮ ਰਿਕਾਰਡਿੰਗ ਪਾਥ';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'ਗਾਈਡ ਡੇਟਾ ਦਿਨ';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ਆਟੋਮੈਟਿਕ';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ਦਿਨ';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'ਪੋਸਟ-ਪ੍ਰੋਸੈਸਿੰਗ ਐਪਲੀਕੇਸ਼ਨ ਪਾਥ';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'ਪੋਸਟ-ਪ੍ਰੋਸੈਸਰ ਆਰਗੂਮੈਂਟ';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'ਰਿਕਾਰਡਿੰਗ NFO ਮੈਟਾਡਾਟਾ ਸੇਵ ਕਰੋ';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'ਰਿਕਾਰਡਿੰਗ ਚਿੱਤਰ ਸੇਵ ਕਰੋ';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'ਸਮਾਂ';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'ਰਿਕਾਰਡਿੰਗ ਪਾਥ';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'ਪੋਸਟ-ਪ੍ਰੋਸੈਸਿੰਗ';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'ਗਾਈਡ ਡੇਟਾ: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6365,7 +6366,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'ਸੈਟਿੰਗਾਂ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6382,7 +6383,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'ਮੈਪਿੰਗ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6399,14 +6400,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminGuideProviders => 'ਗਾਈਡ ਪ੍ਰਦਾਤਾ';
 
   @override
-  String get adminRefreshGuideData => 'ਗਾਈਡ ਡੇਟਾ ਤਾਜ਼ਾ ਕਰੋ';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'ਗਾਈਡ ਡੇਟਾ ਤਾਜ਼ਾ ਕਰਨਾ ਸ਼ੁਰੂ ਹੋਇਆ';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'ਗਾਈਡ ਤਾਜ਼ਾ ਕਰਨ ਦਾ ਕਾਰਜ ਇਸ ਸਰਵਰ \'ਤੇ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'ਪ੍ਰਦਾਤਾ ਸ਼ਾਮਲ ਕਰੋ';
@@ -6417,22 +6418,22 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'ਰਿਕਾਰਡਿੰਗ ਪਾਥ: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'ਲੜੀ ਪਾਥ: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'ਪ੍ਰੀ-ਪੈਡਿੰਗ: $minutes ਮਿੰਟ';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'ਪੋਸਟ-ਪੈਡਿੰਗ: $minutes ਮਿੰਟ';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6464,7 +6465,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'ਹੁਣ ਬੈਕਅੱਪ $name ਬਹਾਲ ਕਰਨਾ ਹੈ?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6494,7 +6495,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminNotSet => 'ਸੈੱਟ ਨਹੀਂ ਹੈ';
 
   @override
-  String get adminReset => 'ਰੀਸੈੱਟ ਕਰੋ';
+  String get adminReset => 'ਰੀਸੈਟ ਕਰੋ';
 
   @override
   String get adminLogsTitle => 'ਸਰਵਰ ਲੌਗਸ';
@@ -6510,27 +6511,27 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutesਮਿੰਟ ਪਹਿਲਾਂ';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hoursਘੰਟੇ ਪਹਿਲਾਂ';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$daysਦਿਨ ਪਹਿਲਾਂ';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count ਮੇਲ';
+    return '$count matches';
   }
 
   @override
@@ -6540,7 +6541,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminMetadataEditorTitle => 'ਮੈਟਾਡੇਟਾ ਸੰਪਾਦਕ';
 
   @override
-  String get adminMetadataIdentify => 'ਪਛਾਣੋ';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'ਟਾਈਪ ਕਰੋ';
@@ -6640,22 +6641,22 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਅੱਪਡੇਟ ਕੀਤਾ';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਅੱਪਲੋਡ ਕੀਤਾ';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਮਿਟਾਇਆ';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'ਚਿੱਤਰ ਡਾਊਨਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6664,12 +6665,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਮਿਟਾਓ';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6678,12 +6679,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'ਚਿੱਤਰ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType ਚਿੱਤਰ ਚੁਣੋ';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6716,7 +6717,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'ਅੱਪਡੇਟ ਉਪਲਬਧ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6740,7 +6741,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'ਅੱਪਡੇਟ ਇੰਸਟਾਲ ਕਰੋ (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6752,7 +6753,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" ਇੰਸਟਾਲ ਹੋ ਰਿਹਾ ਹੈ...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6772,7 +6773,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name ਸੈਟਿੰਗਾਂ';
+    return '$name Settings';
   }
 
   @override
@@ -6812,7 +6813,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'ਰਿਪੋਜ਼ਟਰੀਆਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6820,7 +6821,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ \"$name\" ਨੂੰ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6828,7 +6829,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'ਰਿਪੋਜ਼ਟਰੀਆਂ ਸੇਵ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6953,20 +6954,19 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'ਸਪਲੈਸ਼ ਸਕ੍ਰੀਨ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ';
 
   @override
-  String get adminBrandingSplashUpload => 'ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰੋ';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'ਸਪਲੈਸ਼ਸਕ੍ਰੀਨ ਅੱਪਡੇਟ ਕੀਤੀ';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'ਸਪਲੈਸ਼ਸਕ੍ਰੀਨ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'ਸਪਲੈਸ਼ਸਕ੍ਰੀਨ ਹਟਾਈ ਗਈ';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'ਕੋਈ ਕਸਟਮ ਸਪਲੈਸ਼ਸਕ੍ਰੀਨ ਨਹੀਂ';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'ਹਾਰਡਵੇਅਰ ਪ੍ਰਵੇਗ';
@@ -6983,120 +6983,121 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਇਸ ਲਈ ਹਾਰਡਵੇਅਰ ਡੀਕੋਡਿੰਗ ਨੂੰ ਸਮਰੱਥ ਕਰੋ:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ਡਿਵਾਈਸ';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'ਵਧਾਇਆ NVDEC ਡੀਕੋਡਰ ਸਮਰੱਥ ਕਰੋ';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'ਸਿਸਟਮ ਮੂਲ ਹਾਰਡਵੇਅਰ ਡੀਕੋਡਰ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'ਹਾਰਡਵੇਅਰ ਡੀਕੋਡਿੰਗ ਰੰਗ ਡੂੰਘਾਈ';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC ਡੀਕੋਡਿੰਗ';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 ਡੀਕੋਡਿੰਗ';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit ਡੀਕੋਡਿੰਗ';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit ਡੀਕੋਡਿੰਗ';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'ਹਾਰਡਵੇਅਰ ਏਨਕੋਡਿੰਗ';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC ਏਨਕੋਡਿੰਗ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 ਏਨਕੋਡਿੰਗ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel ਘੱਟ-ਪਾਵਰ H.264 ਏਨਕੋਡਰ ਸਮਰੱਥ ਕਰੋ';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel ਘੱਟ-ਪਾਵਰ HEVC ਏਨਕੋਡਰ ਸਮਰੱਥ ਕਰੋ';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'ਟੋਨ ਮੈਪਿੰਗ';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'ਟੋਨ ਮੈਪਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP ਟੋਨ ਮੈਪਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox ਟੋਨ ਮੈਪਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'ਟੋਨ ਮੈਪਿੰਗ ਐਲਗੋਰਿਦਮ';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'ਟੋਨ ਮੈਪਿੰਗ ਮੋਡ';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'ਟੋਨ ਮੈਪਿੰਗ ਰੇਂਜ';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'ਟੋਨ ਮੈਪਿੰਗ ਡੀਸੈਚੁਰੇਸ਼ਨ';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ਟੋਨ ਮੈਪਿੰਗ ਸਿਖਰ';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'ਟੋਨ ਮੈਪਿੰਗ ਪੈਰਾਮੀਟਰ';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'VPP ਟੋਨ ਮੈਪਿੰਗ ਚਮਕ';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP ਟੋਨ ਮੈਪਿੰਗ ਕੰਟ੍ਰਾਸਟ';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'ਪ੍ਰੀਸੈਟ ਅਤੇ ਗੁਣਵੱਤਾ';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'ਏਨਕੋਡਰ ਪ੍ਰੀਸੈਟ';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 ਏਨਕੋਡਿੰਗ CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) ਏਨਕੋਡਿੰਗ CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'ਡੀਇੰਟਰਲੇਸ ਵਿਧੀ';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ਡੀਇੰਟਰਲੇਸ ਕਰਦੇ ਸਮੇਂ ਫ੍ਰੇਮ ਰੇਟ ਦੁੱਗਣਾ ਕਰੋ';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ਆਡੀਓ';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'ਆਡੀਓ VBR ਏਨਕੋਡਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ਆਡੀਓ ਡਾਊਨਮਿਕਸ ਬੂਸਟ';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ਸਟੀਰੀਓ ਡਾਊਨਮਿਕਸ ਐਲਗੋਰਿਦਮ';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'ਵੱਧ ਤੋਂ ਵੱਧ ਮਕਸਿੰਗ ਕਤਾਰ ਆਕਾਰ';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ਆਟੋ';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'ਏਨਕੋਡਿੰਗ';
@@ -7214,10 +7215,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminTaskNeverRun => 'ਕਦੇ ਨਾ ਦੌੜੋ';
 
   @override
-  String get adminTaskStop => 'ਰੋਕੋ';
+  String get adminTaskStop => 'ਰੂਕੋ';
 
   @override
-  String get adminRunningTasks => 'ਚੱਲ ਰਹੇ ਕਾਰਜ';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'ਚਲਾਓ';
@@ -7239,17 +7240,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'ਰੋਜ਼ਾਨਾ $time \'ਤੇ';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'ਹਰ $day ਨੂੰ $time \'ਤੇ';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'ਹਰ $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7287,8 +7288,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਘੰਟੇ',
-      one: '1 ਘੰਟਾ',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7316,17 +7317,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$daysਦਿਨ ਪਹਿਲਾਂ';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hoursਘੰਟੇ ਪਹਿਲਾਂ';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutesਮਿੰਟ ਪਹਿਲਾਂ';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7334,17 +7335,17 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesਮਿੰਟ';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursਘੰਟੇ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysਦਿਨ';
+    return '${days}d';
   }
 
   @override
@@ -7354,7 +7355,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'ਸੀਕ ਪ੍ਰੀਵਿਊ ਥੰਬਨੇਲ ਲਈ Trickplay ਚਿੱਤਰ ਬਣਾਉਣਾ ਸੰਰਚਿਤ ਕਰੋ।';
+      'ਪੂਰਵਦਰਸ਼ਨ ਥੰਬਨੇਲ ਦੀ ਭਾਲ ਲਈ ਟ੍ਰਿਕਪਲੇ ਚਿੱਤਰ ਜਨਰੇਸ਼ਨ ਨੂੰ ਕੌਂਫਿਗਰ ਕਰੋ।';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'ਜਨਤਕ HTTPS ਪੋਰਟ';
@@ -7363,49 +7364,49 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'ਬੇਸ URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ਜਿਵੇਂ /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ਜਿਵੇਂ ਕਿ /ਜੈਲੀਫਿਨ';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'ਪਬਲਿਕ HTTP ਪੋਰਟ';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS ਦੀ ਲੋੜ ਹੈ';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'ਸਾਰੀਆਂ ਰਿਮੋਟ ਬੇਨਤੀਆਂ ਨੂੰ HTTPS \'ਤੇ ਰੀਡਾਇਰੈਕਟ ਕਰੋ। ਜੇ ਸਰਵਰ ਕੋਲ ਕੋਈ ਵੈਧ ਸਰਟੀਫਿਕੇਟ ਨਹੀਂ ਹੈ ਤਾਂ ਕੋਈ ਪ੍ਰਭਾਵ ਨਹੀਂ ਹੁੰਦਾ।';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'ਸਰਟੀਫਿਕੇਟ ਪਾਸਵਰਡ';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP ਸੈਟਿੰਗਾਂ';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 ਸਮਰੱਥ ਕਰੋ';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 ਸਮਰੱਥ ਕਰੋ';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'ਆਟੋਮੈਟਿਕ ਪੋਰਟ ਮੈਪਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN ਨੈੱਟਵਰਕ';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'ਸਥਾਨਕ ਨੈੱਟਵਰਕ \'ਤੇ ਮੰਨੇ ਜਾਂਦੇ IP ਪਤਿਆਂ ਜਾਂ CIDR ਸਬਨੈੱਟਾਂ ਦੀ ਕਾਮੇ ਜਾਂ ਲਾਈਨ ਨਾਲ ਵੱਖ ਕੀਤੀ ਸੂਚੀ।';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'ਪ੍ਰਕਾਸ਼ਿਤ ਸਰਵਰ URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'ਇੱਕ ਸਬਨੈੱਟ ਜਾਂ ਪਤੇ ਨੂੰ ਪ੍ਰਕਾਸ਼ਿਤ URL ਨਾਲ ਮੈਪ ਕਰੋ, ਜਿਵੇਂ all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'ਸਰਟੀਫਿਕੇਟ ਮਾਰਗ';
@@ -7435,11 +7436,11 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'ਥ੍ਰੋਟਲ ਬਫਰਿੰਗ';
 
   @override
-  String get adminPlaybackThrottleDelay => 'ਥ੍ਰੋਟਲ ਦੇਰੀ (ਸਕਿੰਟ)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'ਤੁਰੰਤ ਉਪਸਿਰਲੇਖ ਕੱਢਣ ਦੀ ਆਗਿਆ ਦਿਓ';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'ਘੱਟੋ-ਘੱਟ ਰੈਜ਼ਿਊਮੇ ਪ੍ਰਤੀਸ਼ਤ';
@@ -7488,29 +7489,29 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'ਸਮੱਗਰੀ ਕਿਸਮ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'ਹੌਲੀ ਜਵਾਬ ਸੀਮਾ (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'ਹੌਲੀ ਜਵਾਬ ਚੇਤਾਵਨੀਆਂ ਸਮਰੱਥ ਕਰੋ';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect ਸਮਰੱਥ ਕਰੋ';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'ਸਰਵਰ';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'ਮੈਟਾਡਾਟਾ';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'ਪਾਥ';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'ਪ੍ਰਦਰਸ਼ਨ';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'ਕੈਸ਼ ਮਾਰਗ';
@@ -7522,7 +7523,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminGeneralServerName => 'ਸਰਵਰ ਦਾ ਨਾਮ';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ਤਰਜੀਹੀ ਡਿਸਪਲੇ ਭਾਸ਼ਾ';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'ਸੈਟਿੰਗਾਂ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
@@ -7532,12 +7533,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'ਮੈਪਿੰਗ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'ਸਮਾਂ ਸੀਮਾ: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7574,8 +7575,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ਭਾਗੀਦਾਰ',
-      one: '# ਭਾਗੀਦਾਰ',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7618,7 +7619,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'ਆਈਟਮ $index';
+    return 'Item $index';
   }
 
   @override
@@ -7666,12 +7667,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay ਸਮੂਹ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਇਆ';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay ਸਮੂਹ ਤੋਂ ਬਾਹਰ ਹੋਇਆ';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7683,7 +7684,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName ਨਾਲ ਪਲੇਬੈਕ ਸਿੰਕ ਹੋ ਰਿਹਾ ਹੈ';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7721,8 +7722,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ਕਤਾਰਾਂ ਲੱਭੀਆਂ',
-      one: '# ਕਤਾਰ ਲੱਭੀ',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7763,21 +7764,20 @@ class AppLocalizationsPa extends AppLocalizations {
   String get offlineSavedMedia => 'ਸੁਰੱਖਿਅਤ ਕੀਤਾ ਮੀਡੀਆ';
 
   @override
-  String get offlineBannerTitle => 'ਤੁਸੀਂ ਆਫਲਾਈਨ ਹੋ';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'ਤੁਹਾਡੇ ਡਾਊਨਲੋਡ ਦਿਖਾ ਰਹੇ ਹਾਂ';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ਡਾਊਨਲੋਡ';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'ਤੁਹਾਡੇ ਸਰਵਰ ਤੱਕ ਪਹੁੰਚ ਨਹੀਂ ਹੋ ਸਕਦੀ';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'ਵਾਪਸ ਆਉਣ ਤੱਕ ਡਾਊਨਲੋਡ ਤੋਂ ਚਲਾ ਰਹੇ ਹਾਂ';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7793,12 +7793,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'ਕਾਸਟ ਕੰਟਰੋਲ ਅਸਫਲ: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind ਕੰਟਰੋਲ';
+    return '$kind Controls';
   }
 
   @override
@@ -7809,7 +7809,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind ਰੋਕੋ';
+    return 'Stop $kind';
   }
 
   @override
@@ -7832,12 +7832,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length-ਅੰਕ ਦਾ PIN ਦਾਖਲ ਕਰੋ';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'ਆਪਣਾ $length-ਅੰਕ ਦਾ PIN ਦਾਖਲ ਕਰੋ';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7850,40 +7850,42 @@ class AppLocalizationsPa extends AppLocalizations {
   String get pinForgot => 'ਪਿੰਨ ਭੁੱਲ ਗਏ ਹੋ?';
 
   @override
-  String get pinClear => 'ਸਾਫ਼ ਕਰੋ';
+  String get pinClear => 'ਸਾਫ਼';
 
   @override
   String get pinBackspace => 'ਬੈਕਸਪੇਸ';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect ਬੇਨਤੀ ਮਨਜ਼ੂਰ ਕੀਤੀ।';
+  String get quickConnectAuthorized =>
+      'ਤਤਕਾਲ ਕਨੈਕਟ ਦੀ ਬੇਨਤੀ ਨੂੰ ਅਧਿਕਾਰਤ ਕੀਤਾ ਗਿਆ ਹੈ।';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect ਕੋਡ ਅਵੈਧ ਹੈ ਜਾਂ ਮਿਆਦ ਪੁੱਗ ਗਈ ਹੈ।';
+      'ਤਤਕਾਲ ਕਨੈਕਟ ਕੋਡ ਅਵੈਧ ਜਾਂ ਮਿਆਦ ਪੁੱਗ ਗਿਆ ਹੈ।';
 
   @override
   String get quickConnectNotSupported =>
-      'ਇਸ ਸਰਵਰ \'ਤੇ Quick Connect ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'ਇਸ ਸਰਵਰ \'ਤੇ ਤੇਜ਼ ਕਨੈਕਟ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect ਕੋਡ ਮਨਜ਼ੂਰ ਕਰਨ ਵਿੱਚ ਅਸਫਲ।';
+      'ਤਤਕਾਲ ਕਨੈਕਟ ਕੋਡ ਨੂੰ ਅਧਿਕਾਰਤ ਕਰਨ ਵਿੱਚ ਅਸਫਲ।';
 
   @override
-  String get quickConnectDisabled => 'ਇਸ ਸਰਵਰ \'ਤੇ Quick Connect ਅਯੋਗ ਹੈ।';
+  String get quickConnectDisabled =>
+      'ਇਸ ਸਰਵਰ \'ਤੇ ਤੇਜ਼ ਕਨੈਕਟ ਨੂੰ ਅਯੋਗ ਬਣਾਇਆ ਗਿਆ ਹੈ।';
 
   @override
   String get quickConnectForbidden =>
-      'ਤੁਹਾਡਾ ਖਾਤਾ ਇਸ Quick Connect ਬੇਨਤੀ ਨੂੰ ਮਨਜ਼ੂਰ ਨਹੀਂ ਕਰ ਸਕਦਾ।';
+      'ਤੁਹਾਡਾ ਖਾਤਾ ਇਸ ਕਵਿੱਕ ਕਨੈਕਟ ਬੇਨਤੀ ਨੂੰ ਅਧਿਕਾਰਤ ਨਹੀਂ ਕਰ ਸਕਦਾ ਹੈ।';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect ਕੋਡ ਨਹੀਂ ਮਿਲਿਆ। ਨਵਾਂ ਕੋਡ ਅਜ਼ਮਾਓ।';
+      'ਤਤਕਾਲ ਕਨੈਕਟ ਕੋਡ ਨਹੀਂ ਮਿਲਿਆ। ਇੱਕ ਨਵਾਂ ਕੋਡ ਅਜ਼ਮਾਓ।';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ਅਸਫਲ: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7894,7 +7896,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'ਕਮਾਂਡ ਅਸਫਲ: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7923,7 +7925,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'ਕਾਸਟਿੰਗ ਸ਼ੁਰੂ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7968,7 +7970,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8049,14 +8051,14 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਪਲੇਬੈਕ ਨੂੰ ਰੋਕਿਆ ਗਿਆ ਹੈ। ਕੀ ਤੁਸੀਂ ਅਜੇ ਵੀ ਦੇਖ ਰਹੇ ਹੋ?';
 
   @override
-  String get stillWatchingStop => 'ਰੋਕੋ';
+  String get stillWatchingStop => 'ਰੂਕੋ';
 
   @override
   String get stillWatchingContinue => 'ਜਾਰੀ ਰੱਖੋ';
 
   @override
   String skipSegment(String segment) {
-    return '$segment ਛੱਡੋ';
+    return 'Skip $segment';
   }
 
   @override
@@ -8067,12 +8069,12 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8133,13 +8135,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get contextMenuGoToSeries => 'ਸੀਰੀਜ਼ \'ਤੇ ਜਾਓ';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'ਦੇਖਣਾ ਜਾਰੀ ਰੱਖੋ ਤੋਂ ਲੁਕਾਓ';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'ਅਗਲਾ ਤੋਂ ਲੁਕਾਓ';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'ਸੰਗ੍ਰਹਿ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'ਸਰਵਰ ਪ੍ਰਸ਼ਾਸਨ ਪੈਨਲ ਤੱਕ ਪਹੁੰਚ';
@@ -8173,7 +8176,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'ਪਲੱਗਇਨ ਸਿੰਕ, Seerr, ਰੇਟਿੰਗ ਅਤੇ ਹੋਰ';
+      'ਪਲੱਗਇਨ ਸਿੰਕ, ਸੀਰਰ, ਰੇਟਿੰਗ, ਅਤੇ ਹੋਰ';
 
   @override
   String get settingsAboutSubtitle => 'ਐਪ ਸੰਸਕਰਣ, ਕਾਨੂੰਨੀ ਜਾਣਕਾਰੀ ਅਤੇ ਕ੍ਰੈਡਿਟ';
@@ -8191,15 +8194,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsAlphabetical => 'ਵਰਣਮਾਲਾ';
 
   @override
-  String get settingsConnectionSection => 'ਕਨੈਕਸ਼ਨ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'ਸਵੈ-ਹਸਤਾਖਰਿਤ ਸਰਟੀਫਿਕੇਟਾਂ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'ਸਵੈ-ਹਸਤਾਖਰਿਤ ਜਾਂ ਪ੍ਰਾਈਵੇਟ-CA TLS ਸਰਟੀਫਿਕੇਟ ਵਰਤਣ ਵਾਲੇ ਸਰਵਰਾਂ \'ਤੇ ਭਰੋਸਾ ਕਰੋ। ਸਿਰਫ ਉਹਨਾਂ ਸਰਵਰਾਂ ਲਈ ਸਮਰੱਥ ਕਰੋ ਜਿਨ੍ਹਾਂ ਨੂੰ ਤੁਸੀਂ ਕੰਟਰੋਲ ਕਰਦੇ ਹੋ। ਇਹ ਸਾਰੇ ਕਨੈਕਸ਼ਨਾਂ ਲਈ ਸਰਟੀਫਿਕੇਟ ਪ੍ਰਮਾਣਿਕਤਾ ਅਯੋਗ ਕਰਦਾ ਹੈ।';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ਗੋਪਨੀਯਤਾ ਅਤੇ ਸੁਰੱਖਿਆ';
@@ -8215,11 +8217,11 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਥੀਮ ਲਹਿਜ਼ੇ, ਬੈਕਡ੍ਰੌਪਸ, ਦੇਖੇ ਗਏ ਸੂਚਕਾਂ, ਅਤੇ ਥੀਮ ਸੰਗੀਤ';
 
   @override
-  String get settingsDetailsScreen => 'ਵੇਰਵਾ ਸਕ੍ਰੀਨ';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'ਸ਼ੈਲੀ, ਪਿਛੋਕੜ ਧੁੰਦਲਾਪਣ ਅਤੇ ਟੈਬ ਵਿਹਾਰ';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'ਮੁੱਖ ਪੰਨਾ';
@@ -8257,11 +8259,11 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'ਨੈਵੀਗੇਸ਼ਨ ਬਾਰ ਵਿੱਚ Seerr ਬਟਨ ਦਿਖਾਓ';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'ਉੱਪਰਲੀ ਨੈਵੀਗੇਸ਼ਨ ਬਾਰ ਵਿੱਚ ਹਮੇਸ਼ਾ ਟੈਕਸਟ ਲੇਬਲ ਦਿਖਾਓ';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8281,7 +8283,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'Moonbase ਵਾਧੂ ਰੇਟਿੰਗ ਸਰੋਤਾਂ, Seerr ਬੇਨਤੀਆਂ ਅਤੇ ਸਿੰਕ ਕੀਤੀਆਂ ਤਰਜੀਹਾਂ ਸਮੇਤ ਸਰਵਰ-ਸਾਈਡ ਏਕੀਕਰਨ ਨੂੰ ਸ਼ਕਤੀ ਦਿੰਦਾ ਹੈ।';
+      'Moonbase ਵਾਧੂ ਰੇਟਿੰਗ ਸਰੋਤਾਂ, ਸੀਰ ਬੇਨਤੀਆਂ, ਅਤੇ ਸਿੰਕ ਕੀਤੀਆਂ ਤਰਜੀਹਾਂ ਸਮੇਤ ਸਰਵਰ-ਸਾਈਡ ਏਕੀਕਰਣ ਨੂੰ ਸ਼ਕਤੀ ਪ੍ਰਦਾਨ ਕਰਦਾ ਹੈ।';
 
   @override
   String get settingsOfflineDownloads => 'ਔਫਲਾਈਨ ਡਾਊਨਲੋਡ';
@@ -8327,7 +8329,8 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsSupportMoonfin => 'ਸਹਾਇਤਾ Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'ਡਿਵੈਲਪਰ ਨੂੰ ਇੱਕ ਕੌਫੀ ਦਾਨ ਕਰੋ';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ਕਾਨੂੰਨੀ';
@@ -8360,8 +8363,8 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ਲਾਇਸੈਂਸ ਸੂਚਨਾਵਾਂ',
-      one: '# ਲਾਇਸੈਂਸ ਸੂਚਨਾ',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8409,16 +8412,16 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros ਅਤੇ Outros ਨੂੰ ਛੱਡਣਾ ਹੈ?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'ਮੀਡੀਆ ਖੰਡ ਕਾਊਂਟਡਾਊਨ';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'ਪ੍ਰਗਤੀ ਬਾਰ';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ਟਾਈਮਰ';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ਕੋਈ ਨਹੀਂ';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ਪ੍ਰੋਂਪਟ ਯੂਜ਼ਰ';
@@ -8452,13 +8455,13 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (ਸਿਫ਼ਾਰਸ਼ੀ)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (ਪੁਰਾਣਾ)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (ਵਿਰਾਸਤੀ)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (ਸਿਫਾਰਸ਼ੀ)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision ਫਾਲਬੈਕ';
@@ -8644,754 +8647,749 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'ਹਾਲ ਹੀ ਵਿੱਚ ਜਾਰੀ $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'ਅਗਲਾ ਐਪੀਸੋਡ ਆਟੋਪਲੇ ਕਰੋ';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'ਉਪਲਬਧ ਹੋਣ \'ਤੇ ਅਗਲਾ ਐਪੀਸੋਡ ਆਪਣੇ-ਆਪ ਚਲਾਓ।';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'ਚੁੱਪ ਛੱਡੋ';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'ਜਦੋਂ ਸਟ੍ਰੀਮ ਸਮਰਥਨ ਕਰਦੀ ਹੈ ਤਾਂ ਚੁੱਪ ਆਡੀਓ ਖੰਡ ਆਪਣੇ-ਆਪ ਛੱਡੋ।';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'ਬਾਹਰੀ ਆਡੀਓ ਪ੍ਰਭਾਵਾਂ ਦੀ ਆਗਿਆ ਦਿਓ';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'ਇਕੁਅਲਾਈਜ਼ਰ ਅਤੇ ਪ੍ਰਭਾਵ ਐਪਾਂ (ਜਿਵੇਂ Wavelet) ਨੂੰ Media3 ਪਲੇਬੈਕ ਸੈਸ਼ਨਾਂ ਨਾਲ ਜੁੜਨ ਦੀ ਆਗਿਆ ਦਿਓ।';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'ਟਨਲਿੰਗ ਅਯੋਗ ਕਰੋ';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'ਗੈਰ-ਟਨਲਡ ਪਲੇਬੈਕ ਲਾਗੂ ਕਰੋ। ਟਨਲਿੰਗ ਆਡੀਓ/ਵੀਡੀਓ ਵਿਘਨ ਵਾਲੇ ਡਿਵਾਈਸਾਂ \'ਤੇ ਲਾਭਦਾਇਕ।';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'ਟਨਲਿੰਗ ਸਮਰੱਥ ਕਰੋ';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'ਉੱਨਤ। ਆਡੀਓ ਅਤੇ ਵੀਡੀਓ ਨੂੰ ਇੱਕ ਜੁੜੇ ਹੋਏ ਹਾਰਡਵੇਅਰ ਪਾਥ ਰਾਹੀਂ ਭੇਜਦਾ ਹੈ। ਡਿਫਾਲਟ ਰੂਪ ਵਿੱਚ ਬੰਦ ਕਿਉਂਕਿ ਇਹ ਕੁਝ ਡਿਵਾਈਸਾਂ \'ਤੇ ਆਡੀਓ/ਵੀਡੀਓ ਡ੍ਰੌਪਆਉਟ ਦਾ ਕਾਰਨ ਬਣਦਾ ਹੈ।';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision ਪ੍ਰੋਫਾਈਲ 7 ਨੂੰ HEVC ਨਾਲ ਮੈਪ ਕਰੋ';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'ਗੈਰ-DV ਡਿਵਾਈਸਾਂ \'ਤੇ Dolby Vision ਪ੍ਰੋਫਾਈਲ 7 ਸਟ੍ਰੀਮਾਂ ਨੂੰ HDR10-ਅਨੁਕੂਲ HEVC ਵਜੋਂ ਚਲਾਓ।';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'ਏਮਬੈੱਡਡ ਉਪਸਿਰਲੇਖ ਸ਼ੈਲੀਆਂ ਵਰਤੋ';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'ਉਪਸਿਰਲੇਖ ਟਰੈਕ ਵਿੱਚ ਏਮਬੈੱਡ ਕੀਤੇ ਰੰਗ, ਫੌਂਟ ਅਤੇ ਸਥਿਤੀ ਲਾਗੂ ਕਰੋ। ਇਸ ਦੀ ਬਜਾਏ ਆਪਣੀਆਂ ਕੈਪਸ਼ਨ ਸ਼ੈਲੀ ਤਰਜੀਹਾਂ ਵਰਤਣ ਲਈ ਅਯੋਗ ਕਰੋ।';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
-  String get subtitlesUseEmbeddedFontSizes => 'ਏਮਬੈੱਡਡ ਉਪਸਿਰਲੇਖ ਫੌਂਟ ਆਕਾਰ ਵਰਤੋ';
+  String get subtitlesUseEmbeddedFontSizes =>
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'ਉਪਸਿਰਲੇਖ ਟਰੈਕ ਵਿੱਚ ਏਮਬੈੱਡ ਕੀਤੇ ਫੌਂਟ-ਆਕਾਰ ਸੰਕੇਤ ਲਾਗੂ ਕਰੋ। ਆਪਣੀਆਂ ਸ਼ੈਲੀ ਤਰਜੀਹਾਂ ਤੋਂ ਉਪਸਿਰਲੇਖ ਆਕਾਰ ਵਰਤਣ ਲਈ ਅਯੋਗ ਕਰੋ।';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'ਮੀਡੀਆ ਵੇਰਵੇ ਦਿਖਾਓ';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'ਲਾਇਬ੍ਰੇਰੀ ਪੰਨਿਆਂ ਦੇ ਉੱਪਰ ਚੁਣੀ ਆਈਟਮ ਦੇ ਵੇਰਵੇ ਦਿਖਾਓ।';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'ਬ੍ਰਾਊਜ਼ ਕਰਦੇ ਸਮੇਂ ਪਿਛੋਕੜ ਲੁਕਾਉਣੇ ਹਨ?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'ਵਿਸਤ੍ਰਿਤ ਉਪ-ਸਿਰਲੇਖ ਵਰਤੋ';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'ਲਾਇਬ੍ਰੇਰੀ ਪੰਨਿਆਂ \'ਤੇ ਵਿਸਤ੍ਰਿਤ ਜਾਂ ਘੱਟੋ-ਘੱਟ ਉਪ-ਕਤਾਰ ਦਿਖਾਓ।';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'ਸੇਵ ਕੀਤੀ ਥੀਮ ਮਿਟਾਉਣੀ ਹੈ?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'ਇਸ ਡਿਵਾਈਸ ਕੈਸ਼ ਵਿੱਚੋਂ \"$themeName\" ਹਟਾਉਣਾ ਹੈ?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'ਥੀਮ ਸਟੋਰ';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'ਕਮਿਊਨਿਟੀ ਥੀਮ ਬ੍ਰਾਊਜ਼ ਅਤੇ ਸੇਵ ਕਰੋ';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'ਕਿਸੇ ਥੀਮ ਨੂੰ ਆਪਣੀਆਂ ਹੋਰ ਸੇਵ ਕੀਤੀਆਂ ਥੀਮਾਂ ਵਾਂਗ ਵਰਤਣ ਲਈ ਸੇਵ ਕਰੋ।';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ਇਸ ਵੇਲੇ ਕੋਈ ਥੀਮ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'ਥੀਮ ਸਟੋਰ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕਿਆ। ਆਪਣਾ ਕਨੈਕਸ਼ਨ ਜਾਂਚੋ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'ਸੇਵ ਕਰੋ';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'ਸੇਵ ਕਰੋ ਅਤੇ ਲਾਗੂ ਕਰੋ';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'ਸੇਵ ਕੀਤਾ';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'ਇਹ ਥੀਮ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕੀ।';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" ਸੇਵ ਕੀਤਾ।';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'ਇਸ ਡਿਵਾਈਸ ਤੋਂ \"$themeName\" ਮਿਟਾਇਆ।';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" ਮਿਟਾਇਆ ਨਹੀਂ ਜਾ ਸਕਿਆ।';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'ਸੇਵ ਕੀਤੀਆਂ ਥੀਮਾਂ';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'ਇਹ ਮੌਜੂਦਾ ਸਰਵਰ ਲਈ Moonfin ਪਲੱਗਇਨ ਤੋਂ ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਥੀਮਾਂ ਹਨ। ਮਿਟਾਉਣ ਨਾਲ ਸਿਰਫ ਇਹ ਲੋਕਲ ਕਾਪੀ ਹਟਦੀ ਹੈ।';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'ਇਸ ਸਰਵਰ ਲਈ ਕੋਈ ਸੇਵ ਕੀਤੀਆਂ ਥੀਮਾਂ ਨਹੀਂ ਮਿਲੀਆਂ।';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • ਇਸ ਵੇਲੇ ਸਰਗਰਮ';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'ਸੇਵ ਕੀਤੀ ਥੀਮ ਮਿਟਾਓ';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਪਲੱਗਇਨ ਥੀਮਾਂ ਦਾ ਪ੍ਰਬੰਧ ਕਰੋ';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'ਥੀਮ ਸੰਪਾਦਕ';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'ਆਪਣੇ ਬ੍ਰਾਊਜ਼ਰ ਵਿੱਚ Moonfin ਥੀਮ ਸੰਪਾਦਕ ਖੋਲ੍ਹੋ';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'ਹੋਮ ਸਕ੍ਰੀਨ';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'ਹੇਠਲੀ ਬਾਰ';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'ਕਲਾਸਿਕ';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'ਮਾਡਰਨ';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'ਹੋਮ ਕਤਾਰਾਂ';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'ਹੋਮ ਕਤਾਰ ਡਿਸਪਲੇ';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'ਹੋਮ ਕਤਾਰ ਭਾਗ';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'ਹੋਮ ਕਤਾਰ ਟੌਗਲ';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'ਲਾਇਬ੍ਰੇਰੀ-ਅਧਾਰਿਤ ਹੋਮ ਕਤਾਰ ਸ਼੍ਰੇਣੀਆਂ ਸਮਰੱਥ ਜਾਂ ਅਯੋਗ ਕਰੋ';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਕਤਾਰਾਂ ਦਿਖਾਉਣ ਲਈ ਹੇਠਲੇ ਟੌਗਲ ਸਮਰੱਥ ਕਰੋ।';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'ਕਲਾਸਿਕ ਪ੍ਰਤੀ-ਕਤਾਰ ਚਿੱਤਰ ਕਿਸਮ ਅਤੇ ਜਾਣਕਾਰੀ ਓਵਰਲੇ ਰੱਖਦਾ ਹੈ। ਮਾਡਰਨ ਪੋਰਟਰੇਟ-ਤੋਂ-ਪਿਛੋਕੜ ਕਤਾਰਾਂ ਵਰਤਦਾ ਹੈ।';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'ਮਨਪਸੰਦ ਕਤਾਰਾਂ ਦਿਖਾਓ';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਮਨਪਸੰਦ ਫਿਲਮਾਂ, ਲੜੀ ਅਤੇ ਹੋਰ ਮਨਪਸੰਦ ਕਤਾਰਾਂ ਦਿਖਾਓ।';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'ਮਨਪਸੰਦ ਕਤਾਰ ਕ੍ਰਮਬੱਧੀ';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ, ਰਿਲੀਜ਼ ਮਿਤੀ, ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ ਅਤੇ ਹੋਰ ਦੁਆਰਾ ਮਨਪਸੰਦ ਕਤਾਰਾਂ ਕ੍ਰਮਬੱਧ ਕਰੋ।';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'ਸੰਗ੍ਰਹਿ ਕਤਾਰਾਂ ਦਿਖਾਓ';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਸੰਗ੍ਰਹਿ ਕਤਾਰਾਂ ਦਿਖਾਓ।';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'ਸੰਗ੍ਰਹਿ ਕਤਾਰ ਕ੍ਰਮਬੱਧੀ';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ, ਰਿਲੀਜ਼ ਮਿਤੀ, ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ ਅਤੇ ਹੋਰ ਦੁਆਰਾ ਸੰਗ੍ਰਹਿ ਕਤਾਰਾਂ ਕ੍ਰਮਬੱਧ ਕਰੋ।';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'ਸ਼ੈਲੀ ਕਤਾਰਾਂ ਦਿਖਾਓ';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਸ਼ੈਲੀ ਕਤਾਰਾਂ ਦਿਖਾਓ।';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'ਸ਼ੈਲੀ ਕਤਾਰ ਕ੍ਰਮਬੱਧੀ';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ, ਰਿਲੀਜ਼ ਮਿਤੀ, ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ ਅਤੇ ਹੋਰ ਦੁਆਰਾ ਸ਼ੈਲੀ ਕਤਾਰਾਂ ਕ੍ਰਮਬੱਧ ਕਰੋ।';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'ਸ਼ੈਲੀ ਕਤਾਰ ਆਈਟਮਾਂ';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'ਸ਼ੈਲੀ ਕਤਾਰਾਂ ਵਿੱਚ ਫਿਲਮਾਂ, ਲੜੀ ਜਾਂ ਦੋਵੇਂ ਦਿਖਾਓ।';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'ਪਲੇਲਿਸਟ ਕਤਾਰਾਂ ਦਿਖਾਓ';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਪਲੇਲਿਸਟ ਕਤਾਰਾਂ ਦਿਖਾਓ।';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'ਪਲੇਲਿਸਟ ਕਤਾਰ ਕ੍ਰਮਬੱਧੀ';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ, ਰਿਲੀਜ਼ ਮਿਤੀ, ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ ਅਤੇ ਹੋਰ ਦੁਆਰਾ ਪਲੇਲਿਸਟ ਕਤਾਰਾਂ ਕ੍ਰਮਬੱਧ ਕਰੋ।';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ਆਡੀਓ ਕਤਾਰਾਂ ਦਿਖਾਓ';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'ਹੋਮ ਭਾਗਾਂ ਵਿੱਚ ਆਡੀਓ ਕਤਾਰਾਂ ਦਿਖਾਓ।';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ਆਡੀਓ ਕਤਾਰ ਕ੍ਰਮਬੱਧੀ';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ, ਰਿਲੀਜ਼ ਮਿਤੀ, ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ ਅਤੇ ਹੋਰ ਦੁਆਰਾ ਆਡੀਓ ਕਤਾਰਾਂ ਕ੍ਰਮਬੱਧ ਕਰੋ।';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ਆਡੀਓ ਪਲੇਲਿਸਟਸ';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'ਦਿੱਖ';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'ਲੇਆਉਟ';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'ਥੀਮ';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'ਕੀਬੋਰਡ';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'ਬਟਨ';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'ਰੈਂਡਰਿੰਗ';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV ਸੰਰਚਨਾ';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'ਬਾਹਰੀ ਪਲੇਅਰ ਐਪ';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'ਲੰਬੀ-ਦਬਾਓ ਪਲੇ ਵਿਕਲਪ ਸਮਰੱਥ ਕਰਨ ਲਈ ਬਾਹਰੀ ਪਲੇਅਰ ਸੈੱਟ ਕਰੋ';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'ਪਲੇਬੈਕ ਸ਼ੁਰੂ ਹੋਣ \'ਤੇ ਐਪ ਚੋਣਕਾਰ ਦਿਖਾਓ।';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'ਇੰਸਟਾਲ ਕੀਤੇ ਪਲੇਅਰ ਲੋਡ ਹੋ ਰਹੇ ਹਨ...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'ਕਨੈਕਸ਼ਨ';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ਆਡੀਓ ਟ੍ਰਾਂਸਕੋਡ ਟਾਰਗੇਟ';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'ਪਾਸਥਰੂ';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਸਮਰਥਿਤ';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਸਮਰਥਿਤ ਨਹੀਂ';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) ਪਾਸਥਰੂ';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) ਬਾਹਰੀ ਡੀਕੋਡਰ ਨੂੰ ਬਿੱਟਸਟ੍ਰੀਮ ਕਰੋ।';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) ਨਾਲ TrueHD ਪਾਸਥਰੂ';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'ਮੀਡੀਆ ਪਲੇਅਰ ਵਿਹਾਰ';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'ਪਲੇਬੈਕ ਸੁਧਾਰ';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'ਹਮੇਸ਼ਾ ਚਾਲੂ।';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'ਸਕਿੱਪ ਆਊਟ੍ਰੋ ਨੂੰ ਅਗਲਾ ਡਿਸਪਲੇ ਨਾਲ ਬਦਲੋ';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'ਸਕਿੱਪ ਆਊਟ੍ਰੋ ਬਟਨ ਦੀ ਬਜਾਏ ਅਗਲਾ ਓਵਰਲੇ ਦਿਖਾਓ।';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'ਪਲੇਅਰ ਰੂਟਿੰਗ';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'ਸਾਫਟਵੇਅਰ ਡੀਕੋਡਰਾਂ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'ਹਾਰਡਵੇਅਰ ਡੀਕੋਡਰਾਂ ਤੋਂ ਪਹਿਲਾਂ FFmpeg (ਆਡੀਓ) ਅਤੇ libgav1 (AV1) ਵਰਤੋ। ਜੇ HDMI ਆਡੀਓ ਪਾਸਥਰੂ ਟੁੱਟਦਾ ਹੈ ਤਾਂ ਅਯੋਗ ਕਰੋ।';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV \'ਤੇ ਆਪਣੀ ਚੁਣੀ ਬਾਹਰੀ ਐਪ ਵਿੱਚ ਵੀਡੀਓ ਪਲੇਬੈਕ ਖੋਲ੍ਹੋ।';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'ਆਟੋਮੈਟਿਕ ਕਤਾਰਬੰਦੀ';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH ਉਪਸਿਰਲੇਖਾਂ ਨੂੰ ਤਰਜੀਹ ਦਿਓ';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'ਆਪਣੇ-ਆਪ ਚੁਣਨ ਵੇਲੇ SDH/CC ਉਪਸਿਰਲੇਖ ਟਰੈਕਾਂ ਨੂੰ ਤਰਜੀਹ ਦਿਓ।';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'ਵੈੱਬ ਡਾਇਗਨੌਸਟਿਕਸ';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin ਵੈੱਬ ਡਾਇਗਨੌਸਟਿਕਸ';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'ਬ੍ਰਾਊਜ਼ਰ ਕਨੈਕਟੀਵਿਟੀ ਮੁੱਦਿਆਂ (CORS, ਮਿਸ਼੍ਰਿਤ ਸਮੱਗਰੀ ਅਤੇ ਖੋਜ ਸੈਟਿੰਗਾਂ) ਦੀ ਜਾਂਚ ਕਰਨ ਲਈ ਇਸ ਪੰਨੇ ਦੀ ਵਰਤੋਂ ਕਰੋ।';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'ਮਿਸ਼੍ਰਿਤ-ਸਮੱਗਰੀ ਅਸਫਲਤਾ ਖੋਜੀ ਗਈ';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight ਅਸਫਲਤਾ ਖੋਜੀ ਗਈ';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin ਨੇ ਇੱਕ HTTPS ਪੰਨਾ ਖੋਜਿਆ ਜੋ ਇੱਕ HTTP ਸਰਵਰ URL ਨੂੰ ਕਾਲ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰ ਰਿਹਾ ਹੈ। ਬ੍ਰਾਊਜ਼ਰ ਇਸ ਬੇਨਤੀ ਨੂੰ ਤੁਹਾਡੇ ਸਰਵਰ ਤੱਕ ਪਹੁੰਚਣ ਤੋਂ ਪਹਿਲਾਂ ਬਲਾਕ ਕਰਦੇ ਹਨ।';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin ਨੇ ਬ੍ਰਾਊਜ਼ਰ-ਪੱਧਰ ਦੀ ਬੇਨਤੀ ਅਸਫਲਤਾ ਖੋਜੀ ਜੋ ਆਮ ਤੌਰ \'ਤੇ ਮੀਡੀਆ ਸਰਵਰ \'ਤੇ ਗਾਇਬ CORS ਜਾਂ preflight ਹੈੱਡਰਾਂ ਕਾਰਨ ਹੁੰਦੀ ਹੈ।';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'ਟਾਰਗੇਟ URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'ਵੇਰਵਾ: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'ਮੌਜੂਦਾ ਰਨਟਾਈਮ ਸੰਦਰਭ';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'ਮੂਲ';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'ਸਕੀਮ';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'ਪਲੱਗਇਨ ਮੋਡ';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC ਸਕੈਨ';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'ਜ਼ਬਰਦਸਤੀ ਸਰਵਰ URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'ਡਿਫਾਲਟ ਸਰਵਰ URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'ਖੋਜ ਪ੍ਰੌਕਸੀ URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'ਸੰਰਚਿਤ ਨਹੀਂ';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'ਮਿਸ਼੍ਰਿਤ ਸਮੱਗਰੀ';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'ਇਹ ਪੰਨਾ HTTPS ਉੱਤੇ ਲੋਡ ਹੋਇਆ ਹੈ, ਪਰ ਇੱਕ ਜਾਂ ਵੱਧ ਸੰਰਚਿਤ URL HTTP ਹਨ। ਬ੍ਰਾਊਜ਼ਰ HTTPS ਪੰਨਿਆਂ ਨੂੰ HTTP API ਕਾਲ ਕਰਨ ਤੋਂ ਬਲਾਕ ਕਰਦੇ ਹਨ।';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'ਹੱਲ: ਆਪਣੇ ਮੀਡੀਆ ਸਰਵਰ ਜਾਂ ਪ੍ਰੌਕਸੀ ਐਂਡਪੁਆਇੰਟ ਨੂੰ HTTPS ਰਾਹੀਂ ਪੇਸ਼ ਕਰੋ, ਜਾਂ Moonfin ਨੂੰ ਸਿਰਫ ਭਰੋਸੇਯੋਗ ਸਥਾਨਕ ਨੈੱਟਵਰਕਾਂ \'ਤੇ HTTP ਉੱਤੇ ਲੋਡ ਕਰੋ।';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'ਮੌਜੂਦਾ ਰਨਟਾਈਮ ਸੈਟਿੰਗਾਂ ਤੋਂ ਕੋਈ ਸਪੱਸ਼ਟ ਮਿਸ਼੍ਰਿਤ-ਸਮੱਗਰੀ ਸੰਰਚਨਾ ਨਹੀਂ ਖੋਜੀ ਗਈ।';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS ਜਾਂਚ-ਸੂਚੀ';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin ਵਿੱਚ ਬ੍ਰਾਊਜ਼ਰ ਮੂਲ ਦੀ ਆਗਿਆ ਦਿਓ।';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers ਵਿੱਚ Authorization, X-Emby-Authorization ਅਤੇ X-Emby-Token ਸ਼ਾਮਲ ਕਰੋ।';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ਸਟ੍ਰੀਮਿੰਗ ਅਤੇ ਸੀਕ ਵਿਹਾਰ ਲਈ Content-Range ਅਤੇ Accept-Ranges ਪ੍ਰਗਟ ਕਰੋ।';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight ਬੇਨਤੀਆਂ ਨੂੰ 204 ਵਾਪਸ ਕਰੋ।';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'ਉਦਾਹਰਨ ਹੈੱਡਰ ਸਨਿੱਪਟ (nginx-ਸ਼ੈਲੀ)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'ਨੋਟ';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'ਇਹ ਡਾਇਗਨੌਸਟਿਕਸ ਰੂਟ ਵੈੱਬ ਬਿਲਡਾਂ ਲਈ ਹੈ। ਜੇ ਤੁਸੀਂ ਇਸ ਨੂੰ ਕਿਸੇ ਹੋਰ ਪਲੇਟਫਾਰਮ \'ਤੇ ਦੇਖ ਰਹੇ ਹੋ, ਤਾਂ ਇਹ ਜਾਂਚਾਂ ਲਾਗੂ ਨਹੀਂ ਹੋ ਸਕਦੀਆਂ।';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'ਸਰਵਰ ਚੋਣ \'ਤੇ ਵਾਪਸ';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'ਸਾਰੇ ਯੂਜ਼ਰ ਸਾਈਨ ਆਉਟ ਕਰੋ';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'ਮਾਈਕ੍ਰੋਫੋਨ ਅਨੁਮਤੀ ਸਥਾਈ ਤੌਰ \'ਤੇ ਇਨਕਾਰ ਕੀਤੀ ਗਈ ਹੈ। ਇਸ ਨੂੰ ਸਿਸਟਮ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਸਮਰੱਥ ਕਰੋ।';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'ਵੌਇਸ ਖੋਜ ਲਈ ਮਾਈਕ੍ਰੋਫੋਨ ਅਨੁਮਤੀ ਦੀ ਲੋੜ ਹੈ।';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'ਇਹ ਸਮਝ ਨਹੀਂ ਆਇਆ। ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'ਕੋਈ ਭਾਸ਼ਣ ਨਹੀਂ ਖੋਜਿਆ।';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'ਮਾਈਕ੍ਰੋਫੋਨ ਗਲਤੀ।';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'ਵੌਇਸ ਖੋਜ ਨੂੰ ਇੰਟਰਨੈੱਟ ਦੀ ਲੋੜ ਹੈ।';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'ਵੌਇਸ ਸੇਵਾ ਰੁੱਝੀ ਹੋਈ ਹੈ। ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'ਮਾਈਕ੍ਰੋਫੋਨ ਅਨੁਮਤੀ ਸਥਾਈ ਤੌਰ \'ਤੇ ਇਨਕਾਰ ਕੀਤੀ ਗਈ ਹੈ।';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'ਮਾਈਕ੍ਰੋਫੋਨ ਅਨੁਮਤੀ ਇਨਕਾਰ ਕੀਤੀ ਗਈ ਹੈ।';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'ਇਸ ਡਿਵਾਈਸ \'ਤੇ ਭਾਸ਼ਣ ਪਛਾਣ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS ਰੂਟ ਚੋਣਕਾਰ ਖੋਲ੍ਹੋ';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'ਇਸ ਡਿਵਾਈਸ \'ਤੇ AirPlay ਰੂਟ ਚੋਣਕਾਰ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'ਵੀਡੀਓ';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'ਪ੍ਰੋਗਰਾਮ';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'ਗੀਤ';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'ਫੋਟੋ ਐਲਬਮਾਂ';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'ਫੋਟੋ';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'ਲੋਕ';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'ਹਾਲ ਹੀ ਵਿੱਚ ਜਾਰੀ ਐਪੀਸੋਡ';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'ਦੁਬਾਰਾ ਦੇਖੋ';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'ਮਹਿਮਾਨ ਪੇਸ਼ਕਾਰੀਆਂ';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'ਪੇਸ਼ਕਾਰੀਆਂ (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'ਕਰੂ ਯੋਗਦਾਨ (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'ਸਮੂਹ ਨਾਲ ਦੇਖੋ';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'ਗਲਤੀਆਂ';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'ਚੇਤਾਵਨੀਆਂ';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'ਡਿਸਕ';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'ਬ੍ਰਾਊਜ਼ਰ ਵਿੱਚ ਖੋਲ੍ਹੋ';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'ਇਸ ਪਲੇਟਫਾਰਮ \'ਤੇ ਏਮਬੈੱਡਡ ਬ੍ਰਾਊਜ਼ਰ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'ਕੀ ਤੁਸੀਂ ਪੱਕਾ ਸਰਵਰ ਮੁੜ-ਚਾਲੂ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'ਕੀ ਤੁਸੀਂ ਪੱਕਾ ਸਰਵਰ ਬੰਦ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ? ਤੁਹਾਨੂੰ ਇਸ ਨੂੰ ਹੱਥੀਂ ਮੁੜ-ਚਾਲੂ ਕਰਨਾ ਪਵੇਗਾ।';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'ਅੰਦਰੂਨੀ';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'ਵਿਹਲਾ';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'ਕੋਈ ਯੂਜ਼ਰ ਨਹੀਂ ਮਿਲੇ';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'ਤੁਹਾਡੀ ਖੋਜ ਨਾਲ ਕੋਈ ਯੂਜ਼ਰ ਮੇਲ ਨਹੀਂ ਖਾਂਦੇ';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'ਕੋਈ ਡਿਵਾਈਸ ਨਹੀਂ ਮਿਲੇ';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'ਮੌਜੂਦਾ ਫਿਲਟਰਾਂ ਨਾਲ ਕੋਈ ਡਿਵਾਈਸ ਮੇਲ ਨਹੀਂ ਖਾਂਦੇ';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'ਪਾਸਵਰਡ ਸੈੱਟ ਕੀਤਾ';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'ਕੋਈ ਪਾਸਵਰਡ ਸੰਰਚਿਤ ਨਹੀਂ';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'ਰਿਮੋਟ ਪਹੁੰਚ';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'ਸਿਰਫ ਲੋਕਲ';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'ਮੀਡੀਆ ਵਿਸ਼ਲੇਸ਼ਣ ਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'ਸਾਰੀਆਂ ਮੀਡੀਆ ਲਾਇਬ੍ਰੇਰੀਆਂ ਵਿੱਚ ਸੰਯੁਕਤ ਵਿਸ਼ਲੇਸ਼ਣ।';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'ਚੋਟੀ ਦੇ ਕਲਾਕਾਰ';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'ਚੋਟੀ ਦੇ ਲੇਖਕ';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'ਚੋਟੀ ਦੇ ਯੋਗਦਾਨੀ';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਲਾਇਬ੍ਰੇਰੀਆਂ',
-      one: '1 ਲਾਇਬ੍ਰੇਰੀ',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'ਇਸ ਚੋਣ ਲਈ ਅਜੇ ਕੋਈ ਸੂਚੀਬੱਧ ਮੀਡੀਆ ਕੁੱਲ ਉਪਲਬਧ ਨਹੀਂ ਹਨ।';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'ਲਾਇਬ੍ਰੇਰੀ ਵੇਰਵੇ';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'ਲਾਇਬ੍ਰੇਰੀ ਵੇਰਵਾ';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'ਕੋਈ ਲਾਇਬ੍ਰੇਰੀਆਂ ਉਪਲਬਧ ਨਹੀਂ ਹਨ।';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'ਸਰਵਰ ਪ੍ਰਸ਼ਾਸਨ';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'ਡੇਟਾ';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'ਚਿੱਤਰ ਕੈਸ਼';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'ਕੈਸ਼';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'ਲੌਗ';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'ਮੈਟਾਡਾਟਾ';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'ਟ੍ਰਾਂਸਕੋਡ';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'ਇਸ ਸਰਵਰ ਦੁਆਰਾ ਕੋਈ ਸਰਵਰ ਪਾਥ ਵਾਪਸ ਨਹੀਂ ਕੀਤੇ ਗਏ।';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% ਵਰਤਿਆ';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'ਯੂਜ਼ਰ ਗਤੀਵਿਧੀ';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'ਸਿਸਟਮ ਘਟਨਾਵਾਂ';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'ਧਿਆਨ ਦੀ ਲੋੜ ਹੈ';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'ਸਰਵਰ';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'ਪਲੇਬੈਕ';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'ਡਿਵਾਈਸ';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'ਉੱਨਤ';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'ਪਲੱਗਇਨ';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'ਲਾਈਵ ਟੀਵੀ';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'ਹੋਮ ਵੀਡੀਓ';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'ਮਿਸ਼੍ਰਿਤ ਸਮੱਗਰੀ';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'ਹੋਮ ਵੀਡੀਓ ਅਤੇ ਫੋਟੋ';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'ਮਿਸ਼੍ਰਿਤ ਫਿਲਮਾਂ ਅਤੇ ਸ਼ੋਅ';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9403,299 +9401,299 @@ class AppLocalizationsPa extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'ਕੋਈ ਰਿਕਾਰਡਿੰਗ ਨਹੀਂ ਮਿਲੀ';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension ਆਰਕਾਈਵ ਦੇ ਅੰਦਰ ਕੋਈ ਚਿੱਤਰ ਪੰਨੇ ਨਹੀਂ ਮਿਲੇ।';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'ਏਮਬੈੱਡਡ ਰੈਂਡਰਰ ਅਸਫਲ ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB ਰੈਂਡਰਰ ਅਸਫਲ ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'ਰੀਡਰ ਲਈ ਲੋਕਲ ਫਾਈਲ ਗਾਇਬ: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri ਤੋਂ ਕਿਤਾਬ ਡੇਟਾ ਖੋਲ੍ਹਦੇ ਸਮੇਂ HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'ਕੋਈ ਪੜ੍ਹਨਯੋਗ ਕਿਤਾਬ ਐਂਡਪੁਆਇੰਟ ਉਪਲਬਧ ਨਹੀਂ';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'ਅਸਮਰਥਿਤ ਕਾਮਿਕ ਆਰਕਾਈਵ ਫਾਰਮੈਟ: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'ਇਸ ਪਲੇਟਫਾਰਮ \'ਤੇ CBR ਕੱਢਣ ਵਾਲਾ ਪਲੱਗਇਨ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '.cbr ਆਰਕਾਈਵ ਕੱਢਣ ਵਿੱਚ ਅਸਫਲ।';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'ਇਸ ਪਲੇਟਫਾਰਮ \'ਤੇ CB7 ਕੱਢਣਾ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'ਇਸ ਪਲੇਟਫਾਰਮ \'ਤੇ CB7 ਕੱਢਣ ਵਾਲਾ ਪਲੱਗਇਨ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'ਸ਼ੈਲੀ ਪੈਨਲ ਬੰਦ ਕਰੋ';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'ਸ਼ਫਲ ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ਲਾਇਬ੍ਰੇਰੀ ਸ਼ਫਲ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ਬੇਤਰਤੀਬ ਸ਼ਫਲ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ਸ਼ੈਲੀ ਸ਼ਫਲ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'ਆਟੋ HDR ਸਵਿਚਿੰਗ';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR ਵੀਡੀਓ ਪਲੇਬੈਕ ਲਈ ਆਪਣੇ-ਆਪ HDR ਸਮਰੱਥ ਕਰੋ ਅਤੇ ਬਾਹਰ ਨਿਕਲਣ \'ਤੇ ਡਿਸਪਲੇ ਮੋਡ ਬਹਾਲ ਕਰੋ।';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'ਜਦੋਂ ਪੂਰੀ ਸਕ੍ਰੀਨ ਹੋਵੇ';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'ਆਰਟਵਰਕ ਬਦਲੋ';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'ਗਾਇਬ';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'ਟ੍ਰਾਂਸਕੋਡਿੰਗ ਸੀਮਾਵਾਂ';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'ਸਾਰਾ ਆਰਟਵਰਕ ਸਾਫ਼ ਕਰਨਾ ਹੈ?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'ਕੀ ਤੁਸੀਂ ਪੱਕਾ ਸਾਰਾ ਡਾਊਨਲੋਡ ਕੀਤਾ ਆਰਟਵਰਕ ਸਾਫ਼ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'ਸਾਫ਼ ਕਰਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'ਕੀ ਤੁਸੀਂ ਪੱਕਾ ਇਹ $itemType ਸਾਫ਼ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'ਅੱਪਲੋਡ ਕਰਨਾ ਹੈ?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'ਰੈਜ਼ੋਲਿਊਸ਼ਨ: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'ਸਿਰਫ ਇੰਟਰਫੇਸ ਭਾਸ਼ਾ ਵਿੱਚ ਆਰਟਵਰਕ ਦਿਖਾਓ';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'ਸਭ ਸਾਫ਼ ਕਰਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'ਚਿੱਤਰ ਸਫਲਤਾਪੂਰਵਕ ਅੱਪਲੋਡ ਕੀਤਾ!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ਚਿੱਤਰ ਸੈੱਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ਚਿੱਤਰ ਮਿਟਾਉਣ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'ਸਾਰਾ ਆਰਟਵਰਕ ਸਾਫ਼ ਕਰਨ ਵਿੱਚ ਅਸਫਲ: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ਹਾਂ';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'ਪੋਸਟਰ';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'ਪਿਛੋਕੜ';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'ਬੈਨਰ';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'ਲੋਗੋ';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'ਥੰਬਨੇਲ';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'ਕਲਾ';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ਡਿਸਕ ਕਲਾ';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'ਸਕ੍ਰੀਨਸ਼ਾਟ';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'ਬਾਕਸ ਕਵਰ';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'ਬਾਕਸ ਪਿਛਲਾ ਕਵਰ';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'ਮੀਨੂ ਕਲਾ';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'ਪੋਸਟਰ';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ਪਿਛੋਕੜ';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'ਬੈਨਰ';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'ਲੋਗੋ';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'ਥੰਬਨੇਲ';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ਕਲਾ';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ਡਿਸਕ ਕਲਾ';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ਸਕ੍ਰੀਨਸ਼ਾਟ';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'ਬਾਕਸ ਕਵਰ';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'ਬਾਕਸ ਪਿਛਲਾ ਕਵਰ';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ਮੀਨੂ ਕਲਾ';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'ਸਾਰੇ';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'ਉੱਚ (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'ਦਰਮਿਆਨਾ (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'ਘੱਟ (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'ਸਰੋਤ';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'ਅਧਿਆਏ';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'ਬੁੱਕਮਾਰਕ';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'ਨੋਟਸ';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'ਕਤਾਰ';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ਟਾਈਮਲਾਈਨ';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ਟਾਈਮਲਾਈਨ ਖਾਲੀ ਹੈ';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'ਪੂਰੀ ਕਿਤਾਬ';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'ਕੇਂਦਰਿਤ ਟਾਈਮਲਾਈਨ';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ਬੁੱਕਮਾਰਕ ਨਿਰਯਾਤ ਕਰੋ';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'ਨੋਟਸ ਨਿਰਯਾਤ ਕਰੋ';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'ਸਭ ਨਿਰਯਾਤ ਕਰੋ';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path ਵਿੱਚ ਨਿਰਯਾਤ ਕੀਤਾ';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'ਨਿਰਯਾਤ ਅਸਫਲ: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'ਬੋਲ';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'ਬੁੱਕਮਾਰਕ ਸ਼ਾਮਲ ਕਰੋ';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'ਨੋਟ ਸ਼ਾਮਲ ਕਰੋ';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'ਨੋਟ ਸੰਪਾਦਿਤ ਕਰੋ';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'ਇਸ ਪਲ ਲਈ ਇੱਕ ਨੋਟ ਲਿਖੋ';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'ਸਲੀਪ ਟਾਈਮਰ';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ਬੰਦ';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'ਅਧਿਆਏ ਦੇ ਅੰਤ';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'ਕਸਟਮ';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining ਬਾਕੀ';
+    return '$remaining left';
   }
 
   @override
@@ -9703,58 +9701,58 @@ class AppLocalizationsPa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ਮਿੰਟ',
-      one: '1 ਮਿੰਟ',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'ਪਲੇਬੈਕ ਗਤੀ';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'ਬਾਕੀ';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'ਬੀਤਿਆ';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$secondsਸ ਪਿੱਛੇ';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$secondsਸ ਅੱਗੇ';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'ਪਿਛਲਾ ਅਧਿਆਏ';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'ਅਗਲਾ ਅਧਿਆਏ';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total ਵਿੱਚੋਂ ਅਧਿਆਏ $current';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'ਕੋਈ ਅਧਿਆਏ ਨਹੀਂ';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'ਅਜੇ ਕੋਈ ਬੁੱਕਮਾਰਕ ਨਹੀਂ';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'ਅਜੇ ਕੋਈ ਨੋਟਸ ਨਹੀਂ';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position \'ਤੇ ਬੁੱਕਮਾਰਕ ਸ਼ਾਮਲ ਕੀਤਾ';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x \'ਤੇ ਰੀਸੈਟ ਕਰੋ';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9762,252 +9760,249 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'ਸੇਵ ਕਰੋ';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'ਰੱਦ ਕਰੋ';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'ਮਿਟਾਓ';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'ਉਪਸਿਰਲੇਖ ਤਰਜੀਹਾਂ';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'ਉਪਸਿਰਲੇਖ ਮੋਡ, ਡਿਫਾਲਟ ਭਾਸ਼ਾਵਾਂ, ਦਿੱਖ ਅਤੇ ਰੈਂਡਰਿੰਗ ਵਿਕਲਪ ਬਦਲੋ।';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'ਉਪਸਿਰਲੇਖ ਰੈਂਡਰਿੰਗ';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'ਡਿਸਪਲੇ ਵਿਕਲਪ';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'ਰਿਲੀਜ਼ ਮਿਤੀ (ਵਧਦੇ ਕ੍ਰਮ)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'ਰਿਲੀਜ਼ ਮਿਤੀ (ਘਟਦੇ ਕ੍ਰਮ)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'ਯੋਗਦਾਨ ਸਮੂਹ ਕਰੋ';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'ਕਈ ਭੂਮਿਕਾਵਾਂ ਸਮੂਹ ਕਰੋ';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'ਲਾਇਬ੍ਰੇਰੀ ਲਿਖਣ ਪਹੁੰਚ ਚੇਤਾਵਨੀ';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'ਇਸ ਨੂੰ ਕਿਵੇਂ ਠੀਕ ਕਰਨਾ ਹੈ:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. ਸਰਵਰ \'ਤੇ ਆਪਣੇ ਮੀਡੀਆ ਲਾਇਬ੍ਰੇਰੀ ਫੋਲਡਰਾਂ ਲਈ Jellyfin ਸੇਵਾ ਯੂਜ਼ਰ (ਜਿਵੇਂ, jellyfin ਜਾਂ Docker PUID/PGID) ਨੂੰ ਲਿਖਣ ਦੀਆਂ ਅਨੁਮਤੀਆਂ ਦਿਓ।\n\n2. ਜਾਂ, ਆਪਣੇ Jellyfin ਡੈਸ਼ਬੋਰਡ -> ਲਾਇਬ੍ਰੇਰੀਆਂ \'ਤੇ ਜਾਓ, ਇਸ ਲਾਇਬ੍ਰੇਰੀ ਨੂੰ ਸੰਪਾਦਿਤ ਕਰੋ, ਅਤੇ ਆਰਟਵਰਕ ਨੂੰ Jellyfin ਦੇ ਅੰਦਰੂਨੀ ਡਾਟਾਬੇਸ ਵਿੱਚ ਸਟੋਰ ਕਰਨ ਲਈ \'Save artwork into media folders\' ਨੂੰ ਅਯੋਗ ਕਰੋ।';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'ਖਾਰਜ ਕਰੋ';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'ਤੁਹਾਡੀ \'$libraryName\' ਲਾਇਬ੍ਰੇਰੀ ਆਰਟਵਰਕ ਨੂੰ ਸਿੱਧਾ ਮੀਡੀਆ ਫੋਲਡਰਾਂ ਵਿੱਚ ਸੇਵ ਕਰਨ ਲਈ ਸੰਰਚਿਤ ਹੈ (\'Save artwork into media folders\' ਸਮਰੱਥ ਹੈ)। ਹਾਲਾਂਕਿ, Jellyfin ਨੇ ਲਿਖਣ ਪਹੁੰਚ ਦੀ ਜਾਂਚ ਕੀਤੀ ਹੈ ਅਤੇ ਇਸ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਫਾਈਲਾਂ ਲਿਖਣ ਦੀ ਅਨੁਮਤੀ ਨਹੀਂ ਹੈ:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'ਇੰਝ ਲੱਗਦਾ ਹੈ ਕਿ Jellyfin ਆਰਟਵਰਕ ਅੱਪਡੇਟ ਕਰਨ ਵਿੱਚ ਅਸਫਲ ਰਿਹਾ। ਤੁਹਾਡੀ ਲਾਇਬ੍ਰੇਰੀ ਆਰਟਵਰਕ ਨੂੰ ਸਿੱਧਾ ਮੀਡੀਆ ਫੋਲਡਰਾਂ ਵਿੱਚ ਸੇਵ ਕਰਨ ਲਈ ਸੰਰਚਿਤ ਹੈ (\'Save artwork into media folders\' ਸਮਰੱਥ ਹੈ)। ਇਹ ਗਲਤੀ ਆਮ ਤੌਰ \'ਤੇ ਉਦੋਂ ਹੁੰਦੀ ਹੈ ਜਦੋਂ Jellyfin ਸਰਵਰ ਪ੍ਰਕਿਰਿਆ ਕੋਲ ਤੁਹਾਡੀਆਂ ਮੀਡੀਆ ਡਾਇਰੈਕਟਰੀਆਂ ਵਿੱਚ ਫਾਈਲਾਂ ਲਿਖਣ ਦੀ ਅਨੁਮਤੀ ਨਹੀਂ ਹੁੰਦੀ।';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'ਬਾਹਰੀ ਸੂਚੀਆਂ';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'ਦੁਬਾਰਾ ਚਲਾਓ';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ਫਾਈਲ ਜਾਣਕਾਰੀ';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'ਆਕਾਰ: $size  •  ਫਾਰਮੈਟ: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'ਸਾਰੇ ($count) ਆਡੀਓ ਟਰੈਕ ਦਿਖਾਓ';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'ਸਾਰੇ ($count) ਉਪਸਿਰਲੇਖ ਟਰੈਕ ਦਿਖਾਓ';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'ਡਾਇਰੈਕਟ ਪਲੇ ਸਮਰੱਥਾ ਜਾਂਚ ਰਹੇ ਹਾਂ...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'ਡਾਇਰੈਕਟ ਪਲੇ ਸਮਰੱਥਾ: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'ਲਾਜ਼ਮੀ';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'ਕੰਟੇਨਰ ਫਾਰਮੈਟ ਪਲੇਅਰ ਦੁਆਰਾ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'ਵੀਡੀਓ ਕੋਡੇਕ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'ਆਡੀਓ ਕੋਡੇਕ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'ਉਪਸਿਰਲੇਖ ਫਾਰਮੈਟ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ (ਬਰਨਿੰਗ ਦੀ ਲੋੜ ਹੈ)।';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ਆਡੀਓ ਪ੍ਰੋਫਾਈਲ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'ਵੀਡੀਓ ਪ੍ਰੋਫਾਈਲ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'ਵੀਡੀਓ ਪੱਧਰ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'ਇਸ ਡਿਵਾਈਸ ਦੁਆਰਾ ਵੀਡੀਓ ਰੈਜ਼ੋਲਿਊਸ਼ਨ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'ਵੀਡੀਓ ਬਿੱਟ ਡੂੰਘਾਈ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'ਵੀਡੀਓ ਫ੍ਰੇਮਰੇਟ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ਫਾਈਲ ਬਿੱਟਰੇਟ ਪਲੇਅਰ ਸਟ੍ਰੀਮਿੰਗ ਸੀਮਾ ਤੋਂ ਵੱਧ ਹੈ।';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'ਵੀਡੀਓ ਬਿੱਟਰੇਟ ਸਟ੍ਰੀਮਿੰਗ ਸੀਮਾ ਤੋਂ ਵੱਧ ਹੈ।';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ਆਡੀਓ ਬਿੱਟਰੇਟ ਸਟ੍ਰੀਮਿੰਗ ਸੀਮਾ ਤੋਂ ਵੱਧ ਹੈ।';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ਆਡੀਓ ਚੈਨਲਾਂ ਦੀ ਗਿਣਤੀ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'ਰਿਲੀਜ਼ ਕ੍ਰਮ (ਵਧਦੇ ਕ੍ਰਮ)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'ਰਿਲੀਜ਼ ਕ੍ਰਮ (ਘਟਦੇ ਕ੍ਰਮ)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'ਕਸਟਮ (ਖਿੱਚੋ-ਅਤੇ-ਛੱਡੋ)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'ਪਲੇਲਿਸਟ ਕ੍ਰਮਬੱਧ ਵਿਕਲਪ';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'ਕ੍ਰਮਬੱਧੀ ਰੀਸੈਟ ਕਰੋ';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode ਦੁਬਾਰਾ ਦੇਖੋ';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'ਪਲੇਲਿਸਟ ਦੁਬਾਰਾ ਦੇਖੋ';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'ਕੋਈ ਉਪਸਿਰਲੇਖ ਨਹੀਂ ਮਿਲੇ।';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'ਐਡਮਿਨ ਕੰਟਰੋਲ';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'ਰੈਂਡਰਿੰਗ ਇੰਜਣ (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller ਸੁਚੱਜੀਆਂ ਐਨੀਮੇਸ਼ਨਾਂ ਅਤੇ ਘੱਟ ਲੜਖੜਾਹਟ ਲਈ Flutter ਦਾ ਆਧੁਨਿਕ GPU ਰੈਂਡਰਰ ਹੈ। ਕੁਝ TV ਬਾਕਸਾਂ ਅਤੇ ਪੁਰਾਣੇ GPU \'ਤੇ ਇਹ ਗੜਬੜ ਜਾਂ ਕਾਲੀ ਵੀਡੀਓ ਦਾ ਕਾਰਨ ਬਣ ਸਕਦਾ ਹੈ; ਜੇ ਤੁਸੀਂ ਇਹ ਦੇਖਦੇ ਹੋ ਤਾਂ ਇਸ ਨੂੰ ਬੰਦ ਕਰੋ। ਆਟੋਮੈਟਿਕ ਤੁਹਾਡੇ ਡਿਵਾਈਸ ਲਈ ਸਭ ਤੋਂ ਵਧੀਆ ਡਿਫਾਲਟ ਚੁਣਦਾ ਹੈ। ਲਾਗੂ ਕਰਨ ਲਈ Moonfin ਮੁੜ-ਚਾਲੂ ਕਰੋ।';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ਆਟੋਮੈਟਿਕ';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ਚਾਲੂ';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ਬੰਦ';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'ਮੁੜ-ਚਾਲੂ ਦੀ ਲੋੜ ਹੈ';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'ਰੈਂਡਰਿੰਗ ਇੰਜਣ ਬਦਲਣ ਲਈ Moonfin ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰਨ ਦੀ ਲੋੜ ਹੈ। ਹੁਣ ਐਪ ਬੰਦ ਕਰੋ, ਫਿਰ ਲਾਗੂ ਕਰਨ ਲਈ ਇਸ ਨੂੰ ਦੁਬਾਰਾ ਖੋਲ੍ਹੋ।';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ਹੁਣ ਐਪ ਬੰਦ ਕਰੋ';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'ਲਾਇਬ੍ਰੇਰੀ ਤਾਜ਼ਾ ਕਰੋ';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'ਸਾਰੀਆਂ ਲਾਇਬ੍ਰੇਰੀਆਂ ਤਾਜ਼ਾ ਕਰੋ';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ (ਸਭ ਤੋਂ ਪੁਰਾਣੀ ਪਹਿਲਾਂ)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'ਸ਼ਾਮਲ ਕਰਨ ਦੀ ਮਿਤੀ (ਸਭ ਤੋਂ ਨਵੀਂ ਪਹਿਲਾਂ)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ (A ਤੋਂ Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'ਵਰਣਮਾਲਾ ਅਨੁਸਾਰ (Z ਤੋਂ A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'ਸਰਵਰ ਵਿਸ਼ਲੇਸ਼ਣ ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'ਸਰੋਤ ਨਾਲ ਮੇਲ ਕਰੋ';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb ਚੋਟੀ ਦੀਆਂ 250 ਫਿਲਮਾਂ';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb ਚੋਟੀ ਦੇ 250 ਟੀਵੀ ਸ਼ੋਅ';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb ਸਭ ਤੋਂ ਪ੍ਰਸਿੱਧ ਫਿਲਮਾਂ';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb ਸਭ ਤੋਂ ਪ੍ਰਸਿੱਧ ਟੀਵੀ ਸ਼ੋਅ';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb ਸਭ ਤੋਂ ਘੱਟ ਰੇਟਿੰਗ ਵਾਲੀਆਂ ਫਿਲਮਾਂ';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb ਚੋਟੀ ਦੀਆਂ ਰੇਟਿੰਗ ਵਾਲੀਆਂ ਅੰਗਰੇਜ਼ੀ ਫਿਲਮਾਂ';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -32,7 +32,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Szybkie połączenie';
 
   @override
   String get password => 'Hasło';
@@ -51,7 +51,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get waitingForAuthorization => 'Autoryzacja...';
 
   @override
-  String get back => 'Wstecz';
+  String get back => 'Powrót';
 
   @override
   String get serverUnavailable => 'Serwer jest niedostępny';
@@ -61,12 +61,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect niedostępny: $detail';
+    return 'Szybkie połączenie nieudane: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect niedostępny ($status): $detail';
+    return 'Szybkie połączenie nieudane ($status): $detail';
   }
 
   @override
@@ -161,11 +161,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Automatycznie pokazuj zawartość zakładki podczas przeglądania. Wyłącz aby otwierać i zamykać zakładki ręcznie.';
 
   @override
-  String get showTechnicalDetails => 'Pokazywać szczegóły techniczne?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Pokazuj informacje o kodeku, rozdzielczości i strumieniu w podsumowaniu banera';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
   String get recommendationSystem => 'System rekomendacji';
@@ -175,7 +175,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Użyj lokalnego algorytmu Moonfin lub metryk online z TMDb. Uwaga! Rekomendacje online wymagają integracji z Seerr.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin poleca';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
   String get recommendationSystemTmdb => 'Dopasowanie TMDb';
@@ -335,7 +335,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gameSaveState => 'Zapisz stan';
 
   @override
-  String get games => 'Gry';
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Wczytaj stan';
@@ -383,7 +383,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noItemsFound => 'Nie znaleziono żadnych elementów';
 
   @override
-  String get home => 'Strona główna';
+  String get home => 'Dom';
 
   @override
   String get browseAll => 'Przeglądaj wszystko';
@@ -506,7 +506,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get albumArtists => 'Wykonawcy albumu';
 
   @override
-  String get artists => 'Wykonawcy';
+  String get artists => 'Artyści';
 
   @override
   String get bookmarks => 'Zakładki';
@@ -754,7 +754,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unread => 'Nieprzeczytane';
 
   @override
-  String get unwatched => 'Nieobejrzane';
+  String get unwatched => 'Zaznacz jako obejrzane';
 
   @override
   String get seriesStatus => 'Status serialu';
@@ -1045,7 +1045,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get play => 'Odtwórz';
+  String get play => 'Włącz';
 
   @override
   String get startOver => 'Zacznij od nowa';
@@ -1268,7 +1268,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get writer => 'SCENARIUSZ';
 
   @override
-  String get writers => 'SCENARZYŚCI';
+  String get writers => 'SCENARIUSZ';
 
   @override
   String get studio => 'STUDIO';
@@ -1449,14 +1449,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unavailable => 'Niedostępne';
 
   @override
-  String get pause => 'Wstrzymaj';
+  String get pause => 'Pauza';
 
   @override
   String get syncPosition => 'Synchronizuj pozycję';
 
   @override
   String stopCast(String label) {
-    return 'Zatrzymaj $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1828,7 +1828,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get favoriteChannel => 'Ulubiony kanał';
 
   @override
-  String get record => 'Nagraj';
+  String get record => 'Nagrywaj';
 
   @override
   String get cancelRecordingAction => 'Anuluj nagrywanie';
@@ -1881,7 +1881,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get no => 'Nie';
+  String get no => 'NIE';
 
   @override
   String get yesCancel => 'Tak, Anuluj';
@@ -2359,7 +2359,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get refreshRateSwitching => 'Zmiana częstotliwości odświeżania';
 
   @override
-  String get disabled => 'Wyłączone';
+  String get disabled => 'Wyłączony';
 
   @override
   String get scaleOnTv => 'Skaluj na TV';
@@ -2535,7 +2535,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Bezstratny)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
   String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo)';
@@ -2567,7 +2567,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kwadrofonia';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2615,34 +2615,34 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Przesyłaj strumień Dolby Atmos przez EAC3 (JOC) do zewnętrznego dekodera.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Przesyłaj strumień DTS-HD MA (zawiera rdzeń DTS) do zewnętrznego dekodera.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Przesyłaj strumień Dolby TrueHD z metadanymi Atmos do zewnętrznego dekodera.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Wykryte możliwości audio';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Brak jeszcze danych o wykrytych możliwościach.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Wyjście';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekodowanie';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Wyjście audio HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2657,51 +2657,50 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Głośnik';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
   String get settingsAudioRouteHeadphones => 'Słuchawki';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostyka';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Poziom wideo';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Zakres wideo';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodek napisów';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Dozwolone kodeki audio';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Kodeki audio HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Kodeki audio HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Aktywne wyjście audio';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Obsługa audio HD przez wyjście';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Tryb nocny';
@@ -2765,7 +2764,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Po $episodes odcinkach / $hours godz.';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2868,17 +2867,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get subtitleModeForcedDescription =>
-      'Wczytuje tylko napisy jawnie oznaczone flagą metadanych „forced”.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Całkowicie wyłącza automatyczne wczytywanie napisów.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Zapasowy język napisów';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Strumień napisów';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2938,17 +2937,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Wczytano ustawienia profilu $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Nie udało się wczytać ustawień profilu $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Zsynchronizowano ustawienia lokalne z profilem $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3083,10 +3082,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Pokaż biblioteki na pasku narzędzi';
 
   @override
-  String get navbarAlwaysExpanded => 'Zawsze rozwijaj etykiety paska nawigacji';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Pokaż przycisk Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Nieprzezroczystość paska nawigacyjnego';
@@ -3161,19 +3160,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Pokaż opcję przeglądania folderów';
 
   @override
-  String get groupItemsIntoCollections => 'Grupuj elementy w kolekcje';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ukryj elementy biblioteki powiązane z kolekcjami podczas przeglądania bibliotek';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Informacja o grupowaniu biblioteki';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Aby korzystać z tego ustawienia, upewnij się, że opcje „Grupuj filmy w kolekcje” i/lub „Grupuj seriale w kolekcje” są włączone w ustawieniach wyświetlania Twojej biblioteki na serwerze Jellyfin lub Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Widoczność biblioteki';
@@ -3202,7 +3200,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return 'Wybrano: $count';
+    return '$count selected';
   }
 
   @override
@@ -3232,7 +3230,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wybierz jeden z różnych stylów paska multimediów lub wyłącz go';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Księżycowa Płetwa';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3285,11 +3283,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Automatyczne odtwarzanie zwiastunów na pasku multimediów po 3 sekundach';
 
   @override
-  String get trailerAudio => 'Dźwięk zwiastunów';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Włącz dźwięk zwiastunów na pasku multimediów';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Podgląd odcinka';
@@ -3366,11 +3363,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get combineBothRows => 'Połącz oba rzędy w jedną sekcję główną';
 
   @override
-  String get fullScreenRows => 'Rozwinięte wiersze ekranu głównego';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Ogranicz ekran główny do 1 wiersza na ekran';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Typ obrazu na wiersz';
@@ -3385,7 +3381,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lastUser => 'Ostatni użytkownik';
 
   @override
-  String get currentUser => 'Bieżący użytkownik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Zawsze uwierzytelniaj';
@@ -3493,10 +3489,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wyświetl zegar podczas wygaszacza ekranu';
 
   @override
-  String get clockModeStatic => 'Statyczny';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Odbijający się';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Zgniłe pomidory (krytycy)';
@@ -3566,7 +3562,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Włącz i zmień kolejność źródeł ocen wyświetlanych w aplikacji';
 
   @override
-  String get pluginLabel => 'Wtyczka Moonbase';
+  String get pluginLabel => 'Wtyczka';
 
   @override
   String get pluginDetected => 'Wykryto wtyczkę';
@@ -3584,7 +3580,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nWersja: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3638,13 +3634,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get networks => 'Sieci';
 
   @override
-  String get seerrDiscoveryRows => 'Wiersze odkrywania Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Zresetuj wiersze do wartości domyślnych';
 
   @override
-  String get enableSeerr => 'Włącz Seerr';
+  String get enableSeerr => 'Włącz Seera';
 
   @override
   String get showSeerrInNavigation =>
@@ -3661,47 +3657,47 @@ class AppLocalizationsPl extends AppLocalizations {
   String get hideAdultContent => 'Ukryj w wynikach treści dla dorosłych';
 
   @override
-  String get seerrNotificationsSection => 'Powiadomienia';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Powiadomienia o nowych żądaniach';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Powiadamiaj mnie, gdy ktoś prześle żądanie';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Aktualizacje żądań';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Zatwierdzone, odrzucone i dodane do biblioteki';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Aktualizacje zgłoszeń';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Nowe zgłoszenia, odpowiedzi i rozwiązania';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Zalogowano jako: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Strona odkrywania Seerr';
+  String get discoverRows => 'Odkryj rzędy';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Włącz wiersze widoczne na stronie głównej Seerr. Przeciągnij, aby zmienić kolejność. Własna kolejność synchronizuje się z Moonbase.';
+      'Przeciągnij, aby zmienić kolejność. Włącz lub wyłącz wiersze. Włączona kolejność wierszy synchronizuje się z wtyczką Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Włącz wiersze widoczne na stronie głównej Seerr. Przeciągnij, aby zmienić kolejność. Własna kolejność synchronizuje się z Moonbase.';
+      'Przeciągnij, aby zmienić kolejność. Włącz lub wyłącz wiersze.';
 
   @override
-  String get enabled => 'Włączone';
+  String get enabled => 'Włączony';
 
   @override
   String get hidden => 'Ukryty';
@@ -3711,7 +3707,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Wersja $version';
+    return 'Version $version';
   }
 
   @override
@@ -3762,7 +3758,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Dostępna aktualizacja: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3774,7 +3770,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Dostępna wersja v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3838,7 +3834,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get imageCacheCleared => 'Wyczyszczono pamięć podręczną obrazów';
 
   @override
-  String get clear => 'Wyczyść';
+  String get clear => 'Jasne';
 
   @override
   String get browse => 'Przeglądać';
@@ -3854,19 +3850,19 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Pobieranie · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importowanie';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count elementów';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Ustawienia Seerr';
+  String get seerrSettings => 'Ustawienia Seera';
 
   @override
   String get requestMore => 'Poproś o więcej';
@@ -3882,7 +3878,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Zażądane przez $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3899,12 +3895,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Anulować żądanie dla „$title”?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Anulować $count żądań dla „$title”?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3919,12 +3915,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Budżet: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Przychód: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3934,7 +3930,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Zażądaj: $type';
+    return 'Request $type';
   }
 
   @override
@@ -3970,7 +3966,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'wiek $age';
+    return 'age $age';
   }
 
   @override
@@ -4001,149 +3997,148 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deletedStatus => 'Usunięto';
 
   @override
-  String get failedStatus => 'Nieudany';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Przetwarzanie';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Zmodyfikowane przez $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Ukończony';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ten tytuł został już zażądany';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Osiągnięto limit żądań';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'Ten tytuł jest na liście zablokowanych';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Nie ma już sezonów do zażądania';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Nie masz uprawnień do złożenia tego żądania';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Żądania';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Zgłoszenia';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Najnowsze';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Ostatnio zmodyfikowane';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Brak zgłoszeń';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Pozostało $remaining z $limit żądań filmów';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Pozostało $remaining z $limit żądań sezonów';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Część kolekcji $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Zobacz kolekcję';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Zażądaj kolekcji';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmów · $available dostępnych';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Zażądaj $count filmów';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Żądanie $current z $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Zażądano $count filmów';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Zażądano $ok z $total filmów';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Wszystkie filmy są już dostępne lub zażądane';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Zgłoś problem';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Wideo';
+  String get issueTypeVideo => 'Video';
 
   @override
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Na czym polega problem?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Wszystkie odcinki';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Odcinek';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Otwarte';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Rozwiązane';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Rozwiąż';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Otwórz ponownie';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Zgłoszone przez $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentarzy';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Dodaj komentarz';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Usunąć to zgłoszenie?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Wyślij zgłoszenie';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Wynik TMDB';
@@ -4167,7 +4162,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get originalLanguageLabel => 'Język oryginalny';
 
   @override
-  String get seasonsLabel => 'Sezony';
+  String get seasonsLabel => 'Pory roku';
 
   @override
   String get episodesLabel => 'Odcinki';
@@ -4176,7 +4171,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get access => 'Dostęp';
 
   @override
-  String get add => 'Dodaj';
+  String get add => 'Dodać';
 
   @override
   String get address => 'Adres';
@@ -4200,10 +4195,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get disable => 'Wyłączyć';
 
   @override
-  String get done => 'Gotowe';
+  String get done => 'Zrobione';
 
   @override
-  String get edit => 'Edytuj';
+  String get edit => 'Redagować';
 
   @override
   String get encoding => 'Kodowanie';
@@ -4215,7 +4210,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get forward => 'Do przodu';
 
   @override
-  String get general => 'Ogólne';
+  String get general => 'Ogólny';
 
   @override
   String get go => 'Iść';
@@ -4236,7 +4231,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get networking => 'Sieć';
 
   @override
-  String get next => 'Dalej';
+  String get next => 'Następny';
 
   @override
   String get path => 'Ścieżka';
@@ -4260,7 +4255,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get refresh => 'Odświeżać';
 
   @override
-  String get remote => 'Pilot';
+  String get remote => 'Zdalny';
 
   @override
   String get rename => 'Przemianować';
@@ -4296,7 +4291,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get status => 'Status';
 
   @override
-  String get stop => 'Zatrzymaj';
+  String get stop => 'Zatrzymywać się';
 
   @override
   String get streaming => 'Transmisja strumieniowa';
@@ -4305,7 +4300,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get time => 'Czas';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trik';
 
   @override
   String get uninstall => 'Odinstaluj';
@@ -4323,7 +4318,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unmute => 'Wyłącz wyciszenie';
 
   @override
-  String get mute => 'Wycisz';
+  String get mute => 'Niemy';
 
   @override
   String get branding => 'Marka';
@@ -4347,25 +4342,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteki';
 
   @override
-  String get adminDrawerDisplay => 'Wyświetlanie';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadane';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Ustawienia NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodowanie';
 
   @override
-  String get adminDrawerResume => 'Wznów';
+  String get adminDrawerResume => 'Wznawiać';
 
   @override
   String get adminDrawerStreaming => 'Transmisja strumieniowa';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trik';
 
   @override
   String get adminDrawerDevices => 'Urządzenia';
@@ -4416,22 +4411,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Dostępne aktualizacje wtyczek: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Wtyczki wymagające ponownego uruchomienia: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Nieudane zadania zaplanowane: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Ostatnie ostrzeżenia/błędy: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4490,7 +4485,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Błąd: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4517,7 +4512,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Polecenie nie powiodło się: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4554,7 +4549,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nowPlaying => 'Teraz odtwarzane';
 
   @override
-  String get volume => 'Głośność';
+  String get volume => 'Tom';
 
   @override
   String get actions => 'Działania';
@@ -4581,14 +4576,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminClearDates => 'Wyczyść daty';
 
   @override
-  String get adminActivitySeverityAll => 'Wszystkie poziomy ważności';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Zakres dat';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Nie udało się wczytać dziennika aktywności: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4606,7 +4601,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Nie udało się zaktualizować urządzenia: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4617,28 +4612,28 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Nie udało się usunąć urządzenia: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Usunąć urządzenie „$name”? Użytkownik będzie musiał ponownie zalogować się na tym urządzeniu.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Usuń wszystkie urządzenia';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Usunąć $count urządzeń? Objęci użytkownicy będą musieli zalogować się ponownie. Nie dotyczy to Twojego bieżącego urządzenia.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Usunięto urządzenia';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Usunięto część urządzeń; nie udało się usunąć $count.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4667,7 +4662,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Nie udało się rozpocząć skanowania: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4678,12 +4673,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Zmieniono nazwę biblioteki na „$name”';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Nie udało się zmienić nazwy: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4691,17 +4686,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Usunięto bibliotekę „$name”';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Nie udało się usunąć biblioteki: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Nie udało się dodać ścieżki: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4709,12 +4704,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Usunąć „$path” z tej biblioteki?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Nie udało się usunąć ścieżki: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4722,7 +4717,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Nie udało się zapisać opcji: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4753,262 +4748,251 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminMetadataCountryHint => 'np. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Ścieżki';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opcje';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Pobieranie';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Zapisywanie metadanych';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Pobieranie napisów';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Pobieranie tekstów utworów';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Pobieranie metadanych: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Pobieranie obrazów: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ten serwer nie udostępnia żadnych źródeł pobierania dla tego typu biblioteki.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Ogólne';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadane';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Osadzone informacje';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Napisy';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Obrazy';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Seriale';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muzyka';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmy';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'Włącz monitorowanie w czasie rzeczywistym';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Wykrywaj zmiany plików i przetwarzaj je automatycznie.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Traktuj archiwa jako pliki multimedialne';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Wyświetlaj zdjęcia';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Zapisuj grafiki w folderach multimediów';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatyczne odświeżanie metadanych';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nigdy';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Domyślnie';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Wyświetlanie';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Wyświetlanie biblioteki';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Pokaż widok folderów dla zwykłych folderów multimedialnych';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Pokazuj odcinki specjalne w sezonach, w których zostały wyemitowane';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupuj filmy w kolekcje';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupuj seriale w kolekcje';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Pokazuj zewnętrzne treści w propozycjach';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Zachowanie daty dodania';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Użyj daty dodania z';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data zeskanowania do biblioteki';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data utworzenia pliku';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadane i obrazy';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Preferowany język metadanych';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Rozdziały';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Długość zastępczych rozdziałów (sekundy)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Długość rozdziałów generowanych dla multimediów, które ich nie mają. Ustaw 0, aby wyłączyć.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Rozdzielczość obrazów rozdziałów';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Ustawienia NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadane NFO są zgodne z Kodi i podobnymi klientami. Ustawienia dotyczą wszystkich bibliotek zapisujących metadane NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Użytkownik, dla którego zapisywane są dane oglądania w plikach NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Zapisuj ścieżki obrazów w plikach NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Włącz podstawianie ścieżek dla ścieżek obrazów NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopiuj obrazy extrafanart do folderu extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Brak';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dni';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Używaj osadzonych tytułów';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Używaj osadzonych tytułów dla dodatków';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Używaj osadzonych informacji o odcinkach';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Zezwalaj na osadzone napisy';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Zezwalaj na wszystkie';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Tylko tekstowe';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Tylko obrazkowe';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Brak';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Pomiń pobieranie, jeśli są osadzone napisy';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Pomiń pobieranie, jeśli ścieżka audio jest w języku pobierania';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Wymagaj idealnego dopasowania napisów';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Zapisuj napisy w folderach multimediów';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Wyodrębniaj obrazy rozdziałów';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Wyodrębniaj obrazy rozdziałów podczas skanowania biblioteki';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Włącz wyodrębnianie obrazów trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Wyodrębniaj obrazy trickplay podczas skanowania biblioteki';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Zapisuj obrazy trickplay w folderach multimediów';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automatycznie scalaj seriale rozproszone w wielu folderach';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nazwa wyświetlana sezonu zerowego';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Włącz skanowanie LUFS do normalizacji dźwięku';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferuj niestandardowy tag wykonawcy';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automatycznie dodawaj filmy do kolekcji';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Nazwa biblioteki jest wymagana';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Nie udało się utworzyć biblioteki: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5035,27 +5019,27 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Wyłączyć użytkownika $name? Nie będzie mógł się zalogować.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Włączyć użytkownika $name? Będzie mógł ponownie się zalogować.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Wyłączono użytkownika „$name”';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Włączono użytkownika „$name”';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Nie udało się zaktualizować zasad użytkownika: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5072,7 +5056,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Nie udało się utworzyć użytkownika: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5092,7 +5076,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Nie udało się zapisać: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5103,7 +5087,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Niepowodzenie: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5242,144 +5226,143 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminEnableAllChannels => 'Włącz dostęp do wszystkich kanałów';
 
   @override
-  String get adminParentalControl => 'Kontrola rodzicielska';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Maksymalna dozwolona kategoria wiekowa';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Treści o wyższej kategorii będą ukryte przed tym użytkownikiem.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Brak';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokuj elementy bez kategorii wiekowej lub z nierozpoznaną kategorią';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Książki';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanały';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Telewizja na żywo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmy';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muzyka';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Zwiastuny';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriale';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Harmonogramy dostępu';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Zezwalaj na dostęp tylko w zaplanowanych godzinach poniżej. Gdy nie ustawiono harmonogramu, dostęp jest możliwy przez cały dzień.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Dodaj harmonogram';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dzień';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Początek';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Koniec';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Codziennie';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Dzień powszedni';
+  String get adminDayWeekday => 'Weekday';
 
   @override
   String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Niedziela';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Poniedziałek';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Wtorek';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Środa';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Czwartek';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Piątek';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sobota';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Dozwolone tagi';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Wyświetlane są tylko treści z tymi tagami. Pozostaw puste, aby zezwolić na wszystkie.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Zablokowane tagi';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Treści z tymi tagami będą ukryte przed tym użytkownikiem.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Dodaj tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Włączone urządzenia';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Włączone kanały';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Dostawca uwierzytelniania';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Dostawca resetowania hasła';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maksymalna liczba nieudanych prób logowania przed zablokowaniem';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Ustaw 0, aby użyć wartości domyślnej, lub -1, aby wyłączyć blokadę.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Dostęp do SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Zezwalaj na tworzenie grup i dołączanie do nich';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Zezwalaj na dołączanie do grup';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Brak dostępu';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Zezwalaj na usuwanie treści z';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5387,22 +5370,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Serwer zwrócił HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Czy na pewno chcesz usunąć użytkownika $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Usunięto użytkownika „$name”';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Nie udało się usunąć użytkownika: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5423,7 +5406,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Nie udało się utworzyć klucza: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5434,7 +5417,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Unieważnić klucz dla $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5442,7 +5425,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Nie udało się unieważnić klucza: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5462,29 +5445,29 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nUtworzono: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Utwórz kopię zapasową';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Wybierz, co uwzględnić w kopii zapasowej.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Baza danych';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Zawsze uwzględniana';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadane';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Napisy';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Obrazy trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Tworzenie kopii zapasowej...';
@@ -5494,7 +5477,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Nie udało się utworzyć kopii zapasowej: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5508,7 +5491,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Nie udało się wczytać manifestu: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5519,7 +5502,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Nie udało się przywrócić kopii zapasowej: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5553,17 +5536,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Zapisano w $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Nie udało się zapisać pliku: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Nie udało się wczytać $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5574,7 +5557,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Nie udało się wczytać zadań: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5586,17 +5569,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Nie udało się uruchomić zadania: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Nie udało się zatrzymać zadania: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Nie udało się wczytać zadania: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5604,12 +5587,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Nie udało się usunąć wyzwalacza: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Nie udało się dodać wyzwalacza: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5635,7 +5618,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours godz.';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5646,7 +5629,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Nie udało się przełączyć wtyczki: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5654,27 +5637,27 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Czy na pewno chcesz odinstalować „$name”?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Nie udało się odinstalować wtyczki: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Nie udało się zainstalować pakietu: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Nie udało się zainstalować aktualizacji: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Nie udało się wczytać wtyczek: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5686,12 +5669,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Zainstaluj aktualizację (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Nie udało się wczytać katalogu: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5713,17 +5696,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '„$name” zostanie usunięta po ponownym uruchomieniu serwera';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Nie udało się odinstalować: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Aktualizowanie „$name” do v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5732,7 +5715,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Nie udało się wczytać wtyczki: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5740,7 +5723,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Wersja $version';
+    return 'Version $version';
   }
 
   @override
@@ -5760,17 +5743,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Czy na pewno chcesz usunąć „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Nie udało się zapisać repozytoriów: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Nie udało się wczytać repozytoriów: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5787,12 +5770,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Nie można wczytać ustawień wtyczki: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Nie można otworzyć $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5917,11 +5900,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminThrottleBuffering => 'Buforowanie przepustnicy';
 
   @override
-  String get adminTrickplaySaved => 'Ustawienia Trickplay zostały zapisane';
+  String get adminTrickplaySaved => 'Ustawienia trików zostały zapisane';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Nie udało się załadować ustawień Trickplay';
+      'Nie udało się załadować ustawień trików';
 
   @override
   String get adminEnableHardwareAcceleration => 'Włącz akcelerację sprzętową';
@@ -6034,7 +6017,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminBaseUrl => 'Bazowy adres URL';
 
   @override
-  String get adminBaseUrlHint => 'np. /jellyfin';
+  String get adminBaseUrlHint => 'np. /galaretowata';
 
   @override
   String get https => 'HTTPS';
@@ -6074,12 +6057,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Nie udało się wczytać metadanych: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Nie udało się zapisać metadanych: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6099,7 +6082,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Nie udało się odświeżyć metadanych: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6113,7 +6096,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Wyszukiwanie zdalne nie powiodło się: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6127,7 +6110,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Nie udało się zaktualizować typu treści: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6143,12 +6126,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Zaktualizowano obraz $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Nie udało się pobrać obrazu: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6159,27 +6142,27 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Przesłano obraz $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Nie udało się przesłać obrazu: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Usuń obraz $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Usunięto obraz $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Nie udało się usunąć obrazu: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6190,70 +6173,67 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Wykrywanie tunerów nie powiodło się: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Dodaj tuner';
 
   @override
-  String get adminEditTuner => 'Edytuj tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Plik lub URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Adres IP tunera';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nazwa przyjazna';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limit jednoczesnych połączeń';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Maksymalna liczba strumieni obsługiwanych jednocześnie przez tuner. Ustaw 0, aby znieść limit.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Zapasowa maksymalna przepływność strumienia';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importuj tylko ulubione kanały';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Zezwalaj na transkodowanie sprzętowe';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Zezwalaj na kontener transkodowania fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Zezwalaj na współdzielenie strumieni';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Włącz zapętlanie strumienia';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignoruj DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Czytaj wejście z natywną liczbą klatek';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Edytuj dostawcę';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6262,50 +6242,50 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Plik lub URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefiks filmów';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategorie filmów';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Oddziel wiele kategorii pionową kreską.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategorie dla dzieci';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategorie wiadomości';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategorie sportowe';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nazwa użytkownika';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Hasło';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Kraj';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Wybierz kraj';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Kod pocztowy';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Pobierz programy';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programy';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Włącz wszystkie tunery';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Typ tunera';
@@ -6315,7 +6295,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Nie udało się dodać tunera: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6329,12 +6309,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Nie udało się dodać dostawcy: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Nie udało się usunąć tunera: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6342,16 +6322,16 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Nie udało się zresetować tunera: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ten typ tunera nie obsługuje resetowania.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Nie udało się usunąć dostawcy: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6370,45 +6350,43 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Ścieżka nagrywania serii';
 
   @override
-  String get adminMovieRecordingPath => 'Ścieżka nagrań filmów';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Liczba dni danych programu';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatycznie';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dni';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Ścieżka aplikacji przetwarzania końcowego';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumenty przetwarzania końcowego';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Zapisuj metadane NFO nagrań';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Zapisuj obrazy nagrań';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Czas';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Ścieżki nagrań';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Przetwarzanie końcowe';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Dane programu: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6417,7 +6395,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Nie udało się zapisać ustawień: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6434,7 +6412,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Nie udało się zaktualizować mapowań: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6451,15 +6429,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminGuideProviders => 'Dostawcy przewodników';
 
   @override
-  String get adminRefreshGuideData => 'Odśwież dane programu';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Rozpoczęto odświeżanie danych programu';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Zadanie odświeżania programu jest niedostępne na tym serwerze.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Dodaj dostawcę';
@@ -6470,22 +6447,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Ścieżka nagrań: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Ścieżka seriali: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Zapas przed: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Zapas po: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6518,7 +6495,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Przywrócić kopię zapasową $name teraz?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6542,13 +6519,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminLiveTvTitle => 'Administracja telewizji na żywo';
 
   @override
-  String get adminApply => 'Zastosuj';
+  String get adminApply => 'Stosować';
 
   @override
   String get adminNotSet => 'Nie ustawiono';
 
   @override
-  String get adminReset => 'Resetuj';
+  String get adminReset => 'Nastawić';
 
   @override
   String get adminLogsTitle => 'Dzienniki serwera';
@@ -6564,27 +6541,27 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes min temu';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours godz. temu';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days dni temu';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Nie udało się wczytać $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count dopasowań';
+    return '$count matches';
   }
 
   @override
@@ -6594,7 +6571,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Edytor metadanych';
 
   @override
-  String get adminMetadataIdentify => 'Zidentyfikuj';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Typ';
@@ -6694,22 +6671,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Zaktualizowano obraz $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Przesłano obraz $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Usunięto obraz $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Nie udało się pobrać obrazu: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6718,12 +6695,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Nie udało się przesłać obrazu: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Usuń obraz $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6732,12 +6709,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Nie udało się usunąć obrazu: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Wybierz obraz $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6770,7 +6747,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Dostępna aktualizacja: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6795,7 +6772,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Zainstaluj aktualizację (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6807,7 +6784,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return 'Trwa instalowanie „$name”...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6827,7 +6804,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Ustawienia: $name';
+    return '$name Settings';
   }
 
   @override
@@ -6867,7 +6844,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Nie udało się wczytać repozytoriów: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6875,15 +6852,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Czy na pewno chcesz usunąć „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Usuń';
+  String get adminReposRemove => 'Usunąć';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Nie udało się zapisać repozytoriów: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7010,20 +6987,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Włącz ekran powitalny';
 
   @override
-  String get adminBrandingSplashUpload => 'Prześlij obraz';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Zaktualizowano ekran powitalny';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Nie udało się przesłać ekranu powitalnego';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Usunięto ekran powitalny';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Brak własnego ekranu powitalnego';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Przyspieszenie sprzętowe';
@@ -7039,123 +7015,118 @@ class AppLocalizationsPl extends AppLocalizations {
       'Włącz dekodowanie sprzętowe dla:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Urządzenie QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Włącz ulepszony dekoder NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferuj natywny sprzętowy dekoder systemu';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Głębia kolorów dekodowania sprzętowego';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Dekodowanie 10-bitowego HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Dekodowanie 10-bitowego VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Dekodowanie HEVC RExt 8/10-bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Dekodowanie HEVC RExt 12-bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Kodowanie sprzętowe';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Zezwalaj na kodowanie HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Zezwalaj na kodowanie AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Włącz niskoenergetyczny koder Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Włącz niskoenergetyczny koder Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapowanie tonów';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Włącz mapowanie tonów';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Włącz mapowanie tonów VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Włącz mapowanie tonów VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algorytm mapowania tonów';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Tryb mapowania tonów';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Zakres mapowania tonów';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturacja mapowania tonów';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Szczyt mapowania tonów';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametr mapowania tonów';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Jasność mapowania tonów VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast mapowania tonów VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Ustawienia wstępne i jakość';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Ustawienie wstępne kodera';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF kodowania H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF kodowania H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metoda usuwania przeplotu';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Podwój liczbę klatek przy usuwaniu przeplotu';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Włącz kodowanie audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Wzmocnienie downmiksu audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algorytm downmiksu do stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maksymalny rozmiar kolejki muksowania';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7279,10 +7250,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminTaskNeverRun => 'Nigdy nie biegaj';
 
   @override
-  String get adminTaskStop => 'Zatrzymaj';
+  String get adminTaskStop => 'Zatrzymywać się';
 
   @override
-  String get adminRunningTasks => 'Uruchomione zadania';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Uruchomić';
@@ -7304,17 +7275,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Codziennie o $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Co $day o $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Co $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7352,8 +7323,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count godz.',
-      one: '1 godzina',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7381,17 +7352,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days dni temu';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours godz. temu';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes min temu';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7399,27 +7370,27 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours godz.';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days dni';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Skonfiguruj generowanie obrazów Trickplay dla miniatur podglądu przewijania.';
+      'Skonfiguruj generowanie obrazu w trybie trików w celu wyszukiwania miniatur podglądu.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Publiczny port HTTPS';
@@ -7428,50 +7399,49 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Bazowy adres URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'np. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'np. /galaretowata';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Publiczny port HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Wymagaj HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Przekierowuj wszystkie zdalne żądania na HTTPS. Nie działa, jeśli serwer nie ma ważnego certyfikatu.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Hasło certyfikatu';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Ustawienia IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Włącz IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Włącz IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Włącz automatyczne mapowanie portów';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Sieci LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Lista adresów IP lub podsieci CIDR (oddzielonych przecinkiem lub nową linią) traktowanych jako sieć lokalna.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Opublikowane adresy URI serwera';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Przypisz podsieć lub adres do opublikowanego adresu URL, np. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Ścieżka certyfikatu';
@@ -7502,11 +7472,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Buforowanie przepustnicy';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Opóźnienie ograniczania (sekundy)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Zezwalaj na wyodrębnianie napisów w locie';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimalny procent wznowienia';
@@ -7555,30 +7525,29 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Nie udało się zaktualizować typu treści: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Próg powolnej reakcji (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Włącz ostrzeżenia o wolnych odpowiedziach';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Włącz Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Serwer';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadane';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Ścieżki';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Wydajność';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Ścieżka pamięci podręcznej';
@@ -7590,7 +7559,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminGeneralServerName => 'Nazwa serwera';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Preferowany język wyświetlania';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nie udało się załadować ustawień';
@@ -7600,12 +7569,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Nie udało się zaktualizować mapowań: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Limit czasu: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7642,8 +7611,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# uczestników',
-      one: '# uczestnik',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7687,7 +7656,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Element $index';
+    return 'Item $index';
   }
 
   @override
@@ -7735,12 +7704,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName dołączył do grupy SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName opuścił grupę SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7752,7 +7721,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Synchronizowanie odtwarzania z $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7791,8 +7760,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# odnalezionych wierszy',
-      one: '# odnaleziony wiersz',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7833,21 +7802,20 @@ class AppLocalizationsPl extends AppLocalizations {
   String get offlineSavedMedia => 'Zapisane multimedia';
 
   @override
-  String get offlineBannerTitle => 'Jesteś offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Wyświetlamy Twoje pobrane pliki';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Pobrane';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Nie można połączyć się z serwerem';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Odtwarzanie z pobranych, dopóki serwer nie wróci';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7863,12 +7831,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Sterowanie przesyłaniem nie powiodło się: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Sterowanie: $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7879,7 +7847,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Zatrzymaj $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7903,12 +7871,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Wprowadź $length-cyfrowy PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Wprowadź swój $length-cyfrowy PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7921,22 +7889,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pinForgot => 'Zapomniałeś kodu PIN?';
 
   @override
-  String get pinClear => 'Wyczyść';
+  String get pinClear => 'Jasne';
 
   @override
   String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized =>
-      'Żądanie Quick Connect zostało zatwierdzone.';
+      'Zatwierdzono żądanie szybkiego połączenia.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Kod Quick Connect jest nieprawidłowy lub wygasł.';
+      'Kod szybkiego połączenia jest nieprawidłowy lub wygasł.';
 
   @override
   String get quickConnectNotSupported =>
-      'Funkcja Quick Connect nie jest obsługiwana na tym serwerze.';
+      'Funkcja szybkiego połączenia nie jest obsługiwana na tym serwerze.';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7944,19 +7912,19 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect jest wyłączony na tym serwerze.';
+      'Szybkie połączenie jest wyłączone na tym serwerze.';
 
   @override
   String get quickConnectForbidden =>
-      'Twoje konto nie może autoryzować tego żądania Quick Connect.';
+      'Twoje konto nie może autoryzować tego żądania szybkiego połączenia.';
 
   @override
   String get quickConnectNotFound =>
-      'Nie znaleziono kodu Quick Connect. Wypróbuj nowy kod.';
+      'Nie znaleziono kodu szybkiego połączenia. Wypróbuj nowy kod.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect nie powiódł się: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7967,7 +7935,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Polecenie nie powiodło się: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7998,7 +7966,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Nie udało się rozpocząć przesyłania: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8044,7 +8012,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Pobieranie $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8066,7 +8034,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shuffleLibrary => 'Biblioteka';
 
   @override
-  String get shuffleGenre => 'Gatunek';
+  String get shuffleGenre => 'Genre';
 
   @override
   String get shuffleNoLibraries => 'Brak dostępnych kompatybilnych bibliotek.';
@@ -8125,14 +8093,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'Odtwarzanie zostało wstrzymane. Czy nadal oglądasz?';
 
   @override
-  String get stillWatchingStop => 'Zatrzymaj';
+  String get stillWatchingStop => 'Zatrzymywać się';
 
   @override
   String get stillWatchingContinue => 'Kontynuować';
 
   @override
   String skipSegment(String segment) {
-    return 'Pomiń $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8143,12 +8111,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Pobieranie $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Pobieranie $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8210,13 +8178,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Ukryj z Kontynuuj oglądanie';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ukryj z Następne';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Dodaj do kolekcji';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8271,15 +8239,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetyczny';
 
   @override
-  String get settingsConnectionSection => 'POŁĄCZENIE';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Zezwalaj na certyfikaty samopodpisane';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Ufaj serwerom używającym samopodpisanych certyfikatów TLS lub certyfikatów z prywatnego CA. Włączaj tylko dla serwerów, które kontrolujesz. Ta opcja wyłącza weryfikację certyfikatów dla wszystkich połączeń.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRYWATNOŚĆ I BEZPIECZEŃSTWO';
@@ -8295,11 +8262,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Akcenty tematyczne, tła, obserwowane wskaźniki i muzyka tematyczna';
 
   @override
-  String get settingsDetailsScreen => 'Ekran szczegółów';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Styl, rozmycie tła i zachowanie zakładek';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Strona główna';
@@ -8337,11 +8304,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Pokaż przycisk Seerr na pasku nawigacji';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Zawsze pokazuj etykiety tekstowe na górnym pasku nawigacji';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8410,7 +8377,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsSupportMoonfin => 'Wesprzyj Moonfina';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Postaw kawę deweloperowi';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'PRAWNY';
@@ -8444,8 +8412,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# informacji licencyjnych',
-      one: '# informacja licencyjna',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8495,16 +8463,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Pominąć wstępy i zakończenia?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Odliczanie segmentu multimediów';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Pasek postępu';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Licznik czasu';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Brak';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Monituj użytkownika';
@@ -8539,13 +8507,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (zalecane)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (starszy)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (starsza wersja)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (zalecany)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Funkcja zastępcza Dolby Vision';
@@ -8736,761 +8704,749 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Ostatnio wydane: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode =>
-      'Automatyczne odtwarzanie następnego odcinka';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Automatycznie odtwarzaj następny odcinek, gdy jest dostępny.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Pomijaj ciszę';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Automatycznie pomijaj ciche fragmenty dźwięku, jeśli strumień to obsługuje.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Zezwalaj na zewnętrzne efekty audio';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Pozwól aplikacjom z korektorem i efektami (np. Wavelet) podłączać się do sesji odtwarzania Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Wyłącz tunelowanie';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Wymuś odtwarzanie bez tunelowania. Przydatne na urządzeniach, na których tunelowanie powoduje przerwy w obrazie lub dźwięku.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Włącz tunelowanie';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Zaawansowane. Kieruje dźwięk i obraz sprzężoną ścieżką sprzętową. Domyślnie wyłączone, ponieważ na niektórych urządzeniach powoduje przerwy w obrazie i dźwięku.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Mapuj Dolby Vision profil 7 na HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Odtwarzaj strumienie Dolby Vision profil 7 jako HEVC zgodny z HDR10 na urządzeniach bez obsługi Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Używaj osadzonych stylów napisów';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Stosuj kolory, czcionki i pozycjonowanie osadzone w ścieżce napisów. Wyłącz, aby korzystać z własnych preferencji stylu napisów.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Używaj osadzonych rozmiarów czcionek napisów';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Stosuj wskazówki dotyczące rozmiaru czcionki osadzone w ścieżce napisów. Wyłącz, aby korzystać z rozmiaru napisów z Twoich preferencji stylu.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Pokaż szczegóły multimediów';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Pokazuj szczegóły wybranego elementu u góry stron biblioteki.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Ukrywać tła podczas przeglądania?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Używaj szczegółowych podtytułów';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Pokazuj szczegółowy lub minimalny podwiersz na stronach biblioteki.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Usunąć zapisany motyw?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Usunąć „$themeName” z pamięci podręcznej tego urządzenia?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Sklep z motywami';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Przeglądaj i zapisuj motywy społeczności';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Zapisz motyw, aby używać go jak innych zapisanych motywów.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Obecnie nie ma dostępnych motywów.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Nie udało się wczytać Sklepu z motywami. Sprawdź połączenie i spróbuj ponownie.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Zapisz';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Zapisz i zastosuj';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Zapisano';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Nie udało się wczytać tego motywu.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Zapisano „$themeName”.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Usunięto „$themeName” z tego urządzenia.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Nie udało się usunąć „$themeName”.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Zapisane motywy';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'To motywy pobrane z wtyczki Moonfin dla bieżącego serwera. Usunięcie kasuje wyłącznie tę lokalną kopię.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Nie znaleziono zapisanych motywów dla tego serwera.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Obecnie aktywny';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Usuń zapisany motyw';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Zarządzaj pobranymi motywami wtyczki na tym urządzeniu';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Edytor motywów';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Otwórz Edytor motywów Moonfin w przeglądarce';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Ekran główny';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Dolny pasek';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasyczny';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Nowoczesny';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Wiersze ekranu głównego';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Wyświetlanie wierszy ekranu głównego';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sekcje wierszy ekranu głównego';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Przełączniki wierszy ekranu głównego';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Włącz lub wyłącz kategorie wierszy ekranu głównego oparte na bibliotekach';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Włącz poniższe przełączniki, aby wyświetlać wiersze w sekcjach ekranu głównego.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasyczny zachowuje typ obrazu na wiersz i nakładkę informacyjną. Nowoczesny używa wierszy portret–tło.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Pokaż wiersze ulubionych';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Pokazuj wiersze ulubionych filmów, seriali i innych ulubionych w sekcjach ekranu głównego.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortowanie wierszy ulubionych';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sortuj wiersze ulubionych według daty dodania, daty wydania, alfabetycznie i nie tylko.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Pokaż wiersze kolekcji';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Pokazuj wiersze kolekcji w sekcjach ekranu głównego.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortowanie wierszy kolekcji';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sortuj wiersze kolekcji według daty dodania, daty wydania, alfabetycznie i nie tylko.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Pokaż wiersze gatunków';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Pokazuj wiersze gatunków w sekcjach ekranu głównego.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortowanie wierszy gatunków';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sortuj wiersze gatunków według daty dodania, daty wydania, alfabetycznie i nie tylko.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementy wierszy gatunków';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Pokazuj filmy, seriale lub jedno i drugie w wierszach gatunków.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Pokaż wiersze playlist';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Pokazuj wiersze playlist w sekcjach ekranu głównego.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortowanie wierszy playlist';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sortuj wiersze playlist według daty dodania, daty wydania, alfabetycznie i nie tylko.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Pokaż wiersze audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Pokazuj wiersze audio w sekcjach ekranu głównego.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortowanie wierszy audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sortuj wiersze audio według daty dodania, daty wydania, alfabetycznie i nie tylko.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Playlisty audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Wygląd';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Układ';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Motyw';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klawiatura';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Przyciski';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderowanie';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfiguracja MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Zewnętrzna aplikacja odtwarzacza';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Ustaw zewnętrzny odtwarzacz, aby włączyć opcję odtwarzania po długim naciśnięciu';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Pokazuj wybór aplikacji przy rozpoczęciu odtwarzania.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Wczytywanie zainstalowanych odtwarzaczy...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Połączenie';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Docelowy format transkodowania audio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Obsługiwane na tym urządzeniu';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Nieobsługiwane na tym urządzeniu';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Przesyłaj strumień DTS:X (DTS UHD) do zewnętrznego dekodera.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD z Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Zachowanie odtwarzacza';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Ulepszenia odtwarzania';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Zawsze włączone.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Zastąp Pomiń napisy końcowe ekranem Następne';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Pokazuj nakładkę Następne zamiast przycisku Pomiń napisy końcowe.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Kierowanie odtwarzacza';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Preferuj dekodery programowe';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Używaj FFmpeg (audio) i libgav1 (AV1) przed dekoderami sprzętowymi. Wyłącz, jeśli passthrough audio przez HDMI przestaje działać.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Otwieraj odtwarzanie wideo w wybranej zewnętrznej aplikacji na Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatyczne kolejkowanie';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferuj napisy SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Priorytetowo wybieraj ścieżki napisów SDH/CC przy automatycznym wyborze.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnostyka sieci Web';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnostyka Moonfin Web';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Użyj tej strony, aby zdiagnozować problemy z połączeniem w przeglądarce (CORS, mieszana treść i ustawienia wykrywania).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Wykryto błąd mieszanej treści';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Wykryto błąd CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin wykrył stronę HTTPS próbującą wywołać adres URL serwera po HTTP. Przeglądarki blokują takie żądanie, zanim dotrze ono do serwera.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin wykrył błąd żądania na poziomie przeglądarki, który zwykle wynika z braku nagłówków CORS lub preflight na serwerze multimediów.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Docelowy URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Szczegóły: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Bieżący kontekst uruchomieniowy';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schemat';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Tryb wtyczki';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Skanowanie WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Wymuszony URL serwera';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Domyślny URL serwera';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL proxy wykrywania';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'nie skonfigurowano';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Mieszana treść';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Ta strona jest wczytana przez HTTPS, ale co najmniej jeden ze skonfigurowanych adresów URL używa HTTP. Przeglądarki blokują wywołania API po HTTP ze stron HTTPS.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Rozwiązanie: udostępnij serwer multimediów lub punkt końcowy proxy przez HTTPS albo ładuj Moonfin przez HTTP wyłącznie w zaufanych sieciach lokalnych.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Na podstawie bieżących ustawień nie wykryto oczywistej konfiguracji z mieszaną treścią.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Lista kontrolna CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Zezwól na origin przeglądarki w Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Uwzględnij Authorization, X-Emby-Authorization i X-Emby-Token w Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Udostępnij Content-Range i Accept-Ranges dla przesyłania strumieniowego i przewijania.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Zwracaj 204 na żądania preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Przykładowy fragment nagłówków (w stylu nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Uwaga';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Ta ścieżka diagnostyczna jest przeznaczona dla wersji webowych. Jeśli widzisz ją na innej platformie, te testy mogą nie mieć zastosowania.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Wróć do wyboru serwera';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Wyloguj wszystkich użytkowników';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Uprawnienie do mikrofonu zostało trwale odrzucone. Włącz je w ustawieniach systemu.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Wyszukiwanie głosowe wymaga uprawnienia do mikrofonu.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nie udało się rozpoznać. Spróbuj ponownie.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nie wykryto mowy.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Błąd mikrofonu.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Wyszukiwanie głosowe wymaga internetu.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Usługa głosowa jest zajęta. Spróbuj ponownie.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Uprawnienie do mikrofonu zostało trwale odrzucone.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Uprawnienie do mikrofonu zostało odrzucone.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Rozpoznawanie mowy jest niedostępne na tym urządzeniu.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Otwórz selektor wyjścia iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Selektor wyjścia AirPlay jest niedostępny na tym urządzeniu.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Filmy wideo';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programy';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Utwory';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Albumy zdjęć';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Zdjęcia';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Osoby';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Ostatnio wydane odcinki';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Obejrzyj ponownie';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Występy gościnne';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Występy (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Udział ekipy (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Oglądaj z grupą';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Błędy';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Ostrzeżenia';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Dysk';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Otwórz w przeglądarce';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Wbudowana przeglądarka jest niedostępna na tej platformie.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Czy na pewno chcesz ponownie uruchomić serwer?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Czy na pewno chcesz wyłączyć serwer? Trzeba będzie uruchomić go ręcznie.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Wewnętrzny';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Bezczynny';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nie znaleziono użytkowników';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Żaden użytkownik nie pasuje do wyszukiwania';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nie znaleziono urządzeń';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Żadne urządzenie nie pasuje do bieżących filtrów';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Hasło ustawione';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nie skonfigurowano hasła';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Dostęp zdalny';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Tylko lokalnie';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Nie udało się wczytać statystyk multimediów';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Łączne statystyki ze wszystkich bibliotek multimediów.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Najpopularniejsi wykonawcy';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Najpopularniejsi autorzy';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Najpopularniejsi twórcy';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bibliotek',
-      one: '1 biblioteka',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Brak zindeksowanych danych o multimediach dla tego wyboru.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Szczegóły biblioteki';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Podział bibliotek';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Brak dostępnych bibliotek.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administracja serwerem';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Dane';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Pamięć podręczna obrazów';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Pamięć podręczna';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Dzienniki';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadane';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transkodowanie';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Ten serwer nie zwrócił żadnych ścieżek.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% wykorzystania';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Aktywność użytkowników';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Zdarzenia systemowe';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Wymaga uwagi';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Serwer';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Odtwarzanie';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Urządzenia';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Zaawansowane';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Wtyczki';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Telewizja na żywo';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Filmy domowe';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Treści mieszane';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Filmy domowe i zdjęcia';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Filmy i seriale (mieszane)';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9502,300 +9458,299 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nie znaleziono nagrań';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Nie znaleziono stron z obrazami w archiwum .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Błąd wbudowanego renderera ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Błąd renderera EPUB ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Brak lokalnego pliku dla czytnika: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status podczas otwierania danych książki z $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Brak dostępnego punktu końcowego do odczytu książki';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Nieobsługiwany format archiwum komiksu: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Wtyczka do wypakowywania CBR jest niedostępna na tej platformie.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Nie udało się wypakować archiwum .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Wypakowywanie CB7 jest niedostępne na tej platformie.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Wtyczka do wypakowywania CB7 jest niedostępna na tej platformie.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Zamknij panel gatunków';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Wczytywanie losowania...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'LOSOWANIE BIBLIOTEKI';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'LOSOWANIE PRZYPADKOWE';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'LOSOWANIE GATUNKÓW';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatyczne przełączanie HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Automatycznie włączaj HDR przy odtwarzaniu wideo HDR i przywracaj tryb wyświetlania po wyjściu.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Na pełnym ekranie';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Zmień grafikę';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Brak';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Limity transkodowania';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Wyczyścić całą grafikę?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Czy na pewno chcesz wyczyścić całą pobraną grafikę?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Potwierdź czyszczenie';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Czy na pewno chcesz wyczyścić: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Przesłać?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Rozdzielczość: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Pokazuj tylko grafikę w języku interfejsu';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Potwierdź czyszczenie wszystkiego';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Pomyślnie przesłano obraz!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Nie udało się przesłać obrazu: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Nie udało się ustawić obrazu: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Nie udało się usunąć obrazu: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Nie udało się wyczyścić całej grafiki: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Tak';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Tła';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Baner';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika płyty';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Zrzut ekranu';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Okładka pudełka';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Tylna okładka pudełka';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'tło';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'baner';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafika płyty';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'zrzut ekranu';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'okładka pudełka';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'tylna okładka pudełka';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafika menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Wszystkie';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Wysoka (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Średnia (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Niska (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Źródła';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Rozdziały';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Zakładki';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notatki';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Kolejka';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Oś czasu';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Oś czasu jest pusta';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Cała książka';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Wybrany fragment osi czasu';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksportuj zakładki';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksportuj notatki';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksportuj wszystko';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Wyeksportowano do $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksport nie powiódł się: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Tekst';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Dodaj zakładkę';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Dodaj notatkę';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Edytuj notatkę';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Zapisz notatkę do tego momentu';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Wyłącznik czasowy';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Wyłączony';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Koniec rozdziału';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Własny';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Pozostało $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9810,51 +9765,51 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Prędkość odtwarzania';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Pozostało';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Upłynęło';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Cofnij ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Do przodu ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Poprzedni rozdział';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Następny rozdział';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Rozdział $current z $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Brak rozdziałów';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Brak zakładek';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Brak notatek';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Dodano zakładkę w $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Przywróć 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9862,255 +9817,249 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Zapisz';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Anuluj';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Usuń';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferencje napisów';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Zmień tryby napisów, domyślne języki, wygląd i opcje renderowania.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderowanie napisów';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opcje wyświetlania';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data wydania (rosnąco)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data wydania (malejąco)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupowanie udziałów';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupuj wiele ról';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Ostrzeżenie o dostępie do zapisu w bibliotece';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Jak to naprawić:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Nadaj użytkownikowi usługi Jellyfin (np. jellyfin lub PUID/PGID w Dockerze) uprawnienia do zapisu w folderach biblioteki multimediów na serwerze.\n\n2. Albo przejdź do panelu Jellyfin -> Biblioteki, edytuj tę bibliotekę i wyłącz opcję „Zapisuj grafiki w folderach multimediów”, aby przechowywać grafiki w wewnętrznej bazie danych Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Zamknij';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Twoja biblioteka „$libraryName” jest skonfigurowana tak, aby zapisywać grafiki bezpośrednio w folderach multimediów (opcja „Zapisuj grafiki w folderach multimediów” jest włączona). Jellyfin sprawdził jednak dostęp do zapisu i nie ma uprawnień do zapisywania plików w tym katalogu:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Wygląda na to, że Jellyfin nie zdołał zaktualizować grafiki. Twoja biblioteka jest skonfigurowana tak, aby zapisywać grafiki bezpośrednio w folderach multimediów (opcja „Zapisuj grafiki w folderach multimediów” jest włączona). Ten błąd zwykle występuje, gdy proces serwera Jellyfin nie ma uprawnień do zapisu plików w Twoich katalogach multimediów.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Listy zewnętrzne';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Odtwórz ponownie';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informacje o pliku';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Rozmiar: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Pokaż wszystkie ścieżki audio ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Pokaż wszystkie ścieżki napisów ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Sprawdzanie możliwości odtwarzania bezpośredniego...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Odtwarzanie bezpośrednie: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Wymuszone';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Format kontenera nie jest obsługiwany przez odtwarzacz.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Kodek wideo nie jest obsługiwany.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Kodek audio nie jest obsługiwany.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Format napisów nie jest obsługiwany (wymaga wypalenia).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Profil audio nie jest obsługiwany.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Profil wideo nie jest obsługiwany.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Poziom wideo nie jest obsługiwany.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Rozdzielczość wideo nie jest obsługiwana przez to urządzenie.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Głębia bitowa wideo nie jest obsługiwana.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Liczba klatek wideo nie jest obsługiwana.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Przepływność pliku przekracza limit odtwarzacza.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Przepływność wideo przekracza limit strumieniowania.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Przepływność audio przekracza limit strumieniowania.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Liczba kanałów audio nie jest obsługiwana.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetycznie';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Kolejność wydania (rosnąco)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Kolejność wydania (malejąco)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Własna (przeciągnij i upuść)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opcje sortowania playlisty';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Resetuj sortowanie';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Obejrzyj ponownie S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Obejrzyj ponownie playlistę';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nie znaleziono napisów.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Ustawienia administratora';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Silnik renderowania (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller to nowoczesny renderer GPU we Flutterze, zapewniający płynniejsze animacje i mniej zacięć. Na niektórych przystawkach TV i starszych GPU może powodować błędy obrazu lub czarny ekran — wtedy wyłącz tę opcję. Automatyczny wybiera najlepsze ustawienie dla Twojego urządzenia. Uruchom Moonfin ponownie, aby zastosować zmiany.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatyczny';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Włączony';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Wyłączony';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Wymagane ponowne uruchomienie';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin musi zostać uruchomiony ponownie, aby zmienić silnik renderowania. Zamknij teraz aplikację, a następnie otwórz ją ponownie, aby zastosować zmiany.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Zamknij aplikację teraz';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Odśwież bibliotekę';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Odśwież wszystkie biblioteki';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Data dodania (od najstarszych)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Data dodania (od najnowszych)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetycznie (od A do Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetycznie (od Z do A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Wczytywanie statystyk serwera... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Jak w źródle';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filmów';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 seriali';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Najpopularniejsze filmy';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Najpopularniejsze seriale';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Najniżej oceniane filmy';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb Najwyżej oceniane filmy anglojęzyczne';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12,19 +12,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERÊNCIAS DA CONTA';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Idioma da Interface';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Padrão do Sistema';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Entrar';
 
   @override
-  String get empty => 'Vazio';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Conexão Rápida';
 
   @override
   String get password => 'Senha';
@@ -141,62 +141,62 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema do aplicativo';
 
   @override
-  String get detailScreenStyle => 'Estilo da tela de detalhes';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Clássico é o layout centralizado original do Moonfin. Moderno é um layout cinematográfico responsivo.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Clássico';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderno';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Abas Expandidas';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Mostrar automaticamente o conteúdo das abas ao navegar entre elas. Desative para abrir e fechar cada aba manualmente.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Mostrar Detalhes Técnicos?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Mostrar informações de codec, resolução e stream no resumo do banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistema de Recomendações';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Use o algoritmo de biblioteca local do Moonfin Recomenda ou as métricas de similaridade online do TMDb. Nota: as recomendações online exigem a integração com o Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin Recomenda';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Similaridade TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Aplicar Limite de Classificação Etária?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limitar as sugestões do Moonfin Recomenda pela classificação etária do conteúdo de destino';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Estilo da Interface';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automático acompanha o seu dispositivo. Escolha Apple ou Material para forçar um visual.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automático';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Qualidade do Vidro';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automático escolhe o melhor efeito de vidro para este dispositivo. Completo força desfoque real; Reduzido usa um vidro leve que poupa energia da GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automático';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Completo';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reduzido';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Alternar entre Moonfin e Neon Pulse sem reiniciar o aplicativo';
 
   @override
-  String get customThemeTitle => 'Tema Personalizado';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Os temas personalizados alteram elementos visuais em todo o Moonfin. Escolha uma destas opções para combinar com o seu estilo.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Prefira o teclado do sistema';
@@ -257,14 +257,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Estilo de vidro líquido com fundo em gradiente flutuante, superfícies foscas e destaque em azul Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Estilo retro em pixel art com paleta robusta, bordas em blocos, sombras marcadas e fonte de pixels';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Entre com sua conta Emby Connect';
@@ -329,32 +329,32 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Em pausa';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Salvar estado';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Jogos';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Carregar estado';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Avanço rápido';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Configurações do emulador';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Este core não tem opções ajustáveis.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Segure para abrir o menu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Este dispositivo ainda não suporta a execução de jogos.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -765,43 +765,43 @@ class AppLocalizationsPt extends AppLocalizations {
   String get books => 'Livros';
 
   @override
-  String get latestBooks => 'Livros Recentes';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Audiolivros Recentes';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count livros',
-      one: '1 livro',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Livro';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiolivro';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% lido';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time restantes';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Ler';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Ouvir';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -879,8 +879,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiolivros',
-      one: '1 audiolivro',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -984,8 +984,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Temporadas',
-      one: '1 Temporada',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -996,40 +996,40 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get items => 'Itens';
+  String get items => 'Items';
 
   @override
   String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Bastidores';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Cenas Excluídas';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Entrevistas';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Cenas';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Curtas';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailers';
+  String get trailers => 'Reboques';
 
   @override
   String timeRemaining(String time) {
-    return '$time restantes';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Termina em $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1074,7 +1074,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cast => 'Transmitir';
 
   @override
-  String get trailer => 'Trailer';
+  String get trailer => 'Reboque';
 
   @override
   String get finished => 'Concluído';
@@ -1188,7 +1188,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get subtitleTrack => 'Faixa de Legenda';
 
   @override
-  String get none => 'Nenhuma';
+  String get none => 'Nenhum';
 
   @override
   String get downloadSubtitlesLabel => 'Baixar legendas...';
@@ -1267,10 +1267,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get director => 'DIRETOR';
 
   @override
-  String get directors => 'DIRETORES';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ROTEIRO';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'ROTEIRISTAS';
@@ -1308,8 +1308,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count faixas',
-      one: '1 faixa',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1319,8 +1319,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count capítulos',
-      one: '1 capítulo',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1350,14 +1350,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shuffle => 'Aleatório';
 
   @override
-  String get shuffleAllMusic => 'Reproduzir toda a música aleatoriamente';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Entre no Moonfin no seu telefone';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable =>
-      'Não foi possível conectar ao seu servidor';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1369,7 +1368,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count canais';
+    return '${count}ch';
   }
 
   @override
@@ -1797,22 +1796,22 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'A seguir: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m restantes';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h restantes';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m restantes';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1835,7 +1834,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get favoriteChannel => 'Favoritar Canal';
 
   @override
-  String get record => 'Gravar';
+  String get record => 'Registro';
 
   @override
   String get cancelRecordingAction => 'Cancelar gravação';
@@ -2019,7 +2018,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -2043,7 +2042,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -2062,8 +2061,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episódios',
-      one: '1 episódio',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2292,7 +2291,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Páginas de detalhes, linhas do início e volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2307,11 +2306,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Reproduzir ao navegar na tela inicial';
 
   @override
-  String get loopThemeMusic => 'Repetir Música-Tema';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repetir a faixa em vez de reproduzi-la uma única vez';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Desfoque do Fundo de Detalhes';
@@ -2334,17 +2333,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get playerZoomMode => 'Modo de Zoom do Reprodutor';
 
   @override
-  String get settingsScrollWheelAction => 'Roda do mouse';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Escolha o que a rolagem da roda do mouse sobre o vídeo faz durante a reprodução.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Desligado';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Buscar (avançar / retroceder)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2365,7 +2364,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get refreshRateSwitching => 'Troca de Taxa de Atualização';
 
   @override
-  String get disabled => 'Desativado';
+  String get disabled => 'Desabilitado';
 
   @override
   String get scaleOnTv => 'Ajustar na TV';
@@ -2404,37 +2403,37 @@ class AppLocalizationsPt extends AppLocalizations {
   String get defaultAudioLanguage => 'Idioma de Áudio Padrão';
 
   @override
-  String get fallbackAudioLanguage => 'Idioma de Áudio Alternativo';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Preferir Faixa de Áudio Padrão';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferir a faixa de áudio original em vez da dublagem localizada.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferir Faixas de Audiodescrição';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferir faixas de audiodescrição em vez das faixas normais.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcodificação (Áudio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Stream Direto (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodificação (Taxa de Bits ou Resolução)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodificação (Vídeo e Áudio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodificação (Vídeo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automático (Padrão do Servidor)';
@@ -2515,7 +2514,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Escolha como o áudio é decodificado. O Passthrough AVR envia streams Dolby/DTS brutos para o seu receptor; Automático ou Downmix decodificam localmente.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Passagem AVR';
@@ -2525,14 +2524,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Selecione o formato de destino para transcodificar áudio multicanal quando o stream de origem não puder ser reproduzido diretamente nem enviado por passthrough.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detecção Automática\n(Recomendado)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Padrão)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2541,39 +2539,38 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sem perdas)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Apenas Estéreo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficiente)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sem perdas)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Máximo de Canais de Áudio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configure o número máximo de canais da sua configuração de áudio. Streams multicanal que excedam este limite serão reduzidos (downmix) ou transcodificados.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detecção Automática\n(Padrão do Hardware)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estéreo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrifônico';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2667,11 +2664,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Palestrante';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Fones de ouvido';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count canais PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2847,45 +2844,45 @@ class AppLocalizationsPt extends AppLocalizations {
       'Personalize a aparência das legendas';
 
   @override
-  String get subtitleMode => 'Modo de Legendas';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Marcadas';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Sempre';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Estrangeiras';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Forçadas';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Reproduz faixas marcadas internamente nos metadados do arquivo de mídia como \"default\" ou \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Carrega e exibe legendas automaticamente sempre que um vídeo começa.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Ativa as legendas automaticamente se a faixa de áudio padrão estiver em um idioma estrangeiro.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Carrega apenas legendas explicitamente marcadas com o sinalizador de metadados \"forced\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Desativa completamente o carregamento automático de legendas.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Idioma de Legendas Alternativo';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream de Legendas';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3091,11 +3088,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar Bibliotecas na Barra de Ferramentas';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Sempre Expandir Rótulos da Barra de Navegação';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Mostrar Botão do Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacidade da Barra de Navegação';
@@ -3171,19 +3167,18 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar opção de navegação por pastas';
 
   @override
-  String get groupItemsIntoCollections => 'Agrupar Itens em Coleções';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ocultar itens da biblioteca associados a coleções ao navegar pelas bibliotecas';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Aviso de Agrupamento de Bibliotecas';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Para usar esta configuração, certifique-se de que as opções \"Agrupar filmes em coleções\" e/ou \"Agrupar séries em coleções\" estão ativadas nas configurações de Exibição da sua biblioteca no seu servidor Jellyfin ou Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibilidade da Biblioteca';
@@ -3248,7 +3243,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Desativado';
+  String get mediaBarModeOff => 'Desativada';
 
   @override
   String get enableMediaBar => 'Habilitar Barra de Mídia';
@@ -3296,11 +3291,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Reproduzir trailers automaticamente na barra de mídia após 3 segundos';
 
   @override
-  String get trailerAudio => 'Áudio do Trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Ativar o áudio dos trailers na barra de mídia';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Pré-visualização de Episódio';
@@ -3377,11 +3371,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get combineBothRows => 'Combinar ambas as linhas em uma única seção';
 
   @override
-  String get fullScreenRows => 'Linhas do Início Expandidas';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limitar as linhas do início a 1 linha por tela';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Tipo de Imagem por Linha';
@@ -3396,7 +3389,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lastUser => 'Último Usuário';
 
   @override
-  String get currentUser => 'Usuário Atual';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Sempre Autenticar';
@@ -3504,10 +3497,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar relógio durante a proteção de tela';
 
   @override
-  String get clockModeStatic => 'Estático';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Saltitante';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Críticos)';
@@ -3581,7 +3574,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Habilite e reordene as fontes de avaliação exibidas em todo o app';
 
   @override
-  String get pluginLabel => 'Plug-in Moonbase';
+  String get pluginLabel => 'Plug-in';
 
   @override
   String get pluginDetected => 'Plugin Detectado';
@@ -3653,7 +3646,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get networks => 'Emissoras';
 
   @override
-  String get seerrDiscoveryRows => 'Linhas de Descoberta do Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Restaurar linhas para os padrões';
@@ -3676,29 +3669,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get hideAdultContent => 'Ocultar conteúdo adulto nos resultados';
 
   @override
-  String get seerrNotificationsSection => 'Notificações';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notificações de novas solicitações';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Avisar quando alguém enviar uma solicitação';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Atualizações de solicitações';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprovadas, recusadas e adicionadas à sua biblioteca';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Atualizações de problemas';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Novos problemas, respostas e resoluções';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3706,18 +3698,18 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Página de Descoberta do Seerr';
+  String get discoverRows => 'Linhas de Descoberta';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Habilite as linhas que deseja ver na página principal do Seerr. Arraste para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arraste para reordenar. Habilite ou desabilite linhas. A ordem das linhas habilitadas sincroniza com o plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Habilite as linhas que deseja ver na página principal do Seerr. Arraste para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arraste para reordenar. Habilite ou desabilite linhas.';
 
   @override
-  String get enabled => 'Ativado';
+  String get enabled => 'Habilitado';
 
   @override
   String get hidden => 'Oculto';
@@ -3870,11 +3862,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Baixando · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importando';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3979,7 +3971,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showMore => 'Mostrar Mais';
 
   @override
-  String get appearances => 'Participações';
+  String get appearances => 'Aparições';
 
   @override
   String get crewSection => 'Equipe';
@@ -4017,148 +4009,148 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deletedStatus => 'Excluído';
 
   @override
-  String get failedStatus => 'Falhou';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Processando';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificado por $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Concluído';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Este título já foi solicitado';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Limite de solicitações atingido';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Este título está na lista de bloqueio';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Não há mais temporadas para solicitar';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Você não tem permissão para fazer esta solicitação';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Solicitações';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemas';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Mais recentes';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Última modificação';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Nenhum problema';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining de $limit solicitações de filmes restantes';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining de $limit solicitações de temporadas restantes';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Parte de $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Ver Coleção';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Solicitar Coleção';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmes · $available disponíveis';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Solicitar $count filmes';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Solicitando $current de $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count filmes solicitados';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$ok de $total filmes solicitados';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Todos os filmes já estão disponíveis ou solicitados';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Relatar Problema';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Vídeo';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Áudio';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Qual é o problema?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Todos os Episódios';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episódio';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Aberto';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Resolvido';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Resolver';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Reabrir';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Relatado por $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comentários';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Adicionar um comentário';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Excluir este problema?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Enviar Relato';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Pontuação TMDB';
@@ -4275,7 +4267,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get refresh => 'Atualizar';
 
   @override
-  String get remote => 'Controle remoto';
+  String get remote => 'Remoto';
 
   @override
   String get rename => 'Renomear';
@@ -4320,7 +4312,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get time => 'Hora';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Truques';
 
   @override
   String get uninstall => 'Desinstalar';
@@ -4362,13 +4354,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotecas';
 
   @override
-  String get adminDrawerDisplay => 'Exibição';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadados';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Configurações de NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodificação';
@@ -4380,7 +4372,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminDrawerStreaming => 'Transmissão';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Truques';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -4596,10 +4588,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminClearDates => 'Limpar datas';
 
   @override
-  String get adminActivitySeverityAll => 'Todas as severidades';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Intervalo de datas';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4636,23 +4628,23 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Remover o dispositivo \'$name\'? O usuário precisará entrar novamente neste dispositivo.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Excluir todos os dispositivos';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Remover $count dispositivos? Os usuários afetados precisarão entrar novamente. O seu dispositivo atual não é afetado.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Dispositivos removidos';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Alguns dispositivos foram removidos; $count não puderam ser removidos.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4768,254 +4760,244 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminMetadataCountryHint => 'ex: US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Caminhos';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opções';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
   String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Gravadores de metadados';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Downloaders de legendas';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Downloaders de letras';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Downloaders de metadados: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Buscadores de imagens: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Este servidor não expõe downloaders para este tipo de biblioteca.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Geral';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadados';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Informações Incorporadas';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Legendas';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imagens';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Séries';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Música';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmes';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Ativar monitoramento em tempo real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detectar alterações nos arquivos e processá-las automaticamente.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratar arquivos compactados como arquivos de mídia';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Exibir fotos';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Salvar imagens nas pastas de mídia';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Atualização automática de metadados';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nunca';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Padrão';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Exibição';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Exibição da biblioteca';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Exibir uma visualização de pastas para mostrar pastas de mídia simples';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Exibir especiais dentro das temporadas em que foram exibidos';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Agrupar filmes em coleções';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Agrupar séries em coleções';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Mostrar conteúdo externo nas sugestões';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportamento da data de adição';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Usar data de adição de';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data da análise na biblioteca';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data de criação do arquivo';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadados e Imagens';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Idioma preferido dos metadados';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capítulos';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Duração dos capítulos fictícios (segundos)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Duração dos capítulos gerados para mídias que não os possuem. Defina como 0 para desativar.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolução das imagens de capítulo';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Configurações de NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Os metadados NFO são compatíveis com o Kodi e clientes semelhantes. As configurações aplicam-se a todas as bibliotecas que salvam metadados NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Usuário cujos dados de exibição serão armazenados nos arquivos NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Salvar caminhos das imagens nos arquivos NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Ativar substituição de caminhos para os caminhos de imagem NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copiar imagens extrafanart para uma pasta extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Nenhum';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dias';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Usar títulos incorporados';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usar títulos incorporados para extras';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usar informações de episódio incorporadas';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Permitir legendas incorporadas';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permitir todas';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Apenas texto';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Apenas imagem';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Nenhum';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Ignorar download se houver legendas incorporadas';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Ignorar download se a faixa de áudio corresponder ao idioma do download';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Exigir correspondência exata de legendas';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Salvar legendas nas pastas de mídia';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Extrair imagens de capítulo';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extrair imagens de capítulo durante a análise da biblioteca';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Ativar extração de imagens trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extrair imagens trickplay durante a análise da biblioteca';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Salvar imagens trickplay nas pastas de mídia';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Mesclar automaticamente séries distribuídas por várias pastas';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Nome de exibição da temporada zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Ativar análise LUFS para normalização de áudio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferir a etiqueta de artistas não padrão';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Adicionar filmes automaticamente às coleções';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'O nome da biblioteca é obrigatório';
@@ -5257,143 +5239,143 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminEnableAllChannels => 'Habilite o acesso a todos os canais';
 
   @override
-  String get adminParentalControl => 'Controle Parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Classificação etária máxima permitida';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'O conteúdo com classificação superior será ocultado deste usuário.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Nenhuma';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Bloquear itens sem classificação ou com classificação não reconhecida';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Livros';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canais';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV ao Vivo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmes';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Música';
+  String get adminUnratedMusic => 'Music';
 
   @override
   String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Séries';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Horários de Acesso';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permitir o acesso apenas durante os horários agendados abaixo. O acesso é permitido o dia todo quando nenhum horário é definido.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Adicionar Horário';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dia';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Início';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fim';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Todos os dias';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Dia de semana';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Fim de semana';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Domingo';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Segunda-feira';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Terça-feira';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Quarta-feira';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Quinta-feira';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Sexta-feira';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sábado';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etiquetas permitidas';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Apenas o conteúdo com estas etiquetas é exibido. Deixe vazio para permitir tudo.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etiquetas bloqueadas';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'O conteúdo com estas etiquetas fica oculto para este usuário.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Adicionar etiqueta';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispositivos ativados';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canais ativados';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Provedor de autenticação';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Provedor de redefinição de senha';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Máximo de tentativas de login malsucedidas antes do bloqueio';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Defina como 0 para o padrão ou -1 para desativar o bloqueio.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Acesso ao SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'Permitir criar e entrar em grupos';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permitir entrar em grupos';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Sem acesso';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Permitir exclusão de conteúdo de';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5481,25 +5463,25 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Criar Backup';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Escolha o que incluir no backup.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Banco de Dados';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Sempre incluído';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadados';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Legendas';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imagens trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Criando backup...';
@@ -6214,65 +6196,60 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminAddTuner => 'Adicionar Sintonizador';
 
   @override
-  String get adminEditTuner => 'Editar Sintonizador';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Sintonizador M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Arquivo ou URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Endereço IP do sintonizador';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nome amigável';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limite de conexões simultâneas';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'O número máximo de streams que o sintonizador permite ao mesmo tempo. Defina como 0 para ilimitado.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Taxa de bits máxima de streaming alternativa';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importar apenas canais favoritos';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permitir transcodificação por hardware';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Permitir contêiner de transcodificação fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Permitir compartilhamento de stream';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Ativar repetição do stream';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorar DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Ler a entrada na taxa de quadros nativa';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Editar Provedor';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6281,50 +6258,50 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Arquivo ou URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefixo de filme';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorias de filmes';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separe várias categorias com uma barra vertical.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorias infantis';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorias de notícias';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorias de esportes';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nome de usuário';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Senha';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'País';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selecione um país';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Código postal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obter listagens';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Listagens';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Ativar todos os sintonizadores';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tipo de Sintonizador';
@@ -6367,7 +6344,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Este tipo de sintonizador não suporta reinicialização.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6390,44 +6367,43 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Caminho de gravação de séries';
 
   @override
-  String get adminMovieRecordingPath => 'Caminho de gravação de filmes';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Dias de dados do guia';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automático';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dias';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Caminho do aplicativo de pós-processamento';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumentos do pós-processador';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Salvar metadados NFO das gravações';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Salvar imagens das gravações';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Temporização';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Caminhos de gravação';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Pós-processamento';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Dados do guia: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6469,15 +6445,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminGuideProviders => 'Provedores de Guia';
 
   @override
-  String get adminRefreshGuideData => 'Atualizar Dados do Guia';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Atualização dos dados do guia iniciada';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'A tarefa de atualização do guia não está disponível neste servidor.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Adicionar Provedor';
@@ -6612,7 +6587,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor de Metadados';
 
   @override
-  String get adminMetadataIdentify => 'Identificar';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -7026,20 +7001,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Habilitar tela de apresentação';
 
   @override
-  String get adminBrandingSplashUpload => 'Enviar imagem';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Tela de abertura atualizada';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Falha ao enviar a tela de abertura';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Tela de abertura removida';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Nenhuma tela de abertura personalizada';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Aceleração de Hardware';
@@ -7056,129 +7030,121 @@ class AppLocalizationsPt extends AppLocalizations {
       'Habilitar decodificação por hardware para:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ativar decodificador NVDEC aprimorado';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferir o decodificador de hardware nativo do sistema';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Profundidade de cor da decodificação por hardware';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodificação HEVC de 10 bits';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodificação VP9 de 10 bits';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodificação HEVC RExt de 8/10 bits';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodificação HEVC RExt de 12 bits';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codificação por hardware';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permitir codificação HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permitir codificação AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Ativar codificador H.264 de baixo consumo da Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Ativar codificador HEVC de baixo consumo da Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapeamento de Tons';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Ativar mapeamento de tons';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Ativar mapeamento de tons VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Ativar mapeamento de tons do VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoritmo de mapeamento de tons';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modo de mapeamento de tons';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Intervalo de mapeamento de tons';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Dessaturação do mapeamento de tons';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Pico do mapeamento de tons';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parâmetro do mapeamento de tons';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Brilho do mapeamento de tons VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste do mapeamento de tons VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Predefinições e Qualidade';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Predefinição do codificador';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF de codificação H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF de codificação H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Método de desentrelaçamento';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dobrar a taxa de quadros ao desentrelaçar';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Áudio';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Ativar codificação de áudio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Reforço do downmix de áudio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo de downmix estéreo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Tamanho máximo da fila de muxing';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automático';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Codificação';
@@ -7302,7 +7268,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminTaskStop => 'Parar';
 
   @override
-  String get adminRunningTasks => 'Tarefas em Execução';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Executar';
@@ -7372,8 +7338,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count horas',
-      one: '1 hora',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7434,7 +7400,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7454,44 +7420,43 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Porta HTTP pública';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Exigir HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Redirecionar todas as solicitações remotas para HTTPS. Não tem efeito se o servidor não tiver um certificado válido.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Senha do certificado';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Configurações de IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Ativar IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Ativar IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Ativar mapeamento automático de portas';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Redes LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Lista de endereços IP ou sub-redes CIDR, separados por vírgula ou por linha, tratados como pertencentes à rede local.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URIs publicados do servidor';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Mapeie uma sub-rede ou endereço para uma URL publicada, por exemplo, all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Caminho do certificado';
@@ -7522,11 +7487,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Limitar buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Atraso de limitação (segundos)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permitir extração de legendas em tempo real';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Porcentagem mínima de retomada';
@@ -7583,23 +7548,22 @@ class AppLocalizationsPt extends AppLocalizations {
       'Limite de resposta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ativar avisos de resposta lenta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Ativar o Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Servidor';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadados';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Caminhos';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Desempenho';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Caminho do cache';
@@ -7611,7 +7575,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminGeneralServerName => 'Nome do servidor';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Idioma de exibição preferido';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Falha ao carregar configurações';
@@ -7663,8 +7627,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# participantes',
-      one: '# participante',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7812,8 +7776,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# linhas descobertas',
-      one: '# linha descoberta',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7854,21 +7818,20 @@ class AppLocalizationsPt extends AppLocalizations {
   String get offlineSavedMedia => 'Mídia Salva';
 
   @override
-  String get offlineBannerTitle => 'Você está offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Mostrando seus downloads';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
   String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Não foi possível conectar ao seu servidor';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Reproduzindo dos downloads até que ele volte';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7975,7 +7938,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Falha no Quick Connect: $message';
+    return 'Falha na conexão rápida: $message';
   }
 
   @override
@@ -8229,13 +8192,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Ocultar de Continuar Assistindo';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ocultar de A Seguir';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Adicionar à Coleção';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8290,15 +8253,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabético';
 
   @override
-  String get settingsConnectionSection => 'CONEXÃO';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permitir certificados autoassinados';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confiar em servidores que usam certificados TLS autoassinados ou de CA privada. Ative apenas para servidores que você controla. Isto desativa a validação de certificados em todas as conexões.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIDADE E SEGURANÇA';
@@ -8314,11 +8276,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Acentos temáticos, cenários, indicadores assistidos e música temática';
 
   @override
-  String get settingsDetailsScreen => 'Tela de Detalhes';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Estilo, desfoque de fundo e comportamento das abas';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Página inicial';
@@ -8356,11 +8318,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Mostrar o botão do Seerr na barra de navegação';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Sempre mostrar rótulos de texto na barra de navegação superior';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8464,8 +8426,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# avisos de licença',
-      one: '# aviso de licença',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8515,17 +8477,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Pular introduções e outros?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Contagem Regressiva de Segmentos de Mídia';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Barra de Progresso';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Cronômetro';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Nenhum';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Solicitar ao usuário';
@@ -8755,7 +8716,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Lançamentos recentes: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8789,11 +8750,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Forçar a reprodução sem tunelamento. Útil em dispositivos com descontinuidades de áudio/vídeo de tunelamento.';
 
   @override
-  String get enableTunnelingTitle => 'Ativar tunelamento';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avançado. Encaminha áudio e vídeo por um caminho de hardware acoplado. Desativado por padrão porque causa falhas de áudio/vídeo em alguns dispositivos.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Mapear Dolby Vision perfil 7 para HEVC';
@@ -8819,14 +8780,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Aplique dicas de tamanho de fonte incorporadas na faixa de legenda. Desative o uso do tamanho da legenda em suas preferências de estilo.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostrar Detalhes da Mídia';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostrar os detalhes do item selecionado no topo das páginas da Biblioteca.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Ocultar Panos de Fundo ao Navegar?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Use subtítulos detalhados';
@@ -8844,37 +8805,37 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Loja de Temas';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Explore e salve temas da comunidade';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Salve um tema para usá-lo como os seus outros temas salvos.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Nenhum tema disponível no momento.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Não foi possível carregar a Loja de Temas. Verifique sua conexão e tente novamente.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Salvar';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Salvar e aplicar';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Salvo';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Não foi possível carregar este tema.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" salvo.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8933,21 +8894,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get homeRowsSection => 'Linhas iniciais';
 
   @override
-  String get homeRowDisplay => 'Exibição das Linhas do Início';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Seções das Linhas do Início';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Alternadores das Linhas do Início';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Ativar ou desativar categorias de linhas do início baseadas em bibliotecas';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Ative os alternadores a seguir para exibir as linhas nas Seções Iniciais.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Tipo de linhas';
@@ -9006,36 +8967,34 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostre filmes, séries ou ambos nas linhas de gêneros.';
 
   @override
-  String get displayPlaylistsRows => 'Exibir Linhas de Listas de Reprodução';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Mostrar linhas de listas de reprodução nas Seções Iniciais.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting =>
-      'Ordenação das Linhas de Listas de Reprodução';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Ordene as linhas de listas de reprodução por data de adição, data de lançamento, ordem alfabética e mais.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Exibir Linhas de Áudio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Mostrar linhas de áudio nas Seções Iniciais.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Ordenação das linhas de áudio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Ordene as linhas de áudio por data de adição, data de lançamento, ordem alfabética e mais.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Listas de Reprodução de Áudio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Aparência';
@@ -9044,19 +9003,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Teclado';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Botões';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderização';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configuração do MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Tamanho do cartão';
@@ -9066,7 +9025,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Defina um reprodutor externo para ativar a opção de reprodução ao pressionar e segurar';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9335,7 +9294,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appearancesSeerr => 'Aparições (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Contribuições da Equipe (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Assista com grupo';
@@ -9421,8 +9380,8 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotecas',
-      one: '1 Biblioteca',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9514,7 +9473,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mixedMoviesAndShows => 'Filmes e programas mistos';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Sincronização rápida Intel';
 
   @override
   String get rockchipMpp => 'MPP Rockchip';
@@ -9581,13 +9540,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loadingShuffle => 'Carregando ordem aleatória...';
 
   @override
-  String get libraryShuffleLabel => 'ALEATÓRIO DA BIBLIOTECA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'TOTALMENTE ALEATÓRIO';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ALEATÓRIO POR GÊNEROS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Troca automática de HDR';
@@ -9600,222 +9559,222 @@ class AppLocalizationsPt extends AppLocalizations {
   String get whenFullscreen => 'Quando em tela cheia';
 
   @override
-  String get changeArtwork => 'Alterar Imagens';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Ausente';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Limites de transcodificação';
 
   @override
-  String get clearAllArtworkButton => 'Limpar todas as imagens?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Tem certeza de que deseja limpar todas as imagens baixadas?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirmar Limpeza';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Tem certeza de que deseja limpar $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Enviar?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Resolução: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Mostrar apenas imagens no idioma da interface';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirmar Limpar Tudo';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Imagem enviada com sucesso!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Falha ao enviar a imagem: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Falha ao definir a imagem: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Falha ao excluir a imagem: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Falha ao limpar todas as imagens: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Sim';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Pôster';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Panos de Fundo';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotipo';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatura';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Arte';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Arte do Disco';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Captura de Tela';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Capa da Caixa';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Capa Traseira da Caixa';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Arte do Menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'o pôster';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'o pano de fundo';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'o banner';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'o logotipo';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'a miniatura';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'a arte';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'a arte do disco';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'a captura de tela';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'a capa da caixa';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'a capa traseira da caixa';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'a arte do menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Todas';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Alta (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Média (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Baixa (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Fontes';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capítulos';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marcadores';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notas';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Fila';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Linha do Tempo';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'A linha do tempo está vazia';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Livro Inteiro';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Linha do Tempo Focada';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportar Marcadores';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportar Notas';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportar Tudo';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportado para $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Falha na exportação: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Letras';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Adicionar marcador';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Adicionar nota';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Editar nota';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Escreva uma nota para este momento';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Temporizador de sono';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Desligado';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fim do capítulo';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalizado';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining restantes';
+    return '$remaining left';
   }
 
   @override
@@ -9830,51 +9789,51 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Velocidade de reprodução';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Restante';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Decorrido';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Voltar ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Avançar ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capítulo anterior';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Próximo capítulo';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capítulo $current de $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Nenhum capítulo';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Nenhum marcador ainda';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Nenhuma nota ainda';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Marcador adicionado em $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Redefinir para 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9882,260 +9841,251 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Salvar';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Cancelar';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Excluir';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferências de Legendas';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Altere os modos de legendas, os idiomas padrão, a aparência e as opções de renderização.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderização de Legendas';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opções de Exibição';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data de Lançamento (Crescente)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data de Lançamento (Decrescente)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Agrupar Contribuições';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Agrupar múltiplos papéis';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Aviso de Acesso de Escrita à Biblioteca';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Como corrigir:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Conceda permissões de escrita ao usuário do serviço Jellyfin (por exemplo, jellyfin ou PUID/PGID do Docker) para as pastas da sua biblioteca de mídia no servidor.\n\n2. Ou vá ao Painel do Jellyfin -> Bibliotecas, edite esta biblioteca e desative \'Salvar imagens nas pastas de mídia\' para armazenar as imagens no banco de dados interno do Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Dispensar';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'A sua biblioteca \'$libraryName\' está configurada para salvar as imagens diretamente nas pastas de mídia (a opção \'Salvar imagens nas pastas de mídia\' está ativada). No entanto, o Jellyfin testou o acesso de escrita e não tem permissão para gravar arquivos neste diretório:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Parece que o Jellyfin não conseguiu atualizar as imagens. A sua biblioteca está configurada para salvar as imagens diretamente nas pastas de mídia (a opção \'Salvar imagens nas pastas de mídia\' está ativada). Este erro geralmente ocorre quando o processo do servidor Jellyfin não tem permissão para gravar arquivos nos seus diretórios de mídia.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Listas Externas';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Reproduzir Novamente';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informações do Arquivo';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Tamanho: $size  •  Formato: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Mostrar Todas as ($count) Faixas de Áudio';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Mostrar Todas as ($count) Faixas de Legendas';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Verificando a capacidade de Reprodução Direta...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Capacidade de Reprodução Direta: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Forçada';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'O formato do contêiner não é suportado pelo reprodutor.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'O codec de vídeo não é suportado.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'O codec de áudio não é suportado.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'O formato de legendas não é suportado (requer incorporação).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'O perfil de áudio não é suportado.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'O perfil de vídeo não é suportado.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'O nível de vídeo não é suportado.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'A resolução do vídeo não é suportada por este dispositivo.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'A profundidade de bits do vídeo não é suportada.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'A taxa de quadros do vídeo não é suportada.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'A taxa de bits do arquivo excede o limite de streaming do reprodutor.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'A taxa de bits do vídeo excede o limite de streaming.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'A taxa de bits do áudio excede o limite de streaming.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'O número de canais de áudio não é suportado.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabética';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ordem de Lançamento (Crescente)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Ordem de Lançamento (Decrescente)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personalizada (Arrastar e Soltar)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Opções de Ordenação da Lista de Reprodução';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Redefinir Ordenação';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Rever T$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Rever Lista de Reprodução';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nenhuma legenda encontrada.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Controles de Administrador';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Mecanismo de renderização (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'O Impeller é o renderizador de GPU moderno do Flutter, para animações mais suaves e menos travamentos. Em alguns TV boxes e GPUs antigas, pode causar falhas gráficas ou vídeo preto; desative-o se notar isso. Automático escolhe o melhor padrão para o seu dispositivo. Reinicie o Moonfin para aplicar.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automático';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ligado';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Desligado';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Reinicialização necessária';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'O Moonfin precisa reiniciar para alterar o mecanismo de renderização. Feche o aplicativo agora e reabra-o para aplicar.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Fechar o aplicativo agora';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Atualizar Biblioteca';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Atualizar Todas as Bibliotecas';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Data de Adição (Mais Antigas Primeiro)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Data de Adição (Mais Recentes Primeiro)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabética (A a Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabética (Z a A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Carregando as Análises do Servidor... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual à origem';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 Filmes';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 Séries';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Filmes Mais Populares do IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Séries Mais Populares do IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Filmes com Pior Avaliação do IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Filmes em Inglês Mais Bem Avaliados do IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
@@ -10146,19 +10096,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERÊNCIAS DA CONTA';
-
-  @override
-  String get interfaceLanguage => 'Idioma da interface';
-
-  @override
-  String get systemLanguageDefault => 'Padrão do sistema';
-
-  @override
   String get signIn => 'Entrar';
-
-  @override
-  String get empty => 'Vazio';
 
   @override
   String connectingToServer(String serverName) {
@@ -10166,7 +10104,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Conexão rápida';
 
   @override
   String get password => 'Senha';
@@ -10275,102 +10213,15 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get settingsAppearanceTheme => 'Tema do aplicativo';
 
   @override
-  String get detailScreenStyle => 'Estilo da tela de detalhes';
-
-  @override
-  String get detailScreenStyleSubtitle =>
-      'Clássico é o layout centralizado original do Moonfin. Moderno é um layout cinematográfico responsivo.';
-
-  @override
-  String get detailScreenStyleMoonfin => 'Clássico';
-
-  @override
-  String get detailScreenStyleModern => 'Moderno';
-
-  @override
-  String get expandedTabs => 'Abas expandidas';
-
-  @override
-  String get expandedTabsSubtitle =>
-      'Mostrar o conteúdo da aba automaticamente ao navegar entre as abas. Desative para abrir e fechar cada aba manualmente.';
-
-  @override
-  String get showTechnicalDetails => 'Mostrar detalhes técnicos?';
-
-  @override
-  String get showTechnicalDetailsSubtitle =>
-      'Mostrar codec, resolução e informações do stream no resumo do banner';
-
-  @override
-  String get recommendationSystem => 'Sistema de recomendações';
-
-  @override
-  String get recommendationSystemSubtitle =>
-      'Use o algoritmo de biblioteca local do Moonfin Recommends ou as métricas de similaridade online do TMDb. Observação: recomendações online exigem a integração com o Seerr.';
-
-  @override
-  String get recommendationSystemMoonfin => 'Moonfin Recommends';
-
-  @override
-  String get recommendationSystemTmdb => 'Similaridade do TMDb';
-
-  @override
-  String get recommendationsApplyParentalRatingCap =>
-      'Aplicar limite de classificação indicativa?';
-
-  @override
-  String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limitar as sugestões do Moonfin Recommends pela classificação indicativa da mídia de destino';
-
-  @override
-  String get interfaceStyle => 'Estilo da interface';
-
-  @override
-  String get interfaceStyleSubtitle =>
-      'Automático acompanha o seu dispositivo. Escolha Apple ou Material para forçar um visual.';
-
-  @override
-  String get interfaceStyleAutomatic => 'Automático';
-
-  @override
-  String get interfaceStyleApple => 'Apple';
-
-  @override
-  String get interfaceStyleMaterial => 'Material';
-
-  @override
-  String get glassQuality => 'Qualidade do vidro';
-
-  @override
-  String get glassQualitySubtitle =>
-      'Automático escolhe o melhor efeito de vidro para este dispositivo. Completo força desfoque real; Reduzido usa um vidro leve que economiza GPU.';
-
-  @override
-  String get glassQualityAuto => 'Auto';
-
-  @override
-  String get glassQualityFull => 'Completo';
-
-  @override
-  String get glassQualityReduced => 'Reduzido';
-
-  @override
   String get settingsAppearanceThemeSubtitle =>
       'Alterne entre Moonfin e Neon Pulse sem reiniciar o aplicativo';
 
   @override
-  String get customThemeTitle => 'Tema personalizado';
-
-  @override
-  String get customThemeSubtitle =>
-      'Temas personalizados alteram elementos visuais em todo o Moonfin. Escolha uma destas opções para combinar com o seu estilo.';
-
-  @override
-  String get keyboardPreferSystemIme => 'Preferir o teclado do sistema';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Usar o método de entrada do seu dispositivo por padrão para digitar';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -10385,20 +10236,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get themeNeonPulseSubtitle =>
       'Estilo Synthwave com brilho magenta, texto ciano e contraste cromado mais forte';
-
-  @override
-  String get themeGlass => 'Glass';
-
-  @override
-  String get themeGlassSubtitle =>
-      'Estilo liquid glass com fundo em gradiente flutuante, superfícies foscas e destaque em azul Apple';
-
-  @override
-  String get theme8BitHero => '8-bit Hero';
-
-  @override
-  String get theme8BitHeroSubtitle =>
-      'Estilo retrô em pixel art com paleta marcante, bordas quadradas, sombras duras e fonte pixelada';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -10461,37 +10298,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get exit => 'Sair';
 
   @override
-  String get gameMenu => 'Menu';
-
-  @override
-  String get gamePaused => 'Pausado';
-
-  @override
-  String get gameSaveState => 'Salvar estado';
-
-  @override
-  String get games => 'Jogos';
-
-  @override
-  String get gameLoadState => 'Carregar estado';
-
-  @override
-  String get gameFastForward => 'Avanço rápido';
-
-  @override
-  String get gameEmulatorSettings => 'Configurações do emulador';
-
-  @override
-  String get gameNoCoreOptions => 'Este core não tem opções ajustáveis.';
-
-  @override
-  String get gameHoldToOpenMenu => 'Segure para abrir o menu';
-
-  @override
-  String get gamePlaybackUnsupported =>
-      'Este dispositivo ainda não tem suporte a jogos.';
-
-  @override
   String get noHomeRowsLoaded => 'Nenhuma seção pôde ser carregada';
 
   @override
@@ -10510,7 +10316,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get schedule => 'Agendar';
 
   @override
-  String get series => 'Séries';
+  String get series => 'Série';
 
   @override
   String get noItemsFound => 'Nenhum item encontrado';
@@ -10568,7 +10374,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String itemCountLabel(int count) {
-    return '$count itens';
+    return '$count items';
   }
 
   @override
@@ -10585,7 +10391,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String totalCountItems(int count) {
-    return '$count Itens';
+    return '$count Items';
   }
 
   @override
@@ -10736,7 +10542,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get listen => 'Ouvir';
 
   @override
-  String get resume => 'Continuar';
+  String get resume => 'Retomar';
 
   @override
   String get failedToLoadLibrary => 'Falha ao carregar a biblioteca';
@@ -10862,7 +10668,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String noLabelFound(String label) {
-    return 'Nenhum $label encontrado';
+    return 'No $label found';
   }
 
   @override
@@ -10897,45 +10703,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get books => 'Livros';
-
-  @override
-  String get latestBooks => 'Livros recentes';
-
-  @override
-  String get latestAudiobooks => 'Audiolivros recentes';
-
-  @override
-  String bookSeriesItemCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count livros',
-      one: '1 livro',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get bookFormatBook => 'Livro';
-
-  @override
-  String get bookFormatAudiobook => 'Audiolivro';
-
-  @override
-  String bookPercentRead(int percent) {
-    return '$percent% lido';
-  }
-
-  @override
-  String bookTimeLeft(String time) {
-    return 'Faltam $time';
-  }
-
-  @override
-  String get bookHeroRead => 'Ler';
-
-  @override
-  String get bookHeroListen => 'Ouvir';
 
   @override
   String get author => 'Autor';
@@ -11013,8 +10780,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiolivros',
-      one: '1 audiolivro',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -11062,7 +10829,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get movies => 'Filmes';
 
   @override
-  String get musicVideos => 'Videoclipes';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Outro';
@@ -11107,7 +10874,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String published(int year) {
-    return 'Publicado em $year';
+    return 'Published $year';
   }
 
   @override
@@ -11130,41 +10897,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get items => 'Itens';
-
-  @override
-  String get extras => 'Extras';
-
-  @override
-  String get behindTheScenes => 'Bastidores';
-
-  @override
-  String get deletedScenes => 'Cenas excluídas';
-
-  @override
-  String get featurettes => 'Featurettes';
-
-  @override
-  String get interviews => 'Entrevistas';
-
-  @override
-  String get scenes => 'Cenas';
-
-  @override
-  String get shorts => 'Curtas';
-
-  @override
   String get trailers => 'Trailers';
-
-  @override
-  String timeRemaining(String time) {
-    return 'Faltam $time';
-  }
-
-  @override
-  String endsIn(String time) {
-    return 'Termina em $time';
-  }
 
   @override
   String get view => 'Visualizar';
@@ -11205,7 +10938,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get version => 'Versão';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Elenco';
 
   @override
   String get trailer => 'Trailer';
@@ -11290,7 +11023,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Nenhum $itemLabel carregado';
+    return 'No $itemLabel loaded';
   }
 
   @override
@@ -11321,7 +11054,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get subtitleTrack => 'Faixa de legenda';
 
   @override
-  String get none => 'Nenhuma';
+  String get none => 'Nenhum';
 
   @override
   String get downloadSubtitlesLabel => 'Baixar legendas...';
@@ -11400,13 +11133,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get director => 'DIRETOR';
 
   @override
-  String get directors => 'DIRETORES';
-
-  @override
-  String get writer => 'ESCRITOR';
-
-  @override
-  String get writers => 'ROTEIRISTAS';
+  String get writers => 'ESCRITORES';
 
   @override
   String get studio => 'ESTÚDIO';
@@ -11483,15 +11210,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get shuffle => 'Aleatório';
 
   @override
-  String get shuffleAllMusic => 'Reproduzir tudo aleatoriamente';
-
-  @override
-  String get carSignInPrompt => 'Entre no Moonfin pelo seu celular';
-
-  @override
-  String get carServerUnreachable => 'Não foi possível acessar seu servidor';
-
-  @override
   String downloadsCount(int count) {
     return '$count downloads';
   }
@@ -11501,7 +11219,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String channelsCount(int count) {
-    return '$count canais';
+    return '${count}ch';
   }
 
   @override
@@ -11568,7 +11286,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Falha na ação $label: $error';
+    return '$label action failed: $error';
   }
 
   @override
@@ -11588,7 +11306,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get unavailable => 'Indisponível';
 
   @override
-  String get pause => 'Pausar';
+  String get pause => 'Pausa';
 
   @override
   String get syncPosition => 'Posição de sincronização';
@@ -11662,7 +11380,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get subtitleDelay => 'Atraso de legenda';
 
   @override
-  String get reset => 'Redefinir';
+  String get reset => 'Reiniciar';
 
   @override
   String get unknown => 'Desconhecido';
@@ -11683,7 +11401,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get directStream => 'Transmissão direta';
 
   @override
-  String get transcoding => 'Transcodificação';
+  String get transcoding => 'Transcoding';
 
   @override
   String get transcodeReasons => 'Razões de transcoding';
@@ -11695,7 +11413,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get container => 'Recipiente';
 
   @override
-  String get bitrate => 'Taxa de bits';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Vídeo';
@@ -11713,7 +11431,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get videoBitrate => 'Taxa de bits de vídeo';
 
   @override
-  String get track => 'Faixa';
+  String get track => 'Acompanhar';
 
   @override
   String get channels => 'Canais';
@@ -11722,7 +11440,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get audioBitrate => 'Bitrate de Áudio';
 
   @override
-  String get sampleRate => 'Taxa de amostragem';
+  String get sampleRate => 'Sample Rate';
 
   @override
   String get format => 'Formatar';
@@ -11740,7 +11458,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Falha ao carregar os detalhes do livro: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -11749,7 +11467,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Este formato (.$extension) ainda não pode ser exibido no aplicativo.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -11762,17 +11480,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Falha ao abrir o leitor do aplicativo: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Já existe um marcador salvo em $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Marcador adicionado: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -11784,7 +11502,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String pageLabel(int number) {
-    return 'Página $number';
+    return 'Page $number';
   }
 
   @override
@@ -11795,12 +11513,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String formatExtension(String extension) {
-    return 'Formato: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% lido';
+    return '$percent% read';
   }
 
   @override
@@ -11824,7 +11542,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String resetZoom(String zoom) {
-    return 'Redefinir zoom (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -11847,7 +11565,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Falha ao atualizar o status de leitura: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -11879,7 +11597,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Esta plataforma não oferece suporte ao mecanismo de documentos integrado para arquivos $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -11918,7 +11636,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Falha ao carregar o guia: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -11926,26 +11644,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get liveBadge => 'AO VIVO';
-
-  @override
-  String guideNextProgram(String time, String title) {
-    return 'A seguir: $time  $title';
-  }
-
-  @override
-  String guideMinutesLeft(int minutes) {
-    return 'Faltam ${minutes}min';
-  }
-
-  @override
-  String guideHoursLeft(int hours) {
-    return 'Faltam ${hours}h';
-  }
-
-  @override
-  String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Faltam ${hours}h ${minutes}min';
-  }
 
   @override
   String get movie => 'Filme';
@@ -11989,7 +11687,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Falha ao reproduzir $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -12015,7 +11713,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Cancelar a gravação agendada de \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -12042,7 +11740,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String stopRecordingName(String name) {
-    return 'Parar a gravação de \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -12057,12 +11755,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Nenhum resultado para \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Falha na pesquisa: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -12119,12 +11817,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Falha ao carregar o álbum: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Nenhuma faixa baixada encontrada para $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -12141,7 +11839,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String removeName(String name) {
-    return 'Remover \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -12151,12 +11849,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Episódio $number';
+    return 'Episode $number';
   }
 
   @override
@@ -12170,12 +11868,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String seasonNumber(int number) {
-    return 'Temporada $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -12186,7 +11884,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Excluir todos os episódios baixados em $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -12194,8 +11892,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episódios',
-      one: '1 episódio',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -12230,7 +11928,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Excluir $count itens baixados?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -12244,7 +11942,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'do limite de $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -12330,7 +12028,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String optionsCount(int count) {
-    return '$count opções';
+    return '$count options';
   }
 
   @override
@@ -12425,10 +12123,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get themeMusicVolume => 'Volume da música temática';
 
   @override
-  String get themeMusicSettingsSubtitle =>
-      'Páginas de detalhes, linhas iniciais e volume';
-
-  @override
   String percentValue(int value) {
     return '$value%';
   }
@@ -12439,13 +12133,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get playWhenBrowsingHomeScreen =>
       'Reproduzir enquanto navega na tela inicial';
-
-  @override
-  String get loopThemeMusic => 'Repetir música tema';
-
-  @override
-  String get loopThemeMusicSubtitle =>
-      'Repetir a faixa em vez de reproduzi-la uma só vez';
 
   @override
   String get detailsBackgroundBlur => 'Detalhes do desfoque de fundo';
@@ -12468,25 +12155,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get playerZoomMode => 'Modo de zoom do player';
 
   @override
-  String get settingsScrollWheelAction => 'Roda do mouse';
-
-  @override
-  String get settingsScrollWheelActionDescription =>
-      'Escolha o que a rolagem da roda do mouse sobre o vídeo faz durante a reprodução.';
-
-  @override
-  String get scrollWheelActionOff => 'Desligado';
-
-  @override
-  String get scrollWheelActionSeek => 'Buscar (avançar / retroceder)';
-
-  @override
-  String get scrollWheelActionVolume => 'Volume';
-
-  @override
-  String get playerTooltipVolume => 'Volume';
-
-  @override
   String get fit => 'Ajustar';
 
   @override
@@ -12499,7 +12167,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get refreshRateSwitching => 'Mudança de taxa de atualização';
 
   @override
-  String get disabled => 'Desativado';
+  String get disabled => 'Desabilitado';
 
   @override
   String get scaleOnTv => 'Escala na TV';
@@ -12536,39 +12204,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get defaultAudioLanguage => 'Idioma de áudio padrão';
-
-  @override
-  String get fallbackAudioLanguage => 'Idioma de áudio alternativo';
-
-  @override
-  String get preferDefaultAudioTrack => 'Preferir a faixa de áudio padrão';
-
-  @override
-  String get preferDefaultAudioTrackDescription =>
-      'Preferir a faixa de áudio original em vez da dublagem localizada.';
-
-  @override
-  String get preferAudioDescription => 'Preferir faixas de audiodescrição';
-
-  @override
-  String get preferAudioDescriptionDescription =>
-      'Preferir faixas de audiodescrição em vez das faixas normais.';
-
-  @override
-  String get transcodingAudio => 'Transcodificação (Áudio)';
-
-  @override
-  String get directStreamRemux => 'Transmissão direta (Remux)';
-
-  @override
-  String get transcodingBitrateOrResolution =>
-      'Transcodificação (Taxa de bits ou resolução)';
-
-  @override
-  String get transcodingVideoAndAudio => 'Transcodificação (Vídeo e Áudio)';
-
-  @override
-  String get transcodingVideo => 'Transcodificação (Vídeo)';
 
   @override
   String get autoServerDefault => 'Automático (padrão do servidor)';
@@ -12645,145 +12280,76 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Ative o áudio TrueHD (pode não funcionar em todas as plataformas)';
 
   @override
-  String get settingsAudioOutputMode => 'Modo de saída de áudio';
-
-  @override
-  String get settingsAudioOutputModeDescription =>
-      'Escolha como o áudio é decodificado. O AVR Passthrough envia os streams Dolby/DTS brutos para o seu receiver; Auto ou Downmix decodificam localmente.';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Codec de áudio alternativo';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
-  String get settingsAudioFallbackCodecDescription =>
-      'Selecione o formato de destino para transcodificar o áudio multicanal quando o stream de origem não puder ser reproduzido diretamente nem enviado por passthrough.';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detecção automática\n(Recomendado)';
-
-  @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Padrão)';
-
-  @override
-  String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
-
-  @override
-  String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
-
-  @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sem perdas)';
-
-  @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Somente estéreo)';
-
-  @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficiente)';
-
-  @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sem perdas)';
-
-  @override
-  String get settingsMaxAudioChannels => 'Máximo de canais de áudio';
-
-  @override
-  String get settingsMaxAudioChannelsDescription =>
-      'Configure o número máximo de canais do seu sistema de áudio. Streams multicanal que excederem esse limite passarão por downmix ou transcodificação.';
-
-  @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detecção automática\n(Padrão do hardware)';
-
-  @override
-  String get settingsMaxAudioChannelsMono => '1.0 Mono';
-
-  @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estéreo';
-
-  @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrafônico';
-
-  @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
-
-  @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (Avançado)';
-
-  @override
-  String get settingsAudioCodecPassthrough => 'Passthrough de codec';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Ative apenas os formatos compatíveis com o seu AVR ou dispositivo HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Envia o bitstream Dolby Digital Plus (EAC3) para o decodificador externo.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Envia o bitstream Dolby Atmos sobre EAC3 (JOC) para o decodificador externo.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Envia o bitstream DTS-HD MA (inclui o DTS core) para o decodificador externo.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Envia o bitstream Dolby TrueHD com metadados Atmos para o decodificador externo.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Recursos de áudio detectados';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Ainda não há um instantâneo dos recursos em tempo de execução.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Rota';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Decodificação';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Rota de áudio HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -12798,50 +12364,47 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Alto-falante';
-
-  @override
-  String get settingsAudioRouteHeadphones => 'Fones de ouvido';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count canais PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnóstico';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Nível de vídeo';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Faixa de vídeo';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Codec de legenda';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Codecs de áudio permitidos';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Codecs de áudio HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Codecs de áudio HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'passthrough audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Rota de áudio ativa';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Suporte a áudio HD na rota';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Modo noturno';
@@ -12905,7 +12468,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Após $episodes episódios / ${hours}h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -12981,47 +12544,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Personalize a aparência das legendas';
 
   @override
-  String get subtitleMode => 'Modo de legenda';
-
-  @override
-  String get subtitleModeFlagged => 'Sinalizadas';
-
-  @override
-  String get subtitleModeAlways => 'Sempre';
-
-  @override
-  String get subtitleModeForeign => 'Estrangeiras';
-
-  @override
-  String get subtitleModeForced => 'Forçadas';
-
-  @override
-  String get subtitleModeFlaggedDescription =>
-      'Reproduz as faixas sinalizadas internamente como \"padrão\" ou \"forçada\" nos metadados do arquivo de mídia.';
-
-  @override
-  String get subtitleModeAlwaysDescription =>
-      'Carrega e exibe as legendas automaticamente sempre que um vídeo começa.';
-
-  @override
-  String get subtitleModeForeignDescription =>
-      'Ativa as legendas automaticamente se a faixa de áudio padrão estiver em um idioma estrangeiro.';
-
-  @override
-  String get subtitleModeForcedDescription =>
-      'Carrega apenas as legendas explicitamente marcadas com o sinalizador de metadados \"forçada\".';
-
-  @override
-  String get subtitleModeNoneDescription =>
-      'Desativa completamente o carregamento automático de legendas.';
-
-  @override
-  String get fallbackSubtitleLanguage => 'Idioma de legenda alternativo';
-
-  @override
-  String get subtitleStream => 'Stream de legenda';
-
-  @override
   String get subtitlePreviewText =>
       'A rápida raposa marrom salta sobre o cachorro preguiçoso';
 
@@ -13079,17 +12601,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Configurações do perfil $profile carregadas.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Falha ao carregar as configurações do perfil $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Configurações locais sincronizadas com o perfil $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -13225,13 +12747,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Mostrar bibliotecas na barra de ferramentas';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Sempre expandir os rótulos da barra de navegação';
-
-  @override
-  String get showSeerrButton => 'Mostrar botão do Seerr';
-
-  @override
   String get navbarOpacity => 'Opacidade da barra de navegação';
 
   @override
@@ -13274,7 +12789,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get libraryDisplay => 'Exibição da Biblioteca';
 
   @override
-  String get posterLabel => 'Pôster';
+  String get posterLabel => 'Poster';
 
   @override
   String get thumbnailLabel => 'Miniatura';
@@ -13304,21 +12819,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get showFolderBrowsingOption => 'Mostrar opção de navegação em pastas';
 
   @override
-  String get groupItemsIntoCollections => 'Agrupar itens em coleções';
-
-  @override
-  String get hideCollectionAssociatedItems =>
-      'Ocultar os itens da biblioteca associados a coleções ao navegar pelas bibliotecas';
-
-  @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Aviso sobre agrupamento de bibliotecas';
-
-  @override
-  String get groupItemsIntoCollectionsDialogMessage =>
-      'Para usar esta configuração, verifique se as opções \"Agrupar filmes em coleções\" e/ou \"Agrupar séries em coleções\" estão ativadas nas configurações de exibição da sua biblioteca no servidor Jellyfin ou Emby.';
-
-  @override
   String get libraryVisibility => 'Visibilidade da Biblioteca';
 
   @override
@@ -13345,7 +12845,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String itemsSelected(int count) {
-    return '$count selecionados';
+    return '$count selected';
   }
 
   @override
@@ -13375,13 +12875,13 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Escolha entre vários estilos de barra de mídia ou desative a barra de mídia';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Barbatana Lunar';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Desativado';
+  String get mediaBarModeOff => 'Desligado';
 
   @override
   String get enableMediaBar => 'Ativar barra de mídia';
@@ -13427,13 +12927,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get autoPlayTrailers =>
       'Reproduza trailers automaticamente na barra de mídia após 3 segundos';
-
-  @override
-  String get trailerAudio => 'Áudio do trailer';
-
-  @override
-  String get enableTrailerAudio =>
-      'Ativar o áudio dos trailers na barra de mídia';
 
   @override
   String get episodePreview => 'Prévia do episódio';
@@ -13511,12 +13004,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Combine as duas linhas em uma única seção inicial';
 
   @override
-  String get fullScreenRows => 'Linhas iniciais expandidas';
-
-  @override
-  String get fullScreenRowsDescription => 'Limitar a 1 linha inicial por tela';
-
-  @override
   String get perRowImageType => 'Tipo de imagem por linha';
 
   @override
@@ -13527,9 +13014,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get lastUser => 'Último usuário';
-
-  @override
-  String get currentUser => 'Usuário atual';
 
   @override
   String get alwaysAuthenticate => 'Sempre autenticar';
@@ -13637,12 +13121,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Exibir relógio durante o protetor de tela';
 
   @override
-  String get clockModeStatic => 'Estático';
-
-  @override
-  String get clockModeBouncing => 'Flutuante';
-
-  @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (críticos)';
 
   @override
@@ -13713,7 +13191,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Ative e reordene as fontes de avaliação mostradas em todo o aplicativo';
 
   @override
-  String get pluginLabel => 'Plug-in Moonbase';
+  String get pluginLabel => 'Plug-in';
 
   @override
   String get pluginDetected => 'Plug-in detectado';
@@ -13731,7 +13209,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersão: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -13785,13 +13263,10 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get networks => 'Redes';
 
   @override
-  String get seerrDiscoveryRows => 'Linhas de descoberta do Seerr';
-
-  @override
   String get resetRowsToDefaults => 'Redefinir seções para os padrões';
 
   @override
-  String get enableSeerr => 'Habilitar Seerr';
+  String get enableSeerr => 'Habilitar Seer';
 
   @override
   String get showSeerrInNavigation =>
@@ -13808,48 +13283,23 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get hideAdultContent => 'Ocultar conteúdo adulto nos resultados';
 
   @override
-  String get seerrNotificationsSection => 'Notificações';
-
-  @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Notificações de novas solicitações';
-
-  @override
-  String get seerrNotifyNewRequestsSubtitle =>
-      'Avisar quando alguém enviar uma solicitação';
-
-  @override
-  String get seerrNotifyLibraryAddedTitle => 'Atualizações de solicitações';
-
-  @override
-  String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprovadas, recusadas e adicionadas à sua biblioteca';
-
-  @override
-  String get seerrNotifyIssuesTitle => 'Atualizações de problemas';
-
-  @override
-  String get seerrNotifyIssuesSubtitle =>
-      'Novos problemas, respostas e resoluções';
-
-  @override
   String loggedInAs(String username) {
     return 'Logado como: $username';
   }
 
   @override
-  String get discoverRows => 'Página de descoberta do Seerr';
+  String get discoverRows => 'Seções de descoberta';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Habilite as seções que você quer ver na página principal do Seerr. Arraste para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arraste para reordenar. Habilite ou desabilite seções. A ordem das seções habilitada é sincronizada com o plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Habilite as seções que você quer ver na página principal do Seerr. Arraste para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arraste para reordenar. Habilite ou desabilite seções.';
 
   @override
-  String get enabled => 'Ativado';
+  String get enabled => 'Habilitado';
 
   @override
   String get hidden => 'Escondido';
@@ -13859,7 +13309,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String versionValue(String version) {
-    return 'Versão $version';
+    return 'Version $version';
   }
 
   @override
@@ -13910,7 +13360,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Atualização disponível: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -13922,7 +13372,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version disponível';
+    return 'v$version Available';
   }
 
   @override
@@ -13986,7 +13436,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get imageCacheCleared => 'Cache de imagens limpo';
 
   @override
-  String get clear => 'Limpar';
+  String get clear => 'Claro';
 
   @override
   String get browse => 'Navegar';
@@ -14001,20 +13451,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get seerrRequestedStatus => 'Solicitado';
 
   @override
-  String seerrDownloadingPercent(int percent) {
-    return 'Baixando · $percent%';
-  }
-
-  @override
-  String get seerrImportingStatus => 'Importando';
-
-  @override
   String itemsCount(int count) {
-    return '$count Itens';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Configurações do Seerr';
+  String get seerrSettings => 'Configurações do visualizador';
 
   @override
   String get requestMore => 'Solicite mais';
@@ -14030,7 +13472,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String requestedByName(String name) {
-    return 'Solicitado por $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -14047,12 +13489,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Cancelar a solicitação de \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Cancelar $count solicitações de \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -14067,12 +13509,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String budgetAmount(String amount) {
-    return 'Orçamento: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Receita: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -14082,7 +13524,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Solicitar $type';
+    return 'Request $type';
   }
 
   @override
@@ -14111,14 +13553,14 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get showMore => 'Mostrar mais';
 
   @override
-  String get appearances => 'Participações';
+  String get appearances => 'Aparências';
 
   @override
   String get crewSection => 'Equipe';
 
   @override
   String ageValue(int age) {
-    return '$age anos';
+    return 'age $age';
   }
 
   @override
@@ -14147,150 +13589,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get deletedStatus => 'Excluído';
-
-  @override
-  String get failedStatus => 'Falhou';
-
-  @override
-  String get processingStatus => 'Processando';
-
-  @override
-  String modifiedByName(String name) {
-    return 'Modificado por $name';
-  }
-
-  @override
-  String get completedStatus => 'Concluído';
-
-  @override
-  String get requestErrorDuplicate => 'Este título já foi solicitado';
-
-  @override
-  String get requestErrorQuota => 'Limite de solicitações atingido';
-
-  @override
-  String get requestErrorBlocklisted => 'Este título está na lista de bloqueio';
-
-  @override
-  String get requestErrorNoSeasons => 'Não há mais temporadas para solicitar';
-
-  @override
-  String get requestErrorPermission =>
-      'Você não tem permissão para fazer esta solicitação';
-
-  @override
-  String get seerrRequestsTitle => 'Solicitações';
-
-  @override
-  String get seerrIssuesTitle => 'Problemas';
-
-  @override
-  String get sortNewest => 'Mais recentes';
-
-  @override
-  String get sortLastModified => 'Última modificação';
-
-  @override
-  String get noIssues => 'Nenhum problema';
-
-  @override
-  String movieQuotaRemaining(int remaining, int limit) {
-    return 'Restam $remaining de $limit solicitações de filmes';
-  }
-
-  @override
-  String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Restam $remaining de $limit solicitações de temporadas';
-  }
-
-  @override
-  String partOfCollectionName(String name) {
-    return 'Faz parte de $name';
-  }
-
-  @override
-  String get viewCollection => 'Ver coleção';
-
-  @override
-  String get requestCollection => 'Solicitar coleção';
-
-  @override
-  String collectionMoviesSummary(int total, int available) {
-    return '$total filmes · $available disponíveis';
-  }
-
-  @override
-  String requestMoviesCount(int count) {
-    return 'Solicitar $count filmes';
-  }
-
-  @override
-  String requestingProgress(int current, int total) {
-    return 'Solicitando $current de $total...';
-  }
-
-  @override
-  String requestedMoviesCount(int count) {
-    return '$count filmes solicitados';
-  }
-
-  @override
-  String requestedMoviesPartial(int ok, int total) {
-    return '$ok de $total filmes solicitados';
-  }
-
-  @override
-  String get collectionAllRequested =>
-      'Todos os filmes já estão disponíveis ou solicitados';
-
-  @override
-  String get reportIssue => 'Relatar problema';
-
-  @override
-  String get issueTypeVideo => 'Vídeo';
-
-  @override
-  String get issueTypeAudio => 'Áudio';
-
-  @override
-  String get whatsWrong => 'O que está errado?';
-
-  @override
-  String get allEpisodes => 'Todos os episódios';
-
-  @override
-  String get episode => 'Episódio';
-
-  @override
-  String get openStatus => 'Aberto';
-
-  @override
-  String get resolvedStatus => 'Resolvido';
-
-  @override
-  String get resolveAction => 'Resolver';
-
-  @override
-  String get reopenAction => 'Reabrir';
-
-  @override
-  String reportedByName(String name) {
-    return 'Relatado por $name';
-  }
-
-  @override
-  String commentsCount(int count) {
-    return '$count comentários';
-  }
-
-  @override
-  String get addComment => 'Adicionar um comentário';
-
-  @override
-  String get deleteIssueConfirm => 'Excluir este problema?';
-
-  @override
-  String get submitReport => 'Enviar relato';
 
   @override
   String get tmdbScore => 'Pontuação TMDB';
@@ -14347,7 +13645,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get disable => 'Desativar';
 
   @override
-  String get done => 'Concluído';
+  String get done => 'Feito';
 
   @override
   String get edit => 'Editar';
@@ -14362,7 +13660,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get forward => 'Avançar';
 
   @override
-  String get general => 'Geral';
+  String get general => 'Em geral';
 
   @override
   String get go => 'Ir';
@@ -14407,7 +13705,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get refresh => 'Atualizar';
 
   @override
-  String get remote => 'Controle remoto';
+  String get remote => 'Remoto';
 
   @override
   String get rename => 'Renomear';
@@ -14425,7 +13723,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get run => 'Correr';
 
   @override
-  String get search => 'Buscar';
+  String get search => 'Procurar';
 
   @override
   String get select => 'Selecione';
@@ -14452,7 +13750,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get time => 'Tempo';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Truques';
 
   @override
   String get uninstall => 'Desinstalar';
@@ -14470,7 +13768,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get unmute => 'Ativar som';
 
   @override
-  String get mute => 'Silenciar';
+  String get mute => 'Mudo';
 
   @override
   String get branding => 'Marca';
@@ -14494,15 +13792,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminDrawerLibraries => 'Bibliotecas';
 
   @override
-  String get adminDrawerDisplay => 'Exibição';
-
-  @override
-  String get adminDrawerMetadata => 'Metadados';
-
-  @override
-  String get adminDrawerNfo => 'Configurações de NFO';
-
-  @override
   String get adminDrawerTranscoding => 'Transcodificação';
 
   @override
@@ -14512,7 +13801,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminDrawerStreaming => 'Transmissão';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Truques';
 
   @override
   String get adminDrawerDevices => 'Dispositivos';
@@ -14563,22 +13852,22 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Atualizações de plug-ins disponíveis: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Plug-ins que exigem reinicialização: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Tarefas agendadas com falha: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Entradas recentes de aviso/erro: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -14637,7 +13926,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String errorGeneric(String error) {
-    return 'Erro: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -14665,7 +13954,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Falha no comando: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -14729,14 +14018,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminClearDates => 'Limpar datas';
 
   @override
-  String get adminActivitySeverityAll => 'Todas as severidades';
-
-  @override
-  String get adminActivityDateRange => 'Período';
-
-  @override
   String adminActivityLoadFailed(String error) {
-    return 'Falha ao carregar o registro de atividades: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -14753,7 +14036,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Falha ao atualizar o dispositivo: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -14764,28 +14047,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Falha ao excluir o dispositivo: $error';
-  }
-
-  @override
-  String adminRemoveDeviceConfirm(String name) {
-    return 'Remover o dispositivo \'$name\'? O usuário precisará entrar novamente neste dispositivo.';
-  }
-
-  @override
-  String get adminDeleteAllDevices => 'Excluir todos os dispositivos';
-
-  @override
-  String adminDeleteAllDevicesConfirm(int count) {
-    return 'Remover $count dispositivos? Os usuários afetados precisarão entrar novamente. Seu dispositivo atual não será afetado.';
-  }
-
-  @override
-  String get adminDevicesDeletedAll => 'Dispositivos removidos';
-
-  @override
-  String adminDevicesDeletedPartial(int count) {
-    return 'Alguns dispositivos foram removidos; não foi possível remover $count.';
+    return 'Failed to delete device: $error';
   }
 
   @override
@@ -14814,7 +14076,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminScanFailed(String error) {
-    return 'Falha ao iniciar a verificação: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -14825,12 +14087,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Biblioteca renomeada para \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Falha ao renomear: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -14838,17 +14100,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Biblioteca \"$name\" excluída';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Falha ao excluir a biblioteca: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Falha ao adicionar o caminho: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -14856,12 +14118,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Remover \"$path\" desta biblioteca?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Falha ao remover o caminho: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -14869,7 +14131,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Falha ao salvar as opções: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -14901,262 +14163,11 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminMetadataCountryHint => 'por exemplo EUA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Caminhos';
-
-  @override
-  String get adminLibraryTabOptions => 'Opções';
-
-  @override
-  String get adminLibraryTabDownloaders => 'Downloaders';
-
-  @override
-  String get adminLibMetadataSavers => 'Gravadores de metadados';
-
-  @override
-  String get adminLibSubtitleDownloaders => 'Downloaders de legendas';
-
-  @override
-  String get adminLibLyricDownloaders => 'Downloaders de letras';
-
-  @override
-  String adminLibMetadataDownloadersFor(String type) {
-    return 'Downloaders de metadados: $type';
-  }
-
-  @override
-  String adminLibImageFetchersFor(String type) {
-    return 'Buscadores de imagens: $type';
-  }
-
-  @override
-  String get adminLibNoDownloaders =>
-      'Este servidor não oferece downloaders para este tipo de biblioteca.';
-
-  @override
-  String get adminLibrarySectionGeneral => 'Geral';
-
-  @override
-  String get adminLibrarySectionMetadata => 'Metadados';
-
-  @override
-  String get adminLibrarySectionEmbedded => 'Informações incorporadas';
-
-  @override
-  String get adminLibrarySectionSubtitles => 'Legendas';
-
-  @override
-  String get adminLibrarySectionImages => 'Imagens';
-
-  @override
-  String get adminLibrarySectionSeries => 'Séries';
-
-  @override
-  String get adminLibrarySectionMusic => 'Música';
-
-  @override
-  String get adminLibrarySectionMovies => 'Filmes';
-
-  @override
-  String get adminLibRealtimeMonitor => 'Ativar monitoramento em tempo real';
-
-  @override
-  String get adminLibRealtimeMonitorHint =>
-      'Detectar alterações nos arquivos e processá-las automaticamente.';
-
-  @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratar arquivos compactados como arquivos de mídia';
-
-  @override
-  String get adminLibEnablePhotos => 'Exibir fotos';
-
-  @override
-  String get adminLibSaveLocalMetadata =>
-      'Salvar as imagens nas pastas de mídia';
-
-  @override
-  String get adminLibRefreshInterval => 'Atualização automática de metadados';
-
-  @override
-  String get adminLibRefreshNever => 'Nunca';
-
-  @override
-  String get adminLibDefault => 'Padrão';
-
-  @override
-  String get adminLibDisplayTitle => 'Exibição';
-
-  @override
-  String get adminLibDisplaySection => 'Exibição da biblioteca';
-
-  @override
-  String get adminLibFolderView =>
-      'Exibir uma visualização de pastas para mostrar as pastas de mídia simples';
-
-  @override
-  String get adminLibSpecialsInSeasons =>
-      'Exibir os especiais nas temporadas em que foram exibidos';
-
-  @override
-  String get adminLibGroupMovies => 'Agrupar filmes em coleções';
-
-  @override
-  String get adminLibGroupShows => 'Agrupar séries em coleções';
-
-  @override
-  String get adminLibExternalSuggestions =>
-      'Mostrar conteúdo externo nas sugestões';
-
-  @override
-  String get adminLibDateAddedSection => 'Comportamento da data de adição';
-
-  @override
-  String get adminLibDateAddedLabel => 'Usar a data de adição de';
-
-  @override
-  String get adminLibDateAddedImport => 'Data da verificação na biblioteca';
-
-  @override
-  String get adminLibDateAddedFile => 'Data de criação do arquivo';
-
-  @override
-  String get adminLibMetadataTitle => 'Metadados e imagens';
-
-  @override
-  String get adminLibMetadataLangSection => 'Idioma preferido dos metadados';
-
-  @override
-  String get adminLibChaptersSection => 'Capítulos';
-
-  @override
-  String get adminLibDummyChapterDuration =>
-      'Duração dos capítulos fictícios (segundos)';
-
-  @override
-  String get adminLibDummyChapterDurationHint =>
-      'Duração dos capítulos gerados para mídias que não os possuem. Defina 0 para desativar.';
-
-  @override
-  String get adminLibChapterImageResolution =>
-      'Resolução das imagens de capítulo';
-
-  @override
-  String get adminLibNfoTitle => 'Configurações de NFO';
-
-  @override
-  String get adminLibNfoHelp =>
-      'Os metadados NFO são compatíveis com o Kodi e clientes semelhantes. As configurações se aplicam a todas as bibliotecas que salvam metadados NFO.';
-
-  @override
-  String get adminLibKodiUser =>
-      'Usuário cujos dados de exibição serão armazenados nos arquivos NFO';
-
-  @override
-  String get adminLibSaveImagePaths =>
-      'Salvar os caminhos das imagens nos arquivos NFO';
-
-  @override
-  String get adminLibPathSubstitution =>
-      'Ativar a substituição de caminhos para os caminhos de imagem NFO';
-
-  @override
-  String get adminLibExtraThumbs =>
-      'Copiar as imagens extrafanart para uma pasta extrathumbs';
-
-  @override
-  String get adminLibNone => 'Nenhum';
-
-  @override
-  String adminLibRefreshDays(int days) {
-    return '$days dias';
-  }
-
-  @override
-  String get adminLibEmbeddedTitles => 'Usar os títulos incorporados';
-
-  @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usar os títulos incorporados para os extras';
-
-  @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usar as informações de episódio incorporadas';
-
-  @override
-  String get adminLibAllowEmbeddedSubtitles => 'Permitir legendas incorporadas';
-
-  @override
-  String get adminLibEmbeddedAllowAll => 'Permitir todas';
-
-  @override
-  String get adminLibEmbeddedAllowText => 'Somente texto';
-
-  @override
-  String get adminLibEmbeddedAllowImage => 'Somente imagem';
-
-  @override
-  String get adminLibEmbeddedAllowNone => 'Nenhum';
-
-  @override
-  String get adminLibSkipIfEmbeddedSubs =>
-      'Ignorar o download se houver legendas incorporadas';
-
-  @override
-  String get adminLibSkipIfAudioMatches =>
-      'Ignorar o download se a faixa de áudio corresponder ao idioma do download';
-
-  @override
-  String get adminLibRequirePerfectMatch =>
-      'Exigir correspondência exata da legenda';
-
-  @override
-  String get adminLibSaveSubtitlesWithMedia =>
-      'Salvar as legendas nas pastas de mídia';
-
-  @override
-  String get adminLibChapterImageExtraction => 'Extrair imagens de capítulo';
-
-  @override
-  String get adminLibChapterImagesDuringScan =>
-      'Extrair as imagens de capítulo durante a verificação da biblioteca';
-
-  @override
-  String get adminLibTrickplayExtraction =>
-      'Ativar a extração de imagens trickplay';
-
-  @override
-  String get adminLibTrickplayDuringScan =>
-      'Extrair as imagens trickplay durante a verificação da biblioteca';
-
-  @override
-  String get adminLibSaveTrickplayWithMedia =>
-      'Salvar as imagens trickplay nas pastas de mídia';
-
-  @override
-  String get adminLibAutomaticSeriesGrouping =>
-      'Mesclar automaticamente as séries distribuídas em várias pastas';
-
-  @override
-  String get adminLibSeasonZeroName => 'Nome de exibição da temporada zero';
-
-  @override
-  String get adminLibLufsScan =>
-      'Ativar a verificação LUFS para normalização de áudio';
-
-  @override
-  String get adminLibPreferNonstandardArtist =>
-      'Preferir a tag de artistas não padrão';
-
-  @override
-  String get adminLibAutoAddToCollection =>
-      'Adicionar filmes automaticamente às coleções';
-
-  @override
   String get adminLibraryNameRequired => 'O nome da biblioteca é obrigatório';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Falha ao criar a biblioteca: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -15183,27 +14194,27 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Desativar $name? Esse usuário não conseguirá entrar.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Ativar $name? Esse usuário poderá entrar novamente.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Usuário \"$name\" desativado';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Usuário \"$name\" ativado';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Falha ao atualizar a política do usuário: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -15220,7 +14231,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Falha ao criar o usuário: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -15240,7 +14251,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Falha ao salvar: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -15251,7 +14262,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminFailed(String error) {
-    return 'Falha: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -15391,168 +14402,27 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminEnableAllChannels => 'Habilite o acesso a todos os canais';
 
   @override
-  String get adminParentalControl => 'Controle parental';
-
-  @override
-  String get adminMaxParentalRating =>
-      'Classificação indicativa máxima permitida';
-
-  @override
-  String get adminMaxParentalRatingHint =>
-      'O conteúdo com classificação superior ficará oculto para este usuário.';
-
-  @override
-  String get adminParentalRatingNone => 'Nenhuma';
-
-  @override
-  String get adminBlockUnratedItems =>
-      'Bloquear itens sem classificação ou com classificação não reconhecida';
-
-  @override
-  String get adminUnratedBook => 'Livros';
-
-  @override
-  String get adminUnratedChannelContent => 'Canais';
-
-  @override
-  String get adminUnratedLiveTvChannel => 'TV ao vivo';
-
-  @override
-  String get adminUnratedMovie => 'Filmes';
-
-  @override
-  String get adminUnratedMusic => 'Música';
-
-  @override
-  String get adminUnratedTrailer => 'Trailers';
-
-  @override
-  String get adminUnratedSeries => 'Séries';
-
-  @override
-  String get adminAccessSchedules => 'Agendamentos de acesso';
-
-  @override
-  String get adminAccessSchedulesHint =>
-      'Permitir o acesso apenas nos horários agendados abaixo. Sem nenhum agendamento definido, o acesso é permitido o dia todo.';
-
-  @override
-  String get adminAddSchedule => 'Adicionar agendamento';
-
-  @override
-  String get adminScheduleDay => 'Dia';
-
-  @override
-  String get adminScheduleStart => 'Início';
-
-  @override
-  String get adminScheduleEnd => 'Fim';
-
-  @override
-  String get adminDayEveryday => 'Todos os dias';
-
-  @override
-  String get adminDayWeekday => 'Dias de semana';
-
-  @override
-  String get adminDayWeekend => 'Fim de semana';
-
-  @override
-  String get adminDaySunday => 'Domingo';
-
-  @override
-  String get adminDayMonday => 'Segunda-feira';
-
-  @override
-  String get adminDayTuesday => 'Terça-feira';
-
-  @override
-  String get adminDayWednesday => 'Quarta-feira';
-
-  @override
-  String get adminDayThursday => 'Quinta-feira';
-
-  @override
-  String get adminDayFriday => 'Sexta-feira';
-
-  @override
-  String get adminDaySaturday => 'Sábado';
-
-  @override
-  String get adminAllowedTags => 'Tags permitidas';
-
-  @override
-  String get adminAllowedTagsHint =>
-      'Apenas o conteúdo com estas tags é exibido. Deixe em branco para permitir tudo.';
-
-  @override
-  String get adminBlockedTags => 'Tags bloqueadas';
-
-  @override
-  String get adminBlockedTagsHint =>
-      'O conteúdo com estas tags fica oculto para este usuário.';
-
-  @override
-  String get adminAddTag => 'Adicionar tag';
-
-  @override
-  String get adminEnabledDevices => 'Dispositivos habilitados';
-
-  @override
-  String get adminEnabledChannels => 'Canais habilitados';
-
-  @override
-  String get adminAuthProvider => 'Provedor de autenticação';
-
-  @override
-  String get adminPasswordResetProvider => 'Provedor de redefinição de senha';
-
-  @override
-  String get adminLoginAttemptsBeforeLockout =>
-      'Máximo de tentativas de login malsucedidas antes do bloqueio';
-
-  @override
-  String get adminLoginAttemptsHint =>
-      'Defina 0 para o padrão ou -1 para desativar o bloqueio.';
-
-  @override
-  String get adminSyncPlayAccess => 'Acesso ao SyncPlay';
-
-  @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Permitir criar grupos e entrar neles';
-
-  @override
-  String get adminSyncPlayJoin => 'Permitir entrar em grupos';
-
-  @override
-  String get adminSyncPlayNone => 'Sem acesso';
-
-  @override
-  String get adminContentDeletionFolders => 'Permitir exclusão de conteúdo de';
-
-  @override
   String get adminResetPasswordWarning =>
       'Isso removerá a senha. O usuário poderá fazer login sem senha.';
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'O servidor retornou HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Tem certeza de que deseja excluir $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Usuário \"$name\" excluído';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Falha ao excluir o usuário: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -15573,7 +14443,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Falha ao criar a chave: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -15585,7 +14455,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Revogar a chave de $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -15593,7 +14463,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Falha ao revogar a chave: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -15613,29 +14483,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nCriado: $created';
+    return 'Token: $token\\nCreated: $created';
   }
-
-  @override
-  String get adminBackupOptionsTitle => 'Criar backup';
-
-  @override
-  String get adminBackupInclude => 'Escolha o que incluir no backup.';
-
-  @override
-  String get adminBackupDatabase => 'Banco de dados';
-
-  @override
-  String get adminBackupDatabaseAlways => 'Sempre incluído';
-
-  @override
-  String get adminBackupMetadata => 'Metadados';
-
-  @override
-  String get adminBackupSubtitles => 'Legendas';
-
-  @override
-  String get adminBackupTrickplay => 'Imagens trickplay';
 
   @override
   String get adminCreatingBackup => 'Criando backup...';
@@ -15645,7 +14494,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Falha ao criar o backup: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -15654,12 +14503,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Manifesto: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Falha ao carregar o manifesto: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -15670,7 +14519,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Falha ao restaurar o backup: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -15702,17 +14551,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminSavedTo(String path) {
-    return 'Salvo em $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Falha ao salvar o arquivo: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Falha ao carregar $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -15723,7 +14572,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Falha ao carregar as tarefas: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -15735,17 +14584,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Falha ao iniciar a tarefa: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Falha ao parar a tarefa: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Falha ao carregar a tarefa: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -15753,12 +14602,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Falha ao remover o gatilho: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Falha ao adicionar o gatilho: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -15784,7 +14633,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminHours(String hours) {
-    return '$hours hora(s)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -15795,7 +14644,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Falha ao alternar o plug-in: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -15803,27 +14652,27 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Tem certeza de que deseja desinstalar \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Falha ao desinstalar o plug-in: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Falha ao instalar o pacote: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Falha ao instalar a atualização: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Falha ao carregar os plug-ins: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -15835,12 +14684,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Instalar atualização (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Falha ao carregar o catálogo: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -15862,17 +14711,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" será removido após a reinicialização do servidor';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Falha ao desinstalar: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Atualizando \"$name\" para a v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -15881,7 +14730,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Falha ao carregar o plug-in: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -15889,7 +14738,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versão $version';
+    return 'Version $version';
   }
 
   @override
@@ -15909,17 +14758,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Tem certeza de que deseja remover \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Falha ao salvar os repositórios: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Falha ao carregar os repositórios: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -15936,12 +14785,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Não foi possível carregar as configurações do plug-in: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Não foi possível abrir $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -16186,7 +15035,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminBaseUrl => 'URL base';
 
   @override
-  String get adminBaseUrlHint => 'por exemplo /jellyfin';
+  String get adminBaseUrlHint => 'por exemplo /geleia';
 
   @override
   String get https => 'HTTPS';
@@ -16226,12 +15075,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Falha ao carregar os metadados: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Falha ao salvar os metadados: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -16252,7 +15101,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Falha ao atualizar os metadados: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -16267,7 +15116,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Falha na pesquisa remota: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -16281,7 +15130,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Falha ao atualizar o tipo de conteúdo: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -16296,12 +15145,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Imagem $imageType atualizada';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Falha ao baixar a imagem: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -16312,27 +15161,27 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Imagem $imageType enviada';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Falha ao enviar a imagem: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Excluir imagem $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Imagem $imageType excluída';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Falha ao excluir a imagem: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -16343,124 +15192,11 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Falha na descoberta de sintonizadores: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Adicionar sintonizador';
-
-  @override
-  String get adminEditTuner => 'Editar sintonizador';
-
-  @override
-  String get adminTunerTypeM3u => 'Sintonizador M3U';
-
-  @override
-  String get adminTunerTypeHdHomerun => 'HDHomeRun';
-
-  @override
-  String get adminTunerFileOrUrl => 'Arquivo ou URL';
-
-  @override
-  String get adminTunerIpAddress => 'Endereço IP do sintonizador';
-
-  @override
-  String get adminTunerFriendlyName => 'Nome amigável';
-
-  @override
-  String get adminTunerUserAgent => 'User agent';
-
-  @override
-  String get adminTunerCount => 'Limite de conexões simultâneas';
-
-  @override
-  String get adminTunerCountHelp =>
-      'O número máximo de streams que o sintonizador permite ao mesmo tempo. Defina 0 para ilimitado.';
-
-  @override
-  String get adminTunerFallbackBitrate =>
-      'Taxa de bits máxima de streaming alternativa';
-
-  @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importar apenas os canais favoritos';
-
-  @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permitir transcodificação por hardware';
-
-  @override
-  String get adminTunerAllowFmp4 =>
-      'Permitir o contêiner de transcodificação fMP4';
-
-  @override
-  String get adminTunerAllowStreamSharing =>
-      'Permitir compartilhamento de streams';
-
-  @override
-  String get adminTunerEnableStreamLooping => 'Ativar repetição de stream';
-
-  @override
-  String get adminTunerIgnoreDts => 'Ignorar DTS';
-
-  @override
-  String get adminTunerReadAtNativeFramerate =>
-      'Ler a entrada na taxa de quadros nativa';
-
-  @override
-  String get adminEditProvider => 'Editar provedor';
-
-  @override
-  String get adminProviderXmltv => 'XMLTV';
-
-  @override
-  String get adminProviderSchedulesDirect => 'Schedules Direct';
-
-  @override
-  String get adminXmltvPath => 'Arquivo ou URL';
-
-  @override
-  String get adminXmltvMoviePrefix => 'Prefixo de filme';
-
-  @override
-  String get adminXmltvMovieCategories => 'Categorias de filmes';
-
-  @override
-  String get adminXmltvCategoriesHelp =>
-      'Separe várias categorias com uma barra vertical.';
-
-  @override
-  String get adminXmltvKidsCategories => 'Categorias infantis';
-
-  @override
-  String get adminXmltvNewsCategories => 'Categorias de notícias';
-
-  @override
-  String get adminXmltvSportsCategories => 'Categorias de esportes';
-
-  @override
-  String get adminSdUsername => 'Nome de usuário';
-
-  @override
-  String get adminSdPassword => 'Senha';
-
-  @override
-  String get adminSdCountry => 'País';
-
-  @override
-  String get adminSdCountrySelect => 'Selecione um país';
-
-  @override
-  String get adminSdPostalCode => 'CEP';
-
-  @override
-  String get adminSdGetListings => 'Obter programação';
-
-  @override
-  String get adminSdListings => 'Programação';
-
-  @override
-  String get adminEnableAllTuners => 'Ativar todos os sintonizadores';
 
   @override
   String get adminTunerType => 'Tipo de sintonizador';
@@ -16470,7 +15206,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Falha ao adicionar o sintonizador: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -16484,12 +15220,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Falha ao adicionar o provedor: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Falha ao remover o sintonizador: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -16498,16 +15234,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Falha ao redefinir o sintonizador: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported =>
-      'Este tipo de sintonizador não pode ser redefinido.';
-
-  @override
   String adminProviderRemoveFailed(String error) {
-    return 'Falha ao remover o provedor: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -16526,52 +15258,11 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminSeriesRecordingPath => 'Caminho de gravação da série';
 
   @override
-  String get adminMovieRecordingPath => 'Caminho de gravação de filmes';
-
-  @override
-  String get adminGuideDays => 'Dias de dados do guia';
-
-  @override
-  String get adminGuideDaysAuto => 'Automático';
-
-  @override
-  String adminGuideDaysValue(int days) {
-    return '$days dias';
-  }
-
-  @override
-  String get adminRecordingPostProcessor =>
-      'Caminho do aplicativo de pós-processamento';
-
-  @override
-  String get adminRecordingPostProcessorArgs => 'Argumentos do pós-processador';
-
-  @override
-  String get adminSaveRecordingNfo => 'Salvar metadados NFO da gravação';
-
-  @override
-  String get adminSaveRecordingImages => 'Salvar imagens da gravação';
-
-  @override
-  String get adminLiveTvSectionTiming => 'Tempo';
-
-  @override
-  String get adminLiveTvSectionPaths => 'Caminhos de gravação';
-
-  @override
-  String get adminLiveTvSectionPostProcessing => 'Pós-processamento';
-
-  @override
-  String adminGuideDaysDisplay(String value) {
-    return 'Dados do guia: $value';
-  }
-
-  @override
   String get adminRecordingSettingsSaved => 'Configurações de gravação salvas';
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Falha ao salvar as configurações: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -16588,7 +15279,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Falha ao atualizar os mapeamentos: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -16605,17 +15296,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminGuideProviders => 'Provedores de guias';
 
   @override
-  String get adminRefreshGuideData => 'Atualizar dados do guia';
-
-  @override
-  String get adminGuideRefreshStarted =>
-      'Atualização dos dados do guia iniciada';
-
-  @override
-  String get adminGuideRefreshUnavailable =>
-      'A tarefa de atualização do guia não está disponível neste servidor.';
-
-  @override
   String get adminAddProvider => 'Adicionar provedor';
 
   @override
@@ -16624,22 +15304,22 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Caminho de gravação: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Caminho das séries: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Margem inicial: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Margem final: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -16672,7 +15352,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Restaurar o backup $name agora?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -16702,7 +15382,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminNotSet => 'Não definido';
 
   @override
-  String get adminReset => 'Redefinir';
+  String get adminReset => 'Reiniciar';
 
   @override
   String get adminLogsTitle => 'Registros do servidor';
@@ -16718,27 +15398,27 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'há ${minutes}min';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'há ${hours}h';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'há ${days}d';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Falha ao carregar $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count correspondências';
+    return '$count matches';
   }
 
   @override
@@ -16746,9 +15426,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get adminMetadataEditorTitle => 'Editor de metadados';
-
-  @override
-  String get adminMetadataIdentify => 'Identificar';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -16848,22 +15525,22 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Imagem $imageType atualizada';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Imagem $imageType enviada';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Imagem $imageType excluída';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Falha ao baixar a imagem: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -16872,12 +15549,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Falha ao enviar a imagem: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Excluir imagem $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -16886,12 +15563,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Falha ao excluir a imagem: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Escolher imagem $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -16924,7 +15601,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Atualização disponível: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -16949,7 +15626,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Instalar atualização (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -16961,7 +15638,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" está sendo instalado...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -16981,7 +15658,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Configurações do $name';
+    return '$name Settings';
   }
 
   @override
@@ -17021,7 +15698,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Falha ao carregar os repositórios: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -17029,7 +15706,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Tem certeza de que deseja remover \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -17037,7 +15714,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Falha ao salvar os repositórios: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -17165,22 +15842,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminBrandingEnableSplash => 'Ativar tela inicial';
 
   @override
-  String get adminBrandingSplashUpload => 'Enviar imagem';
-
-  @override
-  String get adminBrandingSplashUploaded => 'Tela de abertura atualizada';
-
-  @override
-  String get adminBrandingSplashUploadFailed =>
-      'Falha ao enviar a tela de abertura';
-
-  @override
-  String get adminBrandingSplashDeleted => 'Tela de abertura removida';
-
-  @override
-  String get adminBrandingNoSplash => 'Nenhuma tela de abertura personalizada';
-
-  @override
   String get adminPlaybackHwAccel => 'Aceleração de Hardware';
 
   @override
@@ -17193,131 +15854,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get adminPlaybackEnableHwDecoding =>
       'Habilite a decodificação de hardware para:';
-
-  @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
-
-  @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ativar o decodificador NVDEC aprimorado';
-
-  @override
-  String get adminPlaybackPreferNativeDecoder =>
-      'Preferir o decodificador de hardware nativo do sistema';
-
-  @override
-  String get adminPlaybackColorDepth =>
-      'Profundidade de cor da decodificação por hardware';
-
-  @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodificação HEVC de 10 bits';
-
-  @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodificação VP9 de 10 bits';
-
-  @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodificação HEVC RExt de 8/10 bits';
-
-  @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodificação HEVC RExt de 12 bits';
-
-  @override
-  String get adminPlaybackHwEncodingSection => 'Codificação por hardware';
-
-  @override
-  String get adminPlaybackAllowHevcEncoding => 'Permitir codificação HEVC';
-
-  @override
-  String get adminPlaybackAllowAv1Encoding => 'Permitir codificação AV1';
-
-  @override
-  String get adminPlaybackIntelLowPowerH264 =>
-      'Ativar o codificador Intel H.264 de baixo consumo';
-
-  @override
-  String get adminPlaybackIntelLowPowerHevc =>
-      'Ativar o codificador Intel HEVC de baixo consumo';
-
-  @override
-  String get adminPlaybackToneMapping => 'Mapeamento de tons';
-
-  @override
-  String get adminPlaybackEnableTonemapping => 'Ativar o mapeamento de tons';
-
-  @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Ativar o mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackEnableVtTonemapping =>
-      'Ativar o mapeamento de tons do VideoToolbox';
-
-  @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoritmo de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingMode => 'Modo de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingRange => 'Faixa de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingDesat =>
-      'Dessaturação do mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingPeak => 'Pico do mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingParam => 'Parâmetro do mapeamento de tons';
-
-  @override
-  String get adminPlaybackVppTonemappingBrightness =>
-      'Brilho do mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste do mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackPresetsQuality => 'Predefinições e qualidade';
-
-  @override
-  String get adminPlaybackEncoderPreset => 'Predefinição do codificador';
-
-  @override
-  String get adminPlaybackH264Crf => 'CRF de codificação H.264';
-
-  @override
-  String get adminPlaybackH265Crf => 'CRF de codificação H.265 (HEVC)';
-
-  @override
-  String get adminPlaybackDeinterlaceMethod => 'Método de desentrelaçamento';
-
-  @override
-  String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dobrar a taxa de quadros ao desentrelaçar';
-
-  @override
-  String get adminPlaybackAudioSection => 'Áudio';
-
-  @override
-  String get adminPlaybackEnableAudioVbr => 'Ativar a codificação de áudio VBR';
-
-  @override
-  String get adminPlaybackDownmixBoost => 'Reforço do downmix de áudio';
-
-  @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo de downmix estéreo';
-
-  @override
-  String get adminPlaybackMaxMuxingQueue => 'Tamanho máximo da fila de muxing';
-
-  @override
-  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Codificação';
@@ -17441,9 +15977,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminTaskStop => 'Parar';
 
   @override
-  String get adminRunningTasks => 'Tarefas em execução';
-
-  @override
   String get adminTaskRun => 'Correr';
 
   @override
@@ -17463,17 +15996,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Diariamente às $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Semanalmente, $day às $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'A cada $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -17511,8 +16044,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count horas',
-      one: '1 hora',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -17540,17 +16073,17 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'há ${days}d';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'há ${hours}h';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'há ${minutes}min';
+    return '${minutes}m ago';
   }
 
   @override
@@ -17558,7 +16091,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '${minutes}min';
+    return '${minutes}m';
   }
 
   @override
@@ -17573,7 +16106,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -17587,50 +16120,10 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminNetworkingBaseUrl => 'URL base';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'por exemplo /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'por exemplo /geleia';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
-
-  @override
-  String get adminNetworkingPublicHttpPort => 'Porta HTTP pública';
-
-  @override
-  String get adminNetworkingRequireHttps => 'Exigir HTTPS';
-
-  @override
-  String get adminNetworkingRequireHttpsHint =>
-      'Redirecionar todas as solicitações remotas para HTTPS. Não tem efeito se o servidor não tiver um certificado válido.';
-
-  @override
-  String get adminNetworkingCertPassword => 'Senha do certificado';
-
-  @override
-  String get adminNetworkingIpSettings => 'Configurações de IP';
-
-  @override
-  String get adminNetworkingEnableIpv4 => 'Ativar IPv4';
-
-  @override
-  String get adminNetworkingEnableIpv6 => 'Ativar IPv6';
-
-  @override
-  String get adminNetworkingAutoDiscovery =>
-      'Ativar o mapeamento automático de portas';
-
-  @override
-  String get adminNetworkingLocalSubnets => 'Redes LAN';
-
-  @override
-  String get adminNetworkingLocalSubnetsHint =>
-      'Lista de endereços IP ou sub-redes CIDR, separados por vírgula ou por linha, tratados como pertencentes à rede local.';
-
-  @override
-  String get adminNetworkingPublishedUris => 'URIs publicadas do servidor';
-
-  @override
-  String get adminNetworkingPublishedUriHint =>
-      'Mapeie uma sub-rede ou endereço para uma URL publicada, por exemplo: all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Caminho do certificado';
@@ -17659,13 +16152,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get adminPlaybackThrottleBuffering => 'Buffer de aceleração';
-
-  @override
-  String get adminPlaybackThrottleDelay => 'Atraso de limitação (segundos)';
-
-  @override
-  String get adminPlaybackEnableSubtitleExtraction =>
-      'Permitir a extração de legendas em tempo real';
 
   @override
   String get adminResumeMinPct => 'Porcentagem mínima de currículo';
@@ -17714,31 +16200,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Falha ao atualizar o tipo de conteúdo: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold =>
       'Limite de resposta lenta (ms)';
-
-  @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ativar avisos de resposta lenta';
-
-  @override
-  String get adminGeneralQuickConnect => 'Ativar o Quick Connect';
-
-  @override
-  String get adminGeneralSectionServer => 'Servidor';
-
-  @override
-  String get adminGeneralSectionMetadata => 'Metadados';
-
-  @override
-  String get adminGeneralSectionPaths => 'Caminhos';
-
-  @override
-  String get adminGeneralSectionPerformance => 'Desempenho';
 
   @override
   String get adminGeneralCachePath => 'Caminho do cache';
@@ -17750,9 +16217,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get adminGeneralServerName => 'Nome do servidor';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Idioma de exibição preferido';
-
-  @override
   String get adminSettingsLoadFailed => 'Falha ao carregar as configurações';
 
   @override
@@ -17760,12 +16224,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Falha ao atualizar os mapeamentos: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Limite de tempo: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -17802,8 +16266,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# participantes',
-      one: '# participante',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -17895,12 +16359,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName entrou no grupo do SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName saiu do grupo do SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -17912,7 +16376,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Sincronizando a reprodução com $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -17951,8 +16415,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# linhas descobertas',
-      one: '# linha descoberta',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -17993,23 +16457,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get offlineSavedMedia => 'Mídia salva';
 
   @override
-  String get offlineBannerTitle => 'Você está offline';
-
-  @override
-  String get offlineBannerSubtitle => 'Mostrando seus downloads';
-
-  @override
-  String get offlineBannerAction => 'Downloads';
-
-  @override
-  String get serverUnreachableBannerTitle =>
-      'Não foi possível acessar seu servidor';
-
-  @override
-  String get serverUnreachableBannerSubtitle =>
-      'Reproduzindo dos downloads até ele voltar';
-
-  @override
   String get castGoogleCast => 'Google Cast';
 
   @override
@@ -18023,12 +16470,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String castControlFailed(String error) {
-    return 'Falha no controle do Cast: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Controles do $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -18039,7 +16486,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String castStopKind(String kind) {
-    return 'Parar $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -18080,14 +16527,14 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get pinForgot => 'Esqueceu o PIN?';
 
   @override
-  String get pinClear => 'Limpar';
+  String get pinClear => 'Claro';
 
   @override
   String get pinBackspace => 'Retrocesso';
 
   @override
   String get quickConnectAuthorized =>
-      'Solicitação do Quick Connect autorizada.';
+      'Solicitação de conexão rápida autorizada.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -18115,7 +16562,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Falha no Quick Connect: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -18126,7 +16573,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Falha no comando: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -18156,7 +16603,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String castingFailed(String error) {
-    return 'Falha ao iniciar a transmissão: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -18202,7 +16649,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Baixando $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -18241,7 +16688,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get posterImageType => 'Tipo de imagem';
 
   @override
-  String get imageTypePoster => 'Pôster';
+  String get imageTypePoster => 'Poster';
 
   @override
   String get imageTypeThumbnail => 'Miniatura';
@@ -18302,12 +16749,12 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Baixando $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Baixando $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -18368,16 +16815,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get contextMenuGoToSeries => 'Ir para a série';
 
   @override
-  String get contextMenuHideFromContinueWatching =>
-      'Ocultar de Continuar assistindo';
-
-  @override
-  String get contextMenuHideFromNextUp => 'Ocultar de Próximo';
-
-  @override
-  String get contextMenuAddToCollection => 'Adicionar à coleção';
-
-  @override
   String get settingsAdministrationSubtitle =>
       'Acesse o painel de administração do servidor';
 
@@ -18430,17 +16867,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get settingsAlphabetical => 'Alfabético';
 
   @override
-  String get settingsConnectionSection => 'CONEXÃO';
-
-  @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permitir certificados autoassinados';
-
-  @override
-  String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confie em servidores que usam certificados TLS autoassinados ou de CA privada. Ative apenas para servidores que você controla. Isso desativa a validação de certificados em todas as conexões.';
-
-  @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIDADE E SEGURANÇA';
 
   @override
@@ -18452,13 +16878,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get settingsGeneralStyleSubtitle =>
       'Acentos temáticos, cenários, indicadores assistidos e música temática';
-
-  @override
-  String get settingsDetailsScreen => 'Tela de detalhes';
-
-  @override
-  String get settingsDetailsScreenSubtitle =>
-      'Estilo, desfoque do fundo e comportamento das abas';
 
   @override
   String get settingsHomePage => 'Página inicial';
@@ -18493,14 +16912,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get settingsShowLibrariesButtonInNavigation =>
       'Mostrar o botão de bibliotecas na barra de navegação';
-
-  @override
-  String get settingsShowSeerrButtonInNavigation =>
-      'Mostrar o botão do Seerr na barra de navegação';
-
-  @override
-  String get settingsAlwaysExpandNavbarLabels =>
-      'Sempre mostrar os rótulos de texto na barra de navegação superior';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -18570,7 +16981,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Pague um café para o desenvolvedor';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'JURÍDICO';
@@ -18603,8 +17014,8 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# avisos de licença',
-      one: '# aviso de licença',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -18654,19 +17065,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get settingsSkipIntrosAndOutros => 'Pular introduções e outros?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Contagem regressiva do segmento de mídia';
-
-  @override
-  String get settingsProgressBar => 'Barra de progresso';
-
-  @override
-  String get settingsTimer => 'Cronômetro';
-
-  @override
-  String get settingsNone => 'Nenhum';
-
-  @override
   String get settingsPromptUser => 'Solicitar usuário';
 
   @override
@@ -18699,13 +17097,13 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (recomendado)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legado)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (legado)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (recomendado)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Substituição Dolby Vision';
@@ -18893,558 +17291,422 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName lançados recentemente';
-  }
-
-  @override
-  String get autoplayNextEpisode =>
-      'Reproduzir o próximo episódio automaticamente';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Reproduzir automaticamente o próximo episódio quando disponível.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Pular silêncio';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Pular automaticamente os trechos de áudio em silêncio quando o stream permitir.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Permitir efeitos de áudio externos';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Permitir que aplicativos de equalização e efeitos (como o Wavelet) se conectem às sessões de reprodução do Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Desativar o tunelamento';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Forçar a reprodução sem tunelamento. Útil em dispositivos com falhas de sincronia de áudio/vídeo ao usar o tunelamento.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Ativar o tunelamento';
-
-  @override
-  String get enableTunnelingSubtitle =>
-      'Avançado. Encaminha o áudio e o vídeo por um caminho de hardware acoplado. Desativado por padrão porque causa falhas de áudio/vídeo em alguns dispositivos.';
-
-  @override
-  String get mapDolbyVisionP7Title =>
-      'Mapear o perfil 7 do Dolby Vision para HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Reproduzir os streams do perfil 7 do Dolby Vision como HEVC compatível com HDR10 em dispositivos sem Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Usar os estilos de legenda incorporados';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Aplicar as cores, fontes e o posicionamento incorporados na faixa de legenda. Desative para usar as suas preferências de estilo de legenda.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Usar os tamanhos de fonte de legenda incorporados';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Aplicar as sugestões de tamanho de fonte incorporadas na faixa de legenda. Desative para usar o tamanho de legenda das suas preferências de estilo.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostrar detalhes da mídia';
-
-  @override
-  String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostrar os detalhes do item selecionado no topo das páginas de biblioteca.';
-
-  @override
-  String get hideBackdropsInLibraries => 'Ocultar planos de fundo ao navegar?';
-
-  @override
-  String get useDetailedSubHeadings => 'Usar subtítulos detalhados';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Mostrar a linha de subtítulos detalhada ou minimalista nas páginas de biblioteca.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Excluir o tema salvo?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Remover \"$themeName\" do cache deste dispositivo?';
-  }
-
-  @override
-  String get themeStore => 'Loja de temas';
-
-  @override
-  String get themeStoreSubtitle => 'Explore e salve temas da comunidade';
-
-  @override
-  String get themeStoreDescription =>
-      'Salve um tema para usá-lo como os seus outros temas salvos.';
-
-  @override
-  String get themeStoreEmpty => 'Nenhum tema disponível no momento.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Não foi possível carregar a Loja de temas. Verifique sua conexão e tente novamente.';
-
-  @override
-  String get themeStoreSave => 'Salvar';
-
-  @override
-  String get themeStoreSaveAndApply => 'Salvar e aplicar';
-
-  @override
-  String get themeStoreSaved => 'Salvo';
-
-  @override
-  String get themeStoreInvalidMessage => 'Não foi possível carregar este tema.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" salvo.';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" excluído deste dispositivo.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Não foi possível excluir \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Temas salvos';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Estes são os temas baixados do plug-in do Moonfin para o servidor atual. A exclusão remove apenas esta cópia local.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Nenhum tema salvo foi encontrado para este servidor.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Ativo no momento';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Excluir tema salvo';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Gerencie os temas de plug-in baixados neste dispositivo';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Editor de temas';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Abra o Editor de Temas do Moonfin no seu navegador';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Tela inicial';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Barra inferior';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Clássico';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderno';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Linhas iniciais';
-
-  @override
-  String get homeRowDisplay => 'Exibição das linhas iniciais';
-
-  @override
-  String get homeRowSections => 'Seções das linhas iniciais';
-
-  @override
-  String get homeRowToggles => 'Ativação das linhas iniciais';
-
-  @override
-  String get homeRowTogglesSubtitle =>
-      'Ative ou desative as categorias de linhas iniciais baseadas em bibliotecas';
-
-  @override
-  String get homeRowTogglesDescription =>
-      'Ative as opções a seguir para exibir as linhas nas Seções do início.';
+  String get homeRowsSection => 'Home Rows';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Clássico mantém o tipo de imagem e a sobreposição de informações por linha. Moderno usa linhas que vão de retrato a plano de fundo.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Exibir linhas de favoritos';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Mostrar as linhas de filmes e séries favoritos, entre outras, nas Seções do início.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Ordenação das linhas de favoritos';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Ordene as linhas de favoritos por data de adição, data de lançamento, ordem alfabética e muito mais.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Exibir linhas de coleções';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Mostrar as linhas de coleções nas Seções do início.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Ordenação das linhas de coleções';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Ordene as linhas de coleções por data de adição, data de lançamento, ordem alfabética e muito mais.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Exibir linhas de gêneros';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Mostrar as linhas de gêneros nas Seções do início.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Ordenação das linhas de gêneros';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Ordene as linhas de gêneros por data de adição, data de lançamento, ordem alfabética e muito mais.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Itens das linhas de gêneros';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Mostrar filmes, séries ou ambos nas linhas de gêneros.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Exibir linhas de playlists';
-
-  @override
-  String get displayPlaylistsRowsSubtitle =>
-      'Mostrar as linhas de playlists nas Seções do início.';
-
-  @override
-  String get playlistsRowSorting => 'Ordenação das linhas de playlists';
-
-  @override
-  String get playlistsRowSortingDescription =>
-      'Ordene as linhas de playlists por data de adição, data de lançamento, ordem alfabética e muito mais.';
-
-  @override
-  String get displayAudioRows => 'Exibir linhas de áudio';
-
-  @override
-  String get displayAudioRowsSubtitle =>
-      'Mostrar as linhas de áudio nas Seções do início.';
-
-  @override
-  String get audioRowsSorting => 'Ordenação das linhas de áudio';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Ordene as linhas de áudio por data de adição, data de lançamento, ordem alfabética e muito mais.';
-
-  @override
-  String get audioPlaylists => 'Playlists de áudio';
-
-  @override
-  String get appearance => 'Aparência';
-
-  @override
-  String get layout => 'Layout';
-
-  @override
-  String get theme => 'Tema';
-
-  @override
-  String get keyboard => 'Teclado';
-
-  @override
-  String get navButtons => 'Botões';
-
-  @override
-  String get rendering => 'Renderização';
-
-  @override
-  String get mpvConfiguration => 'Configuração do MPV';
+  String get appearance => 'Appearance';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Aplicativo de player externo';
-
-  @override
-  String get externalPlayerAppDescription =>
-      'Defina um player externo para ativar a opção de reprodução ao pressionar e segurar';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Mostrar o seletor de aplicativos ao iniciar a reprodução.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Carregando os players instalados...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Conexão';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Destino da transcodificação de áudio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Compatível com este dispositivo';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Não compatível com este dispositivo';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Envia o bitstream DTS:X (DTS UHD) para o decodificador externo.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD com Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Comportamento do player de mídia';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Aprimoramentos de reprodução';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Sempre ativo.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Substituir Pular encerramento pelo Próximo';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Mostrar a sobreposição do Próximo em vez do botão Pular encerramento.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Roteamento do player';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Preferir decodificadores por software';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Usar o FFmpeg (áudio) e a libgav1 (AV1) antes dos decodificadores de hardware. Desative se o passthrough de áudio HDMI falhar.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Abrir a reprodução de vídeo no aplicativo externo selecionado no Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Enfileiramento automático';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferir legendas SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Priorizar as faixas de legenda SDH/CC na seleção automática.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnóstico da web';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnóstico da Web do Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Use esta página para diagnosticar problemas de conectividade do navegador (CORS, conteúdo misto e configurações de descoberta).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Falha de conteúdo misto detectada';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Falha de CORS/preflight detectada';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'O Moonfin detectou uma página HTTPS tentando chamar uma URL de servidor HTTP. Os navegadores bloqueiam essa solicitação antes que ela chegue ao seu servidor.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'O Moonfin detectou uma falha de solicitação no nível do navegador, geralmente causada pela ausência de cabeçalhos CORS ou de preflight no servidor de mídia.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL de destino: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detalhe: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Contexto de execução atual';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Origem';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Esquema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Modo de plug-in';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Varredura WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL do servidor forçada';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL padrão do servidor';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL do proxy de descoberta';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'não configurado';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Conteúdo misto';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Esta página é carregada por HTTPS, mas uma ou mais URLs configuradas usam HTTP. Os navegadores impedem que páginas HTTPS chamem APIs HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Correção: sirva seu servidor de mídia ou endpoint de proxy via HTTPS ou carregue o Moonfin por HTTP apenas em redes locais confiáveis.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Nenhuma configuração óbvia de conteúdo misto foi detectada nas configurações de execução atuais.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Lista de verificação de CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Permita a origem do navegador em Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Inclua Authorization, X-Emby-Authorization e X-Emby-Token em Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Exponha Content-Range e Accept-Ranges para o streaming e a busca.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Retorne 204 para solicitações preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Exemplo de trecho de cabeçalho (estilo nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Observação';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Esta rota de diagnóstico é destinada às versões web. Se você estiver vendo isto em outra plataforma, estas verificações podem não se aplicar.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Voltar à seleção de servidor';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Sair de todas as contas';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'A permissão do microfone foi negada permanentemente. Ative-a nas configurações do sistema.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'A permissão do microfone é necessária para a pesquisa por voz.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Não entendi. Tente novamente.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nenhuma fala detectada.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Erro no microfone.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'A pesquisa por voz precisa de internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'O serviço de voz está ocupado. Tente novamente.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'A permissão do microfone foi negada permanentemente.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'A permissão do microfone foi negada.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'O reconhecimento de fala não está disponível neste dispositivo.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Abrir o seletor de rotas do iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'O seletor de rotas do AirPlay não está disponível neste dispositivo.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Vídeos';
+  String get videos => 'Videos';
 
   @override
   String get programs => 'Programas';
@@ -19468,188 +17730,183 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get watchAgain => 'Assistir novamente';
 
   @override
-  String get guestAppearances => 'Participações especiais';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Participações (Seerr)';
-
-  @override
-  String get crewContributionsSeerr => 'Contribuições da equipe (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
   String get watchWithGroup => 'Assistir em grupo';
 
   @override
-  String get errors => 'Erros';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Avisos';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Disco';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Abrir no navegador';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'O navegador incorporado não está disponível nesta plataforma.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Tem certeza de que deseja reiniciar o servidor?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Tem certeza de que deseja desligar o servidor? Você precisará reiniciá-lo manualmente.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Interno';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Ocioso';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nenhum usuário encontrado';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Nenhum usuário corresponde à sua pesquisa';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nenhum dispositivo encontrado';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Nenhum dispositivo corresponde aos filtros atuais';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Senha definida';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nenhuma senha configurada';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Acesso remoto';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Somente local';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Falha ao carregar a análise de mídia';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Análise combinada de todas as bibliotecas de mídia.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Principais artistas';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Principais autores';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Principais colaboradores';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Bibliotecas',
-      one: '1 Biblioteca',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Ainda não há totais de mídia indexada para esta seleção.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Detalhes da biblioteca';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Detalhamento por biblioteca';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Nenhuma biblioteca disponível.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administração do servidor';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Dados';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Cache de imagens';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Registros';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadados';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcodificação';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Nenhum caminho foi retornado por este servidor.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% usado';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Atividade dos usuários';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Eventos do sistema';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Requer atenção';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Servidor';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Reprodução';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Dispositivos';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avançado';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Plug-ins';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV ao vivo';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Vídeos caseiros';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Conteúdo misto';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Vídeos caseiros e fotos';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Filmes e séries mistos';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -19661,618 +17918,84 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nenhuma gravação encontrada';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Nenhuma página de imagem encontrada no arquivo .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Falha no renderizador incorporado ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Falha no renderizador de EPUB ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Arquivo local ausente para o leitor: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status ao abrir os dados do livro em $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nenhum endpoint de leitura de livro disponível';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Formato de arquivo de quadrinhos não suportado: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'O plug-in de extração de CBR não está disponível nesta plataforma.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Falha ao extrair o arquivo .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'A extração de CB7 não está disponível nesta plataforma.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'O plug-in de extração de CB7 não está disponível nesta plataforma.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Fechar o painel de gêneros';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Carregando modo aleatório...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ALEATÓRIO POR BIBLIOTECA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'TOTALMENTE ALEATÓRIO';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ALEATÓRIO POR GÊNEROS';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Alternância automática de HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Ativar o HDR automaticamente na reprodução de vídeos HDR e restaurar o modo de exibição ao sair.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
   String get whenFullscreen => 'Quando em tela cheia';
 
   @override
-  String get changeArtwork => 'Alterar imagens';
-
-  @override
-  String get missing => 'Ausente';
-
-  @override
   String get transcodingLimits => 'Limites de transcodificação';
-
-  @override
-  String get clearAllArtworkButton => 'Limpar todas as imagens?';
-
-  @override
-  String get clearAllArtworkWarning =>
-      'Tem certeza de que deseja limpar todas as imagens baixadas?';
-
-  @override
-  String get confirmClear => 'Confirmar limpeza';
-
-  @override
-  String confirmClearMessage(String itemType) {
-    return 'Tem certeza de que deseja limpar esta imagem ($itemType)?';
-  }
-
-  @override
-  String get uploadButton => 'Enviar?';
-
-  @override
-  String get resolutionLabel => 'Resolução: ';
-
-  @override
-  String get onlyShowInterfaceLanguage =>
-      'Mostrar apenas as imagens no idioma da interface';
-
-  @override
-  String get confirmClearAll => 'Confirmar limpeza total';
-
-  @override
-  String get imageUploadSuccess => 'Imagem enviada com sucesso!';
-
-  @override
-  String imageUploadFailed(String error) {
-    return 'Falha ao enviar a imagem: $error';
-  }
-
-  @override
-  String imageDownloadFailed(String error) {
-    return 'Falha ao definir a imagem: $error';
-  }
-
-  @override
-  String imageDeleteFailed(String error) {
-    return 'Falha ao excluir a imagem: $error';
-  }
-
-  @override
-  String clearAllArtworkFailed(String error) {
-    return 'Falha ao limpar todas as imagens: $error';
-  }
-
-  @override
-  String get yes => 'Sim';
-
-  @override
-  String get posterCategory => 'Pôster';
-
-  @override
-  String get backdropsCategory => 'Planos de fundo';
-
-  @override
-  String get bannerCategory => 'Banner';
-
-  @override
-  String get logoCategory => 'Logo';
-
-  @override
-  String get thumbnailCategory => 'Miniatura';
-
-  @override
-  String get artCategory => 'Arte';
-
-  @override
-  String get discArtCategory => 'Arte do disco';
-
-  @override
-  String get screenshotCategory => 'Captura de tela';
-
-  @override
-  String get boxCoverCategory => 'Capa da caixa';
-
-  @override
-  String get boxRearCoverCategory => 'Contracapa da caixa';
-
-  @override
-  String get menuArtCategory => 'Arte do menu';
-
-  @override
-  String get confirmItemPoster => 'pôster';
-
-  @override
-  String get confirmItemBackdrop => 'plano de fundo';
-
-  @override
-  String get confirmItemBanner => 'banner';
-
-  @override
-  String get confirmItemLogo => 'logo';
-
-  @override
-  String get confirmItemThumbnail => 'miniatura';
-
-  @override
-  String get confirmItemArt => 'arte';
-
-  @override
-  String get confirmItemDiscArt => 'arte do disco';
-
-  @override
-  String get confirmItemScreenshot => 'captura de tela';
-
-  @override
-  String get confirmItemBoxCover => 'capa da caixa';
-
-  @override
-  String get confirmItemBoxRearCover => 'contracapa da caixa';
-
-  @override
-  String get confirmItemMenuArt => 'arte do menu';
-
-  @override
-  String get resolutionAll => 'Todas';
-
-  @override
-  String get resolutionHigh => 'Alta (1080p+)';
-
-  @override
-  String get resolutionMedium => 'Média (720p)';
-
-  @override
-  String get resolutionLow => 'Baixa (<720p)';
-
-  @override
-  String get sources => 'Fontes';
-
-  @override
-  String get audiobookChapters => 'Capítulos';
-
-  @override
-  String get audiobookBookmarks => 'Marcadores';
-
-  @override
-  String get audiobookNotes => 'Notas';
-
-  @override
-  String get audiobookQueue => 'Fila';
-
-  @override
-  String get audiobookTimeline => 'Linha do tempo';
-
-  @override
-  String get audiobookTimelineEmpty => 'A linha do tempo está vazia';
-
-  @override
-  String get audiobookWholeBook => 'Livro inteiro';
-
-  @override
-  String get audiobookFocusedTimeline => 'Linha do tempo focada';
-
-  @override
-  String get audiobookExportBookmarks => 'Exportar marcadores';
-
-  @override
-  String get audiobookExportNotes => 'Exportar notas';
-
-  @override
-  String get audiobookExportAll => 'Exportar tudo';
-
-  @override
-  String audiobookExportSuccess(String path) {
-    return 'Exportado para $path';
-  }
-
-  @override
-  String audiobookExportFailed(String error) {
-    return 'Falha na exportação: $error';
-  }
-
-  @override
-  String get audiobookLyrics => 'Letras';
-
-  @override
-  String get audiobookAddBookmark => 'Adicionar marcador';
-
-  @override
-  String get audiobookAddNote => 'Adicionar nota';
-
-  @override
-  String get audiobookEditNote => 'Editar nota';
-
-  @override
-  String get audiobookNoteHint => 'Escreva uma nota para este momento';
-
-  @override
-  String get audiobookSleepTimer => 'Timer de desligamento';
-
-  @override
-  String get audiobookSleepOff => 'Desligado';
-
-  @override
-  String get audiobookSleepEndOfChapter => 'Fim do capítulo';
-
-  @override
-  String get audiobookSleepCustom => 'Personalizado';
-
-  @override
-  String audiobookSleepRemaining(String remaining) {
-    return 'Faltam $remaining';
-  }
-
-  @override
-  String audiobookSleepMinutes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count min',
-      one: '1 min',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get audiobookPlaybackSpeed => 'Velocidade de reprodução';
-
-  @override
-  String get audiobookRemainingTime => 'Restante';
-
-  @override
-  String get audiobookElapsedTime => 'Decorrido';
-
-  @override
-  String audiobookSkipBackSeconds(int seconds) {
-    return 'Voltar ${seconds}s';
-  }
-
-  @override
-  String audiobookSkipForwardSeconds(int seconds) {
-    return 'Avançar ${seconds}s';
-  }
-
-  @override
-  String get audiobookPreviousChapter => 'Capítulo anterior';
-
-  @override
-  String get audiobookNextChapter => 'Próximo capítulo';
-
-  @override
-  String audiobookChapterIndicator(int current, int total) {
-    return 'Capítulo $current de $total';
-  }
-
-  @override
-  String get audiobookNoChapters => 'Nenhum capítulo';
-
-  @override
-  String get audiobookNoBookmarks => 'Ainda não há marcadores';
-
-  @override
-  String get audiobookNoNotes => 'Ainda não há notas';
-
-  @override
-  String audiobookBookmarkAdded(String position) {
-    return 'Marcador adicionado em $position';
-  }
-
-  @override
-  String get audiobookSpeedReset => 'Redefinir para 1.0x';
-
-  @override
-  String audiobookSpeedCustomLabel(String value) {
-    return '${value}x';
-  }
-
-  @override
-  String get audiobookSave => 'Salvar';
-
-  @override
-  String get audiobookCancel => 'Cancelar';
-
-  @override
-  String get audiobookDelete => 'Excluir';
-
-  @override
-  String get subtitlePreferences => 'Preferências de legenda';
-
-  @override
-  String get subtitlePreferencesDescription =>
-      'Altere os modos de legenda, os idiomas padrão, a aparência e as opções de renderização.';
-
-  @override
-  String get subtitleRendering => 'Renderização de legendas';
-
-  @override
-  String get displayOptions => 'Opções de exibição';
-
-  @override
-  String get releaseDateAscending => 'Data de lançamento (crescente)';
-
-  @override
-  String get releaseDateDescending => 'Data de lançamento (decrescente)';
-
-  @override
-  String get groupContributions => 'Agrupar contribuições';
-
-  @override
-  String get groupMultipleRoles => 'Agrupar múltiplos papéis';
-
-  @override
-  String get libraryWriteAccessWarningTitle =>
-      'Aviso de acesso de gravação à biblioteca';
-
-  @override
-  String get libraryWriteAccessHowToFix => 'Como corrigir:';
-
-  @override
-  String get libraryWriteAccessFixSteps =>
-      '1. Conceda permissões de gravação ao usuário do serviço Jellyfin (por exemplo, jellyfin ou o PUID/PGID do Docker) nas pastas da sua biblioteca de mídia no servidor.\n\n2. Ou acesse o Painel do Jellyfin -> Bibliotecas, edite esta biblioteca e desative a opção \'Salvar imagens nas pastas de mídia\' para armazenar as imagens no banco de dados interno do Jellyfin.';
-
-  @override
-  String get dismiss => 'Dispensar';
-
-  @override
-  String libraryWriteAccessProactiveBody(
-    String libraryName,
-    String failedPath,
-  ) {
-    return 'Sua biblioteca \'$libraryName\' está configurada para salvar as imagens diretamente nas pastas de mídia (a opção \'Salvar imagens nas pastas de mídia\' está ativada). No entanto, o Jellyfin testou o acesso de gravação e não tem permissão para gravar arquivos neste diretório:\n\n$failedPath';
-  }
-
-  @override
-  String get libraryWriteAccessReactiveBody =>
-      'Parece que o Jellyfin não conseguiu atualizar as imagens. Sua biblioteca está configurada para salvar as imagens diretamente nas pastas de mídia (a opção \'Salvar imagens nas pastas de mídia\' está ativada). Esse erro geralmente ocorre quando o processo do servidor Jellyfin não tem permissão para gravar arquivos nos seus diretórios de mídia.';
-
-  @override
-  String get externalLists => 'Listas externas';
-
-  @override
-  String get replay => 'Reproduzir novamente';
-
-  @override
-  String get fileInformation => 'Informações do arquivo';
-
-  @override
-  String fileSizeFormat(Object size, Object format) {
-    return 'Tamanho: $size  •  Formato: $format';
-  }
-
-  @override
-  String showAllAudioTracks(int count) {
-    return 'Mostrar todas as ($count) faixas de áudio';
-  }
-
-  @override
-  String showAllSubtitleTracks(int count) {
-    return 'Mostrar todas as ($count) faixas de legenda';
-  }
-
-  @override
-  String get checkingDirectPlay =>
-      'Verificando a compatibilidade com reprodução direta...';
-
-  @override
-  String get directPlayCapabilityLabel =>
-      'Compatibilidade com reprodução direta: ';
-
-  @override
-  String get forced => 'Forçada';
-
-  @override
-  String get transcodeContainerNotSupported =>
-      'O formato do contêiner não é compatível com o player.';
-
-  @override
-  String get transcodeVideoCodecNotSupported =>
-      'O codec de vídeo não é compatível.';
-
-  @override
-  String get transcodeAudioCodecNotSupported =>
-      'O codec de áudio não é compatível.';
-
-  @override
-  String get transcodeSubtitleCodecNotSupported =>
-      'O formato da legenda não é compatível (exige incorporação).';
-
-  @override
-  String get transcodeAudioProfileNotSupported =>
-      'O perfil de áudio não é compatível.';
-
-  @override
-  String get transcodeVideoProfileNotSupported =>
-      'O perfil de vídeo não é compatível.';
-
-  @override
-  String get transcodeVideoLevelNotSupported =>
-      'O nível de vídeo não é compatível.';
-
-  @override
-  String get transcodeVideoResolutionNotSupported =>
-      'A resolução do vídeo não é compatível com este dispositivo.';
-
-  @override
-  String get transcodeVideoBitDepthNotSupported =>
-      'A profundidade de bits do vídeo não é compatível.';
-
-  @override
-  String get transcodeVideoFramerateNotSupported =>
-      'A taxa de quadros do vídeo não é compatível.';
-
-  @override
-  String get transcodeContainerBitrateExceedsLimit =>
-      'A taxa de bits do arquivo excede o limite de streaming do player.';
-
-  @override
-  String get transcodeVideoBitrateExceedsLimit =>
-      'A taxa de bits do vídeo excede o limite de streaming.';
-
-  @override
-  String get transcodeAudioBitrateExceedsLimit =>
-      'A taxa de bits do áudio excede o limite de streaming.';
-
-  @override
-  String get transcodeAudioChannelsNotSupported =>
-      'O número de canais de áudio não é compatível.';
-
-  @override
-  String get sortAlphabetical => 'Alfabética';
-
-  @override
-  String get sortReleaseAscending => 'Ordem de lançamento (crescente)';
-
-  @override
-  String get sortReleaseDescending => 'Ordem de lançamento (decrescente)';
-
-  @override
-  String get sortCustomDragDrop => 'Personalizada (arrastar e soltar)';
-
-  @override
-  String get playlistSortOptions => 'Opções de ordenação da playlist';
-
-  @override
-  String get resetSort => 'Redefinir ordenação';
-
-  @override
-  String rewatchSeasonEpisode(int season, int episode) {
-    return 'Rever T$season:E$episode';
-  }
-
-  @override
-  String get rewatchPlaylist => 'Playlist para rever';
-
-  @override
-  String get noSubtitlesFound => 'Nenhuma legenda encontrada.';
-
-  @override
-  String get adminControls => 'Controles de administração';
-
-  @override
-  String get impellerRendering => 'Mecanismo de renderização (Impeller)';
-
-  @override
-  String get impellerRenderingSubtitle =>
-      'O Impeller é o renderizador de GPU moderno do Flutter, com animações mais suaves e menos travamentos. Em alguns TV boxes e GPUs antigas, ele pode causar falhas visuais ou vídeo preto; desative-o se isso acontecer. Automático escolhe o melhor padrão para o seu dispositivo. Reinicie o Moonfin para aplicar.';
-
-  @override
-  String get impellerAuto => 'Automático';
-
-  @override
-  String get impellerOn => 'Ligado';
-
-  @override
-  String get impellerOff => 'Desligado';
-
-  @override
-  String get impellerRestartTitle => 'Reinicialização necessária';
-
-  @override
-  String get impellerRestartMessage =>
-      'O Moonfin precisa ser reiniciado para alterar o mecanismo de renderização. Feche o aplicativo agora e abra-o novamente para aplicar.';
-
-  @override
-  String get impellerCloseNow => 'Fechar o aplicativo agora';
-
-  @override
-  String get adminRefreshLibrary => 'Atualizar biblioteca';
-
-  @override
-  String get adminRefreshAllLibraries => 'Atualizar todas as bibliotecas';
-
-  @override
-  String get adminRepoSortDateOldest =>
-      'Data de adição (mais antigas primeiro)';
-
-  @override
-  String get adminRepoSortDateNewest =>
-      'Data de adição (mais recentes primeiro)';
-
-  @override
-  String get adminRepoSortNameAsc => 'Alfabética (A a Z)';
-
-  @override
-  String get adminRepoSortNameDesc => 'Alfabética (Z a A)';
-
-  @override
-  String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Carregando a análise do servidor... $percentage%';
-  }
-
-  @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual à origem';
-
-  @override
-  String get imdbTop250Movies => 'Top 250 Filmes do IMDb';
-
-  @override
-  String get imdbTop250TvShows => 'Top 250 Séries do IMDb';
-
-  @override
-  String get imdbMostPopularMovies => 'Filmes mais populares do IMDb';
-
-  @override
-  String get imdbMostPopularTvShows => 'Séries mais populares do IMDb';
-
-  @override
-  String get imdbLowestRatedMovies => 'Filmes com as piores notas do IMDb';
-
-  @override
-  String get imdbTopEnglishMovies => 'Melhores filmes em inglês do IMDb';
 }
 
 /// The translations for Portuguese, as used in Portugal (`pt_PT`).
@@ -20303,7 +18026,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Ligação Rápida';
 
   @override
   String get password => 'Palavra-passe';
@@ -20412,95 +18135,8 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get settingsAppearanceTheme => 'Tema da aplicação';
 
   @override
-  String get detailScreenStyle => 'Estilo do ecrã de detalhes';
-
-  @override
-  String get detailScreenStyleSubtitle =>
-      'Clássico é a disposição centrada original do Moonfin. Moderno é uma disposição cinematográfica responsiva.';
-
-  @override
-  String get detailScreenStyleMoonfin => 'Clássico';
-
-  @override
-  String get detailScreenStyleModern => 'Moderno';
-
-  @override
-  String get expandedTabs => 'Separadores expandidos';
-
-  @override
-  String get expandedTabsSubtitle =>
-      'Mostra automaticamente o conteúdo dos separadores enquanto navegas. Desativa para abrires e fechares cada separador manualmente.';
-
-  @override
-  String get showTechnicalDetails => 'Mostrar detalhes técnicos?';
-
-  @override
-  String get showTechnicalDetailsSubtitle =>
-      'Mostrar informações de codec, resolução e stream no resumo do banner';
-
-  @override
-  String get recommendationSystem => 'Sistema de recomendações';
-
-  @override
-  String get recommendationSystemSubtitle =>
-      'Usa o algoritmo de biblioteca local do Moonfin Recomenda ou as métricas de semelhança online do TMDb. Nota: as recomendações online requerem a integração com o Seerr.';
-
-  @override
-  String get recommendationSystemMoonfin => 'Moonfin Recomenda';
-
-  @override
-  String get recommendationSystemTmdb => 'Semelhança TMDb';
-
-  @override
-  String get recommendationsApplyParentalRatingCap =>
-      'Aplicar limite de classificação etária?';
-
-  @override
-  String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limitar as sugestões do Moonfin Recomenda pela classificação etária do conteúdo de destino';
-
-  @override
-  String get interfaceStyle => 'Estilo da interface';
-
-  @override
-  String get interfaceStyleSubtitle =>
-      'Automático acompanha o teu dispositivo. Escolhe Apple ou Material para forçar um visual.';
-
-  @override
-  String get interfaceStyleAutomatic => 'Automático';
-
-  @override
-  String get interfaceStyleApple => 'Apple';
-
-  @override
-  String get interfaceStyleMaterial => 'Material';
-
-  @override
-  String get glassQuality => 'Qualidade do vidro';
-
-  @override
-  String get glassQualitySubtitle =>
-      'Auto escolhe o melhor efeito de vidro para este dispositivo. Completo força desfoque real; Reduzido usa um vidro leve que poupa energia da GPU.';
-
-  @override
-  String get glassQualityAuto => 'Auto';
-
-  @override
-  String get glassQualityFull => 'Completo';
-
-  @override
-  String get glassQualityReduced => 'Reduzido';
-
-  @override
   String get settingsAppearanceThemeSubtitle =>
       'Alterna entre Moonfin e Neon Pulse sem reiniciar a aplicação';
-
-  @override
-  String get customThemeTitle => 'Tema personalizado';
-
-  @override
-  String get customThemeSubtitle =>
-      'Os temas personalizados alteram elementos visuais em todo o Moonfin. Escolhe uma destas opções para combinar com o teu estilo.';
 
   @override
   String get keyboardPreferSystemIme => 'Preferir o teclado do sistema';
@@ -20522,20 +18158,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get themeNeonPulseSubtitle =>
       'Estilo Synthwave com brilho magenta, texto ciano e contraste cromado mais forte';
-
-  @override
-  String get themeGlass => 'Glass';
-
-  @override
-  String get themeGlassSubtitle =>
-      'Estilo de vidro líquido com fundo em gradiente flutuante, superfícies foscas e destaque em azul Apple';
-
-  @override
-  String get theme8BitHero => '8-bit Hero';
-
-  @override
-  String get theme8BitHeroSubtitle =>
-      'Estilo retro em pixel art com paleta robusta, bordas em blocos, sombras marcadas e um tipo de letra de pixels';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -20596,37 +18218,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get exit => 'Sair';
-
-  @override
-  String get gameMenu => 'Menu';
-
-  @override
-  String get gamePaused => 'Em pausa';
-
-  @override
-  String get gameSaveState => 'Guardar estado';
-
-  @override
-  String get games => 'Jogos';
-
-  @override
-  String get gameLoadState => 'Carregar estado';
-
-  @override
-  String get gameFastForward => 'Avanço rápido';
-
-  @override
-  String get gameEmulatorSettings => 'Definições do emulador';
-
-  @override
-  String get gameNoCoreOptions => 'Este core não tem opções ajustáveis.';
-
-  @override
-  String get gameHoldToOpenMenu => 'Mantém premido para abrir o menu';
-
-  @override
-  String get gamePlaybackUnsupported =>
-      'Este dispositivo ainda não suporta a execução de jogos.';
 
   @override
   String get noHomeRowsLoaded => 'Nenhuma linha inicial pôde ser carregada';
@@ -21025,7 +18616,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get unread => 'Não lido';
 
   @override
-  String get unwatched => 'Não visto';
+  String get unwatched => 'Não vistos';
 
   @override
   String get seriesStatus => 'Estado da série';
@@ -21035,45 +18626,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get books => 'Livros';
-
-  @override
-  String get latestBooks => 'Livros recentes';
-
-  @override
-  String get latestAudiobooks => 'Audiolivros recentes';
-
-  @override
-  String bookSeriesItemCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count livros',
-      one: '1 livro',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get bookFormatBook => 'Livro';
-
-  @override
-  String get bookFormatAudiobook => 'Audiolivro';
-
-  @override
-  String bookPercentRead(int percent) {
-    return '$percent% lido';
-  }
-
-  @override
-  String bookTimeLeft(String time) {
-    return '$time restantes';
-  }
-
-  @override
-  String get bookHeroRead => 'Ler';
-
-  @override
-  String get bookHeroListen => 'Ouvir';
 
   @override
   String get author => 'Autor';
@@ -21268,36 +18820,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String get items => 'Itens';
-
-  @override
-  String get extras => 'Extras';
-
-  @override
-  String get behindTheScenes => 'Bastidores';
-
-  @override
-  String get deletedScenes => 'Cenas eliminadas';
-
-  @override
-  String get featurettes => 'Featurettes';
-
-  @override
-  String get interviews => 'Entrevistas';
-
-  @override
-  String get scenes => 'Cenas';
-
-  @override
-  String get shorts => 'Curtas';
-
-  @override
   String get trailers => 'Trailers';
-
-  @override
-  String timeRemaining(String time) {
-    return '$time restantes';
-  }
 
   @override
   String endsIn(String time) {
@@ -21462,7 +18985,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get subtitleTrack => 'Faixa de legenda';
 
   @override
-  String get none => 'Nenhuma';
+  String get none => 'Nenhum';
 
   @override
   String get downloadSubtitlesLabel => 'Transferir legendas...';
@@ -21541,13 +19064,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get director => 'REALIZAÇÃO';
 
   @override
-  String get directors => 'REALIZAÇÃO';
-
-  @override
-  String get writer => 'ARGUMENTO';
-
-  @override
-  String get writers => 'ARGUMENTISTAS';
+  String get writers => 'AUTORIA';
 
   @override
   String get studio => 'ESTÚDIO';
@@ -21621,17 +19138,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get readMore => 'Lê mais';
 
   @override
-  String get shuffle => 'Aleatório';
-
-  @override
-  String get shuffleAllMusic => 'Reproduzir toda a música aleatoriamente';
-
-  @override
-  String get carSignInPrompt => 'Inicia sessão no Moonfin no teu telemóvel';
-
-  @override
-  String get carServerUnreachable =>
-      'Não foi possível contactar o teu servidor';
+  String get shuffle => 'Baralhar';
 
   @override
   String downloadsCount(int count) {
@@ -21643,7 +19150,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String channelsCount(int count) {
-    return '$count canais';
+    return '${count}ch';
   }
 
   @override
@@ -21731,7 +19238,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get unavailable => 'Indisponível';
 
   @override
-  String get pause => 'Pausar';
+  String get pause => 'Pausa';
 
   @override
   String get syncPosition => 'Posição de sincronização';
@@ -21805,7 +19312,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get subtitleDelay => 'Atraso de legenda';
 
   @override
-  String get reset => 'Repor';
+  String get reset => 'Reiniciar';
 
   @override
   String get unknown => 'Desconhecido';
@@ -21832,7 +19339,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get transcodeReasons => 'Razões de transcodificação';
 
   @override
-  String get player => 'Leitor';
+  String get player => 'Reprodutor';
 
   @override
   String get container => 'Contentor';
@@ -22071,26 +19578,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get liveBadge => 'AO VIVO';
 
   @override
-  String guideNextProgram(String time, String title) {
-    return 'A seguir: $time  $title';
-  }
-
-  @override
-  String guideMinutesLeft(int minutes) {
-    return '${minutes}m restantes';
-  }
-
-  @override
-  String guideHoursLeft(int hours) {
-    return '${hours}h restantes';
-  }
-
-  @override
-  String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m restantes';
-  }
-
-  @override
   String get movie => 'Filme';
 
   @override
@@ -22110,7 +19597,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get favoriteChannel => 'Canal favorito';
 
   @override
-  String get record => 'Gravar';
+  String get record => 'Registro';
 
   @override
   String get cancelRecordingAction => 'Cancelar gravação';
@@ -22294,7 +19781,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'T$season E$episode';
+    return 'S$season E$episode';
   }
 
   @override
@@ -22318,7 +19805,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String seasonChip(int number) {
-    return 'T$number';
+    return 'S$number';
   }
 
   @override
@@ -22567,10 +20054,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get themeMusicVolume => 'Volume da música temática';
 
   @override
-  String get themeMusicSettingsSubtitle =>
-      'Páginas de detalhes, linhas iniciais e volume';
-
-  @override
   String percentValue(int value) {
     return '$value%';
   }
@@ -22581,13 +20064,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get playWhenBrowsingHomeScreen =>
       'Reproduzir ao navegar no ecrã inicial';
-
-  @override
-  String get loopThemeMusic => 'Repetir música-tema';
-
-  @override
-  String get loopThemeMusicSubtitle =>
-      'Repetir a faixa em vez de a reproduzir uma única vez';
 
   @override
   String get detailsBackgroundBlur => 'Detalhes do desfoque de fundo';
@@ -22680,39 +20156,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get defaultAudioLanguage => 'Idioma de áudio predefinido';
 
   @override
-  String get fallbackAudioLanguage => 'Idioma de áudio alternativo';
-
-  @override
-  String get preferDefaultAudioTrack => 'Preferir faixa de áudio predefinida';
-
-  @override
-  String get preferDefaultAudioTrackDescription =>
-      'Preferir a faixa de áudio original em vez da dobragem localizada.';
-
-  @override
-  String get preferAudioDescription => 'Preferir faixas de audiodescrição';
-
-  @override
-  String get preferAudioDescriptionDescription =>
-      'Preferir faixas de audiodescrição em vez das faixas normais.';
-
-  @override
-  String get transcodingAudio => 'Transcodificação (Áudio)';
-
-  @override
-  String get directStreamRemux => 'Transmissão direta (Remux)';
-
-  @override
-  String get transcodingBitrateOrResolution =>
-      'Transcodificação (Taxa de bits ou Resolução)';
-
-  @override
-  String get transcodingVideoAndAudio => 'Transcodificação (Vídeo e Áudio)';
-
-  @override
-  String get transcodingVideo => 'Transcodificação (Vídeo)';
-
-  @override
   String get autoServerDefault => 'Automático (predefinição do servidor)';
 
   @override
@@ -22790,78 +20233,10 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get settingsAudioOutputMode => 'Modo de saída de áudio';
 
   @override
-  String get settingsAudioOutputModeDescription =>
-      'Escolhe como o áudio é descodificado. O Passthrough AVR envia streams Dolby/DTS em bruto para o teu recetor; Auto ou Downmix descodificam localmente.';
-
-  @override
   String get settingsAudioOutputModeAvrPassthrough => 'Passagem AVR';
 
   @override
   String get settingsAudioFallbackCodec => 'Codec substituto de áudio';
-
-  @override
-  String get settingsAudioFallbackCodecDescription =>
-      'Seleciona o formato de destino para transcodificar áudio multicanal quando o stream de origem não pode ser reproduzido diretamente nem enviado por passthrough.';
-
-  @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Deteção automática\n(Recomendado)';
-
-  @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Predefinição)';
-
-  @override
-  String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
-
-  @override
-  String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
-
-  @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Sem perdas)';
-
-  @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Apenas estéreo)';
-
-  @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficiente)';
-
-  @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Sem perdas)';
-
-  @override
-  String get settingsMaxAudioChannels => 'Máximo de canais de áudio';
-
-  @override
-  String get settingsMaxAudioChannelsDescription =>
-      'Configura o número máximo de canais da tua configuração de áudio. Os streams multicanal que excedam este limite serão reduzidos (downmix) ou transcodificados.';
-
-  @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Deteção automática\n(Predefinição do hardware)';
-
-  @override
-  String get settingsMaxAudioChannelsMono => '1.0 Mono';
-
-  @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Estéreo';
-
-  @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrifónico';
-
-  @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
-
-  @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Passagem (avançado)';
@@ -22943,11 +20318,8 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get settingsAudioRouteSpeaker => 'Palestrante';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Auscultadores';
-
-  @override
   String settingsAudioPcmChannels(int count) {
-    return '$count canais PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -23122,47 +20494,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get subtitleCustomizationDescription =>
       'Personalize a aparência das legendas';
-
-  @override
-  String get subtitleMode => 'Modo de legendas';
-
-  @override
-  String get subtitleModeFlagged => 'Marcadas';
-
-  @override
-  String get subtitleModeAlways => 'Sempre';
-
-  @override
-  String get subtitleModeForeign => 'Estrangeiras';
-
-  @override
-  String get subtitleModeForced => 'Forçadas';
-
-  @override
-  String get subtitleModeFlaggedDescription =>
-      'Reproduz faixas marcadas internamente nos metadados do ficheiro multimédia como \"default\" ou \"forced\".';
-
-  @override
-  String get subtitleModeAlwaysDescription =>
-      'Carrega e mostra legendas automaticamente sempre que um vídeo começa.';
-
-  @override
-  String get subtitleModeForeignDescription =>
-      'Ativa as legendas automaticamente se a faixa de áudio predefinida estiver num idioma estrangeiro.';
-
-  @override
-  String get subtitleModeForcedDescription =>
-      'Carrega apenas legendas explicitamente marcadas com o sinalizador de metadados \"forced\".';
-
-  @override
-  String get subtitleModeNoneDescription =>
-      'Desativa completamente o carregamento automático de legendas.';
-
-  @override
-  String get fallbackSubtitleLanguage => 'Idioma de legendas alternativo';
-
-  @override
-  String get subtitleStream => 'Stream de legendas';
 
   @override
   String get subtitlePreviewText =>
@@ -23368,10 +20699,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Mostrar bibliotecas na barra de ferramentas';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Expandir sempre os rótulos da barra de navegação';
-
-  @override
   String get showSeerrButton => 'Mostrar botão Seerr';
 
   @override
@@ -23417,7 +20744,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get libraryDisplay => 'Visualização da Biblioteca';
 
   @override
-  String get posterLabel => 'Póster';
+  String get posterLabel => 'Poster';
 
   @override
   String get thumbnailLabel => 'Miniatura';
@@ -23445,21 +20772,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get showFolderBrowsingOption => 'Mostrar opção de navegação em pastas';
-
-  @override
-  String get groupItemsIntoCollections => 'Agrupar itens em coleções';
-
-  @override
-  String get hideCollectionAssociatedItems =>
-      'Ocultar itens da biblioteca associados a coleções ao navegar pelas bibliotecas';
-
-  @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Aviso de agrupamento de bibliotecas';
-
-  @override
-  String get groupItemsIntoCollectionsDialogMessage =>
-      'Para usares esta definição, certifica-te de que as opções \"Agrupar filmes em coleções\" e/ou \"Agrupar séries em coleções\" estão ativadas nas definições de Visualização da tua biblioteca no teu servidor Jellyfin ou Emby.';
 
   @override
   String get libraryVisibility => 'Visibilidade da Biblioteca';
@@ -23570,13 +20882,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get autoPlayTrailers =>
       'Reproduz trailers automaticamente na barra de conteúdo após 3 segundos';
-
-  @override
-  String get trailerAudio => 'Áudio do trailer';
-
-  @override
-  String get enableTrailerAudio =>
-      'Ativar o áudio dos trailers na barra de conteúdo';
 
   @override
   String get episodePreview => 'Prévia do episódio';
@@ -23780,12 +21085,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Mostrar relógio durante o protetor de ecrã';
 
   @override
-  String get clockModeStatic => 'Estático';
-
-  @override
-  String get clockModeBouncing => 'Saltitante';
-
-  @override
   String get rottenTomatoesCritics => 'Tomates podres (críticos)';
 
   @override
@@ -23857,7 +21156,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Ativa e reordena as fontes de classificação mostradas em toda a aplicação';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin detetado';
@@ -23952,44 +21251,20 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get hideAdultContent => 'Ocultar conteúdo adulto nos resultados';
 
   @override
-  String get seerrNotificationsSection => 'Notificações';
-
-  @override
-  String get seerrNotifyNewRequestsTitle => 'Notificações de novos pedidos';
-
-  @override
-  String get seerrNotifyNewRequestsSubtitle =>
-      'Avisar-me quando alguém enviar um pedido';
-
-  @override
-  String get seerrNotifyLibraryAddedTitle => 'Atualizações de pedidos';
-
-  @override
-  String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprovados, recusados e adicionados à tua biblioteca';
-
-  @override
-  String get seerrNotifyIssuesTitle => 'Atualizações de problemas';
-
-  @override
-  String get seerrNotifyIssuesSubtitle =>
-      'Novos problemas, respostas e resoluções';
-
-  @override
   String loggedInAs(String username) {
     return 'Sessão iniciada como: $username';
   }
 
   @override
-  String get discoverRows => 'Página de Descoberta do Seerr';
+  String get discoverRows => 'Descubra linhas';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Ativa as linhas que queres ver na página principal do Seerr. Arrasta para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arrasta para reordenar. Ativa ou desativa linhas. A ordem das linhas ativadas é sincronizada com o plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Ativa as linhas que queres ver na página principal do Seerr. Arrasta para reordenar. A ordem personalizada é sincronizada com o Moonbase.';
+      'Arrasta para reordenar. Ativa ou desativa linhas.';
 
   @override
   String get enabled => 'Ativado';
@@ -24129,7 +21404,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get imageCacheCleared => 'Cache de imagens limpa';
 
   @override
-  String get clear => 'Limpar';
+  String get clear => 'Claro';
 
   @override
   String get browse => 'Navegar';
@@ -24142,14 +21417,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get seerrRequestedStatus => 'Pedida';
-
-  @override
-  String seerrDownloadingPercent(int percent) {
-    return 'A transferir · $percent%';
-  }
-
-  @override
-  String get seerrImportingStatus => 'A importar';
 
   @override
   String itemsCount(int count) {
@@ -24254,7 +21521,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get showMore => 'Mostrar mais';
 
   @override
-  String get appearances => 'Participações';
+  String get appearances => 'Aparências';
 
   @override
   String get crewSection => 'Equipa';
@@ -24290,150 +21557,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get deletedStatus => 'Eliminado';
-
-  @override
-  String get failedStatus => 'Falhou';
-
-  @override
-  String get processingStatus => 'Em processamento';
-
-  @override
-  String modifiedByName(String name) {
-    return 'Modificado por $name';
-  }
-
-  @override
-  String get completedStatus => 'Concluído';
-
-  @override
-  String get requestErrorDuplicate => 'Este título já foi pedido';
-
-  @override
-  String get requestErrorQuota => 'Limite de pedidos atingido';
-
-  @override
-  String get requestErrorBlocklisted => 'Este título está na lista de bloqueio';
-
-  @override
-  String get requestErrorNoSeasons => 'Não há mais temporadas para pedir';
-
-  @override
-  String get requestErrorPermission =>
-      'Não tens permissão para fazer este pedido';
-
-  @override
-  String get seerrRequestsTitle => 'Pedidos';
-
-  @override
-  String get seerrIssuesTitle => 'Problemas';
-
-  @override
-  String get sortNewest => 'Mais recentes';
-
-  @override
-  String get sortLastModified => 'Última modificação';
-
-  @override
-  String get noIssues => 'Sem problemas';
-
-  @override
-  String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining de $limit pedidos de filmes restantes';
-  }
-
-  @override
-  String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining de $limit pedidos de temporadas restantes';
-  }
-
-  @override
-  String partOfCollectionName(String name) {
-    return 'Parte de $name';
-  }
-
-  @override
-  String get viewCollection => 'Ver coleção';
-
-  @override
-  String get requestCollection => 'Pedir coleção';
-
-  @override
-  String collectionMoviesSummary(int total, int available) {
-    return '$total filmes · $available disponíveis';
-  }
-
-  @override
-  String requestMoviesCount(int count) {
-    return 'Pedir $count filmes';
-  }
-
-  @override
-  String requestingProgress(int current, int total) {
-    return 'A pedir $current de $total...';
-  }
-
-  @override
-  String requestedMoviesCount(int count) {
-    return '$count filmes pedidos';
-  }
-
-  @override
-  String requestedMoviesPartial(int ok, int total) {
-    return '$ok de $total filmes pedidos';
-  }
-
-  @override
-  String get collectionAllRequested =>
-      'Todos os filmes já estão disponíveis ou pedidos';
-
-  @override
-  String get reportIssue => 'Comunicar problema';
-
-  @override
-  String get issueTypeVideo => 'Vídeo';
-
-  @override
-  String get issueTypeAudio => 'Áudio';
-
-  @override
-  String get whatsWrong => 'Qual é o problema?';
-
-  @override
-  String get allEpisodes => 'Todos os episódios';
-
-  @override
-  String get episode => 'Episódio';
-
-  @override
-  String get openStatus => 'Aberto';
-
-  @override
-  String get resolvedStatus => 'Resolvido';
-
-  @override
-  String get resolveAction => 'Resolver';
-
-  @override
-  String get reopenAction => 'Reabrir';
-
-  @override
-  String reportedByName(String name) {
-    return 'Comunicado por $name';
-  }
-
-  @override
-  String commentsCount(int count) {
-    return '$count comentários';
-  }
-
-  @override
-  String get addComment => 'Adicionar um comentário';
-
-  @override
-  String get deleteIssueConfirm => 'Eliminar este problema?';
-
-  @override
-  String get submitReport => 'Enviar relatório';
 
   @override
   String get tmdbScore => 'Pontuação TMDB';
@@ -24490,7 +21613,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get disable => 'Desativar';
 
   @override
-  String get done => 'Concluído';
+  String get done => 'Feito';
 
   @override
   String get edit => 'Editar';
@@ -24550,7 +21673,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get refresh => 'Atualizar';
 
   @override
-  String get remote => 'Controlo remoto';
+  String get remote => 'Remoto';
 
   @override
   String get rename => 'Renomear';
@@ -24568,7 +21691,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get run => 'Executar';
 
   @override
-  String get search => 'Pesquisar';
+  String get search => 'Procurar';
 
   @override
   String get select => 'Selecionar';
@@ -24613,7 +21736,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get unmute => 'Ativar som';
 
   @override
-  String get mute => 'Silenciar';
+  String get mute => 'Mudo';
 
   @override
   String get branding => 'Marca';
@@ -24635,15 +21758,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminDrawerLibraries => 'Bibliotecas';
-
-  @override
-  String get adminDrawerDisplay => 'Visualização';
-
-  @override
-  String get adminDrawerMetadata => 'Metadados';
-
-  @override
-  String get adminDrawerNfo => 'Definições NFO';
 
   @override
   String get adminDrawerTranscoding => 'Transcodificação';
@@ -24829,7 +21943,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get sessionForward => 'Avançar';
 
   @override
-  String get sessionNext => 'Seguinte';
+  String get sessionNext => 'Próximo';
 
   @override
   String get sessionVolumeDown => 'Volume –';
@@ -24871,12 +21985,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get adminClearDates => 'Limpar datas';
 
   @override
-  String get adminActivitySeverityAll => 'Todas as severidades';
-
-  @override
-  String get adminActivityDateRange => 'Intervalo de datas';
-
-  @override
   String adminActivityLoadFailed(String error) {
     return 'Falha ao carregar o log de atividades: $error';
   }
@@ -24907,27 +22015,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String adminDeviceDeleteFailed(String error) {
     return 'Falha ao eliminar dispositivo: $error';
-  }
-
-  @override
-  String adminRemoveDeviceConfirm(String name) {
-    return 'Remover o dispositivo \'$name\'? O utilizador terá de iniciar sessão novamente neste dispositivo.';
-  }
-
-  @override
-  String get adminDeleteAllDevices => 'Eliminar todos os dispositivos';
-
-  @override
-  String adminDeleteAllDevicesConfirm(int count) {
-    return 'Remover $count dispositivos? Os utilizadores afetados terão de iniciar sessão novamente. O teu dispositivo atual não é afetado.';
-  }
-
-  @override
-  String get adminDevicesDeletedAll => 'Dispositivos removidos';
-
-  @override
-  String adminDevicesDeletedPartial(int count) {
-    return 'Alguns dispositivos foram removidos; não foi possível remover $count.';
   }
 
   @override
@@ -25041,257 +22128,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminMetadataCountryHint => 'por exemplo EUA, DE, FR';
-
-  @override
-  String get adminLibraryTabPaths => 'Caminhos';
-
-  @override
-  String get adminLibraryTabOptions => 'Opções';
-
-  @override
-  String get adminLibraryTabDownloaders => 'Downloaders';
-
-  @override
-  String get adminLibMetadataSavers => 'Gravadores de metadados';
-
-  @override
-  String get adminLibSubtitleDownloaders => 'Downloaders de legendas';
-
-  @override
-  String get adminLibLyricDownloaders => 'Downloaders de letras';
-
-  @override
-  String adminLibMetadataDownloadersFor(String type) {
-    return 'Downloaders de metadados: $type';
-  }
-
-  @override
-  String adminLibImageFetchersFor(String type) {
-    return 'Fontes de imagens: $type';
-  }
-
-  @override
-  String get adminLibNoDownloaders =>
-      'Este servidor não expõe downloaders para este tipo de biblioteca.';
-
-  @override
-  String get adminLibrarySectionGeneral => 'Geral';
-
-  @override
-  String get adminLibrarySectionMetadata => 'Metadados';
-
-  @override
-  String get adminLibrarySectionEmbedded => 'Informações incorporadas';
-
-  @override
-  String get adminLibrarySectionSubtitles => 'Legendas';
-
-  @override
-  String get adminLibrarySectionImages => 'Imagens';
-
-  @override
-  String get adminLibrarySectionSeries => 'Séries';
-
-  @override
-  String get adminLibrarySectionMusic => 'Música';
-
-  @override
-  String get adminLibrarySectionMovies => 'Filmes';
-
-  @override
-  String get adminLibRealtimeMonitor => 'Ativar monitorização em tempo real';
-
-  @override
-  String get adminLibRealtimeMonitorHint =>
-      'Detetar alterações nos ficheiros e processá-las automaticamente.';
-
-  @override
-  String get adminLibArchiveMediaFiles =>
-      'Tratar arquivos comprimidos como ficheiros multimédia';
-
-  @override
-  String get adminLibEnablePhotos => 'Mostrar fotografias';
-
-  @override
-  String get adminLibSaveLocalMetadata =>
-      'Guardar imagens nas pastas de conteúdo';
-
-  @override
-  String get adminLibRefreshInterval => 'Atualização automática de metadados';
-
-  @override
-  String get adminLibRefreshNever => 'Nunca';
-
-  @override
-  String get adminLibDefault => 'Predefinição';
-
-  @override
-  String get adminLibDisplayTitle => 'Visualização';
-
-  @override
-  String get adminLibDisplaySection => 'Visualização da biblioteca';
-
-  @override
-  String get adminLibFolderView =>
-      'Mostrar uma vista de pastas para apresentar pastas de conteúdo simples';
-
-  @override
-  String get adminLibSpecialsInSeasons =>
-      'Mostrar especiais dentro das temporadas em que foram exibidos';
-
-  @override
-  String get adminLibGroupMovies => 'Agrupar filmes em coleções';
-
-  @override
-  String get adminLibGroupShows => 'Agrupar séries em coleções';
-
-  @override
-  String get adminLibExternalSuggestions =>
-      'Mostrar conteúdo externo nas sugestões';
-
-  @override
-  String get adminLibDateAddedSection => 'Comportamento da data de adição';
-
-  @override
-  String get adminLibDateAddedLabel => 'Usar data de adição de';
-
-  @override
-  String get adminLibDateAddedImport => 'Data da digitalização na biblioteca';
-
-  @override
-  String get adminLibDateAddedFile => 'Data de criação do ficheiro';
-
-  @override
-  String get adminLibMetadataTitle => 'Metadados e imagens';
-
-  @override
-  String get adminLibMetadataLangSection => 'Idioma preferido dos metadados';
-
-  @override
-  String get adminLibChaptersSection => 'Capítulos';
-
-  @override
-  String get adminLibDummyChapterDuration =>
-      'Duração dos capítulos fictícios (segundos)';
-
-  @override
-  String get adminLibDummyChapterDurationHint =>
-      'Duração dos capítulos gerados para conteúdos que não os têm. Define como 0 para desativar.';
-
-  @override
-  String get adminLibChapterImageResolution =>
-      'Resolução das imagens de capítulo';
-
-  @override
-  String get adminLibNfoTitle => 'Definições NFO';
-
-  @override
-  String get adminLibNfoHelp =>
-      'Os metadados NFO são compatíveis com o Kodi e clientes semelhantes. As definições aplicam-se a todas as bibliotecas que guardam metadados NFO.';
-
-  @override
-  String get adminLibKodiUser =>
-      'Utilizador cujos dados de visualização serão guardados nos ficheiros NFO';
-
-  @override
-  String get adminLibSaveImagePaths =>
-      'Guardar os caminhos das imagens nos ficheiros NFO';
-
-  @override
-  String get adminLibPathSubstitution =>
-      'Ativar substituição de caminhos para os caminhos de imagem NFO';
-
-  @override
-  String get adminLibExtraThumbs =>
-      'Copiar imagens extrafanart para uma pasta extrathumbs';
-
-  @override
-  String get adminLibNone => 'Nenhum';
-
-  @override
-  String adminLibRefreshDays(int days) {
-    return '$days dias';
-  }
-
-  @override
-  String get adminLibEmbeddedTitles => 'Usar títulos incorporados';
-
-  @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Usar títulos incorporados para extras';
-
-  @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Usar informações de episódio incorporadas';
-
-  @override
-  String get adminLibAllowEmbeddedSubtitles => 'Permitir legendas incorporadas';
-
-  @override
-  String get adminLibEmbeddedAllowAll => 'Permitir todas';
-
-  @override
-  String get adminLibEmbeddedAllowText => 'Apenas texto';
-
-  @override
-  String get adminLibEmbeddedAllowImage => 'Apenas imagem';
-
-  @override
-  String get adminLibEmbeddedAllowNone => 'Nenhum';
-
-  @override
-  String get adminLibSkipIfEmbeddedSubs =>
-      'Ignorar transferência se houver legendas incorporadas';
-
-  @override
-  String get adminLibSkipIfAudioMatches =>
-      'Ignorar transferência se a faixa de áudio corresponder ao idioma da transferência';
-
-  @override
-  String get adminLibRequirePerfectMatch =>
-      'Exigir correspondência exata de legendas';
-
-  @override
-  String get adminLibSaveSubtitlesWithMedia =>
-      'Guardar legendas nas pastas de conteúdo';
-
-  @override
-  String get adminLibChapterImageExtraction => 'Extrair imagens de capítulo';
-
-  @override
-  String get adminLibChapterImagesDuringScan =>
-      'Extrair imagens de capítulo durante a digitalização da biblioteca';
-
-  @override
-  String get adminLibTrickplayExtraction =>
-      'Ativar extração de imagens trickplay';
-
-  @override
-  String get adminLibTrickplayDuringScan =>
-      'Extrair imagens trickplay durante a digitalização da biblioteca';
-
-  @override
-  String get adminLibSaveTrickplayWithMedia =>
-      'Guardar imagens trickplay nas pastas de conteúdo';
-
-  @override
-  String get adminLibAutomaticSeriesGrouping =>
-      'Unir automaticamente séries distribuídas por várias pastas';
-
-  @override
-  String get adminLibSeasonZeroName => 'Nome de apresentação da temporada zero';
-
-  @override
-  String get adminLibLufsScan =>
-      'Ativar análise LUFS para normalização de áudio';
-
-  @override
-  String get adminLibPreferNonstandardArtist =>
-      'Preferir a etiqueta de artistas não padrão';
-
-  @override
-  String get adminLibAutoAddToCollection =>
-      'Adicionar filmes automaticamente às coleções';
 
   @override
   String get adminLibraryNameRequired => 'O nome da biblioteca é obrigatório';
@@ -25532,148 +22368,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get adminEnableAllChannels => 'Ativa o acesso a todos os canais';
 
   @override
-  String get adminParentalControl => 'Controlo parental';
-
-  @override
-  String get adminMaxParentalRating => 'Classificação etária máxima permitida';
-
-  @override
-  String get adminMaxParentalRatingHint =>
-      'O conteúdo com classificação superior será ocultado deste utilizador.';
-
-  @override
-  String get adminParentalRatingNone => 'Nenhuma';
-
-  @override
-  String get adminBlockUnratedItems =>
-      'Bloquear itens sem classificação ou com classificação não reconhecida';
-
-  @override
-  String get adminUnratedBook => 'Livros';
-
-  @override
-  String get adminUnratedChannelContent => 'Canais';
-
-  @override
-  String get adminUnratedLiveTvChannel => 'TV ao vivo';
-
-  @override
-  String get adminUnratedMovie => 'Filmes';
-
-  @override
-  String get adminUnratedMusic => 'Música';
-
-  @override
-  String get adminUnratedTrailer => 'Trailers';
-
-  @override
-  String get adminUnratedSeries => 'Séries';
-
-  @override
-  String get adminAccessSchedules => 'Horários de acesso';
-
-  @override
-  String get adminAccessSchedulesHint =>
-      'Permitir o acesso apenas durante os horários agendados abaixo. O acesso é permitido todo o dia quando não está definido nenhum horário.';
-
-  @override
-  String get adminAddSchedule => 'Adicionar horário';
-
-  @override
-  String get adminScheduleDay => 'Dia';
-
-  @override
-  String get adminScheduleStart => 'Início';
-
-  @override
-  String get adminScheduleEnd => 'Fim';
-
-  @override
-  String get adminDayEveryday => 'Todos os dias';
-
-  @override
-  String get adminDayWeekday => 'Dia útil';
-
-  @override
-  String get adminDayWeekend => 'Fim de semana';
-
-  @override
-  String get adminDaySunday => 'Domingo';
-
-  @override
-  String get adminDayMonday => 'Segunda-feira';
-
-  @override
-  String get adminDayTuesday => 'Terça-feira';
-
-  @override
-  String get adminDayWednesday => 'Quarta-feira';
-
-  @override
-  String get adminDayThursday => 'Quinta-feira';
-
-  @override
-  String get adminDayFriday => 'Sexta-feira';
-
-  @override
-  String get adminDaySaturday => 'Sábado';
-
-  @override
-  String get adminAllowedTags => 'Etiquetas permitidas';
-
-  @override
-  String get adminAllowedTagsHint =>
-      'Apenas o conteúdo com estas etiquetas é mostrado. Deixa vazio para permitir tudo.';
-
-  @override
-  String get adminBlockedTags => 'Etiquetas bloqueadas';
-
-  @override
-  String get adminBlockedTagsHint =>
-      'O conteúdo com estas etiquetas fica oculto para este utilizador.';
-
-  @override
-  String get adminAddTag => 'Adicionar etiqueta';
-
-  @override
-  String get adminEnabledDevices => 'Dispositivos ativados';
-
-  @override
-  String get adminEnabledChannels => 'Canais ativados';
-
-  @override
-  String get adminAuthProvider => 'Provedor de autenticação';
-
-  @override
-  String get adminPasswordResetProvider =>
-      'Provedor de reposição da palavra-passe';
-
-  @override
-  String get adminLoginAttemptsBeforeLockout =>
-      'Número máximo de tentativas de início de sessão falhadas antes do bloqueio';
-
-  @override
-  String get adminLoginAttemptsHint =>
-      'Define como 0 para a predefinição ou -1 para desativar o bloqueio.';
-
-  @override
-  String get adminSyncPlayAccess => 'Acesso ao SyncPlay';
-
-  @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Permitir criar e juntar-se a grupos';
-
-  @override
-  String get adminSyncPlayJoin => 'Permitir juntar-se a grupos';
-
-  @override
-  String get adminSyncPlayNone => 'Sem acesso';
-
-  @override
-  String get adminContentDeletionFolders =>
-      'Permitir a eliminação de conteúdo de';
-
-  @override
   String get adminResetPasswordWarning =>
       'Isto removerá a palavra-passe. O utilizador poderá iniciar sessão sem palavra-passe.';
 
@@ -25757,28 +22451,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String adminApiKeyTokenCreated(String token, String created) {
     return 'Token: $token\\nCriado: $created';
   }
-
-  @override
-  String get adminBackupOptionsTitle => 'Criar cópia de segurança';
-
-  @override
-  String get adminBackupInclude =>
-      'Escolhe o que incluir na cópia de segurança.';
-
-  @override
-  String get adminBackupDatabase => 'Base de dados';
-
-  @override
-  String get adminBackupDatabaseAlways => 'Sempre incluída';
-
-  @override
-  String get adminBackupMetadata => 'Metadados';
-
-  @override
-  String get adminBackupSubtitles => 'Legendas';
-
-  @override
-  String get adminBackupTrickplay => 'Imagens trickplay';
 
   @override
   String get adminCreatingBackup => 'A criar cópia de segurança...';
@@ -26492,118 +23164,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get adminAddTuner => 'Adicionar sintonizador';
 
   @override
-  String get adminEditTuner => 'Editar sintonizador';
-
-  @override
-  String get adminTunerTypeM3u => 'Sintonizador M3U';
-
-  @override
-  String get adminTunerTypeHdHomerun => 'HDHomeRun';
-
-  @override
-  String get adminTunerFileOrUrl => 'Ficheiro ou URL';
-
-  @override
-  String get adminTunerIpAddress => 'Endereço IP do sintonizador';
-
-  @override
-  String get adminTunerFriendlyName => 'Nome amigável';
-
-  @override
-  String get adminTunerUserAgent => 'User agent';
-
-  @override
-  String get adminTunerCount => 'Limite de ligações simultâneas';
-
-  @override
-  String get adminTunerCountHelp =>
-      'O número máximo de streams que o sintonizador permite em simultâneo. Define como 0 para ilimitado.';
-
-  @override
-  String get adminTunerFallbackBitrate =>
-      'Taxa de bits máxima de streaming alternativa';
-
-  @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importar apenas os canais favoritos';
-
-  @override
-  String get adminTunerAllowHwTranscoding =>
-      'Permitir transcodificação por hardware';
-
-  @override
-  String get adminTunerAllowFmp4 =>
-      'Permitir contentor de transcodificação fMP4';
-
-  @override
-  String get adminTunerAllowStreamSharing => 'Permitir partilha de stream';
-
-  @override
-  String get adminTunerEnableStreamLooping => 'Ativar repetição do stream';
-
-  @override
-  String get adminTunerIgnoreDts => 'Ignorar DTS';
-
-  @override
-  String get adminTunerReadAtNativeFramerate =>
-      'Ler a entrada na taxa de fotogramas nativa';
-
-  @override
-  String get adminEditProvider => 'Editar fornecedor';
-
-  @override
-  String get adminProviderXmltv => 'XMLTV';
-
-  @override
-  String get adminProviderSchedulesDirect => 'Schedules Direct';
-
-  @override
-  String get adminXmltvPath => 'Ficheiro ou URL';
-
-  @override
-  String get adminXmltvMoviePrefix => 'Prefixo de filme';
-
-  @override
-  String get adminXmltvMovieCategories => 'Categorias de filmes';
-
-  @override
-  String get adminXmltvCategoriesHelp =>
-      'Separa várias categorias com uma barra vertical.';
-
-  @override
-  String get adminXmltvKidsCategories => 'Categorias infantis';
-
-  @override
-  String get adminXmltvNewsCategories => 'Categorias de notícias';
-
-  @override
-  String get adminXmltvSportsCategories => 'Categorias de desporto';
-
-  @override
-  String get adminSdUsername => 'Nome de utilizador';
-
-  @override
-  String get adminSdPassword => 'Palavra-passe';
-
-  @override
-  String get adminSdCountry => 'País';
-
-  @override
-  String get adminSdCountrySelect => 'Seleciona um país';
-
-  @override
-  String get adminSdPostalCode => 'Código postal';
-
-  @override
-  String get adminSdGetListings => 'Obter listagens';
-
-  @override
-  String get adminSdListings => 'Listagens';
-
-  @override
-  String get adminEnableAllTuners => 'Ativar todos os sintonizadores';
-
-  @override
   String get adminTunerType => 'Tipo de sintonizador';
 
   @override
@@ -26643,10 +23203,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String get adminTunerResetNotSupported =>
-      'Este tipo de sintonizador não suporta a reposição.';
-
-  @override
   String adminProviderRemoveFailed(String error) {
     return 'Falha ao remover provedor: $error';
   }
@@ -26665,47 +23221,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminSeriesRecordingPath => 'Caminho de gravação da série';
-
-  @override
-  String get adminMovieRecordingPath => 'Caminho de gravação de filmes';
-
-  @override
-  String get adminGuideDays => 'Dias de dados do guia';
-
-  @override
-  String get adminGuideDaysAuto => 'Automático';
-
-  @override
-  String adminGuideDaysValue(int days) {
-    return '$days dias';
-  }
-
-  @override
-  String get adminRecordingPostProcessor =>
-      'Caminho da aplicação de pós-processamento';
-
-  @override
-  String get adminRecordingPostProcessorArgs => 'Argumentos do pós-processador';
-
-  @override
-  String get adminSaveRecordingNfo => 'Guardar metadados NFO das gravações';
-
-  @override
-  String get adminSaveRecordingImages => 'Guardar imagens das gravações';
-
-  @override
-  String get adminLiveTvSectionTiming => 'Temporização';
-
-  @override
-  String get adminLiveTvSectionPaths => 'Caminhos de gravação';
-
-  @override
-  String get adminLiveTvSectionPostProcessing => 'Pós-processamento';
-
-  @override
-  String adminGuideDaysDisplay(String value) {
-    return 'Dados do guia: $value';
-  }
 
   @override
   String get adminRecordingSettingsSaved => 'Definições de gravação guardadas';
@@ -26744,17 +23259,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminGuideProviders => 'Provedores de guias';
-
-  @override
-  String get adminRefreshGuideData => 'Atualizar dados do guia';
-
-  @override
-  String get adminGuideRefreshStarted =>
-      'Atualização dos dados do guia iniciada';
-
-  @override
-  String get adminGuideRefreshUnavailable =>
-      'A tarefa de atualização do guia não está disponível neste servidor.';
 
   @override
   String get adminAddProvider => 'Adicionar provedor';
@@ -26843,7 +23347,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get adminNotSet => 'Não definido';
 
   @override
-  String get adminReset => 'Repor';
+  String get adminReset => 'Reiniciar';
 
   @override
   String get adminLogsTitle => 'Registos do servidor';
@@ -26887,9 +23391,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminMetadataEditorTitle => 'Editor de metadados';
-
-  @override
-  String get adminMetadataIdentify => 'Identificar';
 
   @override
   String get adminMetadataType => 'Tipo';
@@ -27305,22 +23806,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get adminBrandingEnableSplash => 'Ativar ecrã inicial';
 
   @override
-  String get adminBrandingSplashUpload => 'Enviar imagem';
-
-  @override
-  String get adminBrandingSplashUploaded => 'Ecrã de arranque atualizado';
-
-  @override
-  String get adminBrandingSplashUploadFailed =>
-      'Falha ao enviar o ecrã de arranque';
-
-  @override
-  String get adminBrandingSplashDeleted => 'Ecrã de arranque removido';
-
-  @override
-  String get adminBrandingNoSplash => 'Sem ecrã de arranque personalizado';
-
-  @override
   String get adminPlaybackHwAccel => 'Aceleração de Hardware';
 
   @override
@@ -27332,131 +23817,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get adminPlaybackEnableHwDecoding =>
       'Ativa a descodificação de hardware para:';
-
-  @override
-  String get adminPlaybackQsvDevice => 'Dispositivo QSV';
-
-  @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Ativar descodificador NVDEC melhorado';
-
-  @override
-  String get adminPlaybackPreferNativeDecoder =>
-      'Preferir o descodificador de hardware nativo do sistema';
-
-  @override
-  String get adminPlaybackColorDepth =>
-      'Profundidade de cor da descodificação por hardware';
-
-  @override
-  String get adminPlaybackColorDepth10Hevc => 'Descodificação HEVC de 10 bits';
-
-  @override
-  String get adminPlaybackColorDepth10Vp9 => 'Descodificação VP9 de 10 bits';
-
-  @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Descodificação HEVC RExt de 8/10 bits';
-
-  @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Descodificação HEVC RExt de 12 bits';
-
-  @override
-  String get adminPlaybackHwEncodingSection => 'Codificação por hardware';
-
-  @override
-  String get adminPlaybackAllowHevcEncoding => 'Permitir codificação HEVC';
-
-  @override
-  String get adminPlaybackAllowAv1Encoding => 'Permitir codificação AV1';
-
-  @override
-  String get adminPlaybackIntelLowPowerH264 =>
-      'Ativar codificador H.264 de baixo consumo da Intel';
-
-  @override
-  String get adminPlaybackIntelLowPowerHevc =>
-      'Ativar codificador HEVC de baixo consumo da Intel';
-
-  @override
-  String get adminPlaybackToneMapping => 'Mapeamento de tons';
-
-  @override
-  String get adminPlaybackEnableTonemapping => 'Ativar mapeamento de tons';
-
-  @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Ativar mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackEnableVtTonemapping =>
-      'Ativar mapeamento de tons do VideoToolbox';
-
-  @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoritmo de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingMode => 'Modo de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingRange => 'Intervalo de mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingDesat =>
-      'Dessaturação do mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingPeak => 'Pico do mapeamento de tons';
-
-  @override
-  String get adminPlaybackTonemappingParam => 'Parâmetro do mapeamento de tons';
-
-  @override
-  String get adminPlaybackVppTonemappingBrightness =>
-      'Brilho do mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contraste do mapeamento de tons VPP';
-
-  @override
-  String get adminPlaybackPresetsQuality => 'Predefinições e qualidade';
-
-  @override
-  String get adminPlaybackEncoderPreset => 'Predefinição do codificador';
-
-  @override
-  String get adminPlaybackH264Crf => 'CRF de codificação H.264';
-
-  @override
-  String get adminPlaybackH265Crf => 'CRF de codificação H.265 (HEVC)';
-
-  @override
-  String get adminPlaybackDeinterlaceMethod => 'Método de desentrelaçamento';
-
-  @override
-  String get adminPlaybackDeinterlaceDoubleRate =>
-      'Duplicar a taxa de fotogramas ao desentrelaçar';
-
-  @override
-  String get adminPlaybackAudioSection => 'Áudio';
-
-  @override
-  String get adminPlaybackEnableAudioVbr => 'Ativar codificação de áudio VBR';
-
-  @override
-  String get adminPlaybackDownmixBoost => 'Reforço do downmix de áudio';
-
-  @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmo de downmix estéreo';
-
-  @override
-  String get adminPlaybackMaxMuxingQueue => 'Tamanho máximo da fila de muxing';
-
-  @override
-  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Codificação';
@@ -27578,9 +23938,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminTaskStop => 'Parar';
-
-  @override
-  String get adminRunningTasks => 'Tarefas em execução';
 
   @override
   String get adminTaskRun => 'Executar';
@@ -27712,7 +24069,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -27730,46 +24087,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
-
-  @override
-  String get adminNetworkingPublicHttpPort => 'Porta HTTP pública';
-
-  @override
-  String get adminNetworkingRequireHttps => 'Exigir HTTPS';
-
-  @override
-  String get adminNetworkingRequireHttpsHint =>
-      'Redirecionar todos os pedidos remotos para HTTPS. Não tem efeito se o servidor não tiver um certificado válido.';
-
-  @override
-  String get adminNetworkingCertPassword => 'Palavra-passe do certificado';
-
-  @override
-  String get adminNetworkingIpSettings => 'Definições de IP';
-
-  @override
-  String get adminNetworkingEnableIpv4 => 'Ativar IPv4';
-
-  @override
-  String get adminNetworkingEnableIpv6 => 'Ativar IPv6';
-
-  @override
-  String get adminNetworkingAutoDiscovery =>
-      'Ativar mapeamento automático de portas';
-
-  @override
-  String get adminNetworkingLocalSubnets => 'Redes LAN';
-
-  @override
-  String get adminNetworkingLocalSubnetsHint =>
-      'Lista de endereços IP ou sub-redes CIDR, separados por vírgula ou por linha, tratados como pertencentes à rede local.';
-
-  @override
-  String get adminNetworkingPublishedUris => 'URIs publicados do servidor';
-
-  @override
-  String get adminNetworkingPublishedUriHint =>
-      'Mapeia uma sub-rede ou endereço para um URL publicado, por exemplo, all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Caminho do certificado';
@@ -27798,13 +24115,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminPlaybackThrottleBuffering => 'Buffer de aceleração';
-
-  @override
-  String get adminPlaybackThrottleDelay => 'Atraso de limitação (segundos)';
-
-  @override
-  String get adminPlaybackEnableSubtitleExtraction =>
-      'Permitir extração de legendas em tempo real';
 
   @override
   String get adminResumeMinPct => 'Percentagem mínima para resumo';
@@ -27862,25 +24172,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Limite de resposta lenta (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Ativar avisos de resposta lenta';
-
-  @override
-  String get adminGeneralQuickConnect => 'Ativar o Quick Connect';
-
-  @override
-  String get adminGeneralSectionServer => 'Servidor';
-
-  @override
-  String get adminGeneralSectionMetadata => 'Metadados';
-
-  @override
-  String get adminGeneralSectionPaths => 'Caminhos';
-
-  @override
-  String get adminGeneralSectionPerformance => 'Desempenho';
-
-  @override
   String get adminGeneralCachePath => 'Caminho do cache';
 
   @override
@@ -27888,9 +24179,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get adminGeneralServerName => 'Nome do servidor';
-
-  @override
-  String get adminGeneralDisplayLanguage => 'Idioma de apresentação preferido';
 
   @override
   String get adminSettingsLoadFailed => 'Falha ao carregar as definições';
@@ -28133,23 +24421,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get offlineSavedMedia => 'Conteúdo guardado';
 
   @override
-  String get offlineBannerTitle => 'Estás offline';
-
-  @override
-  String get offlineBannerSubtitle => 'A mostrar as tuas transferências';
-
-  @override
-  String get offlineBannerAction => 'Transferências';
-
-  @override
-  String get serverUnreachableBannerTitle =>
-      'Não foi possível contactar o teu servidor';
-
-  @override
-  String get serverUnreachableBannerSubtitle =>
-      'A reproduzir das transferências até voltar';
-
-  @override
   String get castGoogleCast => 'Google Cast';
 
   @override
@@ -28228,7 +24499,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get quickConnectAuthorized =>
-      'Solicitação de Quick Connect autorizada.';
+      'Solicitação de ligação rápida autorizada.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -28256,7 +24527,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Falha no Quick Connect: $message';
+    return 'Falha na ligação rápida: $message';
   }
 
   @override
@@ -28382,7 +24653,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get posterImageType => 'Tipo de imagem';
 
   @override
-  String get imageTypePoster => 'Póster';
+  String get imageTypePoster => 'Poster';
 
   @override
   String get imageTypeThumbnail => 'Miniatura';
@@ -28509,16 +24780,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get contextMenuGoToSeries => 'Ir para a série';
 
   @override
-  String get contextMenuHideFromContinueWatching =>
-      'Ocultar de Continuar a ver';
-
-  @override
-  String get contextMenuHideFromNextUp => 'Ocultar de Próximo';
-
-  @override
-  String get contextMenuAddToCollection => 'Adicionar à coleção';
-
-  @override
   String get settingsAdministrationSubtitle =>
       'Aceder ao painel de administração do servidor';
 
@@ -28571,17 +24832,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get settingsAlphabetical => 'Alfabético';
 
   @override
-  String get settingsConnectionSection => 'LIGAÇÃO';
-
-  @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permitir certificados autoassinados';
-
-  @override
-  String get settingsAllowSelfSignedCertsSubtitle =>
-      'Confiar em servidores que usam certificados TLS autoassinados ou de CA privada. Ativa apenas para servidores que controlas. Isto desativa a validação de certificados em todas as ligações.';
-
-  @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIDADE E SEGURANÇA';
 
   @override
@@ -28593,13 +24843,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get settingsGeneralStyleSubtitle =>
       'Acentos temáticos, cenários, indicadores vistos e música temática';
-
-  @override
-  String get settingsDetailsScreen => 'Ecrã de detalhes';
-
-  @override
-  String get settingsDetailsScreenSubtitle =>
-      'Estilo, desfoque de fundo e comportamento dos separadores';
 
   @override
   String get settingsHomePage => 'Página inicial';
@@ -28638,10 +24881,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get settingsShowSeerrButtonInNavigation =>
       'Mostrar o botão Seerr na barra de navegação';
-
-  @override
-  String get settingsAlwaysExpandNavbarLabels =>
-      'Mostrar sempre os rótulos de texto na barra de navegação superior';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -29034,11 +25273,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String recentlyReleasedLibraryName(String libraryName) {
-    return 'Lançamentos recentes: $libraryName';
-  }
-
-  @override
   String get autoplayNextEpisode =>
       'Reproduzir automaticamente o próximo episódio';
 
@@ -29099,16 +25333,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Aplica dicas de tamanho de fonte incorporadas na faixa de legenda. Desativa o uso do tamanho da legenda nas tuas preferências de estilo.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Mostrar detalhes do conteúdo';
-
-  @override
-  String get showMediaDetailsOnLibraryPageDescription =>
-      'Mostrar os detalhes do item selecionado no topo das páginas da Biblioteca.';
-
-  @override
-  String get hideBackdropsInLibraries => 'Ocultar panos de fundo ao navegar?';
-
-  @override
   String get useDetailedSubHeadings => 'Usa subtítulos detalhados';
 
   @override
@@ -29121,40 +25345,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
     return 'Remover \"$themeName\" do cache deste dispositivo?';
-  }
-
-  @override
-  String get themeStore => 'Loja de temas';
-
-  @override
-  String get themeStoreSubtitle => 'Explora e guarda temas da comunidade';
-
-  @override
-  String get themeStoreDescription =>
-      'Guarda um tema para o usares como os teus outros temas guardados.';
-
-  @override
-  String get themeStoreEmpty => 'Não há temas disponíveis neste momento.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Não foi possível carregar a Loja de temas. Verifica a tua ligação e tenta novamente.';
-
-  @override
-  String get themeStoreSave => 'Guardar';
-
-  @override
-  String get themeStoreSaveAndApply => 'Guardar e aplicar';
-
-  @override
-  String get themeStoreSaved => 'Guardado';
-
-  @override
-  String get themeStoreInvalidMessage => 'Não foi possível carregar este tema.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" guardado.';
   }
 
   @override
@@ -29301,52 +25491,13 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Classificar linhas de listas de reprodução por data de adição, data de lançamento, ordem alfabética e muito mais.';
 
   @override
-  String get displayAudioRows => 'Mostrar linhas de áudio';
-
-  @override
-  String get displayAudioRowsSubtitle =>
-      'Mostrar linhas de áudio nas Secções iniciais.';
-
-  @override
-  String get audioRowsSorting => 'Ordenação das linhas de áudio';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Ordena as linhas de áudio por data de adição, data de lançamento, ordem alfabética e mais.';
-
-  @override
-  String get audioPlaylists => 'Listas de reprodução de áudio';
-
-  @override
-  String get appearance => 'Aspeto';
-
-  @override
-  String get layout => 'Disposição';
-
-  @override
-  String get theme => 'Tema';
-
-  @override
-  String get keyboard => 'Teclado';
-
-  @override
-  String get navButtons => 'Botões';
-
-  @override
-  String get rendering => 'Renderização';
-
-  @override
-  String get mpvConfiguration => 'Configuração do MPV';
+  String get appearance => 'Aparência';
 
   @override
   String get cardSize => 'Tamanho do cartão';
 
   @override
   String get externalPlayerApp => 'Reprodutor externo';
-
-  @override
-  String get externalPlayerAppDescription =>
-      'Define um reprodutor externo para ativar a opção de reprodução ao premir sem soltar';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -29615,9 +25766,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get appearancesSeerr => 'Aparições (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Contribuições da equipa (Seerr)';
-
-  @override
   String get watchWithGroup => 'Ver com o grupo';
 
   @override
@@ -29879,540 +26027,5 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get whenFullscreen => 'Quando em ecrã inteiro';
 
   @override
-  String get changeArtwork => 'Alterar imagens';
-
-  @override
-  String get missing => 'Em falta';
-
-  @override
   String get transcodingLimits => 'Limites de transcodificação';
-
-  @override
-  String get clearAllArtworkButton => 'Limpar todas as imagens?';
-
-  @override
-  String get clearAllArtworkWarning =>
-      'Tens a certeza de que queres limpar todas as imagens transferidas?';
-
-  @override
-  String get confirmClear => 'Confirmar limpeza';
-
-  @override
-  String confirmClearMessage(String itemType) {
-    return 'Tens a certeza de que queres limpar $itemType?';
-  }
-
-  @override
-  String get uploadButton => 'Enviar?';
-
-  @override
-  String get resolutionLabel => 'Resolução: ';
-
-  @override
-  String get onlyShowInterfaceLanguage =>
-      'Mostrar apenas imagens no idioma da interface';
-
-  @override
-  String get confirmClearAll => 'Confirmar limpar tudo';
-
-  @override
-  String get imageUploadSuccess => 'Imagem enviada com sucesso!';
-
-  @override
-  String imageUploadFailed(String error) {
-    return 'Falha ao enviar a imagem: $error';
-  }
-
-  @override
-  String imageDownloadFailed(String error) {
-    return 'Falha ao definir a imagem: $error';
-  }
-
-  @override
-  String imageDeleteFailed(String error) {
-    return 'Falha ao eliminar a imagem: $error';
-  }
-
-  @override
-  String clearAllArtworkFailed(String error) {
-    return 'Falha ao limpar todas as imagens: $error';
-  }
-
-  @override
-  String get yes => 'Sim';
-
-  @override
-  String get posterCategory => 'Póster';
-
-  @override
-  String get backdropsCategory => 'Panos de fundo';
-
-  @override
-  String get bannerCategory => 'Banner';
-
-  @override
-  String get logoCategory => 'Logótipo';
-
-  @override
-  String get thumbnailCategory => 'Miniatura';
-
-  @override
-  String get artCategory => 'Arte';
-
-  @override
-  String get discArtCategory => 'Arte do disco';
-
-  @override
-  String get screenshotCategory => 'Captura de ecrã';
-
-  @override
-  String get boxCoverCategory => 'Capa da caixa';
-
-  @override
-  String get boxRearCoverCategory => 'Contracapa da caixa';
-
-  @override
-  String get menuArtCategory => 'Arte do menu';
-
-  @override
-  String get confirmItemPoster => 'o póster';
-
-  @override
-  String get confirmItemBackdrop => 'o pano de fundo';
-
-  @override
-  String get confirmItemBanner => 'o banner';
-
-  @override
-  String get confirmItemLogo => 'o logótipo';
-
-  @override
-  String get confirmItemThumbnail => 'a miniatura';
-
-  @override
-  String get confirmItemArt => 'a arte';
-
-  @override
-  String get confirmItemDiscArt => 'a arte do disco';
-
-  @override
-  String get confirmItemScreenshot => 'a captura de ecrã';
-
-  @override
-  String get confirmItemBoxCover => 'a capa da caixa';
-
-  @override
-  String get confirmItemBoxRearCover => 'a contracapa da caixa';
-
-  @override
-  String get confirmItemMenuArt => 'a arte do menu';
-
-  @override
-  String get resolutionAll => 'Todas';
-
-  @override
-  String get resolutionHigh => 'Alta (1080p+)';
-
-  @override
-  String get resolutionMedium => 'Média (720p)';
-
-  @override
-  String get resolutionLow => 'Baixa (<720p)';
-
-  @override
-  String get sources => 'Fontes';
-
-  @override
-  String get audiobookChapters => 'Capítulos';
-
-  @override
-  String get audiobookBookmarks => 'Marcadores';
-
-  @override
-  String get audiobookNotes => 'Notas';
-
-  @override
-  String get audiobookQueue => 'Fila';
-
-  @override
-  String get audiobookTimeline => 'Linha temporal';
-
-  @override
-  String get audiobookTimelineEmpty => 'A linha temporal está vazia';
-
-  @override
-  String get audiobookWholeBook => 'Livro completo';
-
-  @override
-  String get audiobookFocusedTimeline => 'Linha temporal focada';
-
-  @override
-  String get audiobookExportBookmarks => 'Exportar marcadores';
-
-  @override
-  String get audiobookExportNotes => 'Exportar notas';
-
-  @override
-  String get audiobookExportAll => 'Exportar tudo';
-
-  @override
-  String audiobookExportSuccess(String path) {
-    return 'Exportado para $path';
-  }
-
-  @override
-  String audiobookExportFailed(String error) {
-    return 'Falha na exportação: $error';
-  }
-
-  @override
-  String get audiobookLyrics => 'Letras';
-
-  @override
-  String get audiobookAddBookmark => 'Adicionar marcador';
-
-  @override
-  String get audiobookAddNote => 'Adicionar nota';
-
-  @override
-  String get audiobookEditNote => 'Editar nota';
-
-  @override
-  String get audiobookNoteHint => 'Escreve uma nota para este momento';
-
-  @override
-  String get audiobookSleepTimer => 'Temporizador para dormir';
-
-  @override
-  String get audiobookSleepOff => 'Desligado';
-
-  @override
-  String get audiobookSleepEndOfChapter => 'Fim do capítulo';
-
-  @override
-  String get audiobookSleepCustom => 'Personalizado';
-
-  @override
-  String audiobookSleepRemaining(String remaining) {
-    return '$remaining restantes';
-  }
-
-  @override
-  String audiobookSleepMinutes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count min',
-      one: '1 min',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get audiobookPlaybackSpeed => 'Velocidade de reprodução';
-
-  @override
-  String get audiobookRemainingTime => 'Restante';
-
-  @override
-  String get audiobookElapsedTime => 'Decorrido';
-
-  @override
-  String audiobookSkipBackSeconds(int seconds) {
-    return 'Recuar ${seconds}s';
-  }
-
-  @override
-  String audiobookSkipForwardSeconds(int seconds) {
-    return 'Avançar ${seconds}s';
-  }
-
-  @override
-  String get audiobookPreviousChapter => 'Capítulo anterior';
-
-  @override
-  String get audiobookNextChapter => 'Capítulo seguinte';
-
-  @override
-  String audiobookChapterIndicator(int current, int total) {
-    return 'Capítulo $current de $total';
-  }
-
-  @override
-  String get audiobookNoChapters => 'Sem capítulos';
-
-  @override
-  String get audiobookNoBookmarks => 'Ainda sem marcadores';
-
-  @override
-  String get audiobookNoNotes => 'Ainda sem notas';
-
-  @override
-  String audiobookBookmarkAdded(String position) {
-    return 'Marcador adicionado em $position';
-  }
-
-  @override
-  String get audiobookSpeedReset => 'Repor para 1.0x';
-
-  @override
-  String audiobookSpeedCustomLabel(String value) {
-    return '${value}x';
-  }
-
-  @override
-  String get audiobookSave => 'Guardar';
-
-  @override
-  String get audiobookCancel => 'Cancelar';
-
-  @override
-  String get audiobookDelete => 'Eliminar';
-
-  @override
-  String get subtitlePreferences => 'Preferências de legendas';
-
-  @override
-  String get subtitlePreferencesDescription =>
-      'Altera os modos de legendas, os idiomas predefinidos, o aspeto e as opções de renderização.';
-
-  @override
-  String get subtitleRendering => 'Renderização de legendas';
-
-  @override
-  String get displayOptions => 'Opções de visualização';
-
-  @override
-  String get releaseDateAscending => 'Data de lançamento (crescente)';
-
-  @override
-  String get releaseDateDescending => 'Data de lançamento (decrescente)';
-
-  @override
-  String get groupContributions => 'Agrupar contribuições';
-
-  @override
-  String get groupMultipleRoles => 'Agrupar vários papéis';
-
-  @override
-  String get libraryWriteAccessWarningTitle =>
-      'Aviso de acesso de escrita à biblioteca';
-
-  @override
-  String get libraryWriteAccessHowToFix => 'Como corrigir:';
-
-  @override
-  String get libraryWriteAccessFixSteps =>
-      '1. Concede permissões de escrita ao utilizador do serviço Jellyfin (por exemplo, jellyfin ou PUID/PGID do Docker) para as pastas da tua biblioteca de conteúdo no servidor.\n\n2. Ou vai ao Painel do Jellyfin -> Bibliotecas, edita esta biblioteca e desativa \'Guardar imagens nas pastas de conteúdo\' para armazenar as imagens na base de dados interna do Jellyfin.';
-
-  @override
-  String get dismiss => 'Dispensar';
-
-  @override
-  String libraryWriteAccessProactiveBody(
-    String libraryName,
-    String failedPath,
-  ) {
-    return 'A tua biblioteca \'$libraryName\' está configurada para guardar as imagens diretamente nas pastas de conteúdo (a opção \'Guardar imagens nas pastas de conteúdo\' está ativada). No entanto, o Jellyfin testou o acesso de escrita e não tem permissão para escrever ficheiros neste diretório:\n\n$failedPath';
-  }
-
-  @override
-  String get libraryWriteAccessReactiveBody =>
-      'Parece que o Jellyfin não conseguiu atualizar as imagens. A tua biblioteca está configurada para guardar as imagens diretamente nas pastas de conteúdo (a opção \'Guardar imagens nas pastas de conteúdo\' está ativada). Este erro ocorre normalmente quando o processo do servidor Jellyfin não tem permissão para escrever ficheiros nos teus diretórios de conteúdo.';
-
-  @override
-  String get externalLists => 'Listas externas';
-
-  @override
-  String get replay => 'Reproduzir novamente';
-
-  @override
-  String get fileInformation => 'Informações do ficheiro';
-
-  @override
-  String fileSizeFormat(Object size, Object format) {
-    return 'Tamanho: $size  •  Formato: $format';
-  }
-
-  @override
-  String showAllAudioTracks(int count) {
-    return 'Mostrar todas as ($count) faixas de áudio';
-  }
-
-  @override
-  String showAllSubtitleTracks(int count) {
-    return 'Mostrar todas as ($count) faixas de legendas';
-  }
-
-  @override
-  String get checkingDirectPlay =>
-      'A verificar a capacidade de Reprodução direta...';
-
-  @override
-  String get directPlayCapabilityLabel => 'Capacidade de Reprodução direta: ';
-
-  @override
-  String get forced => 'Forçada';
-
-  @override
-  String get transcodeContainerNotSupported =>
-      'O formato do contentor não é suportado pelo reprodutor.';
-
-  @override
-  String get transcodeVideoCodecNotSupported =>
-      'O codec de vídeo não é suportado.';
-
-  @override
-  String get transcodeAudioCodecNotSupported =>
-      'O codec de áudio não é suportado.';
-
-  @override
-  String get transcodeSubtitleCodecNotSupported =>
-      'O formato de legendas não é suportado (requer incorporação).';
-
-  @override
-  String get transcodeAudioProfileNotSupported =>
-      'O perfil de áudio não é suportado.';
-
-  @override
-  String get transcodeVideoProfileNotSupported =>
-      'O perfil de vídeo não é suportado.';
-
-  @override
-  String get transcodeVideoLevelNotSupported =>
-      'O nível de vídeo não é suportado.';
-
-  @override
-  String get transcodeVideoResolutionNotSupported =>
-      'A resolução do vídeo não é suportada por este dispositivo.';
-
-  @override
-  String get transcodeVideoBitDepthNotSupported =>
-      'A profundidade de bits do vídeo não é suportada.';
-
-  @override
-  String get transcodeVideoFramerateNotSupported =>
-      'A taxa de fotogramas do vídeo não é suportada.';
-
-  @override
-  String get transcodeContainerBitrateExceedsLimit =>
-      'A taxa de bits do ficheiro excede o limite de streaming do reprodutor.';
-
-  @override
-  String get transcodeVideoBitrateExceedsLimit =>
-      'A taxa de bits do vídeo excede o limite de streaming.';
-
-  @override
-  String get transcodeAudioBitrateExceedsLimit =>
-      'A taxa de bits do áudio excede o limite de streaming.';
-
-  @override
-  String get transcodeAudioChannelsNotSupported =>
-      'O número de canais de áudio não é suportado.';
-
-  @override
-  String get sortAlphabetical => 'Alfabética';
-
-  @override
-  String get sortReleaseAscending => 'Ordem de lançamento (crescente)';
-
-  @override
-  String get sortReleaseDescending => 'Ordem de lançamento (decrescente)';
-
-  @override
-  String get sortCustomDragDrop => 'Personalizada (arrastar e largar)';
-
-  @override
-  String get playlistSortOptions =>
-      'Opções de ordenação da lista de reprodução';
-
-  @override
-  String get resetSort => 'Repor ordenação';
-
-  @override
-  String rewatchSeasonEpisode(int season, int episode) {
-    return 'Rever T$season:E$episode';
-  }
-
-  @override
-  String get rewatchPlaylist => 'Rever lista de reprodução';
-
-  @override
-  String get noSubtitlesFound => 'Nenhuma legenda encontrada.';
-
-  @override
-  String get adminControls => 'Controlos de administrador';
-
-  @override
-  String get impellerRendering => 'Motor de renderização (Impeller)';
-
-  @override
-  String get impellerRenderingSubtitle =>
-      'O Impeller é o renderizador de GPU moderno do Flutter, para animações mais suaves e menos engasgos. Em algumas TV boxes e GPUs antigas, pode causar falhas gráficas ou vídeo preto; desliga-o se notares isso. Automático escolhe a melhor predefinição para o teu dispositivo. Reinicia o Moonfin para aplicar.';
-
-  @override
-  String get impellerAuto => 'Automático';
-
-  @override
-  String get impellerOn => 'Ligado';
-
-  @override
-  String get impellerOff => 'Desligado';
-
-  @override
-  String get impellerRestartTitle => 'Reinício necessário';
-
-  @override
-  String get impellerRestartMessage =>
-      'O Moonfin precisa de reiniciar para alterar o motor de renderização. Fecha a aplicação agora e volta a abri-la para aplicar.';
-
-  @override
-  String get impellerCloseNow => 'Fechar a aplicação agora';
-
-  @override
-  String get adminRefreshLibrary => 'Atualizar biblioteca';
-
-  @override
-  String get adminRefreshAllLibraries => 'Atualizar todas as bibliotecas';
-
-  @override
-  String get adminRepoSortDateOldest =>
-      'Data de adição (mais antigas primeiro)';
-
-  @override
-  String get adminRepoSortDateNewest =>
-      'Data de adição (mais recentes primeiro)';
-
-  @override
-  String get adminRepoSortNameAsc => 'Alfabética (A a Z)';
-
-  @override
-  String get adminRepoSortNameDesc => 'Alfabética (Z a A)';
-
-  @override
-  String adminAnalyticsLoadingProgress(int percentage) {
-    return 'A carregar a análise do servidor... $percentage%';
-  }
-
-  @override
-  String get adminLibChapterImageResolutionMatchSource => 'Igual à origem';
-
-  @override
-  String get imdbTop250Movies => 'IMDb Top 250 Filmes';
-
-  @override
-  String get imdbTop250TvShows => 'IMDb Top 250 Séries';
-
-  @override
-  String get imdbMostPopularMovies => 'Filmes mais populares do IMDb';
-
-  @override
-  String get imdbMostPopularTvShows => 'Séries mais populares do IMDb';
-
-  @override
-  String get imdbLowestRatedMovies => 'Filmes com pior avaliação do IMDb';
-
-  @override
-  String get imdbTopEnglishMovies =>
-      'Filmes em inglês mais bem avaliados do IMDb';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -12,19 +12,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERINȚE CONT';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Limba interfeței';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Implicit din sistem';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Conectare';
 
   @override
-  String get empty => 'Gol';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Conectare rapidă';
 
   @override
   String get password => 'Parolă';
@@ -51,7 +51,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get waitingForAuthorization => 'Se așteaptă autorizația...';
 
   @override
-  String get back => 'Înapoi';
+  String get back => 'Spate';
 
   @override
   String get serverUnavailable => 'Serverul este indisponibil';
@@ -113,7 +113,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cancel => 'Anula';
 
   @override
-  String get remove => 'Elimină';
+  String get remove => 'Elimina';
 
   @override
   String get connectToServer => 'Conectați-vă la server';
@@ -141,62 +141,62 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema aplicației';
 
   @override
-  String get detailScreenStyle => 'Stilul ecranului de detalii';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Clasic este aspectul centrat original Moonfin. Modern este un aspect cinematografic adaptiv.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Clasic';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'File extinse';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Afișează automat conținutul filelor în timp ce navigați printre ele. Dezactivați pentru a deschide și închide fiecare filă manual.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Afișați detaliile tehnice?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Afișează informații despre codec, rezoluție și flux în rezumatul din banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistem de recomandări';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Folosiți algoritmul local Moonfin Recommends sau metricile de similaritate TMDb online. Notă: recomandările online necesită integrarea Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Similaritate TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Aplicați limita de clasificare parentală?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limitează sugestiile Moonfin Recommends în funcție de clasificarea parentală a conținutului vizat';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Stilul interfeței';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automat se potrivește cu dispozitivul dvs. Alegeți Apple sau Material pentru a impune un anumit aspect.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automat';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsRo extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Calitatea efectului de sticlă';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto alege cel mai bun efect de sticlă pentru acest dispozitiv. Complet impune estomparea reală, iar Redus folosește un efect de sticlă ușor, care economisește resursele GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Complet';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Redus';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Comutați între Moonfin și Neon Pulse fără a reporni aplicația';
 
   @override
-  String get customThemeTitle => 'Temă personalizată';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Temele personalizate modifică elementele vizuale din întreaga aplicație Moonfin. Alegeți una dintre aceste opțiuni, potrivită stilului dvs.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Prefer tastatura de sistem';
@@ -257,14 +257,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Stil liquid-glass, cu un fundal în degrade care se deplasează lent, suprafețe mate și accent albastru Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Stil retro pixel-art, cu o paletă masivă, borduri în blocuri, umbre puternice și un font pixelat';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Conectați-vă cu contul Emby Connect';
@@ -327,35 +327,35 @@ class AppLocalizationsRo extends AppLocalizations {
   String get exit => 'Ieșire';
 
   @override
-  String get gameMenu => 'Meniu';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'În pauză';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Salvează starea';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Jocuri';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Încarcă starea';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Derulare rapidă';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Setări emulator';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Acest nucleu nu are opțiuni reglabile.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Țineți apăsat pentru meniu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Rularea jocurilor nu este încă acceptată pe acest dispozitiv.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nu au putut fi încărcate rânduri de acasă';
@@ -377,7 +377,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get schedule => 'Programa';
 
   @override
-  String get series => 'Seriale';
+  String get series => 'Serie';
 
   @override
   String get noItemsFound => 'Nu s-au găsit articole';
@@ -489,7 +489,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get large => 'Mare';
 
   @override
-  String get extraLarge => 'Foarte mare';
+  String get extraLarge => 'Extra Large';
 
   @override
   String libraryGenresTitle(String name) {
@@ -553,7 +553,7 @@ class AppLocalizationsRo extends AppLocalizations {
       'Alegeți ce fluxuri de subiecte să afișați în Discover.';
 
   @override
-  String get apply => 'Aplică';
+  String get apply => 'Aplicați';
 
   @override
   String get openLink => 'Deschide Link';
@@ -602,7 +602,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get listen => 'Asculta';
 
   @override
-  String get resume => 'Reia';
+  String get resume => 'Relua';
 
   @override
   String get failedToLoadLibrary => 'Nu s-a putut încărca biblioteca';
@@ -747,13 +747,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get readStatus => 'Citire';
 
   @override
-  String get watched => 'Vizionate';
+  String get watched => 'Privit';
 
   @override
   String get unread => 'Necitit';
 
   @override
-  String get unwatched => 'Nevizionate';
+  String get unwatched => 'Nevizionat';
 
   @override
   String get seriesStatus => 'Stare serie';
@@ -765,44 +765,43 @@ class AppLocalizationsRo extends AppLocalizations {
   String get books => 'Cărți';
 
   @override
-  String get latestBooks => 'Cele mai recente cărți';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Cele mai recente cărți audio';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de cărți',
-      few: '$count cărți',
-      one: '1 carte',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Carte';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Carte audio';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% citit';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time rămase';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Citește';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Ascultă';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -879,9 +878,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de cărți audio',
-      few: '$count cărți audio',
-      one: '1 carte audio',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -896,10 +894,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get failedToLoad => 'Nu s-a putut încărca';
 
   @override
-  String get delete => 'Șterge';
+  String get delete => 'Şterge';
 
   @override
-  String get save => 'Salvează';
+  String get save => 'Salva';
 
   @override
   String get moreLikeThis => 'Mai mult ca asta';
@@ -917,7 +915,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get nextUp => 'Următorul';
 
   @override
-  String get seasons => 'Sezoane';
+  String get seasons => 'anotimpuri';
 
   @override
   String get chapters => 'Capitole';
@@ -948,7 +946,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Discul $number';
+    return 'Disc $number';
   }
 
   @override
@@ -985,9 +983,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de Sezoane',
-      few: '$count Sezoane',
-      one: '1 Sezon',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -998,40 +995,40 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get items => 'Elemente';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Extra';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Din culise';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Scene șterse';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Featurette-uri';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Interviuri';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scene';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Scurtmetraje';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailere';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time rămase';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Se termină în $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,7 +1046,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get play => 'Redă';
+  String get play => 'Juca';
 
   @override
   String get startOver => 'Începe de la capăt';
@@ -1073,7 +1070,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get version => 'Versiune';
 
   @override
-  String get cast => 'Proiectează';
+  String get cast => 'Distribuție';
 
   @override
   String get trailer => 'Trailer';
@@ -1191,7 +1188,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get subtitleTrack => 'Piesa de subtitrare';
 
   @override
-  String get none => 'Niciuna';
+  String get none => 'Nici unul';
 
   @override
   String get downloadSubtitlesLabel => 'Descărcați subtitrări...';
@@ -1267,16 +1264,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteFiles => 'Ștergeți fișierele';
 
   @override
-  String get director => 'REGIZOR';
+  String get director => 'DIRECTOR';
 
   @override
-  String get directors => 'REGIZORI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENARIST';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARIȘTI';
+  String get writers => 'SCRIITORII';
 
   @override
   String get studio => 'STUDIO';
@@ -1311,9 +1308,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de piese',
-      few: '$count piese',
-      one: '1 piesă',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1323,9 +1319,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de capitole',
-      few: '$count capitole',
-      one: '1 capitol',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1352,16 +1347,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get readMore => 'Citeşte mai mult';
 
   @override
-  String get shuffle => 'Aleatoriu';
+  String get shuffle => 'Amesteca';
 
   @override
-  String get shuffleAllMusic => 'Redă aleatoriu toată muzica';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Conectați-vă la Moonfin pe telefon';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Serverul nu poate fi contactat';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1373,7 +1368,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '${count}can.';
+    return '${count}ch';
   }
 
   @override
@@ -1535,7 +1530,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get subtitleDelay => 'Întârziere subtitrare';
 
   @override
-  String get reset => 'Resetează';
+  String get reset => 'Resetați';
 
   @override
   String get unknown => 'Necunoscut';
@@ -1553,7 +1548,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get directPlay => 'Redare directă';
 
   @override
-  String get directStream => 'Flux direct';
+  String get directStream => 'Direct Stream';
 
   @override
   String get transcoding => 'Transcodare';
@@ -1586,7 +1581,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoBitrate => 'Rata de biți video';
 
   @override
-  String get track => 'Piesă';
+  String get track => 'Urmări';
 
   @override
   String get channels => 'Canale';
@@ -1801,22 +1796,22 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Urmează: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m rămase';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h rămase';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m rămase';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1839,7 +1834,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get favoriteChannel => 'Canalul preferat';
 
   @override
-  String get record => 'Înregistrează';
+  String get record => 'Înregistra';
 
   @override
   String get cancelRecordingAction => 'Anulează înregistrarea';
@@ -1854,10 +1849,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unableToCreateRecording => 'Nu se poate crea înregistrarea';
 
   @override
-  String get watch => 'Vizionează';
+  String get watch => 'Ceas';
 
   @override
-  String get close => 'Închide';
+  String get close => 'Aproape';
 
   @override
   String failedToPlayChannel(String name) {
@@ -2067,9 +2062,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de episoade',
-      few: '$count episoade',
-      one: '1 episod',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2299,7 +2293,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Pagini de detalii, rânduri de pe ecranul principal și volum';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2314,11 +2308,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Joacă atunci când navighezi pe ecranul de pornire';
 
   @override
-  String get loopThemeMusic => 'Repetă muzica tematică';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repetă piesa în loc să o redea o singură dată';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detalii Blur de fundal';
@@ -2341,23 +2335,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get playerZoomMode => 'Modul Zoom jucător';
 
   @override
-  String get settingsScrollWheelAction => 'Rotița mouse-ului';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Alegeți ce se întâmplă când derulați cu rotița mouse-ului peste videoclip în timpul redării.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Oprit';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Derulare (înainte / înapoi)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Volum';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Volum';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2411,37 +2405,37 @@ class AppLocalizationsRo extends AppLocalizations {
   String get defaultAudioLanguage => 'Limba audio implicită';
 
   @override
-  String get fallbackAudioLanguage => 'Limbă audio de rezervă';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Preferă pista audio implicită';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferă pista audio originală în locul dublajului localizat.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferă pistele cu descriere audio';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferă pistele cu descriere audio în locul celor normale.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transcodare (Audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Flux direct (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcodare (Bitrate sau rezoluție)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcodare (Video & Audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transcodare (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (Server implicit)';
@@ -2522,7 +2516,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Alegeți modul în care este decodat sunetul. AVR Passthrough trimite fluxurile Dolby/DTS brute către receiverul dvs., iar Auto sau Downmix decodează local.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
@@ -2532,14 +2526,13 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Selectați formatul țintă pentru transcodarea sunetului multicanal atunci când fluxul sursă nu poate fi redat direct sau trimis prin passthrough.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Detectare automată\n(Recomandat)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Implicit)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2548,27 +2541,26 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Fără pierderi)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Doar stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Eficient)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Fără pierderi)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Număr maxim de canale audio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configurați numărul maxim de canale al sistemului dvs. audio. Fluxurile multicanal care depășesc această limită vor fi downmixate sau transcodate.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Detectare automată\n(Implicit hardware)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2580,7 +2572,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Cvadrafonic';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2598,7 +2590,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsAudioPassthroughAdvanced => 'Passthrough (avansat)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough codec';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
@@ -2674,11 +2666,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Difuzor';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Căști';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '${count}can. PCM';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2750,7 +2742,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get nextUpAndQueuing => 'Următorul și așteptarea';
 
   @override
-  String get nextUpDisplay => 'Afișare „Urmează”';
+  String get nextUpDisplay => 'Next Up Display';
 
   @override
   String get extended => 'Extins';
@@ -2767,7 +2759,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get mediaQueuing => 'Coadă media';
+  String get mediaQueuing => 'Media Queuing';
 
   @override
   String get autoQueueNextEpisodes =>
@@ -2855,45 +2847,45 @@ class AppLocalizationsRo extends AppLocalizations {
       'Personalizați aspectul subtitrarilor';
 
   @override
-  String get subtitleMode => 'Mod subtitrări';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Marcate';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Întotdeauna';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Străine';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Forțate';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Redă pistele marcate intern în metadatele fișierului media drept „implicite” sau „forțate”.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Încarcă și afișează automat subtitrările de fiecare dată când începe un videoclip.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Activează automat subtitrările dacă pista audio implicită este într-o limbă străină.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Încarcă doar subtitrările marcate explicit cu indicatorul de metadate „forțat”.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Dezactivează complet încărcarea automată a subtitrărilor.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Limbă de rezervă pentru subtitrări';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Flux de subtitrare';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Vulpea maro iute sare peste câinele leneș';
@@ -2902,13 +2894,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get verticalOffset => 'Offset vertical';
 
   @override
-  String get pgsDirectPlay => 'Redare directă PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Redare directă subtitrări PGS';
 
   @override
-  String get assSsaDirectPlay => 'Redare directă ASS/SSA';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles => 'Redare directă subtitrări ASS/SSA';
@@ -3098,11 +3090,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișați bibliotecile în bara de instrumente';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Afișează mereu etichetele barei de navigare';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Afișează butonul Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacitatea barei de navigare';
@@ -3120,7 +3111,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get purple => 'Violet';
 
   @override
-  String get teal => 'Turcoaz';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Marinei';
@@ -3177,19 +3168,18 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișează opțiunea de navigare în folder';
 
   @override
-  String get groupItemsIntoCollections => 'Grupează elementele în colecții';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ascunde elementele asociate colecțiilor când navigați prin biblioteci';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Notificare privind gruparea bibliotecii';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Pentru a folosi această setare, asigurați-vă că setările de bibliotecă „Grupează filmele în colecții” și/sau „Grupează serialele în colecții” sunt activate în setările de afișare ale bibliotecii de pe serverul Jellyfin sau Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Vizibilitatea bibliotecii';
@@ -3222,7 +3212,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get mediaBar => 'Bară media';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Surse media';
@@ -3301,11 +3291,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Redați automat trailerele în bara media după 3 secunde';
 
   @override
-  String get trailerAudio => 'Sunet trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Activează sunetul pentru trailerele din bara media';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Previzualizarea episodului';
@@ -3385,11 +3374,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Combinați ambele rânduri într-o singură secțiune de acasă';
 
   @override
-  String get fullScreenRows => 'Rânduri extinse pe ecranul principal';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limitează ecranul principal la un singur rând';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Tip de imagine pe rând';
@@ -3404,7 +3392,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get lastUser => 'Ultimul utilizator';
 
   @override
-  String get currentUser => 'Utilizator curent';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentificați-vă întotdeauna';
@@ -3465,7 +3453,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableBuiltInScreensaver => 'Activați screensaverul încorporat';
 
   @override
-  String get mode => 'Mod';
+  String get mode => 'Modul';
 
   @override
   String get libraryArt => 'Biblioteca Art';
@@ -3515,7 +3503,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'În mișcare';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (critici)';
@@ -3588,7 +3576,7 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați și reordonați sursele de evaluare afișate în aplicație';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin detectat';
@@ -3633,7 +3621,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get recentlyAdded => 'Adăugat recent';
 
   @override
-  String get trending => 'În tendințe';
+  String get trending => 'Trending';
 
   @override
   String get popularMovies => 'Filme populare';
@@ -3660,7 +3648,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get networks => 'Rețele';
 
   @override
-  String get seerrDiscoveryRows => 'Rânduri de descoperire Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Resetați rândurile la valorile implicite';
@@ -3684,28 +3672,28 @@ class AppLocalizationsRo extends AppLocalizations {
       'Ascunde conținutul pentru adulți în rezultate';
 
   @override
-  String get seerrNotificationsSection => 'Notificări';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Notificări pentru cereri noi';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Anunță-mă când cineva trimite o cerere';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Actualizări ale cererilor';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Aprobate, respinse și adăugate în biblioteca dvs.';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Actualizări ale problemelor';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Probleme noi, răspunsuri și rezolvări';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3713,15 +3701,15 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Pagina de descoperire Seerr';
+  String get discoverRows => 'Descoperiți Rânduri';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Activați rândurile pe care doriți să le vedeți pe pagina principală Seerr. Trageți pentru a le reordona. Ordinea personalizată se sincronizează cu Moonbase.';
+      'Trageți pentru a reordona. Activați sau dezactivați rândurile. Sincronizarea comenzii rândurilor este activată cu pluginul Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Activați rândurile pe care doriți să le vedeți pe pagina principală Seerr. Trageți pentru a le reordona. Ordinea personalizată se sincronizează cu Moonbase.';
+      'Trageți pentru a reordona. Activați sau dezactivați rândurile.';
 
   @override
   String get enabled => 'Activat';
@@ -3861,7 +3849,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get imageCacheCleared => 'Memoria cache pentru imagini a fost golită';
 
   @override
-  String get clear => 'Golește';
+  String get clear => 'Clar';
 
   @override
   String get browse => 'Răsfoiește';
@@ -3877,11 +3865,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Se descarcă · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Se importă';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3915,7 +3903,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get declineAction => 'Declin';
 
   @override
-  String get similar => 'Similare';
+  String get similar => 'Similar';
 
   @override
   String get recommendations => 'Recomandări';
@@ -4018,108 +4006,108 @@ class AppLocalizationsRo extends AppLocalizations {
   String get notRequestedStatus => 'Nu este solicitat';
 
   @override
-  String get blocklistedStatus => 'Pe lista de blocare';
+  String get blocklistedStatus => 'Blocklisted';
 
   @override
   String get deletedStatus => 'Șters';
 
   @override
-  String get failedStatus => 'Eșuat';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'În procesare';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modificat de $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Finalizat';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Acest titlu a fost deja cerut';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Ați atins limita de cereri';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Acest titlu este pe lista de blocare';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Nu mai sunt sezoane de cerut';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Nu aveți permisiunea de a face această cerere';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Cereri';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Probleme';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Cele mai noi';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Ultima modificare';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Nicio problemă';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining din $limit cereri de filme rămase';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining din $limit cereri de sezoane rămase';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Face parte din $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Vezi colecția';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Cere colecția';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filme · $available disponibile';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Cere $count filme';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Se cere $current din $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Au fost cerute $count filme';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Au fost cerute $ok din $total filme';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Toate filmele sunt deja disponibile sau cerute';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Raportează o problemă';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4128,44 +4116,44 @@ class AppLocalizationsRo extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Care este problema?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Toate episoadele';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episod';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Deschisă';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Rezolvată';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Rezolvă';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Redeschide';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Raportată de $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comentarii';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Adăugați un comentariu';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Ștergeți această problemă?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Trimite raportul';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Scorul TMDB';
@@ -4189,7 +4177,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get originalLanguageLabel => 'Limba originală';
 
   @override
-  String get seasonsLabel => 'Sezoane';
+  String get seasonsLabel => 'anotimpuri';
 
   @override
   String get episodesLabel => 'Episoade';
@@ -4198,13 +4186,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get access => 'Acces';
 
   @override
-  String get add => 'Adaugă';
+  String get add => 'Adăuga';
 
   @override
   String get address => 'Adresa';
 
   @override
-  String get analytics => 'Analiză';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Catalog';
@@ -4222,10 +4210,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get disable => 'Dezactivați';
 
   @override
-  String get done => 'Gata';
+  String get done => 'Făcut';
 
   @override
-  String get edit => 'Editează';
+  String get edit => 'Edita';
 
   @override
   String get encoding => 'Codificare';
@@ -4234,7 +4222,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get error => 'Eroare';
 
   @override
-  String get forward => 'Înainte';
+  String get forward => 'Redirecţiona';
 
   @override
   String get general => 'General';
@@ -4282,7 +4270,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get refresh => 'Reîmprospăta';
 
   @override
-  String get remote => 'Telecomandă';
+  String get remote => 'Telecomanda';
 
   @override
   String get rename => 'Redenumiți';
@@ -4300,7 +4288,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get run => 'Fugi';
 
   @override
-  String get search => 'Caută';
+  String get search => 'Căutare';
 
   @override
   String get select => 'Selecta';
@@ -4318,7 +4306,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get status => 'Stare';
 
   @override
-  String get stop => 'Oprește';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Streaming';
@@ -4345,7 +4333,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unmute => 'Activați sunetul';
 
   @override
-  String get mute => 'Fără sunet';
+  String get mute => 'Mut';
 
   @override
   String get branding => 'Branding';
@@ -4354,7 +4342,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminDrawerDashboard => 'Bord';
 
   @override
-  String get adminDrawerAnalytics => 'Analiză';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Setări';
@@ -4369,19 +4357,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminDrawerLibraries => 'Biblioteci';
 
   @override
-  String get adminDrawerDisplay => 'Afișare';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadate';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Setări NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcodare';
 
   @override
-  String get adminDrawerResume => 'Reluare';
+  String get adminDrawerResume => 'Relua';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
@@ -4553,13 +4541,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSetVolume => 'Setați volumul';
 
   @override
-  String get sessionPrev => 'Anter.';
+  String get sessionPrev => 'Prev';
 
   @override
   String get sessionRewind => 'Derulează înapoi';
 
   @override
-  String get sessionForward => 'Înainte';
+  String get sessionForward => 'Redirecţiona';
 
   @override
   String get sessionNext => 'Următorul';
@@ -4589,7 +4577,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audioCodec => 'Codec audio';
 
   @override
-  String get hwAccel => 'Accel. HW';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Finalizare';
@@ -4604,10 +4592,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminClearDates => 'Date clare';
 
   @override
-  String get adminActivitySeverityAll => 'Toate nivelurile de gravitate';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Interval de date';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4645,23 +4633,23 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Eliminați dispozitivul „$name”? Utilizatorul va trebui să se conecteze din nou pe acest dispozitiv.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Șterge toate dispozitivele';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Eliminați $count dispozitive? Utilizatorii afectați vor trebui să se conecteze din nou. Dispozitivul dvs. curent nu este afectat.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Dispozitivele au fost eliminate';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Unele dispozitive au fost eliminate; $count nu au putut fi eliminate.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4778,256 +4766,244 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminMetadataCountryHint => 'de ex. SUA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Căi';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opțiuni';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Servicii de descărcare';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Servicii de salvare a metadatelor';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders =>
-      'Servicii de descărcare a subtitrărilor';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Servicii de descărcare a versurilor';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Servicii de descărcare a metadatelor: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Servicii de preluare a imaginilor: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Acest server nu oferă servicii de descărcare pentru acest tip de bibliotecă.';
+      'This server exposes no downloaders for this library type.';
 
   @override
   String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadate';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Informații încorporate';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Subtitrări';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imagini';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Seriale';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muzică';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filme';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Activează monitorizarea în timp real';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Detectează modificările fișierelor și le procesează automat.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Tratează arhivele ca fișiere media';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Afișează fotografiile';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Salvează imaginile în folderele media';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Reîmprospătare automată a metadatelor';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Niciodată';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Implicit';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Afișare';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Afișarea bibliotecii';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Afișează o vizualizare de foldere pentru folderele media simple';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Afișează episoadele speciale în sezoanele în care au fost difuzate';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupează filmele în colecții';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupează serialele în colecții';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Afișează conținut extern în sugestii';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Comportamentul datei adăugării';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Folosește data adăugării din';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data scanării în bibliotecă';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data creării fișierului';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadate și imagini';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Limba preferată pentru metadate';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Capitole';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Durata capitolelor generate (secunde)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Durata capitolelor generate pentru conținutul media care nu are capitole. Setați 0 pentru dezactivare.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Rezoluția imaginilor de capitol';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Setări NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadatele NFO sunt compatibile cu Kodi și cu clienți similari. Setările se aplică tuturor bibliotecilor care salvează metadate NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Utilizatorul pentru care se salvează datele de vizionare în fișierele NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Salvează căile imaginilor în fișierele NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Activează substituția căilor pentru imaginile din fișierele NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Copiază imaginile extrafanart într-un folder extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Niciunul';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days zile';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Folosește titlurile încorporate';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Folosește titlurile încorporate pentru materialele extra';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Folosește informațiile încorporate despre episoade';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Permite subtitrările încorporate';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Permite toate';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Doar text';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Doar imagine';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Niciuna';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Omite descărcarea dacă există subtitrări încorporate';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Omite descărcarea dacă pista audio corespunde limbii de descărcare';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Necesită o potrivire perfectă a subtitrării';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Salvează subtitrările în folderele media';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Extrage imaginile de capitol';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extrage imaginile de capitol în timpul scanării bibliotecii';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Activează extragerea imaginilor Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extrage imaginile Trickplay în timpul scanării bibliotecii';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Salvează imaginile Trickplay în folderele media';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Îmbină automat serialele răspândite în mai multe foldere';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Numele afișat pentru sezonul zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Activează scanarea LUFS pentru normalizarea audio';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Preferă eticheta non-standard pentru artiști';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Adaugă automat filmele în colecții';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Numele bibliotecii este obligatoriu';
@@ -5267,145 +5243,143 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminEnableAllChannels => 'Activați accesul la toate canalele';
 
   @override
-  String get adminParentalControl => 'Control parental';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Clasificarea parentală maximă permisă';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Conținutul cu o clasificare mai mare va fi ascuns pentru acest utilizator.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Niciuna';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blochează elementele fără clasificare sau cu clasificare nerecunoscută';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Cărți';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Canale';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV în direct';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filme';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muzică';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailere';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriale';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Programe de acces';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Permite accesul doar în intervalele programate mai jos. Dacă nu este setat niciun program, accesul este permis toată ziua.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Adaugă program';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Ziua';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Început';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Sfârșit';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'În fiecare zi';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Zi lucrătoare';
+  String get adminDayWeekday => 'Weekday';
 
   @override
   String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Duminică';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Luni';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Marți';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Miercuri';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Joi';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Vineri';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sâmbătă';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etichete permise';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Se afișează doar conținutul cu aceste etichete. Lăsați gol pentru a permite tot conținutul.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etichete blocate';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Conținutul cu aceste etichete este ascuns pentru acest utilizator.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Adaugă etichetă';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Dispozitive activate';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Canale activate';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Furnizor de autentificare';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Furnizor pentru resetarea parolei';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Numărul maxim de încercări eșuate de conectare înainte de blocare';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Setați 0 pentru valoarea implicită sau -1 pentru a dezactiva blocarea.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Acces SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Permite crearea grupurilor și alăturarea la ele';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Permite alăturarea la grupuri';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Fără acces';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Permite ștergerea conținutului din';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5493,26 +5467,25 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Creează o copie de rezervă';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Alegeți ce să includeți în copia de rezervă.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Baza de date';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Inclusă întotdeauna';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadate';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Subtitrări';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imagini Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Se creează backup...';
@@ -6220,62 +6193,60 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminAddTuner => 'Adăugați tuner';
 
   @override
-  String get adminEditTuner => 'Editează tunerul';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fișier sau URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Adresa IP a tunerului';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Nume prietenos';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limita de conexiuni simultane';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Numărul maxim de fluxuri pe care tunerul le permite simultan. Setați 0 pentru nelimitat.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Bitrate maxim de rezervă pentru streaming';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importă doar canalele favorite';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Permite transcodarea hardware';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Permite containerul de transcodare fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Permite partajarea fluxurilor';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Activează redarea în buclă a fluxului';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignoră DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Citește sursa la rata de cadre nativă';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Editează furnizorul';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6284,50 +6255,50 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fișier sau URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefix pentru filme';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Categorii de filme';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separați mai multe categorii cu o bară verticală.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Categorii pentru copii';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Categorii de știri';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Categorii sportive';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Nume de utilizator';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Parolă';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Țară';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Selectați o țară';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Cod poștal';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Obține programele';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Programe';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Activează toate tunerele';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tip tuner';
@@ -6370,7 +6341,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Acest tip de tuner nu acceptă resetarea.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6393,46 +6364,43 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Calea de înregistrare în serie';
 
   @override
-  String get adminMovieRecordingPath => 'Calea pentru înregistrarea filmelor';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Zile de date pentru ghid';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automat';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days zile';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Calea aplicației de post-procesare';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumente pentru post-procesare';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo =>
-      'Salvează metadatele NFO ale înregistrării';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Salvează imaginile înregistrării';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Sincronizare';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Căi pentru înregistrări';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Post-procesare';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Date pentru ghid: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6475,15 +6443,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminGuideProviders => 'Furnizori de ghiduri';
 
   @override
-  String get adminRefreshGuideData => 'Reîmprospătează datele ghidului';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Reîmprospătarea datelor ghidului a început';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Sarcina de reîmprospătare a ghidului nu este disponibilă pe acest server.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Adăugați furnizorul';
@@ -6509,11 +6476,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Marjă la final: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Detectarea tunerelor';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Mapările canalelor';
@@ -6565,13 +6532,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminLiveTvTitle => 'Administrare TV în direct';
 
   @override
-  String get adminApply => 'Aplică';
+  String get adminApply => 'Aplicați';
 
   @override
   String get adminNotSet => 'Nu setat';
 
   @override
-  String get adminReset => 'Resetează';
+  String get adminReset => 'Resetați';
 
   @override
   String get adminLogsTitle => 'Jurnalele serverului';
@@ -6617,7 +6584,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor de metadate';
 
   @override
-  String get adminMetadataIdentify => 'Identifică';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Tip';
@@ -6902,7 +6869,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Elimină';
+  String get adminReposRemove => 'Elimina';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7034,21 +7001,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Activați ecranul de introducere';
 
   @override
-  String get adminBrandingSplashUpload => 'Încarcă o imagine';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'Ecranul de pornire a fost actualizat';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Încărcarea ecranului de pornire a eșuat';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Ecranul de pornire a fost eliminat';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Niciun ecran de pornire personalizat';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Accelerație hardware';
@@ -7064,123 +7029,118 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați decodarea hardware pentru:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Dispozitiv QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Activează decodorul NVDEC îmbunătățit';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Preferă decodorul hardware nativ al sistemului';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Adâncimea de culoare la decodarea hardware';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Decodare HEVC pe 10 biți';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Decodare VP9 pe 10 biți';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Decodare HEVC RExt pe 8/10 biți';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Decodare HEVC RExt pe 12 biți';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Codare hardware';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Permite codarea HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Permite codarea AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Activează codorul Intel H.264 cu consum redus';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Activează codorul Intel HEVC cu consum redus';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tone mapping';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Activează tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Activează tone mapping VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Activează tone mapping VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritm de tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Mod de tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Interval de tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturare la tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Vârf de tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parametru de tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Luminozitate tone mapping VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'Contrast tone mapping VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Presetări și calitate';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Presetare codor';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF pentru codarea H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF pentru codarea H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metodă de deinterlațare';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dublează rata de cadre la deinterlațare';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Activează codarea audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Amplificare la downmix audio';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritm de downmix stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Dimensiunea maximă a cozii de multiplexare';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7249,7 +7209,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminTrickplayPriorityAboveNormal => 'Peste Normal';
 
   @override
-  String get adminTrickplayPriorityNormal => 'Normală';
+  String get adminTrickplayPriorityNormal => 'Normal';
 
   @override
   String get adminTrickplayPriorityBelowNormal => 'Sub Normal';
@@ -7303,10 +7263,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminTaskNeverRun => 'Nu fugi niciodată';
 
   @override
-  String get adminTaskStop => 'Oprește';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Sarcini în execuție';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Fugi';
@@ -7376,9 +7336,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de ore',
-      few: '$count ore',
-      one: '1 oră',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7434,12 +7393,12 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String adminActivityDaysShort(int days) {
-    return '${days}z';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7459,44 +7418,43 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Port HTTP public';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Solicită HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Redirecționează toate cererile la distanță către HTTPS. Nu are efect dacă serverul nu are un certificat valid.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Parola certificatului';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Setări IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Activează IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Activează IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Activează maparea automată a porturilor';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Rețele LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Listă de adrese IP sau subrețele CIDR, separate prin virgulă sau pe linii separate, considerate ca făcând parte din rețeaua locală.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI-uri publicate ale serverului';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Asociați o subrețea sau o adresă unui URL publicat, de ex. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Calea certificatului';
@@ -7526,11 +7484,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Tampon de accelerație';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Întârziere de limitare (secunde)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Permite extragerea subtitrărilor în timp real';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Procentul minim de reluare';
@@ -7586,23 +7544,22 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Prag de răspuns lent (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Activează avertismentele privind răspunsurile lente';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Activează Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadate';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Căi';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Performanță';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Calea cache';
@@ -7614,7 +7571,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminGeneralServerName => 'Numele serverului';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Limba de afișare preferată';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nu s-au încărcat setările';
@@ -7666,8 +7623,7 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# de participanți',
-      few: '# participanți',
+      other: '# participants',
       one: '# participant',
     );
     return '$_temp0';
@@ -7814,9 +7770,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# de rânduri descoperite',
-      few: '# rânduri descoperite',
-      one: '# rând descoperit',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7857,20 +7812,20 @@ class AppLocalizationsRo extends AppLocalizations {
   String get offlineSavedMedia => 'Media salvate';
 
   @override
-  String get offlineBannerTitle => 'Sunteți offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Se afișează descărcările dvs.';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Descărcări';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Serverul nu poate fi contactat';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Se redă din descărcări până când revine';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7943,42 +7898,42 @@ class AppLocalizationsRo extends AppLocalizations {
   String get pinForgot => 'Ați uitat codul PIN?';
 
   @override
-  String get pinClear => 'Golește';
+  String get pinClear => 'Clar';
 
   @override
   String get pinBackspace => 'Backspace';
 
   @override
   String get quickConnectAuthorized =>
-      'Cererea Quick Connect a fost autorizată.';
+      'Solicitare de conectare rapidă autorizată.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Codul Quick Connect este invalid sau a expirat.';
+      'Codul de conectare rapidă este invalid sau a expirat.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect nu este acceptat pe acest server.';
+      'Conectarea rapidă nu este acceptată pe acest server.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Autorizarea codului Quick Connect a eșuat.';
+      'Nu s-a putut autoriza codul de conectare rapidă.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect este dezactivat pe acest server.';
+      'Conectarea rapidă este dezactivată pe acest server.';
 
   @override
   String get quickConnectForbidden =>
-      'Contul dvs. nu poate autoriza această cerere Quick Connect.';
+      'Contul dvs. nu poate autoriza această solicitare de conectare rapidă.';
 
   @override
   String get quickConnectNotFound =>
-      'Codul Quick Connect nu a fost găsit. Încercați un cod nou.';
+      'Codul de conectare rapidă nu a fost găsit. Încercați un cod nou.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect a eșuat: $message';
+    return 'Conectarea rapidă a eșuat: $message';
   }
 
   @override
@@ -8146,7 +8101,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get stillWatchingContent => 'Redarea a fost întreruptă. Încă te uiți?';
 
   @override
-  String get stillWatchingStop => 'Oprește';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Continua';
@@ -8231,13 +8186,13 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Ascunde din „Continuați vizionarea”';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ascunde din „Urmează”';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Adaugă în colecție';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8292,15 +8247,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetic';
 
   @override
-  String get settingsConnectionSection => 'CONEXIUNE';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Permite certificatele autosemnate';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Aveți încredere în serverele care folosesc certificate TLS autosemnate sau emise de o autoritate privată. Activați doar pentru serverele pe care le controlați. Această opțiune dezactivează validarea certificatelor pentru toate conexiunile.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection =>
@@ -8317,11 +8271,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Accente teme, fundaluri, indicatori vizionați și muzică tematică';
 
   @override
-  String get settingsDetailsScreen => 'Ecranul de detalii';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, estomparea fundalului și comportamentul filelor';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Pagina principală';
@@ -8359,11 +8313,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Afișează butonul Seerr în bara de navigare';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Afișează mereu etichetele text în bara de navigare de sus';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8467,9 +8421,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# de notificări de licență',
-      few: '# notificări de licență',
-      one: '# notificare de licență',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8519,17 +8472,16 @@ class AppLocalizationsRo extends AppLocalizations {
       'Sari peste introsuri si versiuni suplimentare?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Numărătoare inversă pentru segmentele media';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Bară de progres';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Cronometru';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Fără';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Prompt utilizator';
@@ -8666,7 +8618,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get settingsLiveTvDirect => 'TV în direct (direct)';
+  String get settingsLiveTvDirect => 'Live TV Direct';
 
   @override
   String get settingsLiveTvDirectSubtitle =>
@@ -8758,7 +8710,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName lansate recent';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8790,11 +8742,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Forțați redarea fără tunel. Util pe dispozitive cu discontinuități audio/video de tunel.';
 
   @override
-  String get enableTunnelingTitle => 'Activează tunelarea';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Opțiune avansată. Direcționează sunetul și imaginea printr-o cale hardware cuplată. Este dezactivată implicit deoarece provoacă întreruperi audio/video pe unele dispozitive.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Hartați Dolby Vision profilul 7 la HEVC';
@@ -8820,15 +8772,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Aplicați indicii privind dimensiunea fontului încorporate în pista de subtitrare. Dezactivați utilizarea dimensiunii subtitrarilor din preferințele dvs. de stil.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Afișează detaliile media';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Afișează detaliile elementului selectat în partea de sus a paginilor de bibliotecă.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Ascundeți fundalurile în timpul navigării?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Utilizați subtitluri detaliate';
@@ -8846,39 +8797,37 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Magazin de teme';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Descoperiți și salvați teme create de comunitate';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Salvați o temă pentru a o folosi ca pe celelalte teme salvate.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Momentan nu este disponibilă nicio temă.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Magazinul de teme nu a putut fi încărcat. Verificați conexiunea și încercați din nou.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Salvează';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Salvează și aplică';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Salvată';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage =>
-      'Această temă nu a putut fi încărcată.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '„$themeName” a fost salvată.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8915,609 +8864,597 @@ class AppLocalizationsRo extends AppLocalizations {
       'Gestionați temele de plugin descărcate pe acest dispozitiv';
 
   @override
-  String get themeEditor => 'Editor de teme';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Deschideți editorul de teme Moonfin în browser';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Ecran principal';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Bară inferioară';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Clasic';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Rânduri pe ecranul principal';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Afișarea rândurilor de pe ecranul principal';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Secțiunile rândurilor de pe ecranul principal';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles =>
-      'Comutatoare pentru rândurile de pe ecranul principal';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Activați sau dezactivați categoriile de rânduri bazate pe biblioteci';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Activați comutatoarele de mai jos pentru a afișa rândurile în secțiunile ecranului principal.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Modul Clasic păstrează tipul de imagine și suprapunerea cu informații pentru fiecare rând. Modul Modern folosește rânduri de la portret la fundal.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Afișează rândurile cu favorite';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Afișează filmele și serialele favorite, precum și celelalte rânduri cu favorite, în secțiunile ecranului principal.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortarea rândurilor cu favorite';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sortați rândurile cu favorite după data adăugării, data lansării, alfabetic și după alte criterii.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Afișează rândurile cu colecții';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Afișează rândurile cu colecții în secțiunile ecranului principal.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortarea rândurilor cu colecții';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sortați rândurile cu colecții după data adăugării, data lansării, alfabetic și după alte criterii.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Afișează rândurile cu genuri';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Afișează rândurile cu genuri în secțiunile ecranului principal.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortarea rândurilor cu genuri';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sortați rândurile cu genuri după data adăugării, data lansării, alfabetic și după alte criterii.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementele rândurilor cu genuri';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Afișați filme, seriale sau ambele în rândurile cu genuri.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Afișează rândurile cu liste de redare';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Afișează rândurile cu liste de redare în secțiunile ecranului principal.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortarea rândurilor cu liste de redare';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sortați rândurile cu liste de redare după data adăugării, data lansării, alfabetic și după alte criterii.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Afișează rândurile audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Afișează rândurile audio în secțiunile ecranului principal.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortarea rândurilor audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sortați rândurile audio după data adăugării, data lansării, alfabetic și după alte criterii.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Liste de redare audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Aspect';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Aranjament';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Temă';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastatură';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Butoane';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Randare';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Configurare MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Aplicație player extern';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Setați un player extern pentru a activa opțiunea de redare la apăsare lungă';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Afișează selectorul de aplicații la începerea redării.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Se încarcă playerele instalate...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Conexiune';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Format țintă pentru transcodarea audio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Acceptat pe acest dispozitiv';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Neacceptat pe acest dispozitiv';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Trimite DTS:X (DTS UHD) ca bitstream către decodorul extern.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD cu Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Comportamentul playerului media';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Îmbunătățiri ale redării';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Întotdeauna activ.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Înlocuiește „Sari peste generic” cu afișarea „Urmează”';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Afișează suprapunerea „Urmează” în locul butonului „Sari peste generic”.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Direcționarea playerului';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Preferă decodoarele software';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Folosește FFmpeg (audio) și libgav1 (AV1) înaintea decodoarelor hardware. Dezactivați dacă passthrough-ul audio HDMI nu funcționează.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Deschide redarea video în aplicația externă selectată, pe Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Adăugare automată în coadă';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Preferă subtitrările SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Prioritizează pistele de subtitrare SDH/CC la selectarea automată.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnosticare web';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnosticare web Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Folosiți această pagină pentru a diagnostica problemele de conectivitate ale browserului (CORS, conținut mixt și setări de descoperire).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'A fost detectată o eroare de conținut mixt';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'A fost detectată o eroare CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin a detectat o pagină HTTPS care încearcă să apeleze un URL de server HTTP. Browserele blochează această cerere înainte să ajungă la server.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin a detectat o eroare de cerere la nivel de browser, cauzată de obicei de lipsa antetelor CORS sau preflight de pe serverul media.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL țintă: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detaliu: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Contextul curent de execuție';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Origine';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schemă';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Mod plugin';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Scanare WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL de server forțat';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL de server implicit';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL proxy pentru descoperire';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'neconfigurat';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Conținut mixt';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Această pagină este încărcată prin HTTPS, dar unul sau mai multe URL-uri configurate folosesc HTTP. Browserele blochează apelurile către API-uri HTTP din pagini HTTPS.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Soluție: serviți serverul media sau punctul final proxy prin HTTPS ori încărcați Moonfin prin HTTP doar în rețele locale de încredere.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Nu a fost detectată nicio configurație evidentă de conținut mixt în setările curente de execuție.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Listă de verificare CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Permiteți originea browserului în Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Includeți Authorization, X-Emby-Authorization și X-Emby-Token în Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Expuneți Content-Range și Accept-Ranges pentru streaming și derulare.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Returnați 204 la cererile preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Exemplu de fragment de antet (stil nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Notă';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Această rută de diagnosticare este destinată versiunilor web. Dacă o vedeți pe altă platformă, este posibil ca aceste verificări să nu se aplice.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Înapoi la selectarea serverului';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Deconectează toți utilizatorii';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Permisiunea pentru microfon este refuzată definitiv. Activați-o din setările sistemului.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Căutarea vocală necesită permisiunea pentru microfon.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nu am înțeles. Încercați din nou.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nu a fost detectată nicio voce.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Eroare de microfon.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Căutarea vocală necesită conexiune la internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Serviciul vocal este ocupat. Încercați din nou.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Permisiunea pentru microfon este refuzată definitiv.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Permisiunea pentru microfon este refuzată.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Recunoașterea vocală nu este disponibilă pe acest dispozitiv.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Deschide selectorul de rute iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Selectorul de rute AirPlay nu este disponibil pe acest dispozitiv.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videoclipuri';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programe';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Melodii';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Albume foto';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotografii';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Persoane';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Episoade lansate recent';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Vizionează din nou';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Apariții ca invitat';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Apariții (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr =>
-      'Contribuții în echipa de producție (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Vizionează cu grupul';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Erori';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Avertismente';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Disc';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Deschide în browser';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Browserul încorporat nu este disponibil pe această platformă.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Sigur doriți să reporniți serverul?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Sigur doriți să opriți serverul? Va trebui să îl reporniți manual.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Intern';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inactiv';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Niciun utilizator găsit';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Niciun utilizator nu corespunde căutării';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Niciun dispozitiv găsit';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Niciun dispozitiv nu corespunde filtrelor curente';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Parolă setată';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nicio parolă configurată';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Acces la distanță';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Doar local';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Încărcarea analizelor media a eșuat';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Analize combinate din toate bibliotecile media.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Artiști de top';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Autori de top';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Contribuitori de top';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de Biblioteci',
-      few: '$count Biblioteci',
-      one: '1 Bibliotecă',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Nu sunt încă disponibile totaluri de conținut media indexat pentru această selecție.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Detalii despre bibliotecă';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Defalcare pe biblioteci';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'Nu este disponibilă nicio bibliotecă.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administrarea serverului';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Date';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Cache de imagini';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Jurnale';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadate';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcodare';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Acest server nu a returnat nicio cale.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% utilizat';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Activitatea utilizatorilor';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Evenimente de sistem';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Necesită atenție';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Redare';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Dispozitive';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avansat';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Pluginuri';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV în direct';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Videoclipuri personale';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Conținut mixt';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Videoclipuri și fotografii personale';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Filme și seriale mixte';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9529,150 +9466,150 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nicio înregistrare găsită';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Nu au fost găsite pagini imagine în arhiva .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Randarea încorporată a eșuat ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Randarea EPUB a eșuat ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Lipsește fișierul local pentru cititor: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status la deschiderea datelor cărții din $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nu este disponibil niciun punct final pentru citirea cărții';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Format de arhivă de benzi desenate neacceptat: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Pluginul de extragere CBR nu este disponibil pe această platformă.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Extragerea arhivei .cbr a eșuat.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Extragerea CB7 nu este disponibilă pe această platformă.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Pluginul de extragere CB7 nu este disponibil pe această platformă.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Închide panoul cu genuri';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Se încarcă redarea aleatorie...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'REDARE ALEATORIE DIN BIBLIOTECĂ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'REDARE ALEATORIE';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'REDARE ALEATORIE PE GENURI';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Comutare automată HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Activează automat HDR la redarea videoclipurilor HDR și restabilește modul de afișare la ieșire.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Pe ecran complet';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Schimbă imaginea';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Lipsă';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Limite de transcodare';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Ștergeți toate imaginile?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Sigur doriți să ștergeți toate imaginile descărcate?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirmați ștergerea';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Sigur doriți să ștergeți imaginea de tip $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Încărcați?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Rezoluție: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Afișează doar imaginile în limba interfeței';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirmați ștergerea tuturor';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Imaginea a fost încărcată cu succes!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Încărcarea imaginii a eșuat: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Setarea imaginii a eșuat: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Ștergerea imaginii a eșuat: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Ștergerea tuturor imaginilor a eșuat: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Da';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Fundaluri';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9681,31 +9618,31 @@ class AppLocalizationsRo extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatură';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafică';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafică de disc';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Captură de ecran';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Copertă cutie';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Coperta din spate a cutiei';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafică de meniu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'fundal';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9714,114 +9651,114 @@ class AppLocalizationsRo extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatură';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafică';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafică de disc';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'captură de ecran';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'copertă cutie';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'coperta din spate a cutiei';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafică de meniu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Toate';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Înaltă (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Medie (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Scăzută (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Surse';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Capitole';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Marcaje';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Notițe';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Coadă';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Cronologie';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Cronologia este goală';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Toată cartea';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Cronologie focalizată';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportă marcajele';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportă notițele';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportă tot';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportat în $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Exportul a eșuat: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Versuri';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Adaugă un marcaj';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Adaugă o notiță';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Editează notița';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Scrieți o notiță pentru acest moment';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Cronometru de adormire';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Oprit';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Sfârșitul capitolului';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Personalizat';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining rămase';
+    return '$remaining left';
   }
 
   @override
@@ -9836,51 +9773,51 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Viteza de redare';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Rămas';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Scurs';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Înapoi ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Înainte ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Capitolul anterior';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Capitolul următor';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Capitolul $current din $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Niciun capitol';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Niciun marcaj încă';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Nicio notiță încă';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Marcaj adăugat la $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Resetează la 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9888,256 +9825,249 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Salvează';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Anulează';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Șterge';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferințe pentru subtitrări';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Modificați modurile de subtitrare, limbile implicite, aspectul și opțiunile de randare.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Randarea subtitrărilor';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opțiuni de afișare';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data lansării (crescător)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data lansării (descrescător)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Gruparea contribuțiilor';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupează rolurile multiple';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Avertisment privind accesul de scriere în bibliotecă';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Cum puteți rezolva:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Acordați permisiuni de scriere utilizatorului serviciului Jellyfin (de ex. jellyfin sau PUID/PGID din Docker) pentru folderele bibliotecii media de pe server.\n\n2. Sau accesați panoul de control Jellyfin -> Biblioteci, editați această bibliotecă și dezactivați „Salvează imaginile în folderele media” pentru a stoca imaginile în baza de date internă a Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Închide';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Biblioteca dvs. „$libraryName” este configurată să salveze imaginile direct în folderele media (opțiunea „Salvează imaginile în folderele media” este activată). Totuși, Jellyfin a testat accesul de scriere și nu are permisiunea de a scrie fișiere în acest director:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Se pare că Jellyfin nu a reușit să actualizeze imaginea. Biblioteca dvs. este configurată să salveze imaginile direct în folderele media (opțiunea „Salvează imaginile în folderele media” este activată). Această eroare apare de obicei atunci când procesul serverului Jellyfin nu are permisiunea de a scrie fișiere în directoarele media.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Liste externe';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Redă din nou';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informații despre fișier';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Dimensiune: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Afișează toate pistele audio ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Afișează toate pistele de subtitrare ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Se verifică suportul pentru redare directă...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Suport pentru redare directă: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Forțat';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Formatul containerului nu este acceptat de player.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Codecul video nu este acceptat.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Codecul audio nu este acceptat.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Formatul subtitrării nu este acceptat (necesită încorporare în imagine).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Profilul audio nu este acceptat.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Profilul video nu este acceptat.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Nivelul video nu este acceptat.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Rezoluția video nu este acceptată de acest dispozitiv.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Adâncimea de biți a imaginii nu este acceptată.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Rata de cadre nu este acceptată.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Bitrate-ul fișierului depășește limita de streaming a playerului.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Bitrate-ul video depășește limita de streaming.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Bitrate-ul audio depășește limita de streaming.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Numărul de canale audio nu este acceptat.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetic';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Ordinea lansării (crescător)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Ordinea lansării (descrescător)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Personalizat (trageți și plasați)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Opțiuni de sortare a listei de redare';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Resetează sortarea';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Revizionează S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Revizionează lista de redare';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nu au fost găsite subtitrări.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Comenzi de administrare';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motor de randare (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller este motorul GPU modern al Flutter, pentru animații mai fluide și mai puține sacadări. Pe unele TV box-uri și plăci grafice mai vechi poate provoca artefacte sau imagine neagră; dezactivați-l dacă observați astfel de probleme. Opțiunea Automat alege cea mai bună valoare implicită pentru dispozitivul dvs. Reporniți Moonfin pentru a aplica modificarea.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automat';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Activat';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Dezactivat';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Repornire necesară';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin trebuie repornit pentru a schimba motorul de randare. Închideți aplicația acum, apoi redeschideți-o pentru a aplica modificarea.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Închide aplicația acum';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Reîmprospătează biblioteca';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Reîmprospătează toate bibliotecile';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Data adăugării (cele mai vechi primele)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Data adăugării (cele mai noi primele)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetic (de la A la Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetic (de la Z la A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Se încarcă analizele serverului... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Ca sursa';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filme';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 seriale TV';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Cele mai populare filme IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Cele mai populare seriale TV IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Filme cu cel mai mic scor IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Cele mai bine cotate filme în engleză pe IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -9,30 +9,30 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Лунный плавник';
 
   @override
-  String get accountPreferences => 'НАСТРОЙКИ АККАУНТА';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Язык интерфейса';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Как в системе';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Войти';
 
   @override
-  String get empty => 'Пусто';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Подключение к $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Быстрое подключение';
 
   @override
   String get password => 'Пароль';
@@ -61,12 +61,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect недоступен: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect недоступен ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin версии $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Удалить «$serverName» из списка серверов?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'Отмена';
 
   @override
-  String get remove => 'Удалить';
+  String get remove => 'Удалять';
 
   @override
   String get connectToServer => 'Подключиться к серверу';
@@ -141,62 +141,62 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsAppearanceTheme => 'Тема приложения';
 
   @override
-  String get detailScreenStyle => 'Стиль экрана сведений';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '«Классический» — исходная центрированная компоновка Moonfin. «Современный» — адаптивная кинематографичная компоновка.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Классический';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Современный';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Развёрнутые вкладки';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Автоматически показывать содержимое вкладки при её выборе. Отключите, чтобы открывать и закрывать вкладки вручную.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Показывать технические сведения?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Показывать кодек, разрешение и сведения о потоке в сводке баннера';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Система рекомендаций';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Использовать алгоритм локальной библиотеки «Moonfin рекомендует» или онлайн-метрики схожести TMDb. Примечание: для онлайн-рекомендаций нужна интеграция с Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin рекомендует';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Схожесть TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Ограничивать по возрастному рейтингу?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ограничивать подборку «Moonfin рекомендует» возрастным рейтингом выбранного медиа';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стиль интерфейса';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '«Автоматически» подстраивается под ваше устройство. Выберите Apple или Material, чтобы задать вид принудительно.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автоматически';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsRu extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Качество стекла';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '«Авто» подбирает лучший эффект стекла для этого устройства. «Полное» включает настоящее размытие, «Упрощённое» — облегчённое стекло, экономящее ресурсы GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Авто';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Полное';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Упрощённое';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Переключайтесь между Moonfin и Neon Pulse, не перезапуская приложение.';
 
   @override
-  String get customThemeTitle => 'Своя тема';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Пользовательские темы меняют оформление во всём Moonfin. Выберите вариант на свой вкус.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Системная клавиатура';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'По умолчанию использовать способ ввода устройства для набора текста';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Лунный плавник';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsRu extends AppLocalizations {
       'Стиль Synthwave с пурпурным свечением, голубым текстом и более сильным хромированным контрастом.';
 
   @override
-  String get themeGlass => 'Стекло';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Оформление в стиле жидкого стекла: плавающий градиентный фон, матовые поверхности и синий акцент Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-битный герой';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретро-оформление в стиле пиксель-арта: контрастная палитра, блочные рамки, резкие тени и пиксельный шрифт';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Не удалось подключиться к $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,35 +327,35 @@ class AppLocalizationsRu extends AppLocalizations {
   String get exit => 'Выход';
 
   @override
-  String get gameMenu => 'Меню';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Пауза';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Сохранить состояние';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Игры';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Загрузить состояние';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Ускорение';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Настройки эмулятора';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'У этого ядра нет настраиваемых параметров.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Удерживайте, чтобы открыть меню';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Запуск игр пока не поддерживается на этом устройстве.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Не удалось загрузить ни одну главную строку.';
@@ -377,13 +377,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get schedule => 'Расписание';
 
   @override
-  String get series => 'Сериалы';
+  String get series => 'Ряд';
 
   @override
   String get noItemsFound => 'Элементы не найдены';
 
   @override
-  String get home => 'Главная';
+  String get home => 'Дом';
 
   @override
   String get browseAll => 'Просмотреть все';
@@ -427,7 +427,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Не удалось загрузить папку: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -435,7 +435,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return 'Элементов: $count';
+    return '$count items';
   }
 
   @override
@@ -452,7 +452,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return 'Элементов: $count';
+    return '$count Items';
   }
 
   @override
@@ -493,7 +493,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — жанры';
+    return '$name — Genres';
   }
 
   @override
@@ -506,7 +506,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get albumArtists => 'Исполнители альбомов';
 
   @override
-  String get artists => 'Исполнители';
+  String get artists => 'Художники';
 
   @override
   String get bookmarks => 'Закладки';
@@ -532,17 +532,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count мин назад';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count ч назад';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count дн назад';
+    return '${count}d ago';
   }
 
   @override
@@ -553,7 +553,7 @@ class AppLocalizationsRu extends AppLocalizations {
       'Выберите, какие тематические каналы показывать в Discover.';
 
   @override
-  String get apply => 'Применить';
+  String get apply => 'Применять';
 
   @override
   String get openLink => 'Открыть ссылку';
@@ -577,7 +577,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return 'Наименований: $count';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +603,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get listen => 'Слушать';
 
   @override
-  String get resume => 'Продолжить';
+  String get resume => 'Резюме';
 
   @override
   String get failedToLoadLibrary => 'Не удалось загрузить библиотеку';
@@ -666,17 +666,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return 'Авторов: $count';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return 'Жанров: $count';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% завершено';
+    return '$percent% completed';
   }
 
   @override
@@ -693,11 +693,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'Библиотека из $count наименований, собранная для чтения.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => 'Названия';
+  String get titles => 'Титулы';
 
   @override
   String get allTitles => 'Все названия';
@@ -730,7 +730,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label: ничего не найдено';
+    return 'No $label found';
   }
 
   @override
@@ -749,13 +749,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get readStatus => 'Читать';
 
   @override
-  String get watched => 'Просмотрено';
+  String get watched => 'Смотрел';
 
   @override
   String get unread => 'Непрочитано';
 
   @override
-  String get unwatched => 'Не просмотрено';
+  String get unwatched => 'Непросмотренный';
 
   @override
   String get seriesStatus => 'Статус серии';
@@ -767,45 +767,43 @@ class AppLocalizationsRu extends AppLocalizations {
   String get books => 'Книги';
 
   @override
-  String get latestBooks => 'Новые книги';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Новые аудиокниги';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count книги',
-      many: '$count книг',
-      few: '$count книги',
-      one: '$count книга',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Книга';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудиокнига';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Прочитано $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Осталось $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Читать';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слушать';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Автор';
@@ -843,12 +841,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return 'Разделов: $count';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Первое издание: $year';
+    return 'First published $year';
   }
 
   @override
@@ -863,7 +861,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return 'Книг: $count';
+    return '$count books';
   }
 
   @override
@@ -875,7 +873,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return 'Авторов: $count';
+    return '$count Authors';
   }
 
   @override
@@ -883,10 +881,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудиокниги',
-      many: '$count аудиокниг',
-      few: '$count аудиокниги',
-      one: '$count аудиокнига',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -904,7 +900,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get delete => 'Удалить';
 
   @override
-  String get save => 'Сохранить';
+  String get save => 'Сохранять';
 
   @override
   String get moreLikeThis => 'Больше подобного';
@@ -922,7 +918,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get nextUp => 'Далее';
 
   @override
-  String get seasons => 'Сезоны';
+  String get seasons => 'Времена года';
 
   @override
   String get chapters => 'Главы';
@@ -934,7 +930,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get movies => 'Фильмы';
 
   @override
-  String get musicVideos => 'Клипы';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Другой';
@@ -953,7 +949,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Диск $number';
+    return 'Disc $number';
   }
 
   @override
@@ -977,7 +973,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Издано в $year';
+    return 'Published $year';
   }
 
   @override
@@ -988,54 +984,52 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count сезона',
-      many: '$count сезонов',
-      few: '$count сезона',
-      one: '$count сезон',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Закончится в $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Элементы';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Дополнения';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Со съёмок';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Удалённые сцены';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Дополнительные ролики';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Интервью';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцены';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Короткометражки';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Трейлеры';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'Осталось $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Завершится через $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,11 +1043,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Продолжить с $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Воспроизвести';
+  String get play => 'Играть';
 
   @override
   String get startOver => 'Начать сначала';
@@ -1077,7 +1071,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get version => 'Версия';
 
   @override
-  String get cast => 'Транслировать';
+  String get cast => 'Бросать';
 
   @override
   String get trailer => 'Трейлер';
@@ -1147,7 +1141,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Удалить скачанные треки альбома «$title»?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1162,17 +1156,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel: ничего не загружено';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Скачивание «$title» (элементов: $count)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Удалить «$name» с сервера? Это действие нельзя отменить.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1183,7 +1177,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Формат книги не поддерживается: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1193,7 +1187,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get subtitleTrack => 'Дорожка субтитров';
 
   @override
-  String get none => 'Нет';
+  String get none => 'Никто';
 
   @override
   String get downloadSubtitlesLabel => 'Скачать субтитры...';
@@ -1210,7 +1204,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Субтитры скачаны и выбраны: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1219,7 +1213,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'В сети не найдено субтитров на языке $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1227,7 +1221,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Версия $number';
+    return 'Version $number';
   }
 
   @override
@@ -1249,7 +1243,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Скачивание $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1257,7 +1251,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Удалить локальные файлы: $typeLabel?\n\nЭто освободит место в хранилище. Позже можно скачать заново.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1273,25 +1267,25 @@ class AppLocalizationsRu extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕЖИССЁРЫ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТЫ';
+  String get writers => 'ПИСАТЕЛИ';
 
   @override
   String get studio => 'СТУДИЯ';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count ещё';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return 'Эпизодов: $count';
+    return '$count Episodes';
   }
 
   @override
@@ -1301,12 +1295,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Эпизод $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Глава $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1314,10 +1308,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count трека',
-      many: '$count треков',
-      few: '$count трека',
-      one: '$count трек',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1327,27 +1319,25 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count главы',
-      many: '$count глав',
-      few: '$count главы',
-      one: '$count глава',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Дата рождения: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Дата смерти: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Возраст: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1357,20 +1347,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get readMore => 'Читать далее';
 
   @override
-  String get shuffle => 'Перемешать';
+  String get shuffle => 'Перетасовать';
 
   @override
-  String get shuffleAllMusic => 'Перемешать всю музыку';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Войдите в Moonfin на телефоне';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Сервер недоступен';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return 'Скачиваний: $count';
+    return '$count downloads';
   }
 
   @override
@@ -1378,43 +1368,43 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count кан.';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Моно';
+  String get mono => 'Мононуклеоз';
 
   @override
   String get stereo => 'Стерео';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Для действия «$action» с внешними субтитрами нужно разрешение Jellyfin на управление субтитрами для этого пользователя.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Элемент не найден на сервере для действия «$action» с внешними субтитрами.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Не удалось выполнить «$action» для внешних субтитров: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Не удалось выполнить «$action» для внешних субтитров (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Не удалось выполнить «$action» для внешних субтитров.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'все скачанные эпизоды «$name»';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1445,17 +1435,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Не удалось выполнить действие $label: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Не удалось изменить громкость трансляции: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Управление $label';
+    return '$label Controls';
   }
 
   @override
@@ -1472,7 +1462,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Остановить $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1480,7 +1470,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Трек $number';
+    return 'Track $number';
   }
 
   @override
@@ -1497,14 +1487,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds сек';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'Длительное нажатие, чтобы разблокировать';
 
   @override
-  String get off => 'Выкл.';
+  String get off => 'Выключенный';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1516,7 +1506,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String bitrateValueMbps(int mbps) {
-    return '$mbps Мбит/с';
+    return '$mbps Mbps';
   }
 
   @override
@@ -1527,19 +1517,19 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value мс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value мс';
+    return '+${value}ms';
   }
 
   @override
   String get subtitleDelay => 'Задержка субтитров';
 
   @override
-  String get reset => 'Сбросить';
+  String get reset => 'Перезагрузить';
 
   @override
   String get unknown => 'Неизвестный';
@@ -1566,7 +1556,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get transcodeReasons => 'Причины перекодирования';
 
   @override
-  String get player => 'Плеер';
+  String get player => 'Игрок';
 
   @override
   String get container => 'Контейнер';
@@ -1590,7 +1580,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get videoBitrate => 'Битрейт видео';
 
   @override
-  String get track => 'Дорожка';
+  String get track => 'Отслеживать';
 
   @override
   String get channels => 'Каналы';
@@ -1612,12 +1602,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Ошибка сеанса $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Не удалось загрузить сведения о книге: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1626,7 +1616,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Этот формат (.$extension) пока нельзя открыть в приложении.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1639,17 +1629,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Не удалось открыть встроенную читалку: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Закладка на «$label» уже сохранена.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Закладка добавлена: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1661,7 +1651,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Страница $number';
+    return 'Page $number';
   }
 
   @override
@@ -1672,12 +1662,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Формат: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return 'Прочитано $percent%';
+    return '$percent% read';
   }
 
   @override
@@ -1701,7 +1691,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Сбросить масштаб (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1724,7 +1714,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Не удалось изменить статус прочтения: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1758,7 +1748,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Эта платформа не поддерживает встроенный движок документов для файлов $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1797,7 +1787,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Не удалось загрузить телепрограмму: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1808,22 +1798,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Далее: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Осталось $minutes мин';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Осталось $hours ч';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Осталось $hours ч $minutes мин';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1846,29 +1836,29 @@ class AppLocalizationsRu extends AppLocalizations {
   String get favoriteChannel => 'Любимый канал';
 
   @override
-  String get record => 'Записать';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Отменить запись';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Запись передачи запланирована';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Запись отменена';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Не удалось создать запись';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Смотреть';
 
   @override
-  String get close => 'Закрыть';
+  String get close => 'Закрывать';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Не удалось воспроизвести $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1894,7 +1884,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Отменить запланированную запись «$name»?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1921,7 +1911,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Остановить запись «$name»?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1936,12 +1926,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Нет результатов по запросу «$query»';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Ошибка поиска: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1982,12 +1972,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Удалить «$name» и его файлы?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return 'Треков: $count';
+    return '$count tracks';
   }
 
   @override
@@ -1998,12 +1988,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Не удалось загрузить альбом: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Для «$name» нет скачанных треков.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2020,22 +2010,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Удалить «$name»?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Э$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Эпизод $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2049,12 +2039,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Сезон $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2065,7 +2055,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Удалить все скачанные эпизоды сезона «$season»?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2073,10 +2063,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count эпизода',
-      many: '$count эпизодов',
-      few: '$count эпизода',
-      one: '$count эпизод',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2111,7 +2099,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Удалить скачанные элементы ($count)?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2125,7 +2113,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'из лимита $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2209,7 +2197,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return 'Параметров: $count';
+    return '$count options';
   }
 
   @override
@@ -2305,7 +2293,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Страницы сведений, ряды на главной и громкость';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2320,18 +2308,18 @@ class AppLocalizationsRu extends AppLocalizations {
       'Играть при просмотре главного экрана';
 
   @override
-  String get loopThemeMusic => 'Зациклить заглавную музыку';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Повторять трек, а не проигрывать его один раз';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Детали размытия фона';
 
   @override
   String pixelValue(int value) {
-    return '$value пикс.';
+    return '${value}px';
   }
 
   @override
@@ -2347,23 +2335,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get playerZoomMode => 'Режим масштабирования игрока';
 
   @override
-  String get settingsScrollWheelAction => 'Колёсико мыши';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Выберите, что делает прокрутка колёсиком мыши поверх видео во время воспроизведения.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Выкл.';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Перемотка (вперёд / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Громкость';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Громкость';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Соответствовать';
@@ -2378,7 +2366,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get refreshRateSwitching => 'Переключение частоты обновления';
 
   @override
-  String get disabled => 'Отключено';
+  String get disabled => 'Неполноценный';
 
   @override
   String get scaleOnTv => 'Масштабирование на ТВ';
@@ -2417,37 +2405,37 @@ class AppLocalizationsRu extends AppLocalizations {
   String get defaultAudioLanguage => 'Язык аудио по умолчанию';
 
   @override
-  String get fallbackAudioLanguage => 'Запасной язык звука';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Предпочитать дорожку по умолчанию';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Предпочитать оригинальную звуковую дорожку локализованному дубляжу.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Предпочитать тифлокомментарии';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Предпочитать дорожки с тифлокомментариями обычным.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскодирование (звук)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Прямой поток (ремукс)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскодирование (битрейт или разрешение)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскодирование (видео и звук)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскодирование (видео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Авто (по умолчанию для сервера)';
@@ -2524,28 +2512,27 @@ class AppLocalizationsRu extends AppLocalizations {
       'Включить звук TrueHD (может работать не на всех платформах)';
 
   @override
-  String get settingsAudioOutputMode => 'Режим вывода звука';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Выберите способ декодирования звука. AVR Passthrough передаёт исходные потоки Dolby/DTS на ресивер, «Авто» и «Сведение» декодируют локально.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Запасной аудиокодек';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Выберите формат для транскодирования многоканального звука, когда исходный поток нельзя воспроизвести напрямую или передать без обработки.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Автоопределение\n(рекомендуется)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(по умолчанию)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2554,61 +2541,60 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(без потерь)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(только стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(экономичный)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(без потерь)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максимум аудиоканалов';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Укажите максимальное число каналов вашей аудиосистемы. Потоки сверх этого лимита будут сведены или транскодированы.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Автоопределение\n(по оборудованию)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 объёмный';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 квадрофония';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 объёмный';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 объёмный';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 объёмный';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 объёмный';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (дополнительно)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough кодеков';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Включайте только форматы, которые поддерживает ваш ресивер или приёмник HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
   String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
@@ -2630,39 +2616,38 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Передавать битовый поток Dolby Digital Plus (EAC3) на внешний декодер.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Передавать битовый поток Dolby Atmos через EAC3 (JOC) на внешний декодер.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Передавать битовый поток DTS-HD MA (включая ядро DTS) на внешний декодер.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Передавать битовый поток Dolby TrueHD с метаданными Atmos на внешний декодер.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Обнаруженные возможности звука';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Данные о текущих возможностях устройства пока недоступны.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Маршрут';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Декодирование';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Маршрут HD-звука';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2677,51 +2662,50 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Динамик';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Наушники';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return 'PCM, $count кан.';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Диагностика';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Уровень видео';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Диапазон видео';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Кодек субтитров';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Разрешённые аудиокодеки';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Аудиокодеки HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Аудиокодеки HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Активный аудиомаршрут';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Поддержка HD-звука маршрутом';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Ночной режим';
@@ -2771,7 +2755,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value с';
+    return '${value}s';
   }
 
   @override
@@ -2786,7 +2770,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'После $episodes эпизодов / $hours ч';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2862,45 +2846,45 @@ class AppLocalizationsRu extends AppLocalizations {
       'Настройте внешний вид субтитров';
 
   @override
-  String get subtitleMode => 'Режим субтитров';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'По флагу';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Всегда';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Иностранные';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Форсированные';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Воспроизводит дорожки, помеченные в метаданных файла как «default» или «forced».';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Автоматически загружает и показывает субтитры при каждом запуске видео.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Автоматически включает субтитры, если звуковая дорожка по умолчанию на иностранном языке.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Загружает только субтитры с явным флагом «forced».';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Полностью отключает автоматическую загрузку субтитров.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Запасной язык субтитров';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Поток субтитров';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2960,17 +2944,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Настройки профиля «$profile» загружены.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Не удалось загрузить настройки профиля «$profile».';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Локальные настройки синхронизированы с профилем «$profile».';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3106,11 +3090,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показать библиотеки на панели инструментов';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Всегда показывать подписи в панели навигации';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Показывать кнопку Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Непрозрачность панели навигации';
@@ -3185,18 +3168,18 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showFolderBrowsingOption => 'Показать опцию просмотра папок';
 
   @override
-  String get groupItemsIntoCollections => 'Группировать элементы в коллекции';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Скрывать элементы, входящие в коллекции, при просмотре библиотек';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'О группировке библиотек';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Чтобы использовать эту настройку, убедитесь, что параметры «Группировать фильмы в коллекции» и (или) «Группировать сериалы в коллекции» включены в настройках отображения вашей библиотеки на сервере Jellyfin или Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Видимость библиотеки';
@@ -3225,7 +3208,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return 'Выбрано: $count';
+    return '$count selected';
   }
 
   @override
@@ -3255,13 +3238,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Выберите один из вариантов оформления панели управления медиафайлами или отключите её';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Лунный плавник';
 
   @override
   String get mediaBarModeMakd => 'МакД';
 
   @override
-  String get mediaBarModeOff => 'Выкл.';
+  String get mediaBarModeOff => 'Выключенный';
 
   @override
   String get enableMediaBar => 'Включить медиа-панель';
@@ -3308,10 +3291,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Автовоспроизведение трейлеров на медиабаре через 3 секунды.';
 
   @override
-  String get trailerAudio => 'Звук трейлеров';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Включить звук трейлеров в медиапанели';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Предварительный просмотр эпизода';
@@ -3389,11 +3372,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get combineBothRows => 'Объедините оба ряда в один домашний раздел.';
 
   @override
-  String get fullScreenRows => 'Развёрнутые ряды на главной';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Показывать не больше одного ряда на экране';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тип изображения по строкам';
@@ -3408,7 +3390,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lastUser => 'Последний пользователь';
 
   @override
-  String get currentUser => 'Текущий пользователь';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Всегда аутентифицироваться';
@@ -3485,7 +3467,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
@@ -3516,10 +3498,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Отображать часы во время заставки';
 
   @override
-  String get clockModeStatic => 'Статичные';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Прыгающие';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Тухлые помидоры (критики)';
@@ -3531,7 +3513,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get imdb => 'IMDb';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'ТМДБ';
 
   @override
   String get metacritic => 'Метакритик';
@@ -3540,7 +3522,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get metacriticUser => 'Метакритик (Пользователь)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'почтовый ящик';
@@ -3591,7 +3573,7 @@ class AppLocalizationsRu extends AppLocalizations {
       'Включите и измените порядок источников рейтингов, отображаемых в приложении.';
 
   @override
-  String get pluginLabel => 'Плагин Moonbase';
+  String get pluginLabel => 'Плагин';
 
   @override
   String get pluginDetected => 'Плагин обнаружен';
@@ -3609,7 +3591,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nВерсия: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3663,13 +3645,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get networks => 'Сети';
 
   @override
-  String get seerrDiscoveryRows => 'Ряды подборок Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Сбросить строки к значениям по умолчанию';
 
   @override
-  String get enableSeerr => 'Включить Seerr';
+  String get enableSeerr => 'Включить Сирр';
 
   @override
   String get showSeerrInNavigation =>
@@ -3686,43 +3668,44 @@ class AppLocalizationsRu extends AppLocalizations {
   String get hideAdultContent => 'Скрыть контент для взрослых в результатах';
 
   @override
-  String get seerrNotificationsSection => 'Уведомления';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Уведомления о новых запросах';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Оповещать, когда кто-то отправляет запрос';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Обновления запросов';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Одобрено, отклонено и добавлено в библиотеку';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Обновления проблем';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Новые проблемы, ответы и решения';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Вход выполнен: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Страница обзора Seerr';
+  String get discoverRows => 'Откройте для себя строки';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Включите строки, которые будут отображаться на главной странице Seerr. Перетащите, чтобы изменить порядок. Пользовательский порядок синхронизируется с Moonbase.';
+      'Перетащите, чтобы изменить порядок. Включите или отключите строки. Включена синхронизация порядка строк с плагином Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Включите строки, которые будут отображаться на главной странице Seerr. Перетащите, чтобы изменить порядок. Пользовательский порядок синхронизируется с Moonbase.';
+      'Перетащите, чтобы изменить порядок. Включите или отключите строки.';
 
   @override
   String get enabled => 'Включено';
@@ -3735,7 +3718,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Версия $version';
+    return 'Version $version';
   }
 
   @override
@@ -3786,7 +3769,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Доступно обновление: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3798,7 +3781,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Доступна версия v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3844,7 +3827,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value ГБ';
+    return '$value GB';
   }
 
   @override
@@ -3862,7 +3845,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get imageCacheCleared => 'Кэш изображений очищен';
 
   @override
-  String get clear => 'Очистить';
+  String get clear => 'Прозрачный';
 
   @override
   String get browse => 'Просматривать';
@@ -3878,15 +3861,15 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Скачивание · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Импорт';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return 'Элементов: $count';
+    return '$count Items';
   }
 
   @override
@@ -3906,7 +3889,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Запрос от $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3923,12 +3906,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Отменить запрос на «$title»?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Отменить запросы ($count) на «$title»?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3943,12 +3926,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Бюджет: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Сборы: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3958,7 +3941,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Запросить: $type';
+    return 'Request $type';
   }
 
   @override
@@ -3993,7 +3976,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'возраст $age';
+    return 'age $age';
   }
 
   @override
@@ -4024,146 +4007,148 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deletedStatus => 'Удалено';
 
   @override
-  String get failedStatus => 'Ошибка';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'В обработке';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Изменено: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завершено';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Этот запрос уже был отправлен';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Достигнут лимит запросов';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Этот материал в чёрном списке';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Нет сезонов, доступных для запроса';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'У вас нет прав на такой запрос';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Запросы';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Проблемы';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Сначала новые';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'По дате изменения';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Проблем нет';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Осталось запросов фильмов: $remaining из $limit';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Осталось запросов сезонов: $remaining из $limit';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Входит в «$name»';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Открыть коллекцию';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Запросить коллекцию';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'Фильмов: $total · доступно: $available';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Запросить фильмы ($count)';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Запрос $current из $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Запрошено фильмов: $count';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Запрошено $ok из $total фильмов';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'Все фильмы уже доступны или запрошены';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Сообщить о проблеме';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Видео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Звук';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Что не так?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Все эпизоды';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Эпизод';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Открыта';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Решена';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Решить';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Открыть заново';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Сообщение от $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return 'Комментариев: $count';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Добавить комментарий';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Удалить эту проблему?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Отправить сообщение';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Оценка TMDB';
@@ -4187,7 +4172,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get originalLanguageLabel => 'Исходный язык';
 
   @override
-  String get seasonsLabel => 'Сезоны';
+  String get seasonsLabel => 'Времена года';
 
   @override
   String get episodesLabel => 'Эпизоды';
@@ -4196,7 +4181,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get access => 'Доступ';
 
   @override
-  String get add => 'Добавить';
+  String get add => 'Добавлять';
 
   @override
   String get address => 'Адрес';
@@ -4220,10 +4205,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get disable => 'Запрещать';
 
   @override
-  String get done => 'Готово';
+  String get done => 'Сделанный';
 
   @override
-  String get edit => 'Изменить';
+  String get edit => 'Редактировать';
 
   @override
   String get encoding => 'Кодирование';
@@ -4232,10 +4217,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get error => 'Ошибка';
 
   @override
-  String get forward => 'Вперёд';
+  String get forward => 'Вперед';
 
   @override
-  String get general => 'Общие';
+  String get general => 'Общий';
 
   @override
   String get go => 'Идти';
@@ -4256,7 +4241,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get networking => 'сеть';
 
   @override
-  String get next => 'Далее';
+  String get next => 'Следующий';
 
   @override
   String get path => 'Путь';
@@ -4280,7 +4265,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get refresh => 'Обновить';
 
   @override
-  String get remote => 'Пульт';
+  String get remote => 'Удаленный';
 
   @override
   String get rename => 'Переименовать';
@@ -4316,7 +4301,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Остановить';
+  String get stop => 'Останавливаться';
 
   @override
   String get streaming => 'Потоковое вещание';
@@ -4325,7 +4310,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get time => 'Время';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Трикплей';
 
   @override
   String get uninstall => 'Удалить';
@@ -4343,7 +4328,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unmute => 'Включить звук';
 
   @override
-  String get mute => 'Без звука';
+  String get mute => 'Немой';
 
   @override
   String get branding => 'Брендинг';
@@ -4367,25 +4352,25 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminDrawerLibraries => 'Библиотеки';
 
   @override
-  String get adminDrawerDisplay => 'Отображение';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метаданные';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Настройки NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Транскодирование';
 
   @override
-  String get adminDrawerResume => 'Продолжить';
+  String get adminDrawerResume => 'Резюме';
 
   @override
   String get adminDrawerStreaming => 'Потоковое вещание';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Трикплей';
 
   @override
   String get adminDrawerDevices => 'Устройства';
@@ -4437,22 +4422,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Доступно обновлений плагинов: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Плагинов, требующих перезапуска: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Невыполненных запланированных задач: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Недавних предупреждений и ошибок: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4511,7 +4496,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Ошибка: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4538,7 +4523,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Не удалось выполнить команду: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4557,7 +4542,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sessionRewind => 'Перемотка назад';
 
   @override
-  String get sessionForward => 'Вперёд';
+  String get sessionForward => 'Вперед';
 
   @override
   String get sessionNext => 'Следующий';
@@ -4575,7 +4560,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get nowPlaying => 'Сейчас играет';
 
   @override
-  String get volume => 'Громкость';
+  String get volume => 'Объем';
 
   @override
   String get actions => 'Действия';
@@ -4602,14 +4587,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminClearDates => 'Очистить даты';
 
   @override
-  String get adminActivitySeverityAll => 'Любая важность';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Диапазон дат';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Не удалось загрузить журнал активности: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4626,7 +4611,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Не удалось обновить устройство: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4637,28 +4622,28 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Не удалось удалить устройство: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Удалить устройство «$name»? Пользователю придётся войти на нём заново.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Удалить все устройства';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Удалить устройства ($count)? Затронутым пользователям придётся войти заново. Текущее устройство не будет удалено.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Устройства удалены';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Часть устройств удалена; не удалось удалить: $count.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4687,7 +4672,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Не удалось запустить сканирование: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4698,12 +4683,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Библиотека переименована в «$name»';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Не удалось переименовать: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4711,17 +4696,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Библиотека «$name» удалена';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Не удалось удалить библиотеку: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Не удалось добавить путь: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4729,12 +4714,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Удалить «$path» из этой библиотеки?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Не удалось удалить путь: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4742,7 +4727,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Не удалось сохранить параметры: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4773,257 +4758,251 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminMetadataCountryHint => 'например США, Германия, Франция';
 
   @override
-  String get adminLibraryTabPaths => 'Пути';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Параметры';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Загрузчики';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Сохранение метаданных';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Загрузчики субтитров';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Загрузчики текстов песен';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Загрузчики метаданных: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Источники изображений: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Сервер не предоставляет загрузчиков для этого типа библиотеки.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Общие';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метаданные';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Встроенные данные';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Субтитры';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Изображения';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Сериалы';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музыка';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Фильмы';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Отслеживание в реальном времени';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Обнаруживать изменения файлов и обрабатывать их автоматически.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Считать архивы медиафайлами';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Показывать фотографии';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Сохранять обложки в папки с медиа';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Автоматическое обновление метаданных';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Никогда';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'По умолчанию';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Отображение';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Отображение библиотеки';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Показывать обычные папки с медиа в виде каталога';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Показывать спецвыпуски в сезонах, в которых они вышли';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Группировать фильмы в коллекции';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Группировать сериалы в коллекции';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Показывать внешний контент в рекомендациях';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Определение даты добавления';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Брать дату добавления из';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Дата сканирования в библиотеку';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Дата создания файла';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метаданные и изображения';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Предпочитаемый язык метаданных';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Главы';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Длительность фиктивной главы (сек)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Длительность глав, создаваемых для медиа без глав. 0 — отключить.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Разрешение изображений глав';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Настройки NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Метаданные NFO совместимы с Kodi и похожими клиентами. Настройки применяются ко всем библиотекам, которые сохраняют метаданные NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Пользователь, чьи данные о просмотре сохраняются в файлы NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Сохранять пути к изображениям в файлах NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Включить подстановку путей для изображений в NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Копировать изображения extrafanart в папку extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Нет';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days дн.';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Использовать встроенные названия';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Использовать встроенные названия для дополнений';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Использовать встроенные сведения об эпизодах';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Разрешить встроенные субтитры';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Разрешить все';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Только текстовые';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Только графические';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Нет';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Не скачивать, если есть встроенные субтитры';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Не скачивать, если язык звуковой дорожки совпадает с языком скачивания';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Требовать точного совпадения субтитров';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Сохранять субтитры в папки с медиа';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Извлекать изображения глав';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Извлекать изображения глав во время сканирования библиотеки';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Извлекать изображения trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Извлекать изображения trickplay во время сканирования библиотеки';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Сохранять изображения trickplay в папки с медиа';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Автоматически объединять сериалы, разбросанные по нескольким папкам';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Название нулевого сезона';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Включить LUFS-анализ для нормализации звука';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Предпочитать нестандартный тег исполнителей';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Автоматически добавлять фильмы в коллекции';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Укажите название библиотеки.';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Не удалось создать библиотеку: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5049,27 +5028,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Отключить пользователя $name? Он не сможет войти.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Включить пользователя $name? Он снова сможет входить.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Пользователь «$name» отключён';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Пользователь «$name» включён';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Не удалось обновить политику пользователя: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5086,7 +5065,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Не удалось создать пользователя: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5107,7 +5086,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Не удалось сохранить: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5118,7 +5097,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Ошибка: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5257,145 +5236,143 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminEnableAllChannels => 'Включить доступ ко всем каналам';
 
   @override
-  String get adminParentalControl => 'Родительский контроль';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Максимальный разрешённый возрастной рейтинг';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Контент с более высоким рейтингом будет скрыт от этого пользователя.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Нет';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блокировать материалы без рейтинга или с нераспознанным рейтингом';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Книги';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Каналы';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Прямой эфир';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Фильмы';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музыка';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трейлеры';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Сериалы';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Расписание доступа';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Разрешать доступ только в указанное ниже время. Если расписание не задано, доступ открыт круглосуточно.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Добавить расписание';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'День';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Начало';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Конец';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Ежедневно';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Будни';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Выходные';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Воскресенье';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Понедельник';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Вторник';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Среда';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Четверг';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Пятница';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Суббота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Разрешённые теги';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Показывается только контент с этими тегами. Оставьте пустым, чтобы разрешить всё.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Заблокированные теги';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Контент с этими тегами скрыт от этого пользователя.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Добавить тег';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Разрешённые устройства';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Разрешённые каналы';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Провайдер аутентификации';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Провайдер сброса пароля';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максимум неудачных попыток входа до блокировки';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      '0 — значение по умолчанию, -1 — отключить блокировку.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Доступ к SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Разрешить создавать группы и присоединяться к ним';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Разрешить присоединяться к группам';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Нет доступа';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Разрешить удаление контента из';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5403,22 +5380,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Сервер вернул HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Удалить пользователя $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Пользователь «$name» удалён';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Не удалось удалить пользователя: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5439,7 +5416,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Не удалось создать ключ: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5450,7 +5427,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Отозвать ключ для $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5458,7 +5435,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Не удалось отозвать ключ: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5478,29 +5455,29 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Токен: $token\\nСоздан: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Создать резервную копию';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Выберите, что включить в резервную копию.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База данных';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Включается всегда';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метаданные';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Субтитры';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Изображения trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Создание резервной копии...';
@@ -5510,7 +5487,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Не удалось создать резервную копию: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5519,12 +5496,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Манифест: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Не удалось загрузить манифест: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5535,7 +5512,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Не удалось восстановить резервную копию: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5567,17 +5544,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Сохранено в $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Не удалось сохранить файл: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Не удалось загрузить $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5588,7 +5565,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Не удалось загрузить задачи: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5600,17 +5577,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Не удалось запустить задачу: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Не удалось остановить задачу: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Не удалось загрузить задачу: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5618,12 +5595,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Не удалось удалить триггер: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Не удалось добавить триггер: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5649,7 +5626,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ч';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5660,7 +5637,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Не удалось переключить плагин: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5668,27 +5645,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Удалить плагин «$name»?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Не удалось удалить плагин: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Не удалось установить пакет: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Не удалось установить обновление: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Не удалось загрузить плагины: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5700,12 +5677,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Установить обновление (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Не удалось загрузить каталог: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5727,17 +5704,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '«$name» будет удалён после перезапуска сервера';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Не удалось удалить: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Обновление «$name» до v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5746,7 +5723,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Не удалось загрузить плагин: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5754,7 +5731,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Версия $version';
+    return 'Version $version';
   }
 
   @override
@@ -5774,17 +5751,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Удалить «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Не удалось сохранить репозитории: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Не удалось загрузить репозитории: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5801,12 +5778,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Не удалось загрузить настройки плагина: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Не удалось открыть $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5933,11 +5910,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminThrottleBuffering => 'Буферизация дроссельной заслонки';
 
   @override
-  String get adminTrickplaySaved => 'Настройки Trickplay сохранены';
+  String get adminTrickplaySaved => 'Настройки трикплея сохранены.';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Не удалось загрузить настройки Trickplay';
+      'Не удалось загрузить настройки трикплея.';
 
   @override
   String get adminEnableHardwareAcceleration => 'Включить аппаратное ускорение';
@@ -6052,7 +6029,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminBaseUrl => 'Базовый URL';
 
   @override
-  String get adminBaseUrlHint => 'например /jellyfin';
+  String get adminBaseUrlHint => 'например /желефин';
 
   @override
   String get https => 'HTTPS';
@@ -6092,12 +6069,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Не удалось загрузить метаданные: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Не удалось сохранить метаданные: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6117,7 +6094,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Не удалось обновить метаданные: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6131,7 +6108,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Ошибка поиска в сети: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6145,7 +6122,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Не удалось изменить тип контента: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6160,12 +6137,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Изображение «$imageType» обновлено';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Не удалось скачать изображение: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6178,27 +6155,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Изображение «$imageType» загружено';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Не удалось загрузить изображение: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Удалить изображение «$imageType»';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Изображение «$imageType» удалено';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Не удалось удалить изображение: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6209,71 +6186,67 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Не удалось найти тюнеры: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Добавить тюнер';
 
   @override
-  String get adminEditTuner => 'Изменить тюнер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-тюнер';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл или URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-адрес тюнера';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Понятное имя';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Лимит одновременных подключений';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максимальное число потоков, которое тюнер допускает одновременно. 0 — без ограничений.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Запасной максимальный битрейт потока';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Импортировать только избранные каналы';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Разрешить аппаратное транскодирование';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Разрешить контейнер транскодирования fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Разрешить совместное использование потока';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Включить зацикливание потока';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Игнорировать DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Читать входной поток с исходной частотой кадров';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Изменить провайдера';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6282,50 +6255,50 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл или URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Префикс фильмов';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Категории фильмов';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Разделяйте несколько категорий вертикальной чертой.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Детские категории';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Категории новостей';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Спортивные категории';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Имя пользователя';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Пароль';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Страна';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Выберите страну';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Почтовый индекс';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Получить списки';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Списки';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Включить все тюнеры';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тип тюнера';
@@ -6335,7 +6308,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Не удалось добавить тюнер: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6349,12 +6322,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Не удалось добавить провайдера: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Не удалось удалить тюнер: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6362,16 +6335,16 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Не удалось сбросить тюнер: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Этот тип тюнера не поддерживает сброс.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Не удалось удалить провайдера: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6390,43 +6363,43 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Путь записи серии';
 
   @override
-  String get adminMovieRecordingPath => 'Путь для записи фильмов';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Дней телепрограммы';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автоматически';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days дн.';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Путь к приложению постобработки';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Аргументы постобработчика';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Сохранять NFO-метаданные записей';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Сохранять изображения записей';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Время';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Пути записи';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Постобработка';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Телепрограмма: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6434,7 +6407,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Не удалось сохранить настройки: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6452,7 +6425,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Не удалось обновить сопоставления: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6469,14 +6442,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminGuideProviders => 'Поставщики руководств';
 
   @override
-  String get adminRefreshGuideData => 'Обновить телепрограмму';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Обновление телепрограммы запущено';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Задача обновления телепрограммы недоступна на этом сервере.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Добавить поставщика';
@@ -6486,22 +6459,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Путь записи: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Путь сериалов: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Запас до: $minutes мин';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Запас после: $minutes мин';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6534,7 +6507,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Восстановить резервную копию $name сейчас?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6558,13 +6531,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminLiveTvTitle => 'Администрация прямого эфира';
 
   @override
-  String get adminApply => 'Применить';
+  String get adminApply => 'Применять';
 
   @override
   String get adminNotSet => 'Не установлено';
 
   @override
-  String get adminReset => 'Сбросить';
+  String get adminReset => 'Перезагрузить';
 
   @override
   String get adminLogsTitle => 'Журналы сервера';
@@ -6580,27 +6553,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes мин назад';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours ч назад';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days дн назад';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Не удалось загрузить $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return 'Совпадений: $count';
+    return '$count matches';
   }
 
   @override
@@ -6610,7 +6583,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Редактор метаданных';
 
   @override
-  String get adminMetadataIdentify => 'Определить';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тип';
@@ -6625,7 +6598,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminMetadataImages => 'Изображения';
 
   @override
-  String get adminMetadataFieldTitle => 'Название';
+  String get adminMetadataFieldTitle => 'Заголовок';
 
   @override
   String get adminMetadataFieldSortTitle => 'Сортировать заголовок';
@@ -6710,22 +6683,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Изображение «$imageType» обновлено';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Изображение «$imageType» загружено';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Изображение «$imageType» удалено';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Не удалось скачать изображение: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6734,12 +6707,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Не удалось загрузить изображение: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Удалить изображение «$imageType»';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6748,12 +6721,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Не удалось удалить изображение: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Выбрать изображение «$imageType»';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6786,7 +6759,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Доступно обновление: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6810,7 +6783,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Установить обновление (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6822,7 +6795,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return 'Идёт установка «$name»...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6842,7 +6815,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Настройки $name';
+    return '$name Settings';
   }
 
   @override
@@ -6882,7 +6855,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Не удалось загрузить репозитории: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6890,15 +6863,15 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Удалить «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Удалить';
+  String get adminReposRemove => 'Удалять';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Не удалось сохранить репозитории: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7027,19 +7000,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Включить заставку';
 
   @override
-  String get adminBrandingSplashUpload => 'Загрузить изображение';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Заставка обновлена';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => 'Не удалось загрузить заставку';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Заставка удалена';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Своя заставка не задана';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Аппаратное ускорение';
@@ -7055,129 +7028,121 @@ class AppLocalizationsRu extends AppLocalizations {
       'Включить аппаратное декодирование для:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Устройство QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Включить расширенный декодер NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Предпочитать системный аппаратный декодер';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Глубина цвета при аппаратном декодировании';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-битное декодирование HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-битное декодирование VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Декодирование HEVC RExt 8/10 бит';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Декодирование HEVC RExt 12 бит';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Аппаратное кодирование';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Разрешить кодирование HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Разрешить кодирование AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Включить энергоэффективный кодировщик Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Включить энергоэффективный кодировщик Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тональное отображение';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Включить тональное отображение';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Включить тональное отображение VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Включить тональное отображение VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Алгоритм тонального отображения';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Режим тонального отображения';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Диапазон тонального отображения';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Десатурация тонального отображения';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Пик тонального отображения';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Параметр тонального отображения';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Яркость тонального отображения VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Контраст тонального отображения VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Пресеты и качество';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Пресет кодировщика';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF кодирования H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF кодирования H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метод деинтерлейсинга';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Удваивать частоту кадров при деинтерлейсинге';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Звук';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Включить VBR-кодирование звука';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Усиление при сведении звука';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгоритм сведения в стерео';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максимальный размер очереди мультиплексирования';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Авто';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодирование';
@@ -7297,10 +7262,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminTaskNeverRun => 'Никогда не беги';
 
   @override
-  String get adminTaskStop => 'Остановить';
+  String get adminTaskStop => 'Останавливаться';
 
   @override
-  String get adminRunningTasks => 'Выполняемые задачи';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Бегать';
@@ -7322,17 +7287,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Ежедневно в $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Еженедельно: $day в $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Каждые $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7370,10 +7335,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count часа',
-      many: '$count часов',
-      few: '$count часа',
-      one: '$count час',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7401,17 +7364,17 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days дн назад';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours ч назад';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes мин назад';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7419,27 +7382,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes мин';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours ч';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days дн';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Настройте создание изображений Trickplay для миниатюр предварительного просмотра при перемотке.';
+      'Настройте генерацию изображений для поиска миниатюр предварительного просмотра.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Публичный HTTPS-порт';
@@ -7448,50 +7411,49 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Базовый URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'например /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'например /желефин';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Публичный порт HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Требовать HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Перенаправлять все удалённые запросы на HTTPS. Не действует, если у сервера нет действительного сертификата.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Пароль сертификата';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Настройки IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Включить IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Включить IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Включить автоматический проброс портов';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Сети LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Список IP-адресов или подсетей CIDR через запятую или с новой строки, которые считаются локальной сетью.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Публикуемые URI сервера';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Сопоставьте подсеть или адрес с публикуемым URL, например all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Путь сертификата';
@@ -7522,11 +7484,11 @@ class AppLocalizationsRu extends AppLocalizations {
       'Буферизация дроссельной заслонки';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Задержка троттлинга (сек)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Разрешить извлечение субтитров на лету';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Минимальный процент резюме';
@@ -7576,7 +7538,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Не удалось изменить тип контента: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7584,23 +7546,22 @@ class AppLocalizationsRu extends AppLocalizations {
       'Порог медленного ответа (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Включить предупреждения о медленных ответах';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Включить Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метаданные';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Пути';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Производительность';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Путь к кэшу';
@@ -7612,7 +7573,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminGeneralServerName => 'Имя сервера';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Предпочитаемый язык интерфейса';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Не удалось загрузить настройки';
@@ -7622,12 +7583,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Не удалось обновить сопоставления: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Ограничение времени: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7664,10 +7625,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# участника',
-      many: '# участников',
-      few: '# участника',
-      one: '# участник',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7711,7 +7670,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Элемент $index';
+    return 'Item $index';
   }
 
   @override
@@ -7759,12 +7718,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName присоединился к группе SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName покинул группу SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7776,7 +7735,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Синхронизация воспроизведения с «$groupName»';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7814,10 +7773,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'обнаружено # ряда',
-      many: 'обнаружено # рядов',
-      few: 'обнаружено # ряда',
-      one: 'обнаружен # ряд',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7858,20 +7815,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get offlineSavedMedia => 'Сохраненные медиа';
 
   @override
-  String get offlineBannerTitle => 'Нет подключения';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Показаны ваши загрузки';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Загрузки';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Сервер недоступен';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Пока он не восстановится, воспроизводятся загрузки';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7887,12 +7844,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Не удалось выполнить команду трансляции: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Управление $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7903,7 +7860,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Остановить $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7927,12 +7884,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Введите PIN из $length цифр';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Введите свой PIN из $length цифр';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7945,17 +7902,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pinForgot => 'Забыли PIN-код?';
 
   @override
-  String get pinClear => 'Очистить';
+  String get pinClear => 'Прозрачный';
 
   @override
-  String get pinBackspace => 'Стереть';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Запрос Quick Connect одобрен.';
+  String get quickConnectAuthorized => 'Запрос быстрого подключения разрешен.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Код Quick Connect недействителен или истек.';
+      'Код быстрого подключения недействителен или срок его действия истек.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7963,22 +7920,23 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Не удалось авторизовать код Quick Connect.';
+      'Не удалось авторизовать код быстрого подключения.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect отключен на этом сервере.';
+  String get quickConnectDisabled =>
+      'Быстрое подключение отключено на этом сервере.';
 
   @override
   String get quickConnectForbidden =>
-      'Ваша учетная запись не может авторизовать этот запрос Quick Connect.';
+      'Ваша учетная запись не может авторизовать этот запрос на быстрое подключение.';
 
   @override
   String get quickConnectNotFound =>
-      'Код Quick Connect не найден. Попробуйте новый код.';
+      'Код быстрого подключения не найден. Попробуйте новый код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Ошибка Quick Connect: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7989,7 +7947,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Не удалось выполнить команду: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8019,7 +7977,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Не удалось начать трансляцию: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8065,7 +8023,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Скачивание $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8147,14 +8105,14 @@ class AppLocalizationsRu extends AppLocalizations {
       'Воспроизведение приостановлено. Вы все еще смотрите?';
 
   @override
-  String get stillWatchingStop => 'Остановить';
+  String get stillWatchingStop => 'Останавливаться';
 
   @override
   String get stillWatchingContinue => 'Продолжать';
 
   @override
   String skipSegment(String segment) {
-    return 'Пропустить: $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8165,12 +8123,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Скачивание $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Скачивание $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8232,13 +8190,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Скрыть из «Продолжить просмотр»';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Скрыть из «Далее»';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Добавить в коллекцию';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8293,15 +8251,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsAlphabetical => 'Алфавитный';
 
   @override
-  String get settingsConnectionSection => 'ПОДКЛЮЧЕНИЕ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Разрешить самоподписанные сертификаты';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Доверять серверам с самоподписанными сертификатами TLS или сертификатами частного центра. Включайте только для своих серверов: проверка сертификатов отключится для всех подключений.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection =>
@@ -8318,11 +8275,11 @@ class AppLocalizationsRu extends AppLocalizations {
       'Тематические акценты, фоны, индикаторы просмотра и музыкальная тема.';
 
   @override
-  String get settingsDetailsScreen => 'Экран сведений';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стиль, размытие фона и поведение вкладок';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Домашняя страница';
@@ -8360,11 +8317,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Показывать кнопку Seerr в панели навигации';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Всегда показывать подписи в верхней панели навигации';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8432,7 +8389,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Угостите разработчика чашкой кофе';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ЮРИДИЧЕСКИЙ';
@@ -8466,10 +8423,8 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лицензионных уведомления',
-      many: '# лицензионных уведомлений',
-      few: '# лицензионных уведомления',
-      one: '# лицензионное уведомление',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8519,16 +8474,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Пропустить интро и аутро?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Обратный отсчёт сегментов';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Полоса прогресса';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Нет';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Подскажите пользователю';
@@ -8564,13 +8519,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Media3 (рекомендуется)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (устаревший)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (старый вариант)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (рекомендуется)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Резервный режим Dolby Vision';
@@ -8665,7 +8620,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8763,757 +8718,749 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Недавно вышедшее: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Автовоспроизведение следующего эпизода';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Автоматически включать следующий эпизод, если он доступен.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Пропускать тишину';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Автоматически пропускать участки тишины, если поток это поддерживает.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Разрешить внешние аудиоэффекты';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Разрешить приложениям эквалайзера и эффектов (например, Wavelet) подключаться к сеансам воспроизведения Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Отключить туннелирование';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Принудительно воспроизводить без туннелирования. Полезно на устройствах с разрывами звука и видео при туннелировании.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Включить туннелирование';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Для опытных пользователей. Направляет звук и видео по связанному аппаратному тракту. Выключено по умолчанию, так как на некоторых устройствах вызывает выпадения звука и видео.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Преобразовывать Dolby Vision профиля 7 в HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Воспроизводить потоки Dolby Vision профиля 7 как HDR10-совместимый HEVC на устройствах без Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Использовать встроенные стили субтитров';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Применять цвета, шрифты и позиционирование, встроенные в дорожку субтитров. Отключите, чтобы использовать ваши настройки стиля.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Использовать встроенные размеры шрифта субтитров';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Применять размеры шрифта, встроенные в дорожку субтитров. Отключите, чтобы использовать размер из ваших настроек стиля.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Показывать сведения о медиа';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Показывать сведения о выбранном элементе вверху страниц библиотеки.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Скрывать фоны при просмотре?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Подробные подзаголовки';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Показывать подробный или минималистичный подзаголовок на страницах библиотеки.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Удалить сохранённую тему?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Удалить «$themeName» из кэша этого устройства?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Магазин тем';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Смотрите и сохраняйте темы сообщества';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Сохраните тему, чтобы пользоваться ей как остальными сохранёнными темами.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Сейчас нет доступных тем.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Не удалось загрузить магазин тем. Проверьте подключение и повторите попытку.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Сохранить';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Сохранить и применить';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Сохранено';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Не удалось загрузить эту тему.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Тема «$themeName» сохранена.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Тема «$themeName» удалена с этого устройства.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Не удалось удалить «$themeName».';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Сохранённые темы';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Это темы, скачанные из плагина Moonfin для текущего сервера. Удаление затрагивает только локальную копию.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Для этого сервера сохранённых тем не найдено.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • сейчас активна';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Удалить сохранённую тему';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Управление скачанными темами плагина на этом устройстве';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Редактор тем';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'Открыть редактор тем Moonfin в браузере';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Главный экран';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Нижняя панель';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Классический';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Современный';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Ряды на главной';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Отображение рядов на главной';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Разделы рядов на главной';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Переключатели рядов';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Включайте и отключайте категории рядов на основе библиотек';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Включите переключатели ниже, чтобы ряды появились в разделах главной.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      '«Классический» сохраняет тип изображения для каждого ряда и информационный оверлей. «Современный» использует ряды с переходом от постера к фону.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Показывать ряды избранного';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Показывать ряды с избранными фильмами, сериалами и другим в разделах главной.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Сортировка рядов избранного';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Сортируйте ряды избранного по дате добавления, дате выхода, алфавиту и не только.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Показывать ряды коллекций';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Показывать ряды коллекций в разделах главной.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Сортировка рядов коллекций';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Сортируйте ряды коллекций по дате добавления, дате выхода, алфавиту и не только.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Показывать ряды жанров';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Показывать ряды жанров в разделах главной.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Сортировка рядов жанров';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Сортируйте ряды жанров по дате добавления, дате выхода, алфавиту и не только.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Содержимое рядов жанров';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Показывать в рядах жанров фильмы, сериалы или и то, и другое.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Показывать ряды плейлистов';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Показывать ряды плейлистов в разделах главной.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Сортировка рядов плейлистов';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Сортируйте ряды плейлистов по дате добавления, дате выхода, алфавиту и не только.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Показывать аудиоряды';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Показывать аудиоряды в разделах главной.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Сортировка аудиорядов';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Сортируйте аудиоряды по дате добавления, дате выхода, алфавиту и не только.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудиоплейлисты';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Внешний вид';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Компоновка';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тема';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Клавиатура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Кнопки';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Отрисовка';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Настройка MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Внешний плеер';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Выберите внешний плеер, чтобы включить запуск долгим нажатием';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Показывать выбор приложения при запуске воспроизведения.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Загрузка установленных плееров...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Подключение';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Целевой формат транскодирования звука';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Поддерживается на этом устройстве';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Не поддерживается на этом устройстве';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Передавать битовый поток DTS:X (DTS UHD) на внешний декодер.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD с Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Поведение плеера';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Улучшения воспроизведения';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Всегда включено.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Заменять «Пропустить титры» на «Далее»';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Показывать оверлей «Далее» вместо кнопки «Пропустить титры».';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Маршрутизация плеера';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Предпочитать программные декодеры';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Использовать FFmpeg (звук) и libgav1 (AV1) вместо аппаратных декодеров. Отключите, если ломается passthrough звука по HDMI.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Открывать видео в выбранном внешнем приложении на Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Автоматическая очередь';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Предпочитать субтитры SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Отдавать приоритет дорожкам SDH/CC при автовыборе.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Веб-диагностика';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Веб-диагностика Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Эта страница помогает диагностировать проблемы подключения в браузере (CORS, смешанное содержимое и настройки обнаружения).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Обнаружен сбой из-за смешанного содержимого';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Обнаружен сбой CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin обнаружил, что HTTPS-страница обращается к серверу по HTTP. Браузеры блокируют такой запрос ещё до того, как он дойдёт до сервера.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin обнаружил сбой запроса на уровне браузера. Обычно он вызван отсутствием заголовков CORS или preflight на медиасервере.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Целевой URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Подробности: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Текущий контекст выполнения';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Схема';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Режим плагина';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Сканирование WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Принудительный URL сервера';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL сервера по умолчанию';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL прокси обнаружения';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'не настроено';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Смешанное содержимое';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Эта страница загружена по HTTPS, но один или несколько заданных URL используют HTTP. Браузеры блокируют обращения HTTPS-страниц к HTTP-API.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Решение: используйте HTTPS для медиасервера или прокси либо открывайте Moonfin по HTTP только в доверенных локальных сетях.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'В текущих настройках явных признаков смешанного содержимого не обнаружено.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Чек-лист CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Разрешите источник браузера в Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Добавьте Authorization, X-Emby-Authorization и X-Emby-Token в Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Откройте Content-Range и Accept-Ranges для потоковой передачи и перемотки.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Отвечайте 204 на preflight-запросы OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Пример фрагмента заголовков (в стиле nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Примечание';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Этот раздел диагностики предназначен для веб-сборок. Если вы видите его на другой платформе, проверки могут быть неприменимы.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Назад к выбору сервера';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Выйти из всех аккаунтов';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Доступ к микрофону запрещён навсегда. Включите его в системных настройках.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Для голосового поиска нужен доступ к микрофону.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Не удалось разобрать. Попробуйте ещё раз.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Речь не обнаружена.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Ошибка микрофона.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Для голосового поиска нужен интернет.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Голосовая служба занята. Попробуйте ещё раз.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Доступ к микрофону запрещён навсегда.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Доступ к микрофону запрещён.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Распознавание речи недоступно на этом устройстве.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Открыть выбор устройства вывода iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Выбор устройства AirPlay недоступен на этом устройстве.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Видео';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Передачи';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Песни';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Фотоальбомы';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Фото';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Люди';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Недавно вышедшие эпизоды';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Посмотреть снова';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Гостевые появления';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Появления (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Работа в съёмочной группе (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Смотреть с группой';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Ошибки';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Предупреждения';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Диск';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Открыть в браузере';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Встроенный браузер недоступен на этой платформе.';
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get adminRestartServerConfirmation => 'Перезапустить сервер?';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Выключить сервер? Запускать его придётся вручную.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Внутренний';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Ожидание';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Пользователи не найдены';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Нет пользователей по вашему запросу';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Устройства не найдены';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Нет устройств, подходящих под текущие фильтры';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Пароль задан';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Пароль не задан';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Удалённый доступ';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Только локально';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Не удалось загрузить аналитику медиа';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Сводная аналитика по всем медиабиблиотекам.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Топ исполнителей';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Топ авторов';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Топ участников';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count библиотеки',
-      many: '$count библиотек',
-      few: '$count библиотеки',
-      one: '$count библиотека',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Для этого выбора пока нет данных по проиндексированным медиа.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Сведения о библиотеке';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Разбивка по библиотекам';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Библиотеки недоступны.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Администрирование сервера';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Данные';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Кэш изображений';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Кэш';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Журналы';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Метаданные';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Транскодирование';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'Этот сервер не вернул пути.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return 'Использовано $percent%';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Активность пользователей';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Системные события';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Требует внимания';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Сервер';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Воспроизведение';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Устройства';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Дополнительно';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Плагины';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Прямой эфир';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Домашнее видео';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Смешанный контент';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Домашнее видео и фото';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Фильмы и сериалы вместе';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9525,298 +9472,299 @@ class AppLocalizationsRu extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Записи не найдены';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'В архиве .$extension не найдено страниц с изображениями.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Ошибка встроенного отображения ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Ошибка отображения EPUB ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Отсутствует локальный файл для читалки: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status при открытии данных книги из $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Нет доступной конечной точки для чтения книги';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Формат архива комикса не поддерживается: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Плагин распаковки CBR недоступен на этой платформе.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Не удалось распаковать архив .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Распаковка CB7 недоступна на этой платформе.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Плагин распаковки CB7 недоступен на этой платформе.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Закрыть панель жанров';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Подготовка перемешивания...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ПЕРЕМЕШАТЬ БИБЛИОТЕКУ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'СЛУЧАЙНОЕ ПЕРЕМЕШИВАНИЕ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ПЕРЕМЕШАТЬ ПО ЖАНРАМ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Автопереключение HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Автоматически включать HDR при воспроизведении HDR-видео и восстанавливать режим экрана при выходе.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'В полноэкранном режиме';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Изменить обложку';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Отсутствует';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Ограничения транскодирования';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Очистить все обложки?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
-  String get clearAllArtworkWarning => 'Очистить все скачанные обложки?';
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Подтвердите очистку';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Очистить: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Загрузить?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Разрешение: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Показывать обложки только на языке интерфейса';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Подтвердите полную очистку';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Изображение загружено!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Не удалось загрузить изображение: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Не удалось установить изображение: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Не удалось удалить изображение: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Не удалось очистить все обложки: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Да';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Фоны';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Баннер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Логотип';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Миниатюра';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Арт';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Арт диска';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Скриншот';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Обложка коробки';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задняя обложка коробки';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Арт меню';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'фон';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'баннер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'логотип';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'миниатюра';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'арт';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'арт диска';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'скриншот';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'обложка коробки';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задняя обложка коробки';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'арт меню';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Все';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Высокое (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Среднее (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Низкое (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Источники';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Главы';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Закладки';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Заметки';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Очередь';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Хронология';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Хронология пуста';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Вся книга';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Текущий фрагмент';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Экспорт закладок';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Экспорт заметок';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Экспорт всего';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Экспортировано в $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Ошибка экспорта: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Текст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Добавить закладку';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Добавить заметку';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Изменить заметку';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напишите заметку к этому моменту';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Таймер сна';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Выкл.';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Конец главы';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Свой';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Осталось $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9824,58 +9772,58 @@ class AppLocalizationsRu extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Скорость воспроизведения';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Осталось';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Прошло';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $seconds с';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Вперёд $seconds с';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Предыдущая глава';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Следующая глава';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Глава $current из $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Глав нет';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Закладок пока нет';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Заметок пока нет';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Закладка добавлена на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Сбросить до 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9883,251 +9831,249 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Сохранить';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Отмена';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Удалить';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Настройки субтитров';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Измените режимы субтитров, языки по умолчанию, оформление и параметры отрисовки.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Отрисовка субтитров';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Параметры отображения';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Дата выхода (по возрастанию)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Дата выхода (по убыванию)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Группировка работ';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Объединять несколько ролей';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Предупреждение о доступе на запись';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Как это исправить:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Предоставьте пользователю службы Jellyfin (например, jellyfin или PUID/PGID в Docker) права на запись в папки вашей медиабиблиотеки на сервере.\n\n2. Либо откройте панель Jellyfin -> «Библиотеки», измените эту библиотеку и отключите параметр «Сохранять обложки в папки с медиа», чтобы обложки хранились во внутренней базе данных Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Закрыть';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Библиотека «$libraryName» настроена на сохранение обложек прямо в папки с медиа (включён параметр «Сохранять обложки в папки с медиа»). Однако при проверке Jellyfin не смог записать файлы в этот каталог:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Похоже, Jellyfin не смог обновить обложку. Ваша библиотека настроена на сохранение обложек прямо в папки с медиа (включён параметр «Сохранять обложки в папки с медиа»). Обычно эта ошибка возникает, когда у процесса сервера Jellyfin нет прав на запись в ваши медиакаталоги.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Внешние списки';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Смотреть заново';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Сведения о файле';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Размер: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Показать все аудиодорожки ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Показать все дорожки субтитров ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Проверка прямого воспроизведения...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Прямое воспроизведение: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Форсированные';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Контейнер не поддерживается плеером.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видеокодек не поддерживается.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудиокодек не поддерживается.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Формат субтитров не поддерживается (требуется вшивание).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Профиль звука не поддерживается.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Профиль видео не поддерживается.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Уровень видео не поддерживается.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Разрешение видео не поддерживается этим устройством.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Битовая глубина видео не поддерживается.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Частота кадров видео не поддерживается.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Битрейт файла превышает лимит потоковой передачи плеера.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Битрейт видео превышает лимит потоковой передачи.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Битрейт звука превышает лимит потоковой передачи.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Число аудиоканалов не поддерживается.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'По алфавиту';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Порядок выхода (по возрастанию)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Порядок выхода (по убыванию)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Свой (перетаскиванием)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Сортировка плейлиста';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Сбросить сортировку';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Пересмотреть С$season:Э$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Пересмотреть плейлист';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Субтитры не найдены.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Средства администратора';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Движок отрисовки (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller — современный GPU-рендерер Flutter: анимации плавнее, подтормаживаний меньше. На некоторых ТВ-приставках и старых GPU он может вызывать артефакты или чёрное видео — тогда выберите «Выкл». «Автоматически» подбирает лучший вариант для вашего устройства. Перезапустите Moonfin, чтобы применить.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автоматически';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Вкл.';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Выкл.';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Требуется перезапуск';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Чтобы сменить движок отрисовки, Moonfin нужно перезапустить. Закройте приложение и откройте его снова.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Закрыть приложение';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Обновить библиотеку';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Обновить все библиотеки';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Дата добавления (сначала старые)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Дата добавления (сначала новые)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'По алфавиту (А–Я)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'По алфавиту (Я–А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Загрузка аналитики сервера... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Как в источнике';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb: топ-250 фильмов';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb: топ-250 сериалов';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb: самые популярные фильмы';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb: самые популярные сериалы';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb: фильмы с худшим рейтингом';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb: лучшие англоязычные фильмы';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -9,30 +9,30 @@ class AppLocalizationsSi extends AppLocalizations {
   AppLocalizationsSi([String locale = 'si']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'මූන්ෆින්';
 
   @override
-  String get accountPreferences => 'ගිණුම් මනාප';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'අතුරුමුහුණතේ භාෂාව';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'පද්ධතියේ පෙරනිමිය';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'පුරන්න';
 
   @override
-  String get empty => 'හිස්';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName වෙත සම්බන්ධ වෙමින්';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'ඉක්මන් සම්බන්ධතාවය';
 
   @override
   String get password => 'මුරපදය';
@@ -61,12 +61,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ලබා ගත නොහැක: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ලබා ගත නොහැක ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin අනුවාදය $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'ඔබේ සේවාදායක අතරින් \"$serverName\" ඉවත් කරන්නද?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsAppearanceTheme => 'යෙදුම් තේමාව';
 
   @override
-  String get detailScreenStyle => 'විස්තර තිරයේ විලාසය';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'සම්භාව්‍ය යනු Moonfin හි මුල් මධ්‍යගත සැකැස්මයි. නවීන යනු ප්‍රතිචාරාත්මක සිනමාත්මක සැකැස්මකි.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'සම්භාව්‍ය';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'නවීන';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'විස්තීරණ ටැබ';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ටැබ පිරික්සන විට ටැබයේ අන්තර්ගතය ස්වයංක්‍රීයව පෙන්වයි. එක් එක් ටැබය අතින් විවෘත කර වැසීමට මෙය ක්‍රියාවිරහිත කරන්න.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'තාක්ෂණික විස්තර පෙන්වන්නද?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'බැනර සාරාංශයේ කෝඩෙක්, විභේදනය සහ ප්‍රවාහ තොරතුරු පෙන්වන්න';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'නිර්දේශ පද්ධතිය';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin නිර්දේශ නම් දේශීය පුස්තකාල ඇල්ගොරිතමය හෝ මාර්ගගත TMDb සමානතා මිතික භාවිත කරන්න. සටහන: මාර්ගගත නිර්දේශ සඳහා Seerr ඒකාබද්ධතාව අවශ්‍ය වේ.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin නිර්දේශ';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb සමානතාව';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'මාපිය ශ්‍රේණිගත සීමාව යොදන්නද?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'ඉලක්ක මාධ්‍යයේ මාපිය ශ්‍රේණිගත කිරීම අනුව Moonfin නිර්දේශ යෝජනා සීමා කරන්න';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'අතුරුමුහුණතේ විලාසය';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ස්වයංක්‍රීය යනු ඔබේ උපාංගයට ගැළපෙන පෙනුමයි. නිශ්චිත පෙනුමක් බලාත්මක කිරීමට Apple හෝ Material තෝරන්න.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ස්වයංක්‍රීය';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsSi extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'වීදුරු ගුණාත්මකභාවය';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ස්වයංක්‍රීය මඟින් මෙම උපාංගයට හොඳම වීදුරු ප්‍රයෝගය තෝරයි. සම්පූර්ණ මඟින් සැබෑ බොඳ කිරීම බලාත්මක කරයි; අඩු කළ මඟින් GPU බලය ඉතිරි කරන සැහැල්ලු වීදුරුවක් භාවිත කරයි.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ස්වයංක්‍රීය';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'සම්පූර්ණ';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'අඩු කළ';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'යෙදුම නැවත ආරම්භ නොකර Moonfin සහ Neon Pulse අතර මාරු වන්න';
 
   @override
-  String get customThemeTitle => 'අභිරුචි තේමාව';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'අභිරුචි තේමා Moonfin පුරා දෘශ්‍ය අංග වෙනස් කරයි. ඔබේ විලාසයට ගැළපෙන විකල්පයක් තෝරන්න.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'පද්ධති යතුරුපුවරුවට මුල් තැන දෙන්න';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'පෙළ ඇතුළත් කිරීම සඳහා පෙරනිමියෙන් ඔබේ උපාංගයේ ආදාන ක්‍රමය භාවිත කරන්න';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'මූන්ෆින්';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsSi extends AppLocalizations {
       'මැජෙන්ටා දිලිසීම, සයන් පෙළ සහ ශක්තිමත් ක්‍රෝම් ප්‍රතිවිරෝධය සහිත සින්ත්වේව් මෝස්තරය';
 
   @override
-  String get themeGlass => 'වීදුරු';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'ගලා යන අනුක්‍රමික පසුබිමක්, තුහින තලයන් සහ Apple-නිල් අවධාරකයක් සහිත ද්‍රව-වීදුරු විලාසය';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit වීරයා';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'ඝන වර්ණාවලියක්, කොටස්-හැඩැති මායිම්, තද සෙවනැලි සහ පික්සල අකුරු සහිත රෙට්‍රෝ පික්සල-කලා විලාසය';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'ඔබගේ Emby Connect ගිණුමෙන් පුරන්න';
@@ -313,7 +313,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target වෙත සම්බන්ධ විය නොහැක';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -326,35 +326,35 @@ class AppLocalizationsSi extends AppLocalizations {
   String get exit => 'පිටවෙන්න';
 
   @override
-  String get gameMenu => 'මෙනුව';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'විරාම කර ඇත';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'තත්ත්වය සුරකින්න';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ක්‍රීඩා';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'තත්ත්වය පූරණය කරන්න';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'වේගයෙන් ඉදිරියට';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'අනුකාරක සැකසීම්';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'මෙම කෝරයෙහි සකස් කළ හැකි විකල්ප නොමැත.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'මෙනුව විවෘත කිරීමට තදින් අල්ලාගෙන සිටින්න';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'මෙම උපාංගයේ ක්‍රීඩා ධාවනයට තවම සහාය නොදක්වයි.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'මුල් පේළි කිසිවක් පූරණය කළ නොහැක';
@@ -376,13 +376,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get schedule => 'කාලසටහන';
 
   @override
-  String get series => 'කතාමාලා';
+  String get series => 'මාලාව';
 
   @override
   String get noItemsFound => 'අයිතම කිසිවක් හමු නොවීය';
 
   @override
-  String get home => 'මුල් පිටුව';
+  String get home => 'නිවස';
 
   @override
   String get browseAll => 'සියල්ල බ්‍රවුස් කරන්න';
@@ -426,7 +426,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'ෆෝල්ඩරය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -434,7 +434,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return 'අයිතම $count';
+    return '$count items';
   }
 
   @override
@@ -451,7 +451,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return 'අයිතම $count';
+    return '$count Items';
   }
 
   @override
@@ -492,7 +492,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ප්‍රභේද';
+    return '$name — Genres';
   }
 
   @override
@@ -531,17 +531,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'මිනි. $countකට පෙර';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'පැය $countකට පෙර';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'දින $countකට පෙර';
+    return '${count}d ago';
   }
 
   @override
@@ -552,7 +552,7 @@ class AppLocalizationsSi extends AppLocalizations {
       'Discover හි පෙන්විය යුතු විෂය සංග්‍රහ තෝරන්න.';
 
   @override
-  String get apply => 'යොදන්න';
+  String get apply => 'අයදුම් කරන්න';
 
   @override
   String get openLink => 'සබැඳිය විවෘත කරන්න';
@@ -576,7 +576,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return 'මාතෘකා $count';
+    return '$count titles';
   }
 
   @override
@@ -601,7 +601,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get listen => 'සවන් දෙන්න';
 
   @override
-  String get resume => 'දිගටම කරගෙන යන්න';
+  String get resume => 'අරඹන්න';
 
   @override
   String get failedToLoadLibrary => 'පුස්තකාලය පූරණය කිරීමට අසමත් විය';
@@ -660,17 +660,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return 'කතුවරුන් $count';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return 'ප්‍රභේද $count';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% සම්පූර්ණයි';
+    return '$percent% completed';
   }
 
   @override
@@ -687,7 +687,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'කියවීම මුල් කරගත් පිරික්සීම සඳහා සකසන ලද මාතෘකා $countක්.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -724,7 +724,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label හමු නොවීය';
+    return 'No $label found';
   }
 
   @override
@@ -743,13 +743,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get readStatus => 'කියවන්න';
 
   @override
-  String get watched => 'නරඹා ඇත';
+  String get watched => 'නැරඹුවා';
 
   @override
   String get unread => 'නොකියවූ';
 
   @override
-  String get unwatched => 'නරඹා නැත';
+  String get unwatched => 'නැරඹුවේ නැත';
 
   @override
   String get seriesStatus => 'මාලාවේ තත්ත්වය';
@@ -761,43 +761,43 @@ class AppLocalizationsSi extends AppLocalizations {
   String get books => 'පොත්';
 
   @override
-  String get latestBooks => 'නවතම පොත්';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'නවතම ශ්‍රව්‍ය පොත්';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'පොත් $count',
-      one: 'පොත 1',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'පොත';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ශ්‍රව්‍ය පොත';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% කියවා ඇත';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time ඉතිරියි';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'කියවන්න';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'අසන්න';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'කර්තෘ';
@@ -835,12 +835,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return 'කොටස් $count';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'මුලින්ම ප්‍රකාශිත $year';
+    return 'First published $year';
   }
 
   @override
@@ -855,7 +855,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return 'පොත් $count';
+    return '$count books';
   }
 
   @override
@@ -866,7 +866,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return 'කතුවරුන් $count';
+    return '$count Authors';
   }
 
   @override
@@ -874,8 +874,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'ශ්‍රව්‍ය පොත් $count',
-      one: 'ශ්‍රව්‍ය පොත 1',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -899,7 +899,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get moreLikeThis => 'තවත් මේ වගේ';
 
   @override
-  String get castAndCrew => 'රංගන ශිල්පීන් සහ කණ්ඩායම';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'එකතුව';
@@ -911,7 +911,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get nextUp => 'ඊළඟට';
 
   @override
-  String get seasons => 'වාර';
+  String get seasons => 'ඍතු';
 
   @override
   String get chapters => 'පරිච්ඡේද';
@@ -923,7 +923,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get movies => 'චිත්රපට';
 
   @override
-  String get musicVideos => 'සංගීත වීඩියෝ';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'වෙනත්';
@@ -942,7 +942,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'තැටිය $number';
+    return 'Disc $number';
   }
 
   @override
@@ -966,7 +966,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'ප්‍රකාශිත $year';
+    return 'Published $year';
   }
 
   @override
@@ -977,52 +977,52 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'වාර $count',
-      one: 'වාරය 1',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$timeට අවසන් වේ';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'අයිතම';
+  String get items => 'Items';
 
   @override
-  String get extras => 'අමතර';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'තිර පිටුපස';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ඉවත් කළ දර්ශන';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'විශේෂාංග';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'සම්මුඛ සාකච්ඡා';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'දර්ශන';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'කෙටි චිත්‍රපට';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ට්‍රේලර්';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time ඉතිරියි';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$timeකින් අවසන් වේ';
+    return 'Ends in $time';
   }
 
   @override
@@ -1036,11 +1036,11 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position සිට දිගටම කරන්න';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'වාදනය කරන්න';
+  String get play => 'සෙල්ලම් කරන්න';
 
   @override
   String get startOver => 'නැවත ආරම්භ කරන්න';
@@ -1064,10 +1064,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get version => 'අනුවාදය';
 
   @override
-  String get cast => 'කාස්ට් කරන්න';
+  String get cast => 'කස්ටිය';
 
   @override
-  String get trailer => 'ට්‍රේලරය';
+  String get trailer => 'ට්රේලරය';
 
   @override
   String get finished => 'අවසන්';
@@ -1134,7 +1134,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" සඳහා බාගත කළ ගීත මකන්නද?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1149,17 +1149,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel පූරණය කර නැත';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title බාගත කරමින් (අයිතම $count)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'ඔබට \"$name\" සේවාදායකයෙන් මකා දැමීමට අවශ්‍ය බව විශ්වාසද? මෙම ක්‍රියාව අහෝසි කළ නොහැක.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1170,7 +1170,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'සහාය නොදක්වන පොත් ආකෘතියකි: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1197,7 +1197,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'උපසිරැසි බාගත කර තෝරා ගන්නා ලදී: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1206,7 +1206,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language සඳහා දුරස්ථ උපසිරැසි හමු නොවීය.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1214,7 +1214,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'අනුවාදය $number';
+    return 'Version $number';
   }
 
   @override
@@ -1234,7 +1234,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name බාගත කරමින් ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1242,7 +1242,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel සඳහා දේශීය ගොනු මකන්නද?\n\nමෙය ගබඩා ඉඩ නිදහස් කරයි. ඔබට පසුව නැවත බාගත කළ හැක.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1258,25 +1258,25 @@ class AppLocalizationsSi extends AppLocalizations {
   String get director => 'අධ්යක්ෂක';
 
   @override
-  String get directors => 'අධ්‍යක්ෂවරු';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'රචකයා';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'තිර රචකයන්';
+  String get writers => 'ලේඛකයින්';
 
   @override
   String get studio => 'ස්ටුඩියෝව';
 
   @override
   String studioMoreCount(int count) {
-    return 'තවත් +$count';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return 'කථාංග $count';
+    return '$count Episodes';
   }
 
   @override
@@ -1286,12 +1286,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'කථාංගය $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'පරිච්ඡේදය $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1299,8 +1299,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'ගීත $count',
-      one: 'ගීතය 1',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1310,25 +1310,25 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'පරිච්ඡේද $count',
-      one: 'පරිච්ඡේදය 1',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'උපත $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'මිය ගියේ $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'වයස $age';
+    return 'Age $age';
   }
 
   @override
@@ -1341,17 +1341,17 @@ class AppLocalizationsSi extends AppLocalizations {
   String get shuffle => 'කලවම් කරන්න';
 
   @override
-  String get shuffleAllMusic => 'සියලු සංගීතය කලවම් කර වාදනය කරන්න';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'ඔබේ දුරකථනයෙන් Moonfin වෙත පුරන්න';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'ඔබේ සේවාදායකයට ළඟා විය නොහැක';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return 'බාගැනීම් $count';
+    return '$count downloads';
   }
 
   @override
@@ -1370,32 +1370,32 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'දුරස්ථ උපසිරැසි $action සඳහා මෙම පරිශීලකයාට Jellyfin උපසිරැසි කළමනාකරණ අවසරය අවශ්‍ය වේ.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'දුරස්ථ උපසිරැසි $action සඳහා මෙම අයිතමය සේවාදායකයේ හමු නොවීය.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'දුරස්ථ උපසිරැසි $action අසාර්ථක විය: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'දුරස්ථ උපසිරැසි $action අසාර්ථක විය (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'දුරස්ථ උපසිරැසි $action කිරීමට අසමත් විය.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" සඳහා බාගත කළ සියලු කථාංග';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1425,17 +1425,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label ක්‍රියාව අසාර්ථක විය: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'කාස්ට් හඬ පරිමාව සැකසීමට අසමත් විය: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label පාලන';
+    return '$label Controls';
   }
 
   @override
@@ -1445,14 +1445,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get unavailable => 'ලබා ගත නොහැක';
 
   @override
-  String get pause => 'විරාමය';
+  String get pause => 'නවත්වන්න';
 
   @override
   String get syncPosition => 'සමමුහුර්ත ස්ථානය';
 
   @override
   String stopCast(String label) {
-    return '$label නවත්වන්න';
+    return 'Stop $label';
   }
 
   @override
@@ -1460,7 +1460,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ගීතය $number';
+    return 'Track $number';
   }
 
   @override
@@ -1477,14 +1477,14 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return 'තත්පර $seconds';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'අගුලු හැරීමට දිගු ඔබන්න';
 
   @override
-  String get off => 'අක්‍රියයි';
+  String get off => 'අක්රියයි';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1519,7 +1519,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get subtitleDelay => 'උපසිරැසි ප්‍රමාදය';
 
   @override
-  String get reset => 'යළි සකසන්න';
+  String get reset => 'යළි පිහිටුවන්න';
 
   @override
   String get unknown => 'නොදන්නා';
@@ -1546,7 +1546,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get transcodeReasons => 'ට්‍රාන්ස්කෝඩ් හේතු';
 
   @override
-  String get player => 'වාදකය';
+  String get player => 'ක්රීඩකයා';
 
   @override
   String get container => 'කන්ටේනර්';
@@ -1570,7 +1570,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get videoBitrate => 'වීඩියෝ බිට්රේට්';
 
   @override
-  String get track => 'පථය';
+  String get track => 'ලුහුබැඳීම';
 
   @override
   String get channels => 'නාලිකා';
@@ -1588,16 +1588,16 @@ class AppLocalizationsSi extends AppLocalizations {
   String get external => 'බාහිර';
 
   @override
-  String get embedded => 'කාවැද්දූ';
+  String get embedded => 'Embedded';
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol සැසි දෝෂයකි';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'පොතේ විස්තර පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1606,7 +1606,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'මෙම ආකෘතිය (.$extension) තවම යෙදුම තුළ පෙන්විය නොහැක.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1618,17 +1618,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'යෙදුම තුළ ඇති කියවනය විවෘත කිරීමට අසමත් විය: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label හි පිටු සලකුණ දැනටමත් සුරකිනු ලැබ ඇත.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'පිටු සලකුණ එක් කරන ලදී: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1640,7 +1640,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'පිටුව $number';
+    return 'Page $number';
   }
 
   @override
@@ -1651,12 +1651,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'ආකෘතිය: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% කියවා ඇත';
+    return '$percent% read';
   }
 
   @override
@@ -1679,7 +1679,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'විශාලනය යළි පිහිටුවන්න (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1702,7 +1702,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'කියවීම් තත්ත්වය යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1734,7 +1734,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '$extension ගොනු සඳහා වන කාවැද්දූ ලේඛන එන්ජිම මෙම වේදිකාවට දරාගත නොහැක.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1773,7 +1773,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'මාර්ගෝපදේශකය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1784,22 +1784,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'ඊළඟට: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'මිනි. $minutesක් ඉතිරියි';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'පැය $hoursක් ඉතිරියි';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'පැය $hours මිනි. $minutesක් ඉතිරියි';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1823,19 +1823,19 @@ class AppLocalizationsSi extends AppLocalizations {
   String get favoriteChannel => 'ප්රියතම නාලිකාව';
 
   @override
-  String get record => 'පටිගත කරන්න';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'පටිගත කිරීම අවලංගු කරන්න';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'වැඩසටහන පටිගත කිරීමට සකසන ලදී';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'පටිගත කිරීම අවලංගු කරන ලදී';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'පටිගත කිරීමක් සෑදිය නොහැක';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'නරඹන්න';
@@ -1845,7 +1845,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name වාදනය කිරීමට අසමත් විය';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1871,7 +1871,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" හි නියමිත පටිගත කිරීම අවලංගු කරන්නද?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1899,7 +1899,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" පටිගත කිරීම නවත්වන්නද?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1914,12 +1914,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" සඳහා ප්‍රතිඵල නැත';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'සෙවීම අසාර්ථක විය: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1960,12 +1960,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" සහ එහි ගොනු ඉවත් කරන්නද?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return 'ගීත $count';
+    return '$count tracks';
   }
 
   @override
@@ -1976,12 +1976,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ඇල්බමය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name සඳහා බාගත කළ ගීත හමු නොවීය.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -1998,12 +1998,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" ඉවත් කරන්නද?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return 'මිනි. $minutes';
+    return '$minutes min';
   }
 
   @override
@@ -2013,7 +2013,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'කථාංගය $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2027,7 +2027,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'වාරය $number';
+    return 'Season $number';
   }
 
   @override
@@ -2043,7 +2043,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season හි බාගත කළ සියලු කථාංග මකන්නද?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2051,8 +2051,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'කථාංග $count',
-      one: 'කථාංගය 1',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2087,7 +2087,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'බාගත කළ අයිතම $countක් මකන්නද?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2101,7 +2101,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit සීමාවෙන්';
+    return 'of $limit limit';
   }
 
   @override
@@ -2186,7 +2186,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return 'විකල්ප $count';
+    return '$count options';
   }
 
   @override
@@ -2279,7 +2279,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'විස්තර පිටු, මුල් තිර පේළි සහ හඬ පරිමාව';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2294,11 +2294,11 @@ class AppLocalizationsSi extends AppLocalizations {
       'මුල් තිරය බ්‍රවුස් කරන විට සෙල්ලම් කරන්න';
 
   @override
-  String get loopThemeMusic => 'තේමා සංගීතය පුනරාවර්තනය කරන්න';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'ගීතය එක් වරක් වාදනය කරනවා වෙනුවට නැවත නැවත වාදනය කරන්න';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'විස්තර පසුබිම බොඳ කිරීම';
@@ -2321,23 +2321,23 @@ class AppLocalizationsSi extends AppLocalizations {
   String get playerZoomMode => 'ක්‍රීඩක විශාලන ප්‍රකාරය';
 
   @override
-  String get settingsScrollWheelAction => 'මූසික අනුචලන රෝදය';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'ධාවනය අතරතුර වීඩියෝව මතින් මූසික රෝදය අනුචලනය කිරීමෙන් සිදුවන දේ තෝරන්න.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'අක්‍රියයි';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'ගමන් කරන්න (ඉදිරියට / ආපසු)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'හඬ පරිමාව';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'හඬ පරිමාව';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'සුදුසුයි';
@@ -2349,10 +2349,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get stretch => 'දිගු කරන්න';
 
   @override
-  String get refreshRateSwitching => 'නැවුම් අනුපාත මාරු කිරීම';
+  String get refreshRateSwitching => 'Refresh Rate Switching';
 
   @override
-  String get disabled => 'අක්‍රියයි';
+  String get disabled => 'ආබාධිතයි';
 
   @override
   String get scaleOnTv => 'රූපවාහිනියේ පරිමාණය';
@@ -2391,37 +2391,37 @@ class AppLocalizationsSi extends AppLocalizations {
   String get defaultAudioLanguage => 'පෙරනිමි ශ්‍රව්‍ය භාෂාව';
 
   @override
-  String get fallbackAudioLanguage => 'විකල්ප ශ්‍රව්‍ය භාෂාව';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'පෙරනිමි ශ්‍රව්‍ය පථයට මුල් තැන දෙන්න';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'දේශීයකරණය කළ හඬකැවීමට වඩා මුල් ශ්‍රව්‍ය පථයට මුල් තැන දෙන්න.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ශ්‍රව්‍ය විස්තර පථවලට මුල් තැන දෙන්න';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'සාමාන්‍ය පථවලට වඩා ශ්‍රව්‍ය විස්තර පථවලට මුල් තැන දෙන්න.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ට්‍රාන්ස්කෝඩිං (ශ්‍රව්‍ය)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'සෘජු ප්‍රවාහය (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ට්‍රාන්ස්කෝඩිං (බිට්රේට් හෝ විභේදනය)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ට්‍රාන්ස්කෝඩිං (වීඩියෝ සහ ශ්‍රව්‍ය)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ට්‍රාන්ස්කෝඩිං (වීඩියෝ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ස්වයංක්‍රීය (සේවාදායක පෙරනිමිය)';
@@ -2481,10 +2481,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get polish => 'පෝලන්ත';
 
   @override
-  String get ac3Passthrough => 'AC3 පාස්ත්‍රූ';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'DTS පාස්ත්‍රූ';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'TrueHD සහාය';
@@ -2498,28 +2498,27 @@ class AppLocalizationsSi extends AppLocalizations {
       'TrueHD ශ්‍රව්‍ය සක්‍රීය කරන්න (සියලු වේදිකාවල ක්‍රියා නොකරනු ඇත)';
 
   @override
-  String get settingsAudioOutputMode => 'ශ්‍රව්‍ය ප්‍රතිදාන ප්‍රකාරය';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ශ්‍රව්‍ය විකේතනය කරන ආකාරය තෝරන්න. AVR පාස්ත්‍රූ මඟින් අමු Dolby/DTS ප්‍රවාහ ඔබේ ග්‍රාහකයට යවයි; ස්වයංක්‍රීය හෝ ඩවුන්මික්ස් මඟින් දේශීයව විකේතනය කරයි.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR පාස්ත්‍රූ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'විකල්ප ශ්‍රව්‍ය කෝඩෙක්';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'මූලාශ්‍ර ප්‍රවාහය සෘජුව වාදනය කිරීමට හෝ පාස්ත්‍රූ කිරීමට නොහැකි විට බහු-නාලිකා ශ්‍රව්‍ය ට්‍රාන්ස්කෝඩ් කිරීමට ඉලක්ක ආකෘතිය තෝරන්න.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'ස්වයංක්‍රීයව හඳුනාගන්න\n(නිර්දේශිත)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(පෙරනිමි)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2528,114 +2527,113 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(හානි රහිත)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ස්ටීරියෝ පමණි)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(කාර්යක්ෂම)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(හානි රහිත)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'උපරිම ශ්‍රව්‍ය නාලිකා';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'ඔබේ ශ්‍රව්‍ය පිහිටුවීමේ උපරිම නාලිකා ගණන වින්‍යාස කරන්න. මෙම සීමාව ඉක්මවන බහු-නාලිකා ප්‍රවාහ ඩවුන්මික්ස් හෝ ට්‍රාන්ස්කෝඩ් වේ.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ස්වයංක්‍රීයව හඳුනාගන්න\n(දෘඪාංග පෙරනිමිය)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 මොනෝ';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ස්ටීරියෝ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 සරවුන්ඩ්';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 ක්වඩ්‍රොෆොනික්';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 සරවුන්ඩ්';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 සරවුන්ඩ්';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 සරවුන්ඩ්';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 සරවුන්ඩ්';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'පාස්ත්‍රූ (උසස්)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'කෝඩෙක් පාස්ත්‍රූ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'ඔබේ AVR හෝ HDMI ග්‍රාහකය සහාය දක්වන ආකෘති පමණක් සබල කරන්න.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 පාස්ත්‍රූ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) පාස්ත්‍රූ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core පාස්ත්‍රූ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA පාස්ත්‍රූ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD පාස්ත්‍රූ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos පාස්ත්‍රූ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) බාහිර විකේතකයට බිට්ස්ට්‍රීම් කරන්න.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) හරහා Dolby Atmos බාහිර විකේතකයට බිට්ස්ට්‍රීම් කරන්න.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS core ඇතුළුව) බාහිර විකේතකයට බිට්ස්ට්‍රීම් කරන්න.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos පාරදත්ත සහිත Dolby TrueHD බාහිර විකේතකයට බිට්ස්ට්‍රීම් කරන්න.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'හඳුනාගත් ශ්‍රව්‍ය හැකියාවන්';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'ධාවන කාලයේ හැකියාවන් පිළිබඳ තොරතුරු තවම නොමැත.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'මාර්ගය';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'විකේතනය';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'පාස්ත්‍රූ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ශ්‍රව්‍ය මාර්ගය';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2650,10 +2648,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'ස්පීකරය';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'හෙඩ්ෆෝන්';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2661,40 +2659,39 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'දෝෂ නිර්ණය';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'වීඩියෝ මට්ටම';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'වීඩියෝ පරාසය';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'උපසිරැසි කෝඩෙක්';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'අවසර ලත් ශ්‍රව්‍ය කෝඩෙක්';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ශ්‍රව්‍ය කෝඩෙක්';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ශ්‍රව්‍ය කෝඩෙක්';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif පාස්ත්‍රූ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'ක්‍රියාකාරී ශ්‍රව්‍ය මාර්ගය';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'මාර්ගයේ HD ශ්‍රව්‍ය සහාය';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'රාත්රී මාදිලිය';
@@ -2743,7 +2740,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueතත්';
+    return '${value}s';
   }
 
   @override
@@ -2757,14 +2754,14 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'කථාංග $episodesක් / පැය $hoursකට පසු';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
-  String get resumeAndSkip => 'දිගටම කිරීම සහ මඟහැරීම';
+  String get resumeAndSkip => 'Resume & Skip';
 
   @override
-  String get resumeRewind => 'දිගටම කිරීමේදී ආපසු යාම';
+  String get resumeRewind => 'Resume Rewind';
 
   @override
   String get unpauseRewind => 'Rewind නවත්වන්න';
@@ -2782,10 +2779,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get thirtySeconds => 'තත්පර 30 යි';
 
   @override
-  String get skipBackLength => 'ආපසු මඟහරින කාලය';
+  String get skipBackLength => 'Skip Back Length';
 
   @override
-  String get skipForwardLength => 'ඉදිරියට මඟහරින කාලය';
+  String get skipForwardLength => 'Skip Forward Length';
 
   @override
   String get customMpvConfPath => 'අභිරුචි mpv.conf මාර්ගය';
@@ -2833,45 +2830,45 @@ class AppLocalizationsSi extends AppLocalizations {
       'උපසිරැසි පෙනුම අභිරුචිකරණය කරන්න';
 
   @override
-  String get subtitleMode => 'උපසිරැසි ප්‍රකාරය';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'සලකුණු කළ';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'සැමවිටම';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'විදෙස්';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'බලාත්මක';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'මාධ්‍ය ගොනුවේ පාරදත්තවල \"default\" හෝ \"forced\" ලෙස අභ්‍යන්තරව සලකුණු කර ඇති පථ වාදනය කරයි.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'වීඩියෝවක් ආරම්භ වන සෑම විටම ස්වයංක්‍රීයව උපසිරැසි පූරණය කර පෙන්වයි.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'පෙරනිමි ශ්‍රව්‍ය පථය විදෙස් භාෂාවකින් නම් ස්වයංක්‍රීයව උපසිරැසි ක්‍රියාත්මක කරයි.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'forced පාරදත්ත සලකුණින් පැහැදිලිව ටැග් කර ඇති උපසිරැසි පමණක් පූරණය කරයි.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'ස්වයංක්‍රීය උපසිරැසි පූරණය සම්පූර්ණයෙන්ම අබල කරයි.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'විකල්ප උපසිරැසි භාෂාව';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'උපසිරැසි ප්‍රවාහය';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2881,13 +2878,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get verticalOffset => 'සිරස් ඕෆ්සෙට්';
 
   @override
-  String get pgsDirectPlay => 'PGS සෘජු වාදනය';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'සෘජු වාදනය PGS උපසිරැසි';
 
   @override
-  String get assSsaDirectPlay => 'ASS/SSA සෘජු වාදනය';
+  String get assSsaDirectPlay => 'ASS/SSA Direct Play';
 
   @override
   String get directPlayAssSsaSubtitles => 'සෘජු වාදනය ASS/SSA උපසිරැසි';
@@ -2930,17 +2927,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile පැතිකඩේ සැකසීම් පූරණය කරන ලදී.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile පැතිකඩේ සැකසීම් පූරණය කිරීමට අසමත් විය.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'දේශීය සැකසීම් $profile පැතිකඩට සමමුහුර්ත කරන ලදී.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3075,10 +3072,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showLibrariesInToolbar => 'මෙවලම් තීරුවේ පුස්තකාල පෙන්වන්න';
 
   @override
-  String get navbarAlwaysExpanded => 'සංචාලන තීරුවේ ලේබල සැමවිටම විදහන්න';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr බොත්තම පෙන්වන්න';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar පාරාන්ධතාව';
@@ -3152,19 +3149,18 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showFolderBrowsingOption => 'ෆෝල්ඩර බ්‍රවුසින් විකල්පය පෙන්වන්න';
 
   @override
-  String get groupItemsIntoCollections => 'අයිතම එකතුවලට කාණ්ඩගත කරන්න';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'පුස්තකාල පිරික්සන විට එකතුවකට අයත් පුස්තකාල අයිතම සඟවන්න';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'පුස්තකාල කාණ්ඩගත කිරීමේ දැන්වීම';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'මෙම සැකසුම භාවිත කිරීමට, ඔබේ Jellyfin හෝ Emby සේවාදායකයේ ඔබේ පුස්තකාලයේ Display සැකසීම් යටතේ \"Group movies into collections\" සහ/හෝ \"Group shows into collections\" පුස්තකාල සැකසීම් සබල කර ඇති බවට වග බලා ගන්න.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'පුස්තකාල දෘශ්‍යතාව';
@@ -3193,7 +3189,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$countක් තෝරා ඇත';
+    return '$count selected';
   }
 
   @override
@@ -3223,13 +3219,13 @@ class AppLocalizationsSi extends AppLocalizations {
       'Moonfin, MakD අතර තෝරන්න, නැතහොත් මාධ්‍ය තීරුව අක්‍රිය කරන්න';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'මූන්ෆින්';
 
   @override
   String get mediaBarModeMakd => 'මැක්ඩී';
 
   @override
-  String get mediaBarModeOff => 'අක්‍රියයි';
+  String get mediaBarModeOff => 'අක්රියයි';
 
   @override
   String get enableMediaBar => 'මාධ්‍ය තීරුව සබල කරන්න';
@@ -3276,11 +3272,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'තත්පර 3කට පසු මාධ්‍ය තීරුවේ ට්‍රේලර් ස්වයංක්‍රීයව ධාවනය කරන්න';
 
   @override
-  String get trailerAudio => 'ට්‍රේලර ශ්‍රව්‍යය';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'මාධ්‍ය තීරුවේ ට්‍රේලර සඳහා ශ්‍රව්‍යය සබල කරන්න';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'කථාංග පෙරදසුන';
@@ -3357,11 +3352,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get combineBothRows => 'පේළි දෙකම එක් නිවසක කොටසකට ඒකාබද්ධ කරන්න';
 
   @override
-  String get fullScreenRows => 'විස්තීරණ මුල් තිර පේළි';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'මුල් තිර පේළි එක් තිරයකට පේළි 1කට සීමා කරන්න';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'පේළි රූප වර්ගය අනුව';
@@ -3376,7 +3370,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get lastUser => 'අවසාන පරිශීලකයා';
 
   @override
-  String get currentUser => 'වත්මන් පරිශීලකයා';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'සැමවිටම සත්‍යාපනය කරන්න';
@@ -3437,7 +3431,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get enableBuiltInScreensaver => 'බිල්ට් තිර සුරැකුම සබල කරන්න';
 
   @override
-  String get mode => 'ප්‍රකාරය';
+  String get mode => 'මාදිලිය';
 
   @override
   String get libraryArt => 'පුස්තකාල කලාව';
@@ -3453,7 +3447,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return 'මිනි. $minutes';
+    return '$minutes min';
   }
 
   @override
@@ -3484,10 +3478,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'තිර සුරැකුම අතරතුර ඔරලෝසුව පෙන්වන්න';
 
   @override
-  String get clockModeStatic => 'ස්ථිර';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'පනින';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'කුණු වූ තක්කාලි (විවේචකයන්)';
@@ -3508,7 +3502,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get metacriticUser => 'Metacritic (පරිශීලක)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ට්රැක්ට්';
 
   @override
   String get letterboxd => 'ලිපි පෙට්ටිය';
@@ -3560,7 +3554,7 @@ class AppLocalizationsSi extends AppLocalizations {
       'යෙදුම පුරා පෙන්වා ඇති ශ්‍රේණිගත කිරීමේ මූලාශ්‍ර සබල කර නැවත ඇණවුම් කරන්න';
 
   @override
-  String get pluginLabel => 'Moonbase ප්ලගිනය';
+  String get pluginLabel => 'ප්ලගිනය';
 
   @override
   String get pluginDetected => 'ප්ලගිනය අනාවරණය විය';
@@ -3578,7 +3572,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nඅනුවාදය: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3632,7 +3626,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get networks => 'ජාල';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr සොයාගැනීමේ පේළි';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'පේළි පෙරනිමියට නැවත සකසන්න';
@@ -3642,7 +3636,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get showSeerrInNavigation =>
-      'සංචාලනයේ Seerr පෙන්වන්න (සේවාදායක ප්ලගිනය අවශ්‍යයි)';
+      'Serr සංචලනය තුළ පෙන්වන්න (සේවාදායක ප්ලගිනය අවශ්‍යයි)';
 
   @override
   String get seerrUnavailable =>
@@ -3655,46 +3649,47 @@ class AppLocalizationsSi extends AppLocalizations {
   String get hideAdultContent => 'ප්‍රතිඵලවල වැඩිහිටි අන්තර්ගතය සඟවන්න';
 
   @override
-  String get seerrNotificationsSection => 'දැනුම්දීම්';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'නව ඉල්ලීම් දැනුම්දීම්';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'යමෙකු ඉල්ලීමක් ඉදිරිපත් කරන විට මට දැනුම් දෙන්න';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'ඉල්ලීම් යාවත්කාලීන';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'අනුමත කළ, ප්‍රතික්ෂේප කළ සහ ඔබේ පුස්තකාලයට එක් කළ';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'ගැටලු යාවත්කාලීන';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'නව ගැටලු, පිළිතුරු සහ විසඳුම්';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'පුරන ලද්දේ: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr සොයාගැනීමේ පිටුව';
+  String get discoverRows => 'පේළි සොයා ගන්න';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr ප්‍රධාන පිටුවේ දැකීමට පේළි සබල කරන්න. නැවත පිළිවෙළට සැකසීමට ඇදගෙන යන්න. අභිරුචි පිළිවෙළ Moonbase සමඟ සමමුහුර්ත වේ.';
+      'නැවත ඇණවුම් කිරීමට අදින්න. පේළි සක්රිය හෝ අක්රිය කරන්න. සබල කළ පේළි ඇණවුම Moonfin ප්ලගිනය සමඟ සමමුහුර්ත කරයි.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr ප්‍රධාන පිටුවේ දැකීමට පේළි සබල කරන්න. නැවත පිළිවෙළට සැකසීමට ඇදගෙන යන්න. අභිරුචි පිළිවෙළ Moonbase සමඟ සමමුහුර්ත වේ.';
+      'නැවත ඇණවුම් කිරීමට අදින්න. පේළි සක්රිය හෝ අක්රිය කරන්න.';
 
   @override
-  String get enabled => 'සක්‍රියයි';
+  String get enabled => 'සබල කර ඇත';
 
   @override
   String get hidden => 'සැඟවී ඇත';
@@ -3704,7 +3699,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'අනුවාදය $version';
+    return 'Version $version';
   }
 
   @override
@@ -3753,7 +3748,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'යාවත්කාලීනයක් තිබේ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3764,7 +3759,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version තිබේ';
+    return 'v$version Available';
   }
 
   @override
@@ -3828,7 +3823,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get imageCacheCleared => 'රූප හැඹිලිය හිස් කරන ලදී';
 
   @override
-  String get clear => 'හිස් කරන්න';
+  String get clear => 'පැහැදිලියි';
 
   @override
   String get browse => 'බ්‍රවුස් කරන්න';
@@ -3844,19 +3839,19 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'බාගත වෙමින් · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ආයාත වෙමින්';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return 'අයිතම $count';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr සැකසීම්';
+  String get seerrSettings => 'සීරර් සැකසුම්';
 
   @override
   String get requestMore => 'තවත් ඉල්ලන්න';
@@ -3872,7 +3867,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name විසින් ඉල්ලා ඇත';
+    return 'Requested by $name';
   }
 
   @override
@@ -3889,12 +3884,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" සඳහා ඉල්ලීම අවලංගු කරන්නද?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" සඳහා ඉල්ලීම් $countක් අවලංගු කරන්නද?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3909,12 +3904,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'අයවැය: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'ආදායම: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3924,7 +3919,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type ඉල්ලන්න';
+    return 'Request $type';
   }
 
   @override
@@ -3952,14 +3947,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showMore => 'තවත් පෙන්වන්න';
 
   @override
-  String get appearances => 'පෙනී සිටීම්';
+  String get appearances => 'පෙනුම';
 
   @override
   String get crewSection => 'කාර්ය මණ්ඩලය';
 
   @override
   String ageValue(int age) {
-    return 'වයස $age';
+    return 'age $age';
   }
 
   @override
@@ -3990,147 +3985,148 @@ class AppLocalizationsSi extends AppLocalizations {
   String get deletedStatus => 'මකා දමන ලදී';
 
   @override
-  String get failedStatus => 'අසාර්ථකයි';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'සකසමින්';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name විසින් වෙනස් කරන ලදී';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'සම්පූර්ණයි';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'මෙම මාතෘකාව දැනටමත් ඉල්ලා ඇත';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'ඉල්ලීම් සීමාවට පැමිණ ඇත';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'මෙම මාතෘකාව අවහිර ලැයිස්තුවේ ඇත';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'ඉල්ලීමට තවත් වාර ඉතිරි නැත';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'මෙම ඉල්ලීම කිරීමට ඔබට අවසර නැත';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'ඉල්ලීම්';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'ගැටලු';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'නවතම';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'අවසන් වරට වෙනස් කළ';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'ගැටලු නැත';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'චිත්‍රපට ඉල්ලීම් $limitන් $remainingක් ඉතිරියි';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'වාර ඉල්ලීම් $limitන් $remainingක් ඉතිරියි';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name හි කොටසකි';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'එකතුව බලන්න';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'එකතුව ඉල්ලන්න';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'චිත්‍රපට $total · $availableක් තිබේ';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'චිත්‍රපට $countක් ඉල්ලන්න';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$totalන් $current ඉල්ලමින්...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'චිත්‍රපට $countක් ඉල්ලා ඇත';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'චිත්‍රපට $totalන් $okක් ඉල්ලා ඇත';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'සියලු චිත්‍රපට දැනටමත් තිබේ හෝ ඉල්ලා ඇත';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'ගැටලුව වාර්තා කරන්න';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'වීඩියෝ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ශ්‍රව්‍ය';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'වැරැද්ද කුමක්ද?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'සියලු කථාංග';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'කථාංගය';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'විවෘතයි';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'විසඳා ඇත';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'විසඳන්න';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'නැවත විවෘත කරන්න';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name විසින් වාර්තා කරන ලදී';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return 'අදහස් $count';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'අදහසක් එක් කරන්න';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'මෙම ගැටලුව මකන්නද?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'වාර්තාව යොමු කරන්න';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB ලකුණු';
@@ -4154,7 +4150,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get originalLanguageLabel => 'මුල් භාෂාව';
 
   @override
-  String get seasonsLabel => 'වාර';
+  String get seasonsLabel => 'ඍතු';
 
   @override
   String get episodesLabel => 'කථාංග';
@@ -4163,7 +4159,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get access => 'ප්රවේශය';
 
   @override
-  String get add => 'එක් කරන්න';
+  String get add => 'එකතු කරන්න';
 
   @override
   String get address => 'ලිපිනය';
@@ -4187,7 +4183,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get disable => 'අක්රිය කරන්න';
 
   @override
-  String get done => 'අවසන්';
+  String get done => 'කළා';
 
   @override
   String get edit => 'සංස්කරණය කරන්න';
@@ -4202,7 +4198,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get forward => 'ඉදිරියට';
 
   @override
-  String get general => 'සාමාන්‍ය';
+  String get general => 'ජෙනරාල්';
 
   @override
   String get go => 'යන්න';
@@ -4247,7 +4243,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get refresh => 'නැවුම් කරන්න';
 
   @override
-  String get remote => 'දුරස්ථ පාලකය';
+  String get remote => 'දුරස්ථ';
 
   @override
   String get rename => 'නැවත නම් කරන්න';
@@ -4292,7 +4288,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get time => 'කාලය';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'කපටි ක්‍රීඩාව';
 
   @override
   String get uninstall => 'අස්ථාපනය කරන්න';
@@ -4334,25 +4330,25 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminDrawerLibraries => 'පුස්තකාල';
 
   @override
-  String get adminDrawerDisplay => 'සංදර්ශනය';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'පාරදත්ත';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO සැකසීම්';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ට්‍රාන්ස්කෝඩිං';
 
   @override
-  String get adminDrawerResume => 'දිගටම කරගෙන යන්න';
+  String get adminDrawerResume => 'අරඹන්න';
 
   @override
   String get adminDrawerStreaming => 'ප්‍රවාහය';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'කපටි ක්‍රීඩාව';
 
   @override
   String get adminDrawerDevices => 'උපාංග';
@@ -4403,22 +4399,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'ප්ලගින යාවත්කාලීන තිබේ: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'නැවත ඇරඹීම අවශ්‍ය ප්ලගින: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'අසාර්ථක නියමිත කාර්ය: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'මෑත අනතුරු ඇඟවීම්/දෝෂ ඇතුළත් කිරීම්: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4477,7 +4473,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'දෝෂය: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4505,7 +4501,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'විධානය අසාර්ථක විය: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4542,7 +4538,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get nowPlaying => 'දැන් සෙල්ලම් කරනවා';
 
   @override
-  String get volume => 'හඬ පරිමාව';
+  String get volume => 'පරිමාව';
 
   @override
   String get actions => 'ක්රියාවන්';
@@ -4554,7 +4550,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audioCodec => 'ශ්රව්ය කෝඩෙක්';
 
   @override
-  String get hwAccel => 'දෘඪාංග ත්වරණය';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'සම්පූර්ණ කිරීම';
@@ -4569,14 +4565,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminClearDates => 'පැහැදිලි දිනයන්';
 
   @override
-  String get adminActivitySeverityAll => 'සියලු බරපතළකම්';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'දින පරාසය';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'ක්‍රියාකාරකම් ලොගය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4593,7 +4589,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'උපාංගය යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4604,28 +4600,28 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'උපාංගය මැකීමට අසමත් විය: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' උපාංගය ඉවත් කරන්නද? පරිශීලකයාට මෙම උපාංගයේ නැවත පුරන්නට සිදුවේ.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'සියලු උපාංග මකන්න';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'උපාංග $countක් ඉවත් කරන්නද? බලපෑමට ලක්වන පරිශීලකයන්ට නැවත පුරන්නට සිදුවේ. ඔබේ වත්මන් උපාංගයට බලපෑමක් නොවේ.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'උපාංග ඉවත් කරන ලදී';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'සමහර උපාංග ඉවත් කරන ලදී; $countක් ඉවත් කළ නොහැකි විය.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4654,7 +4650,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'පරිලෝකනය ආරම්භ කිරීමට අසමත් විය: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4665,12 +4661,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'පුස්තකාලය \"$name\" ලෙස නැවත නම් කරන ලදී';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'නැවත නම් කිරීමට අසමත් විය: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4678,17 +4674,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" පුස්තකාලය මකා දමන ලදී';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'පුස්තකාලය මැකීමට අසමත් විය: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'මාර්ගය එක් කිරීමට අසමත් විය: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4696,12 +4692,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'මෙම පුස්තකාලයෙන් \"$path\" ඉවත් කරන්නද?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'මාර්ගය ඉවත් කිරීමට අසමත් විය: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4709,7 +4705,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'විකල්ප සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4740,257 +4736,251 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminMetadataCountryHint => 'උදා. එක්සත් ජනපදය, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'මාර්ග';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'විකල්ප';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'බාගැනීම් මෙවලම්';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'පාරදත්ත සුරකින්නන්';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'උපසිරැසි බාගැනීම් මෙවලම්';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'ගී පද බාගැනීම් මෙවලම්';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'පාරදත්ත බාගැනීම් මෙවලම්: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'රූප ලබාගන්නන්: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'මෙම සේවාදායකය මෙම පුස්තකාල වර්ගය සඳහා බාගැනීම් මෙවලම් සපයන්නේ නැත.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'සාමාන්‍ය';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'පාරදත්ත';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'කාවැද්දූ තොරතුරු';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'උපසිරැසි';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'රූප';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'කතාමාලා';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'සංගීතය';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'චිත්‍රපට';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'තත්‍ය කාලීන නිරීක්ෂණය සබල කරන්න';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ගොනු වෙනස්කම් හඳුනාගෙන ස්වයංක්‍රීයව සකසන්න.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'සංරක්ෂිත ගොනු මාධ්‍ය ගොනු ලෙස සලකන්න';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ඡායාරූප පෙන්වන්න';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'කලා නිර්මාණ මාධ්‍ය ෆෝල්ඩරවලට සුරකින්න';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'ස්වයංක්‍රීය පාරදත්ත නැවුම් කිරීම';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'කිසිවිටෙක';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'පෙරනිමිය';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'සංදර්ශනය';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'පුස්තකාල සංදර්ශනය';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'සරල මාධ්‍ය ෆෝල්ඩර පෙන්වීමට ෆෝල්ඩර දසුනක් සංදර්ශනය කරන්න';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'විශේෂාංග ඒවා විකාශය වූ වාර තුළ පෙන්වන්න';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'චිත්‍රපට එකතුවලට කාණ්ඩගත කරන්න';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'වැඩසටහන් එකතුවලට කාණ්ඩගත කරන්න';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'යෝජනාවල බාහිර අන්තර්ගතය පෙන්වන්න';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'එක් කළ දිනයේ හැසිරීම';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'එක් කළ දිනය ලබාගන්නේ';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'පුස්තකාලයට පරිලෝකනය කළ දිනය';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ගොනුව සෑදූ දිනය';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'පාරදත්ත සහ රූප';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'කැමති පාරදත්ත භාෂාව';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'පරිච්ඡේද';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ව්‍යාජ පරිච්ඡේද කාලය (තත්පර)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'පරිච්ඡේද නොමැති මාධ්‍ය සඳහා ජනනය කරන පරිච්ඡේදවල දිග. අබල කිරීමට 0 ලෙස සකසන්න.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'පරිච්ඡේද රූප විභේදනය';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO සැකසීම්';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO පාරදත්ත Kodi සහ සමාන සේවාලාභීන් සමඟ ගැළපේ. සැකසීම් NFO පාරදත්ත සුරකින සියලු පුස්තකාලවලට අදාළ වේ.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'NFO ගොනුවල නැරඹීමේ දත්ත ගබඩා කරන පරිශීලකයා';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'NFO ගොනු තුළ රූප මාර්ග සුරකින්න';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO රූප මාර්ග සඳහා මාර්ග ආදේශනය සබල කරන්න';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart රූප extrathumbs ෆෝල්ඩරයකට පිටපත් කරන්න';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'කිසිවක් නැත';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return 'දින $days';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'කාවැද්දූ මාතෘකා භාවිත කරන්න';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'අමතර සඳහා කාවැද්දූ මාතෘකා භාවිත කරන්න';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'කාවැද්දූ කථාංග තොරතුරු භාවිත කරන්න';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'කාවැද්දූ උපසිරැසිවලට ඉඩ දෙන්න';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'සියල්ලට ඉඩ දෙන්න';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'පෙළ පමණි';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'රූප පමණි';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'කිසිවක් නැත';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'කාවැද්දූ උපසිරැසි තිබේ නම් බාගැනීම මඟහරින්න';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ශ්‍රව්‍ය පථය බාගැනීමේ භාෂාවට ගැළපේ නම් බාගැනීම මඟහරින්න';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'පරිපූර්ණ උපසිරැසි ගැළපීමක් අවශ්‍යයි';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'උපසිරැසි මාධ්‍ය ෆෝල්ඩරවලට සුරකින්න';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'පරිච්ඡේද රූප උපුටා ගන්න';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'පුස්තකාල පරිලෝකනය අතරතුර පරිච්ඡේද රූප උපුටා ගන්න';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay රූප උපුටා ගැනීම සබල කරන්න';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'පුස්තකාල පරිලෝකනය අතරතුර Trickplay රූප උපුටා ගන්න';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay රූප මාධ්‍ය ෆෝල්ඩරවලට සුරකින්න';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'බහු ෆෝල්ඩර හරහා විසිරී ඇති මාලා ස්වයංක්‍රීයව එකට ඒකාබද්ධ කරන්න';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'බිංදු වාරයේ සංදර්ශන නාමය';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'ශ්‍රව්‍ය සාමාන්‍යකරණය සඳහා LUFS පරිලෝකනය සබල කරන්න';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'සම්මත නොවන කලාකරු ටැගයට මුල් තැන දෙන්න';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'චිත්‍රපට ස්වයංක්‍රීයව එකතුවලට එක් කරන්න';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'පුස්තකාලයේ නම අවශ්‍යයි';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'පුස්තකාලය සෑදීමට අසමත් විය: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5016,27 +5006,27 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name අබල කරන්නද? ඔවුන්ට පුරන්නට නොහැකි වේ.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name සබල කරන්නද? ඔවුන්ට නැවත පුරන්නට හැකි වේ.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" පරිශීලකයා අබල කරන ලදී';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" පරිශීලකයා සබල කරන ලදී';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'පරිශීලක ප්‍රතිපත්තිය යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5053,7 +5043,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'පරිශීලකයා සෑදීමට අසමත් විය: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5073,7 +5063,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5084,7 +5074,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'අසාර්ථක විය: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5220,144 +5210,143 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminEnableAllChannels => 'සියලුම නාලිකා වෙත ප්‍රවේශය සබල කරන්න';
 
   @override
-  String get adminParentalControl => 'මාපිය පාලනය';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'උපරිම අනුමත මාපිය ශ්‍රේණිගත කිරීම';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'ඊට වඩා ඉහළ ශ්‍රේණිගත කිරීමක් සහිත අන්තර්ගතය මෙම පරිශීලකයාගෙන් සඟවනු ලැබේ.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'කිසිවක් නැත';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'ශ්‍රේණිගත තොරතුරු නොමැති හෝ හඳුනාගත නොහැකි අයිතම අවහිර කරන්න';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'පොත්';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'නාලිකා';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'සජීවී රූපවාහිනිය';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'චිත්‍රපට';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'සංගීතය';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ට්‍රේලර්';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'වැඩසටහන්';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'ප්‍රවේශ කාලසටහන්';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'පහත නියමිත වේලාවන්හිදී පමණක් ප්‍රවේශයට ඉඩ දෙන්න. කාලසටහනක් සකසා නොමැති විට දවස පුරා ප්‍රවේශයට ඉඩ දෙනු ලැබේ.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'කාලසටහනක් එක් කරන්න';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'දිනය';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'ආරම්භය';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'අවසානය';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'සෑම දිනකම';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'සතියේ දිනයක්';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'සති අන්තය';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ඉරිදා';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'සඳුදා';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'අඟහරුවාදා';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'බදාදා';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'බ්‍රහස්පතින්දා';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'සිකුරාදා';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'සෙනසුරාදා';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'අවසර ලත් ටැග';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'මෙම ටැග සහිත අන්තර්ගතය පමණක් පෙන්වයි. සියල්ලට ඉඩ දීමට හිස්ව තබන්න.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'අවහිර කළ ටැග';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'මෙම ටැග සහිත අන්තර්ගතය මෙම පරිශීලකයාගෙන් සඟවනු ලැබේ.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ටැගයක් එක් කරන්න';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'සබල උපාංග';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'සබල නාලිකා';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'සත්‍යාපන සපයන්නා';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'මුරපද යළි පිහිටුවීමේ සපයන්නා';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'අගුළු දැමීමට පෙර උපරිම අසාර්ථක පිවිසුම් උත්සාහ';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'පෙරනිමිය සඳහා 0 ලෙසත්, අගුළු දැමීම අබල කිරීමට -1 ලෙසත් සකසන්න.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay ප්‍රවේශය';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'කණ්ඩායම් සෑදීමට සහ ඒවාට එක්වීමට ඉඩ දෙන්න';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'කණ්ඩායම්වලට එක්වීමට ඉඩ දෙන්න';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'ප්‍රවේශයක් නැත';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'අන්තර්ගතය මැකීමට ඉඩ දෙන්නේ';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5365,22 +5354,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'සේවාදායකය HTTP $status ලබා දුන්නේය';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'ඔබට $name මකා දැමීමට අවශ්‍ය බව විශ්වාසද?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" පරිශීලකයා මකා දමන ලදී';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'පරිශීලකයා මැකීමට අසමත් විය: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5401,7 +5390,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'යතුර සෑදීමට අසමත් විය: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5413,7 +5402,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name සඳහා යතුර අවලංගු කරන්නද?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5421,7 +5410,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'යතුර අවලංගු කිරීමට අසමත් විය: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5441,29 +5430,29 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'ටෝකනය: $token\\nසෑදූ දිනය: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'උපස්ථයක් සාදන්න';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'උපස්ථයට ඇතුළත් කරන දේ තෝරන්න.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'දත්ත සමුදාය';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'සැමවිටම ඇතුළත්';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'පාරදත්ත';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'උපසිරැසි';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay රූප';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'උපස්ථයක් නිර්මාණය කරමින්...';
@@ -5473,7 +5462,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'උපස්ථය සෑදීමට අසමත් විය: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5482,12 +5471,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'මැනිෆෙස්ට්: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'මැනිෆෙස්ට් පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5498,7 +5487,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'උපස්ථය ප්‍රතිසාධනය කිරීමට අසමත් විය: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5530,17 +5519,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path වෙත සුරකින ලදී';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ගොනුව සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName පූරණය කිරීමට අසමත් විය';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5551,7 +5540,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'කාර්ය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5562,17 +5551,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'කාර්යය ආරම්භ කිරීමට අසමත් විය: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'කාර්යය නැවැත්වීමට අසමත් විය: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'කාර්යය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5580,12 +5569,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'ප්‍රේරකය ඉවත් කිරීමට අසමත් විය: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'ප්‍රේරකය එක් කිරීමට අසමත් විය: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5611,7 +5600,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return 'පැය $hours';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5622,7 +5611,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'ප්ලගිනය මාරු කිරීමට අසමත් විය: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5630,27 +5619,27 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'ඔබට \"$name\" අස්ථාපනය කිරීමට අවශ්‍ය බව විශ්වාසද?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'ප්ලගිනය අස්ථාපනය කිරීමට අසමත් විය: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'පැකේජය ස්ථාපනය කිරීමට අසමත් විය: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'යාවත්කාලීනය ස්ථාපනය කිරීමට අසමත් විය: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'ප්ලගින පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5662,12 +5651,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'යාවත්කාලීනය ස්ථාපනය කරන්න (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'නාමාවලිය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5688,17 +5677,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'සේවාදායකය නැවත ඇරඹීමෙන් පසු \"$name\" ඉවත් කරනු ලැබේ';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'අස්ථාපනය කිරීමට අසමත් විය: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" v$version වෙත යාවත්කාලීන කරමින්...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5707,7 +5696,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'ප්ලගිනය පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5715,7 +5704,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'අනුවාදය $version';
+    return 'Version $version';
   }
 
   @override
@@ -5735,17 +5724,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'ඔබට \"$name\" ඉවත් කිරීමට අවශ්‍ය බව විශ්වාසද?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'ගබඩා සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'ගබඩා පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5762,12 +5751,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'ප්ලගින සැකසීම් පූරණය කළ නොහැක: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri විවෘත කළ නොහැකි විය';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5884,14 +5873,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminSegmentKeepSeconds => 'කොටස තබා ගන්න (තත්පර)';
 
   @override
-  String get adminThrottleBuffering => 'බෆරින් සීමා කරන්න';
+  String get adminThrottleBuffering => 'Throttle buffering';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay සැකසීම් සුරකින ලදී';
+  String get adminTrickplaySaved => 'ට්‍රික්ප්ලේ සැකසීම් සුරකින ලදී';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Trickplay සැකසීම් පූරණය කිරීමට අසමත් විය';
+      'උපක්‍රම සැකසීම් පූරණය කිරීමට අසමත් විය';
 
   @override
   String get adminEnableHardwareAcceleration => 'දෘඪාංග ත්වරණය සබල කරන්න';
@@ -6003,7 +5992,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminBaseUrl => 'මූලික URL';
 
   @override
-  String get adminBaseUrlHint => 'උදා. /jellyfin';
+  String get adminBaseUrlHint => 'උදා. / ජෙලිෆින්';
 
   @override
   String get https => 'HTTPS';
@@ -6043,12 +6032,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'පාරදත්ත පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'පාරදත්ත සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6068,7 +6057,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'පාරදත්ත නැවුම් කිරීමට අසමත් විය: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6082,7 +6071,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'දුරස්ථ සෙවීම අසාර්ථක විය: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6096,7 +6085,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'අන්තර්ගත වර්ගය යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6111,12 +6100,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType රූපය යාවත්කාලීන කරන ලදී';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'රූපය බාගැනීමට අසමත් විය: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6127,27 +6116,27 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType රූපය උඩුගත කරන ලදී';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'රූපය උඩුගත කිරීමට අසමත් විය: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType රූපය මකන්න';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType රූපය මකා දමන ලදී';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'රූපය මැකීමට අසමත් විය: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6158,68 +6147,67 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'ට්‍යූනර සොයාගැනීම අසාර්ථක විය: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'සුසරකය එක් කරන්න';
 
   @override
-  String get adminEditTuner => 'ට්‍යූනරය සංස්කරණය කරන්න';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ට්‍යූනරය';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ගොනුව හෝ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ට්‍යූනර IP ලිපිනය';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'හඳුනාගැනීමේ නම';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'පරිශීලක නියෝජිතයා';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'එකවර සම්බන්ධතා සීමාව';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ට්‍යූනරය එකවර ඉඩ දෙන උපරිම ප්‍රවාහ ගණන. අසීමිත සඳහා 0 ලෙස සකසන්න.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'විකල්ප උපරිම ප්‍රවාහ බිට්රේට්';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'ප්‍රියතම නාලිකා පමණක් ආයාත කරන්න';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'දෘඪාංග ට්‍රාන්ස්කෝඩිංට ඉඩ දෙන්න';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 ට්‍රාන්ස්කෝඩිං බහාලුමට ඉඩ දෙන්න';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ප්‍රවාහ බෙදාගැනීමට ඉඩ දෙන්න';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ප්‍රවාහ ලූප් කිරීම සබල කරන්න';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS නොසලකා හරින්න';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'ආදානය දේශීය රාමු අනුපාතයෙන් කියවන්න';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'සපයන්නා සංස්කරණය කරන්න';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6228,50 +6216,50 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ගොනුව හෝ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'චිත්‍රපට උපසර්ගය';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'චිත්‍රපට ප්‍රවර්ග';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'බහු ප්‍රවර්ග සිරස් තීරුවකින් වෙන් කරන්න.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'ළමා ප්‍රවර්ග';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'පුවත් ප්‍රවර්ග';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'ක්‍රීඩා ප්‍රවර්ග';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'පරිශීලක නාමය';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'මුරපදය';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'රට';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'රටක් තෝරන්න';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'තැපැල් කේතය';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'ලැයිස්තු ලබාගන්න';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'ලැයිස්තු';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'සියලු ට්‍යූනර සබල කරන්න';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'සුසරක වර්ගය';
@@ -6281,7 +6269,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'ට්‍යූනරය එක් කිරීමට අසමත් විය: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6295,12 +6283,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'සපයන්නා එක් කිරීමට අසමත් විය: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'ට්‍යූනරය ඉවත් කිරීමට අසමත් විය: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6308,16 +6296,16 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'ට්‍යූනරය යළි පිහිටුවීමට අසමත් විය: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'මෙම ට්‍යූනර වර්ගය යළි පිහිටුවීමට සහාය නොදක්වයි.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'සපයන්නා ඉවත් කිරීමට අසමත් විය: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6336,43 +6324,43 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminSeriesRecordingPath => 'මාලාව පටිගත කිරීමේ මාර්ගය';
 
   @override
-  String get adminMovieRecordingPath => 'චිත්‍රපට පටිගත කිරීමේ මාර්ගය';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'මාර්ගෝපදේශ දත්ත දින';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ස්වයංක්‍රීය';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return 'දින $days';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'පසු සැකසුම් යෙදුම් මාර්ගය';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'පසු සකසනයේ තර්ක';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'පටිගත කිරීමේ NFO පාරදත්ත සුරකින්න';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'පටිගත කිරීමේ රූප සුරකින්න';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'වේලාව';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'පටිගත කිරීමේ මාර්ග';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'පසු සැකසුම්';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'මාර්ගෝපදේශ දත්ත: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6380,7 +6368,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'සැකසීම් සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6398,7 +6386,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'සිතියම්කරණ යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6415,15 +6403,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminGuideProviders => 'මාර්ගෝපදේශ සපයන්නන්';
 
   @override
-  String get adminRefreshGuideData => 'මාර්ගෝපදේශ දත්ත නැවුම් කරන්න';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'මාර්ගෝපදේශ දත්ත නැවුම් කිරීම ආරම්භ විය';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'මාර්ගෝපදේශ නැවුම් කිරීමේ කාර්යය මෙම සේවාදායකයේ නොමැත.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'සපයන්නා එක් කරන්න';
@@ -6434,22 +6421,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'පටිගත කිරීමේ මාර්ගය: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'මාලා මාර්ගය: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'පූර්ව-පෑඩිං: මිනි. $minutes';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'පසු-පෑඩිං: මිනි. $minutes';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6481,7 +6468,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'දැන් $name උපස්ථය ප්‍රතිසාධනය කරන්නද?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6505,13 +6492,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminLiveTvTitle => 'සජීවී රූපවාහිනී පරිපාලනය';
 
   @override
-  String get adminApply => 'යොදන්න';
+  String get adminApply => 'අයදුම් කරන්න';
 
   @override
   String get adminNotSet => 'සකසා නැත';
 
   @override
-  String get adminReset => 'යළි සකසන්න';
+  String get adminReset => 'යළි පිහිටුවන්න';
 
   @override
   String get adminLogsTitle => 'සේවාදායක ලොග්';
@@ -6527,27 +6514,27 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'මිනි. $minutesකට පෙර';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'පැය $hoursකට පෙර';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'දින $daysකට පෙර';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName පූරණය කිරීමට අසමත් විය';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return 'ගැළපීම් $count';
+    return '$count matches';
   }
 
   @override
@@ -6557,7 +6544,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminMetadataEditorTitle => 'පාරදත්ත සංස්කාරකය';
 
   @override
-  String get adminMetadataIdentify => 'හඳුනාගන්න';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'ටයිප් කරන්න';
@@ -6657,22 +6644,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType රූපය යාවත්කාලීන කරන ලදී';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType රූපය උඩුගත කරන ලදී';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType රූපය මකා දමන ලදී';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'රූපය බාගැනීමට අසමත් විය: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6680,12 +6667,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'රූපය උඩුගත කිරීමට අසමත් විය: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType රූපය මකන්න';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6694,12 +6681,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'රූපය මැකීමට අසමත් විය: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType රූපය තෝරන්න';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6732,7 +6719,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'යාවත්කාලීනයක් තිබේ: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6757,7 +6744,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'යාවත්කාලීනය ස්ථාපනය කරන්න (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6769,7 +6756,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" ස්ථාපනය වෙමින් පවතී...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6789,7 +6776,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name සැකසීම්';
+    return '$name Settings';
   }
 
   @override
@@ -6829,7 +6816,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'ගබඩා පූරණය කිරීමට අසමත් විය: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6837,7 +6824,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'ඔබට \"$name\" ඉවත් කිරීමට අවශ්‍ය බව විශ්වාසද?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6845,7 +6832,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'ගබඩා සුරැකීමට අසමත් විය: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6970,20 +6957,19 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminBrandingEnableSplash => 'ස්ප්ලෑෂ් තිරය සබල කරන්න';
 
   @override
-  String get adminBrandingSplashUpload => 'රූපය උඩුගත කරන්න';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'විවෘත තිරය යාවත්කාලීන කරන ලදී';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'විවෘත තිරය උඩුගත කිරීමට අසමත් විය';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'විවෘත තිරය ඉවත් කරන ලදී';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'අභිරුචි විවෘත තිරයක් නැත';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'දෘඪාංග ත්වරණය';
@@ -6998,124 +6984,121 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'දෘඪාංග විකේතනය සක්රිය කරන්න:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV උපාංගය';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'වැඩිදියුණු කළ NVDEC විකේතකය සබල කරන්න';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'පද්ධතියේ දේශීය දෘඪාංග විකේතකයට මුල් තැන දෙන්න';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'දෘඪාංග විකේතන වර්ණ ගැඹුර';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC විකේතනය';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 විකේතනය';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit විකේතනය';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit විකේතනය';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'දෘඪාංග කේතනය';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC කේතනයට ඉඩ දෙන්න';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 කේතනයට ඉඩ දෙන්න';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel අඩු-බල H.264 කේතකය සබල කරන්න';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel අඩු-බල HEVC කේතකය සබල කරන්න';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'ටෝන් සිතියම්කරණය';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'ටෝන් සිතියම්කරණය සබල කරන්න';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP ටෝන් සිතියම්කරණය සබල කරන්න';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox ටෝන් සිතියම්කරණය සබල කරන්න';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'ටෝන් සිතියම්කරණ ඇල්ගොරිතමය';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'ටෝන් සිතියම්කරණ ප්‍රකාරය';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'ටෝන් සිතියම්කරණ පරාසය';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'ටෝන් සිතියම්කරණ අසංතෘප්තිය';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ටෝන් සිතියම්කරණ උච්චය';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'ටෝන් සිතියම්කරණ පරාමිතිය';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP ටෝන් සිතියම්කරණ දීප්තිය';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP ටෝන් සිතියම්කරණ ප්‍රතිවිරෝධය';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'පෙරසැකසුම් සහ ගුණාත්මකභාවය';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'කේතක පෙරසැකසුම';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 කේතන CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) කේතන CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'ඩීඉන්ටර්ලේස් ක්‍රමය';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ඩීඉන්ටර්ලේස් කිරීමේදී රාමු අනුපාතය දෙගුණ කරන්න';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ශ්‍රව්‍ය';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'ශ්‍රව්‍ය VBR කේතනය සබල කරන්න';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ශ්‍රව්‍ය ඩවුන්මික්ස් වර්ධනය';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ස්ටීරියෝ ඩවුන්මික්ස් ඇල්ගොරිතමය';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'උපරිම මක්සිං පෝලිම් ප්‍රමාණය';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ස්වයංක්‍රීය';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'කේතනය කිරීම';
@@ -7236,7 +7219,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminTaskStop => 'නවත්වන්න';
 
   @override
-  String get adminRunningTasks => 'ධාවනය වන කාර්ය';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'දුවන්න';
@@ -7258,17 +7241,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'දිනපතා $timeට';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'සෑම $dayම $timeට';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'සෑම $durationකට';
+    return 'Every $duration';
   }
 
   @override
@@ -7306,8 +7289,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'පැය $count',
-      one: 'පැය 1',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7335,17 +7318,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'දින $daysකට පෙර';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'පැය $hoursකට පෙර';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'මිනි. $minutesකට පෙර';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7353,17 +7336,17 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return 'මිනි. $minutes';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return 'පැය $hours';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return 'දින $days';
+    return '${days}d';
   }
 
   @override
@@ -7373,7 +7356,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'ගමන් පෙරදැක්ම සිඟිති රූ සඳහා Trickplay රූප ජනනය වින්‍යාස කරන්න.';
+      'පෙරදසුන් සිඟිති රූ සෙවීම සඳහා උපක්‍රමශීලී රූප උත්පාදනය වින්‍යාස කරන්න.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'පොදු HTTPS වරාය';
@@ -7382,50 +7365,49 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'මූලික URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'උදා. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'උදා. / ජෙලිෆින්';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'පොදු HTTP තොට';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS අවශ්‍යයි';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'සියලු දුරස්ථ ඉල්ලීම් HTTPS වෙත හරවා යවන්න. සේවාදායකයට වලංගු සහතිකයක් නොමැති නම් බලපෑමක් නැත.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'සහතික මුරපදය';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP සැකසීම්';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 සබල කරන්න';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 සබල කරන්න';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'ස්වයංක්‍රීය තොට සිතියම්කරණය සබල කරන්න';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN ජාල';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'දේශීය ජාලයේ ඇතැයි සලකන IP ලිපින හෝ CIDR උපජාලවල කොමා හෝ පේළියෙන් වෙන් කළ ලැයිස්තුවක්.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'ප්‍රකාශිත සේවාදායක URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'උපජාලයක් හෝ ලිපිනයක් ප්‍රකාශිත URL එකකට සිතියම්ගත කරන්න, උදා. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'සහතික මාර්ගය';
@@ -7452,14 +7434,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminPlaybackSegmentKeep => 'කොටස තබා ගන්න (තත්පර)';
 
   @override
-  String get adminPlaybackThrottleBuffering => 'බෆරින් සීමා කරන්න';
+  String get adminPlaybackThrottleBuffering => 'Throttle buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'සීමා ප්‍රමාදය (තත්පර)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'ක්ෂණිකව උපසිරැසි උපුටා ගැනීමට ඉඩ දෙන්න';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'අවම නැවත ආරම්භ කිරීමේ ප්‍රතිශතය';
@@ -7509,7 +7491,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'අන්තර්ගත වර්ගය යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7517,23 +7499,22 @@ class AppLocalizationsSi extends AppLocalizations {
       'මන්දගාමී ප්‍රතිචාර සීමාව (මිලි)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'මන්දගාමී ප්‍රතිචාර අනතුරු ඇඟවීම් සබල කරන්න';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect සබල කරන්න';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'සේවාදායකය';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'පාරදත්ත';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'මාර්ග';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'කාර්යසාධනය';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'හැඹිලි මාර්ගය';
@@ -7545,7 +7526,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminGeneralServerName => 'සේවාදායකයේ නම';
 
   @override
-  String get adminGeneralDisplayLanguage => 'කැමති සංදර්ශන භාෂාව';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'සැකසීම් පූරණය කිරීමට අසමත් විය';
@@ -7555,12 +7536,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'සිතියම්කරණ යාවත්කාලීන කිරීමට අසමත් විය: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'කාල සීමාව: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7597,8 +7578,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# සහභාගිවන්නන්',
-      one: '# සහභාගිවන්නා',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7641,7 +7622,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'අයිතමය $index';
+    return 'Item $index';
   }
 
   @override
@@ -7689,12 +7670,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay කණ්ඩායමට එක් විය';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay කණ්ඩායමෙන් ඉවත් විය';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7706,7 +7687,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName වෙත ධාවනය සමමුහුර්ත කරමින්';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7744,8 +7725,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'පේළි # ක් සොයාගන්නා ලදී',
-      one: 'පේළි # ක් සොයාගන්නා ලදී',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7785,20 +7766,20 @@ class AppLocalizationsSi extends AppLocalizations {
   String get offlineSavedMedia => 'සුරැකි මාධ්‍ය';
 
   @override
-  String get offlineBannerTitle => 'ඔබ නොබැඳියි';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'ඔබේ බාගැනීම් පෙන්වමින්';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'බාගැනීම්';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'ඔබේ සේවාදායකයට ළඟා විය නොහැක';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'එය නැවත එනතුරු බාගැනීම්වලින් වාදනය කරමින්';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7814,12 +7795,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'කාස්ට් පාලනය අසාර්ථක විය: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind පාලන';
+    return '$kind Controls';
   }
 
   @override
@@ -7830,7 +7811,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind නවත්වන්න';
+    return 'Stop $kind';
   }
 
   @override
@@ -7854,12 +7835,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'අංක $lengthක PIN එකක් ඇතුළත් කරන්න';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'ඔබේ අංක $lengthක PIN එක ඇතුළත් කරන්න';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7872,17 +7853,17 @@ class AppLocalizationsSi extends AppLocalizations {
   String get pinForgot => 'PIN අමතකද?';
 
   @override
-  String get pinClear => 'හිස් කරන්න';
+  String get pinClear => 'පැහැදිලියි';
 
   @override
-  String get pinBackspace => 'පසුඉඩ';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect ඉල්ලීම අනුමත කරන ලදී.';
+  String get quickConnectAuthorized => 'ඉක්මන් සම්බන්ධතා ඉල්ලීම අනුමත කර ඇත.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect කේතය වලංගු නැත හෝ කල් ඉකුත් වී ඇත.';
+      'ඉක්මන් සම්බන්ධතා කේතය අවලංගු හෝ කල් ඉකුත් වී ඇත.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7890,22 +7871,22 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect කේතය අනුමත කිරීමට අසමත් විය.';
+      'ඉක්මන් සම්බන්ධතා කේතය අනුමත කිරීමට අසමත් විය.';
 
   @override
   String get quickConnectDisabled => 'මෙම සේවාදායකයේ Quick Connect අබල කර ඇත.';
 
   @override
   String get quickConnectForbidden =>
-      'ඔබේ ගිණුමට මෙම Quick Connect ඉල්ලීම අනුමත කළ නොහැක.';
+      'ඔබගේ ගිණුමට මෙම ඉක්මන් සම්බන්ධතා ඉල්ලීමට අවසර දිය නොහැක.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect කේතය හමු නොවීය. නව කේතයක් උත්සාහ කරන්න.';
+      'ඉක්මන් සම්බන්ධතා කේතය හමු නොවීය. නව කේතයක් උත්සාහ කරන්න.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect අසාර්ථක විය: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7916,7 +7897,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'විධානය අසාර්ථක විය: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7945,7 +7926,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'කාස්ට් කිරීම ආරම්භ කිරීමට අසමත් විය: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7990,7 +7971,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name බාගත වෙමින්...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8077,7 +8058,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return '$segment මඟහරින්න';
+    return 'Skip $segment';
   }
 
   @override
@@ -8088,12 +8069,12 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'බාගත වෙමින් $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName බාගත වෙමින්';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8155,13 +8136,13 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'නැරඹීම දිගටම කරන්නෙන් සඟවන්න';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'ඊළඟට කින් සඟවන්න';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'එකතුවට එක් කරන්න';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8214,15 +8195,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsAlphabetical => 'අකාරාදී';
 
   @override
-  String get settingsConnectionSection => 'සම්බන්ධතාව';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'ස්වයං-අත්සන් කළ සහතිකවලට ඉඩ දෙන්න';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'ස්වයං-අත්සන් කළ හෝ පෞද්ගලික-CA TLS සහතික භාවිත කරන සේවාදායක විශ්වාස කරන්න. ඔබ පාලනය කරන සේවාදායක සඳහා පමණක් සබල කරන්න. මෙය සියලු සම්බන්ධතා සඳහා සහතික වලංගුකරණය අබල කරයි.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'පෞද්ගලිකත්වය සහ ආරක්ෂාව';
@@ -8238,11 +8218,11 @@ class AppLocalizationsSi extends AppLocalizations {
       'තේමා උච්චාරණ, පසුබිම්, නැරඹූ දර්ශක සහ තේමා සංගීතය';
 
   @override
-  String get settingsDetailsScreen => 'විස්තර තිරය';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'විලාසය, පසුබිම් බොඳ කිරීම සහ ටැබ හැසිරීම';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'මුල් පිටුව';
@@ -8280,11 +8260,11 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'සංචාලන තීරුවේ Seerr බොත්තම පෙන්වන්න';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'ඉහළ සංචාලන තීරුවේ පෙළ ලේබල සැමවිටම පෙන්වන්න';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8354,7 +8334,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'සංවර්ධකයාට කෝපි කෝප්පයක් පරිත්‍යාග කරන්න';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'නීතිමය';
@@ -8387,8 +8367,8 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'බලපත්‍ර දැන්වීම් #',
-      one: 'බලපත්‍ර දැන්වීම් #',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8437,16 +8417,16 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'හැඳින්වීම් සහ පිටවීම් මඟ හරින්නද?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'මාධ්‍ය කොටස් ආපසු ගණන් කිරීම';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'ප්‍රගති තීරුව';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ටයිමරය';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'කිසිවක් නැත';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ඉක්මන් පරිශීලක';
@@ -8480,13 +8460,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (නිර්දේශිත)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (පැරණි)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (උරුමය)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (නිර්දේශිත)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision පසුබැසීම';
@@ -8674,757 +8654,749 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'මෑතකදී නිකුත් වූ $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'ඊළඟ කථාංගය ස්වයංක්‍රීයව වාදනය කරන්න';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'ලද හැකි විට ඊළඟ කථාංගය ස්වයංක්‍රීයව වාදනය කරන්න.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'නිශ්ශබ්දතාව මඟහරින්න';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'ප්‍රවාහය සහාය දක්වන විට නිශ්ශබ්ද ශ්‍රව්‍ය කොටස් ස්වයංක්‍රීයව මඟහරින්න.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'බාහිර ශ්‍රව්‍ය ප්‍රයෝගවලට ඉඩ දෙන්න';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'සමකාරක සහ ප්‍රයෝග යෙදුම් (උදා. Wavelet) Media3 ධාවන සැසිවලට සම්බන්ධ වීමට ඉඩ දෙන්න.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'ටනලින් අබල කරන්න';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'ටනල් නොකළ ධාවනය බලාත්මක කරන්න. ටනලින් ශ්‍රව්‍ය/වීඩියෝ අඛණ්ඩතා ගැටලු ඇති උපාංගවල ප්‍රයෝජනවත්.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'ටනලින් සබල කරන්න';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'උසස්. ශ්‍රව්‍ය සහ වීඩියෝ සම්බන්ධිත දෘඪාංග මාර්ගයක් හරහා යවයි. සමහර උපාංගවල ශ්‍රව්‍ය/වීඩියෝ බිඳවැටීම් ඇති කරන බැවින් පෙරනිමියෙන් ක්‍රියාවිරහිතයි.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision පැතිකඩ 7 HEVC වෙත සිතියම්ගත කරන්න';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'DV නොවන උපාංගවල Dolby Vision පැතිකඩ 7 ප්‍රවාහ HDR10-ගැළපෙන HEVC ලෙස වාදනය කරන්න.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'කාවැද්දූ උපසිරැසි විලාස භාවිත කරන්න';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'උපසිරැසි පථයේ කාවැද්දූ වර්ණ, අකුරු සහ පිහිටුම යොදන්න. ඒ වෙනුවට ඔබේ සිරැසි විලාස මනාප භාවිත කිරීමට අබල කරන්න.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'කාවැද්දූ උපසිරැසි අකුරු ප්‍රමාණ භාවිත කරන්න';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'උපසිරැසි පථයේ කාවැද්දූ අකුරු-ප්‍රමාණ ඉඟි යොදන්න. ඔබේ විලාස මනාපවල උපසිරැසි ප්‍රමාණය භාවිත කිරීමට අබල කරන්න.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'මාධ්‍ය විස්තර පෙන්වන්න';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'පුස්තකාල පිටුවල ඉහළින් තෝරාගත් අයිතමයේ විස්තර පෙන්වන්න.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'පිරික්සන විට පසුබිම් සඟවන්නද?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'විස්තරාත්මක උප-මාතෘකා භාවිත කරන්න';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'පුස්තකාල පිටුවල විස්තරාත්මක හෝ අවම උප-පේළියක් පෙන්වන්න.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'සුරැකි තේමාව මකන්නද?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'මෙම උපාංග හැඹිලියෙන් \"$themeName\" ඉවත් කරන්නද?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'තේමා වෙළඳසැල';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'ප්‍රජා තේමා පිරික්සා සුරකින්න';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'ඔබේ අනෙකුත් සුරැකි තේමා මෙන් භාවිත කිරීමට තේමාවක් සුරකින්න.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'දැන් තේමා කිසිවක් නොමැත.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'තේමා වෙළඳසැල පූරණය කළ නොහැකි විය. ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'සුරකින්න';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'සුරැකා යොදන්න';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'සුරකින ලදී';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'මෙම තේමාව පූරණය කළ නොහැකි විය.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" සුරකින ලදී.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'මෙම උපාංගයෙන් \"$themeName\" මකා දමන ලදී.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" මැකිය නොහැකි විය.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'සුරැකි තේමා';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'මේවා වත්මන් සේවාදායකය සඳහා Moonfin ප්ලගිනයෙන් බාගත කළ තේමා වේ. මැකීමෙන් මෙම දේශීය පිටපත පමණක් ඉවත් වේ.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'මෙම සේවාදායකය සඳහා සුරැකි තේමා හමු නොවීය.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • දැනට ක්‍රියාත්මකයි';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'සුරැකි තේමාව මකන්න';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'මෙම උපාංගයේ බාගත කළ ප්ලගින තේමා කළමනාකරණය කරන්න';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'තේමා සංස්කාරකය';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'ඔබේ බ්‍රවුසරයේ Moonfin තේමා සංස්කාරකය විවෘත කරන්න';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'මුල් තිරය';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'පහළ තීරුව';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'සම්භාව්‍ය';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'නවීන';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'මුල් තිර පේළි';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'මුල් තිර පේළි සංදර්ශනය';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'මුල් තිර පේළි කොටස්';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'මුල් තිර පේළි ටොගල';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'පුස්තකාල පදනම් මුල් තිර පේළි ප්‍රවර්ග සබල හෝ අබල කරන්න';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'මුල් තිර කොටස්වල පේළි පෙන්වීමට පහත ටොගල සබල කරන්න.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'සම්භාව්‍ය මඟින් පේළියකට රූප වර්ගය සහ තොරතුරු උඩැතිරිය තබා ගනී. නවීන මඟින් සිරස්-සිට-පසුබිම පේළි භාවිත කරයි.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'ප්‍රියතම පේළි පෙන්වන්න';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'මුල් තිර කොටස්වල ප්‍රියතම චිත්‍රපට, මාලා සහ අනෙකුත් ප්‍රියතම පේළි පෙන්වන්න.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'ප්‍රියතම පේළි වර්ග කිරීම';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'එක් කළ දිනය, නිකුත් වූ දිනය, අකාරාදී ලෙස සහ තවත් ක්‍රම අනුව ප්‍රියතම පේළි වර්ග කරන්න.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'එකතු පේළි පෙන්වන්න';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'මුල් තිර කොටස්වල එකතු පේළි පෙන්වන්න.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'එකතු පේළි වර්ග කිරීම';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'එක් කළ දිනය, නිකුත් වූ දිනය, අකාරාදී ලෙස සහ තවත් ක්‍රම අනුව එකතු පේළි වර්ග කරන්න.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'ප්‍රභේද පේළි පෙන්වන්න';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'මුල් තිර කොටස්වල ප්‍රභේද පේළි පෙන්වන්න.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'ප්‍රභේද පේළි වර්ග කිරීම';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'එක් කළ දිනය, නිකුත් වූ දිනය, අකාරාදී ලෙස සහ තවත් ක්‍රම අනුව ප්‍රභේද පේළි වර්ග කරන්න.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'ප්‍රභේද පේළි අයිතම';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'ප්‍රභේද පේළිවල චිත්‍රපට, මාලා හෝ දෙකම පෙන්වන්න.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'ධාවන ලැයිස්තු පේළි පෙන්වන්න';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'මුල් තිර කොටස්වල ධාවන ලැයිස්තු පේළි පෙන්වන්න.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'ධාවන ලැයිස්තු පේළි වර්ග කිරීම';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'එක් කළ දිනය, නිකුත් වූ දිනය, අකාරාදී ලෙස සහ තවත් ක්‍රම අනුව ධාවන ලැයිස්තු පේළි වර්ග කරන්න.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ශ්‍රව්‍ය පේළි පෙන්වන්න';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'මුල් තිර කොටස්වල ශ්‍රව්‍ය පේළි පෙන්වන්න.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ශ්‍රව්‍ය පේළි වර්ග කිරීම';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'එක් කළ දිනය, නිකුත් වූ දිනය, අකාරාදී ලෙස සහ තවත් ක්‍රම අනුව ශ්‍රව්‍ය පේළි වර්ග කරන්න.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ශ්‍රව්‍ය ධාවන ලැයිස්තු';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'පෙනුම';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'සැකැස්ම';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'තේමාව';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'යතුරුපුවරුව';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'බොත්තම්';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'විදැහුම්කරණය';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV වින්‍යාසය';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'බාහිර ධාවක යෙදුම';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'දිගු-ඔබන්න වාදන විකල්පය සබල කිරීමට බාහිර ධාවකයක් සකසන්න';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'ධාවනය ආරම්භ වන විට යෙදුම් තෝරකය පෙන්වන්න.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'ස්ථාපිත ධාවක පූරණය වෙමින්...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'සම්බන්ධතාව';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ශ්‍රව්‍ය ට්‍රාන්ස්කෝඩ් ඉලක්කය';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'පාස්ත්‍රූ';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'මෙම උපාංගයේ සහාය දක්වයි';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'මෙම උපාංගයේ සහාය නොදක්වයි';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) පාස්ත්‍රූ';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) බාහිර විකේතකයට බිට්ස්ට්‍රීම් කරන්න.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) සහිත TrueHD පාස්ත්‍රූ';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'මාධ්‍ය ධාවක හැසිරීම';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'වාදන වැඩිදියුණු කිරීම්';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'සැමවිටම ක්‍රියාත්මකයි.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'අවසානය මඟහැරීම ඊළඟට සංදර්ශනයෙන් ප්‍රතිස්ථාපනය කරන්න';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'අවසානය මඟහරින බොත්තම වෙනුවට ඊළඟට උඩැතිරිය පෙන්වන්න.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'ධාවක මාර්ගගත කිරීම';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'මෘදුකාංග විකේතකවලට මුල් තැන දෙන්න';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'දෘඪාංග විකේතකවලට පෙර FFmpeg (ශ්‍රව්‍ය) සහ libgav1 (AV1) භාවිත කරන්න. HDMI ශ්‍රව්‍ය පාස්ත්‍රූ බිඳ වැටේ නම් අබල කරන්න.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV හි ඔබ තෝරාගත් බාහිර යෙදුමේ වීඩියෝ ධාවනය විවෘත කරන්න.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'ස්වයංක්‍රීය පෝලිම් කිරීම';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH උපසිරැසිවලට මුල් තැන දෙන්න';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'ස්වයංක්‍රීයව තෝරන විට SDH/CC උපසිරැසි පථවලට ප්‍රමුඛත්වය දෙන්න.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'වෙබ් දෝෂ නිර්ණය';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin වෙබ් දෝෂ නිර්ණය';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'බ්‍රවුසර සම්බන්ධතා ගැටලු (CORS, මිශ්‍ර අන්තර්ගතය සහ සොයාගැනීමේ සැකසීම්) විනිශ්චය කිරීමට මෙම පිටුව භාවිත කරන්න.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'මිශ්‍ර-අන්තර්ගත අසාර්ථකත්වයක් හඳුනාගන්නා ලදී';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight අසාර්ථකත්වයක් හඳුනාගන්නා ලදී';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'HTTP සේවාදායක URL එකක් ඇමතීමට උත්සාහ කරන HTTPS පිටුවක් Moonfin හඳුනාගත්තේය. බ්‍රවුසර මෙම ඉල්ලීම ඔබේ සේවාදායකයට ළඟා වීමට පෙර අවහිර කරයි.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'මාධ්‍ය සේවාදායකයේ අස්ථානගත වූ CORS හෝ preflight ශීර්ෂ නිසා බහුලව ඇතිවන බ්‍රවුසර මට්ටමේ ඉල්ලීම් අසාර්ථකත්වයක් Moonfin හඳුනාගත්තේය.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'ඉලක්ක URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'විස්තරය: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'වත්මන් ධාවන කාල සන්දර්භය';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'මූලාරම්භය';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'යෝජනා ක්‍රමය';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'ප්ලගින ප්‍රකාරය';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC පරිලෝකනය';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'බලෙන් යෙදූ සේවාදායක URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'පෙරනිමි සේවාදායක URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'සොයාගැනීමේ ප්‍රොක්සි URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'වින්‍යාස කර නැත';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'මිශ්‍ර අන්තර්ගතය';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'මෙම පිටුව HTTPS හරහා පූරණය වී ඇත, නමුත් වින්‍යාස කළ URL එකක් හෝ කිහිපයක් HTTP වේ. බ්‍රවුසර HTTPS පිටුවලට HTTP API ඇමතීම අවහිර කරයි.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'විසඳුම: ඔබේ මාධ්‍ය සේවාදායකය හෝ ප්‍රොක්සි අන්තය HTTPS හරහා සපයන්න, නැතහොත් Moonfin HTTP හරහා විශ්වාසනීය දේශීය ජාලවල පමණක් පූරණය කරන්න.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'වත්මන් ධාවන කාල සැකසීම්වලින් පැහැදිලි මිශ්‍ර-අන්තර්ගත වින්‍යාසයක් හඳුනාගත නොහැකි විය.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS පිරික්සුම් ලැයිස්තුව';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin හි බ්‍රවුසර මූලාරම්භයට ඉඩ දෙන්න.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers හි Authorization, X-Emby-Authorization සහ X-Emby-Token ඇතුළත් කරන්න.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ප්‍රවාහ සහ ගමන් හැසිරීම සඳහා Content-Range සහ Accept-Ranges හෙළිදරව් කරන්න.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight ඉල්ලීම්වලට 204 ලබා දෙන්න.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'උදාහරණ ශීර්ෂ කැබැල්ල (nginx-විලාසය)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'සටහන';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'මෙම දෝෂ නිර්ණ මාර්ගය වෙබ් නිර්මාණ සඳහා අදහස් කර ඇත. ඔබ මෙය වෙනත් වේදිකාවක දකින්නේ නම්, මෙම පරීක්ෂණ අදාළ නොවිය හැක.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'සේවාදායක තේරීමට ආපසු';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'සියලු පරිශීලකයන් නික්මන්න';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'මයික්‍රොෆෝන අවසරය ස්ථිරවම ප්‍රතික්ෂේප වී ඇත. එය පද්ධති සැකසීම්වල සබල කරන්න.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'හඬ සෙවීම සඳහා මයික්‍රොෆෝන අවසරය අවශ්‍යයි.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'එය හසු නොවීය. නැවත උත්සාහ කරන්න.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'කථනයක් හඳුනාගත නොහැකි විය.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'මයික්‍රොෆෝන දෝෂයකි.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'හඬ සෙවීමට අන්තර්ජාලය අවශ්‍යයි.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'හඬ සේවාව කාර්යබහුලයි. නැවත උත්සාහ කරන්න.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'මයික්‍රොෆෝන අවසරය ස්ථිරවම ප්‍රතික්ෂේප වී ඇත.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'මයික්‍රොෆෝන අවසරය ප්‍රතික්ෂේප වී ඇත.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'මෙම උපාංගයේ කථන හඳුනාගැනීම නොමැත.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS මාර්ග තෝරකය විවෘත කරන්න';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'මෙම උපාංගයේ AirPlay මාර්ග තෝරකය නොමැත.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'වීඩියෝ';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'වැඩසටහන්';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'ගීත';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'ඡායාරූප ඇල්බම';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'ඡායාරූප';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'පුද්ගලයන්';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'මෑතකදී නිකුත් වූ කථාංග';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'නැවත නරඹන්න';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'අමුත්තන්ගේ පෙනී සිටීම්';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'පෙනී සිටීම් (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'කණ්ඩායම් දායකත්ව (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'කණ්ඩායම සමඟ නරඹන්න';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'දෝෂ';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'අනතුරු ඇඟවීම්';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'තැටිය';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'බ්‍රවුසරයේ විවෘත කරන්න';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'මෙම වේදිකාවේ කාවැද්දූ බ්‍රවුසරයක් නොමැත.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'ඔබට සේවාදායකය නැවත ඇරඹීමට අවශ්‍ය බව විශ්වාසද?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'ඔබට සේවාදායකය වසා දැමීමට අවශ්‍ය බව විශ්වාසද? ඔබට එය අතින් නැවත ඇරඹීමට සිදුවේ.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'අභ්‍යන්තර';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'නිෂ්ක්‍රීය';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'පරිශීලකයන් හමු නොවීය';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'ඔබේ සෙවීමට ගැළපෙන පරිශීලකයන් නැත';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'උපාංග හමු නොවීය';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'වත්මන් පෙරහන්වලට ගැළපෙන උපාංග නැත';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'මුරපදය සකසා ඇත';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'මුරපදයක් වින්‍යාස කර නැත';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'දුරස්ථ ප්‍රවේශය';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'දේශීය පමණි';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'මාධ්‍ය විශ්ලේෂණ පූරණය කිරීමට අසමත් විය';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'සියලු මාධ්‍ය පුස්තකාල හරහා ඒකාබද්ධ විශ්ලේෂණ.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'ප්‍රමුඛ කලාකරුවන්';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'ප්‍රමුඛ කතුවරුන්';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'ප්‍රමුඛ දායකයන්';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'පුස්තකාල $count',
-      one: 'පුස්තකාලය 1',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'මෙම තේරීම සඳහා සුචිගත මාධ්‍ය එකතුවක් තවම නොමැත.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'පුස්තකාල විස්තර';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'පුස්තකාල විග්‍රහය';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'පුස්තකාල කිසිවක් නොමැත.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'සේවාදායක පරිපාලනය';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'දත්ත';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'රූප හැඹිලිය';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'හැඹිලිය';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'ලොග';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'පාරදත්ත';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'ට්‍රාන්ස්කෝඩ්';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'මෙම සේවාදායකය සේවාදායක මාර්ග කිසිවක් ලබා දුන්නේ නැත.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% භාවිත කර ඇත';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'පරිශීලක ක්‍රියාකාරකම්';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'පද්ධති සිදුවීම්';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'අවධානය අවශ්‍යයි';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'සේවාදායකය';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'වාදනය';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'උපාංග';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'උසස්';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'ප්ලගින';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'සජීවී රූපවාහිනිය';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'නිවසේ වීඩියෝ';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'මිශ්‍ර අන්තර්ගතය';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'නිවසේ වීඩියෝ සහ ඡායාරූප';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'මිශ්‍ර චිත්‍රපට සහ වැඩසටහන්';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9436,299 +9408,299 @@ class AppLocalizationsSi extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'පටිගත කිරීම් හමු නොවීය';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension සංරක්ෂිතය තුළ රූප පිටු හමු නොවීය.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'කාවැද්දූ විදැහුම්කරු අසාර්ථක විය ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB විදැහුම්කරු අසාර්ථක විය ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'කියවනය සඳහා දේශීය ගොනුව අස්ථානගතයි: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri වෙතින් පොත් දත්ත විවෘත කිරීමේදී HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'කියවිය හැකි පොත් අන්තයක් නොමැත';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'සහාය නොදක්වන කොමික් සංරක්ෂිත ආකෘතියකි: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'මෙම වේදිකාවේ CBR උපුටාගැනීමේ ප්ලගිනය නොමැත.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr සංරක්ෂිතය උපුටා ගැනීමට අසමත් විය.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => 'මෙම වේදිකාවේ CB7 උපුටාගැනීම නොමැත.';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'මෙම වේදිකාවේ CB7 උපුටාගැනීමේ ප්ලගිනය නොමැත.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'ප්‍රභේද පැනලය වසන්න';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'කලවම් කිරීම පූරණය වෙමින්...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'පුස්තකාල කලවම් කිරීම';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'අහඹු කලවම් කිරීම';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ප්‍රභේද කලවම් කිරීම';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'ස්වයංක්‍රීය HDR මාරු කිරීම';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR වීඩියෝ ධාවනය සඳහා ස්වයංක්‍රීයව HDR සබල කර පිටවීමේදී සංදර්ශන ප්‍රකාරය ප්‍රතිසාධනය කරන්න.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'පූර්ණ තිරයේදී';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'කලා නිර්මාණය වෙනස් කරන්න';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'අස්ථානගතයි';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'ට්‍රාන්ස්කෝඩිං සීමා';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'සියලු කලා නිර්මාණ හිස් කරන්නද?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'ඔබට බාගත කළ සියලු කලා නිර්මාණ හිස් කිරීමට අවශ්‍ය බව විශ්වාසද?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'හිස් කිරීම තහවුරු කරන්න';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'ඔබට මෙම $itemType හිස් කිරීමට අවශ්‍ය බව විශ්වාසද?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'උඩුගත කරන්නද?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'විභේදනය: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'අතුරුමුහුණතේ භාෂාවෙන් පමණක් කලා නිර්මාණ පෙන්වන්න';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'සියල්ල හිස් කිරීම තහවුරු කරන්න';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'රූපය සාර්ථකව උඩුගත කරන ලදී!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'රූපය උඩුගත කිරීමට අසමත් විය: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'රූපය සැකසීමට අසමත් විය: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'රූපය මැකීමට අසමත් විය: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'සියලු කලා නිර්මාණ හිස් කිරීමට අසමත් විය: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ඔව්';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'පෝස්ටරය';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'පසුබිම්';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'බැනරය';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'ලාංඡනය';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'සිඟිති රූව';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'කලාව';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'තැටි කලාව';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'තිර රුව';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'පෙට්ටි කවරය';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'පෙට්ටියේ පිටුපස කවරය';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'මෙනු කලාව';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'පෝස්ටරය';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'පසුබිම';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'බැනරය';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'ලාංඡනය';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'සිඟිති රූව';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'කලාව';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'තැටි කලාව';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'තිර රුව';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'පෙට්ටි කවරය';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'පෙට්ටියේ පිටුපස කවරය';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'මෙනු කලාව';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'සියල්ල';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'ඉහළ (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'මධ්‍යම (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'අඩු (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'මූලාශ්‍ර';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'පරිච්ඡේද';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'පිටු සලකුණු';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'සටහන්';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'පෝලිම';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'කාල රේඛාව';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'කාල රේඛාව හිස්ය';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'සම්පූර්ණ පොත';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'නාභිගත කාල රේඛාව';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'පිටු සලකුණු නිර්යාත කරන්න';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'සටහන් නිර්යාත කරන්න';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'සියල්ල නිර්යාත කරන්න';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path වෙත නිර්යාත කරන ලදී';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'නිර්යාත කිරීම අසාර්ථක විය: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'ගී පද';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'පිටු සලකුණක් එක් කරන්න';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'සටහනක් එක් කරන්න';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'සටහන සංස්කරණය කරන්න';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'මෙම මොහොත සඳහා සටහනක් ලියන්න';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'නින්ද ටයිමරය';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'අක්‍රියයි';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'පරිච්ඡේදය අවසානය';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'අභිරුචි';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining ඉතිරියි';
+    return '$remaining left';
   }
 
   @override
@@ -9736,58 +9708,58 @@ class AppLocalizationsSi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'මිනි. $count',
-      one: 'මිනි. 1',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'වාදන වේගය';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'ඉතිරි';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'ගත වූ';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'තත් $seconds ආපසු';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'තත් $seconds ඉදිරියට';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'පෙර පරිච්ඡේදය';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'ඊළඟ පරිච්ඡේදය';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'පරිච්ඡේද $totalන් $current';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'පරිච්ඡේද නැත';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'තවම පිටු සලකුණු නැත';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'තවම සටහන් නැත';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position හි පිටු සලකුණක් එක් කරන ලදී';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x වෙත යළි පිහිටුවන්න';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9795,251 +9767,249 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'සුරකින්න';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'අවලංගු කරන්න';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'මකන්න';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'උපසිරැසි මනාප';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'උපසිරැසි ප්‍රකාර, පෙරනිමි භාෂා, පෙනුම සහ විදැහුම්කරණ විකල්ප වෙනස් කරන්න.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'උපසිරැසි විදැහුම්කරණය';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'සංදර්ශන විකල්ප';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'නිකුත් වූ දිනය (ආරෝහණ)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'නිකුත් වූ දිනය (අවරෝහණ)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'දායකත්ව කාණ්ඩගත කරන්න';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'බහු භූමිකා කාණ්ඩගත කරන්න';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'පුස්තකාල ලිවීමේ ප්‍රවේශ අනතුරු ඇඟවීම';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'මෙය නිවැරදි කරන ආකාරය:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. සේවාදායකයේ ඔබේ මාධ්‍ය පුස්තකාල ෆෝල්ඩර සඳහා Jellyfin සේවා පරිශීලකයාට (උදා. jellyfin හෝ Docker PUID/PGID) ලිවීමේ අවසර ලබා දෙන්න.\n\n2. නැතහොත්, ඔබේ Jellyfin උපකරණ පුවරුව -> පුස්තකාල වෙත ගොස්, මෙම පුස්තකාලය සංස්කරණය කර, කලා නිර්මාණ Jellyfin හි අභ්‍යන්තර දත්ත සමුදායේ ගබඩා කිරීමට \'Save artwork into media folders\' අබල කරන්න.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'නොසලකන්න';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'ඔබේ \'$libraryName\' පුස්තකාලය කලා නිර්මාණ කෙලින්ම මාධ්‍ය ෆෝල්ඩරවලට සුරැකීමට වින්‍යාස කර ඇත (\'Save artwork into media folders\' සබලයි). කෙසේ වෙතත්, Jellyfin ලිවීමේ ප්‍රවේශය පරීක්ෂා කර ඇති අතර මෙම නාමාවලියට ගොනු ලිවීමට අවසරයක් නැත:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin කලා නිර්මාණය යාවත්කාලීන කිරීමට අසමත් වූ බව පෙනේ. ඔබේ පුස්තකාලය කලා නිර්මාණ කෙලින්ම මාධ්‍ය ෆෝල්ඩරවලට සුරැකීමට වින්‍යාස කර ඇත (\'Save artwork into media folders\' සබලයි). Jellyfin සේවාදායක ක්‍රියාවලියට ඔබේ මාධ්‍ය නාමාවලිවලට ගොනු ලිවීමට අවසරයක් නොමැති විට මෙම දෝෂය සාමාන්‍යයෙන් ඇතිවේ.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'බාහිර ලැයිස්තු';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'නැවත වාදනය';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ගොනු තොරතුරු';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'ප්‍රමාණය: $size  •  ආකෘතිය: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'සියලු ($count) ශ්‍රව්‍ය පථ පෙන්වන්න';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'සියලු ($count) උපසිරැසි පථ පෙන්වන්න';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'සෘජු වාදන හැකියාව පරීක්ෂා කරමින්...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'සෘජු වාදන හැකියාව: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'බලාත්මක';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'බහාලුම් ආකෘතියට ධාවකය සහාය නොදක්වයි.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'වීඩියෝ කෝඩෙක් සහාය නොදක්වයි.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'ශ්‍රව්‍ය කෝඩෙක් සහාය නොදක්වයි.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'උපසිරැසි ආකෘතියට සහාය නොදක්වයි (දැවීම අවශ්‍යයි).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ශ්‍රව්‍ය පැතිකඩට සහාය නොදක්වයි.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'වීඩියෝ පැතිකඩට සහාය නොදක්වයි.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'වීඩියෝ මට්ටමට සහාය නොදක්වයි.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'මෙම උපාංගය වීඩියෝ විභේදනයට සහාය නොදක්වයි.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'වීඩියෝ බිට් ගැඹුරට සහාය නොදක්වයි.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'වීඩියෝ රාමු අනුපාතයට සහාය නොදක්වයි.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ගොනු බිට්රේට් ධාවක ප්‍රවාහ සීමාව ඉක්මවයි.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'වීඩියෝ බිට්රේට් ප්‍රවාහ සීමාව ඉක්මවයි.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ශ්‍රව්‍ය බිට්රේට් ප්‍රවාහ සීමාව ඉක්මවයි.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ශ්‍රව්‍ය නාලිකා ගණනට සහාය නොදක්වයි.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'අකාරාදී';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'නිකුත් වූ පිළිවෙළ (ආරෝහණ)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'නිකුත් වූ පිළිවෙළ (අවරෝහණ)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'අභිරුචි (ඇදගෙන-දමන්න)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'ධාවන ලැයිස්තු වර්ග කිරීමේ විකල්ප';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'වර්ග කිරීම යළි පිහිටුවන්න';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode නැවත නරඹන්න';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'ධාවන ලැයිස්තුව නැවත නරඹන්න';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'උපසිරැසි හමු නොවීය.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'පරිපාලක පාලන';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'විදැහුම්කරණ එන්ජිම (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller යනු සුමට සජීවීකරණ සහ අඩු ගැහීම් සඳහා Flutter හි නවීන GPU විදැහුම්කරුයි. සමහර TV පෙට්ටි සහ පැරණි GPU වල එය දෝෂ හෝ කළු වීඩියෝ ඇති කළ හැක; ඒවා දුටුවහොත් එය ක්‍රියාවිරහිත කරන්න. ස්වයංක්‍රීය මඟින් ඔබේ උපාංගයට හොඳම පෙරනිමිය තෝරයි. යෙදීමට Moonfin නැවත අරඹන්න.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ස්වයංක්‍රීය';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'සක්‍රියයි';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'අක්‍රියයි';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'නැවත ඇරඹීම අවශ්‍යයි';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'විදැහුම්කරණ එන්ජිම වෙනස් කිරීමට Moonfin නැවත ඇරඹිය යුතුය. දැන් යෙදුම වසා, යෙදීමට එය නැවත විවෘත කරන්න.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'දැන් යෙදුම වසන්න';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'පුස්තකාලය නැවුම් කරන්න';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'සියලු පුස්තකාල නැවුම් කරන්න';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'එක් කළ දිනය (පැරණිතම පළමුව)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'එක් කළ දිනය (නවතම පළමුව)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'අකාරාදී (A සිට Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'අකාරාදී (Z සිට A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'සේවාදායක විශ්ලේෂණ පූරණය වෙමින්... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'මූලාශ්‍රයට ගැළපෙන';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb හොඳම චිත්‍රපට 250';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb හොඳම රූපවාහිනී වැඩසටහන් 250';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb වඩාත් ජනප්‍රිය චිත්‍රපට';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb වඩාත් ජනප්‍රිය රූපවාහිනී වැඩසටහන්';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb අඩුම ශ්‍රේණිගත චිත්‍රපට';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb හොඳම ශ්‍රේණිගත ඉංග්‍රීසි චිත්‍රපට';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -12,27 +12,27 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREDVOĽBY ÚČTU';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Jazyk rozhrania';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Predvolené systémom';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Prihlásiť sa';
 
   @override
-  String get empty => 'Prázdne';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Pripájanie k serveru $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Rýchle pripojenie';
 
   @override
   String get password => 'heslo';
@@ -41,7 +41,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get username => 'Používateľské meno';
 
   @override
-  String get email => 'E-mail';
+  String get email => 'Email';
 
   @override
   String get quickConnectInstruction =>
@@ -61,12 +61,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect nie je dostupný: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect nie je dostupný ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin verzia $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Odstrániť „$serverName“ zo zoznamu serverov?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -142,62 +142,62 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsAppearanceTheme => 'Téma aplikácie';
 
   @override
-  String get detailScreenStyle => 'Štýl obrazovky s detailmi';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasický je pôvodné vycentrované rozloženie Moonfin. Moderný je responzívne filmové rozloženie.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasický';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderný';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Rozbalené karty';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automaticky zobrazovať obsah karty pri prechádzaní kartami. Vypnite, ak chcete karty otvárať a zatvárať ručne.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Zobraziť technické podrobnosti?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Zobraziť kodek, rozlíšenie a informácie o streame v súhrne bannera';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Systém odporúčaní';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Použite algoritmus Moonfin odporúča pre lokálnu knižnicu alebo online metriky podobnosti TMDb. Poznámka: Online odporúčania vyžadujú integráciu Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin odporúča';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Podobnosť TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Použiť limit rodičovského hodnotenia?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Obmedziť návrhy funkcie Moonfin odporúča podľa rodičovského hodnotenia cieľového média';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Štýl rozhrania';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatický sa prispôsobí vášmu zariadeniu. Vyberte Apple alebo Material, ak chcete vzhľad vynútiť.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatický';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,38 +206,38 @@ class AppLocalizationsSk extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kvalita skla';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automatická vyberie najlepší efekt skla pre toto zariadenie. Plná vynúti skutočné rozostrenie, Znížená použije odľahčené sklo, ktoré šetrí výkon GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Automatická';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Plná';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Znížená';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Prepínajte medzi Moonfin a Neon Pulse bez reštartovania aplikácie';
 
   @override
-  String get customThemeTitle => 'Vlastná téma';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Vlastné témy menia vizuálne prvky v celej aplikácii Moonfin. Vyberte si možnosť, ktorá vyhovuje vášmu štýlu.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Uprednostniť systémovú klávesnicu';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Na zadávanie textu predvolene používať metódu vstupu vášho zariadenia';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -254,18 +254,18 @@ class AppLocalizationsSk extends AppLocalizations {
       'Synthwave štýl s purpurovou žiarou, azúrovým textom a silnejším chrómovým kontrastom';
 
   @override
-  String get themeGlass => 'Sklo';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Štýl tekutého skla s plynúcim gradientovým pozadím, matnými povrchmi a modrým akcentom Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bitový hrdina';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixel-art štýl s výraznou paletou, hranatými okrajmi, ostrými tieňmi a pixelovým písmom';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Nepodarilo sa pripojiť k $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,36 +327,35 @@ class AppLocalizationsSk extends AppLocalizations {
   String get exit => 'VÝCHOD';
 
   @override
-  String get gameMenu => 'Ponuka';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pozastavené';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Uložiť stav';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Hry';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Načítať stav';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Zrýchlene vpred';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Nastavenia emulátora';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Toto jadro nemá žiadne nastaviteľné možnosti.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Podržaním otvoríte ponuku';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Hranie hier zatiaľ nie je na tomto zariadení podporované.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nepodarilo sa načítať žiadne domáce riadky';
@@ -378,7 +377,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get schedule => 'Rozvrh';
 
   @override
-  String get series => 'Seriály';
+  String get series => 'séria';
 
   @override
   String get noItemsFound => 'Nenašli sa žiadne položky';
@@ -428,7 +427,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Priečinok sa nepodarilo načítať: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count položiek';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count položiek';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Žánre';
+    return '$name — Genres';
   }
 
   @override
@@ -507,7 +506,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get albumArtists => 'Umelci albumov';
 
   @override
-  String get artists => 'Interpreti';
+  String get artists => 'Umelci';
 
   @override
   String get bookmarks => 'Záložky';
@@ -533,17 +532,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'pred $count min';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'pred $count h';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'pred $count d';
+    return '${count}d ago';
   }
 
   @override
@@ -578,7 +577,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count titulov';
+    return '$count titles';
   }
 
   @override
@@ -604,7 +603,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get listen => 'Počúvaj';
 
   @override
-  String get resume => 'Pokračovať';
+  String get resume => 'Obnoviť';
 
   @override
   String get failedToLoadLibrary => 'Nepodarilo sa načítať knižnicu';
@@ -616,7 +615,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get savedForLater => 'Uložené na neskôr';
 
   @override
-  String get topListens => 'Najpočúvanejšie';
+  String get topListens => 'Top Listens';
 
   @override
   String get unreadDiscoveries => 'Neprečítané objavy';
@@ -666,17 +665,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count autorov';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count žánrov';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent % dokončené';
+    return '$percent% completed';
   }
 
   @override
@@ -693,7 +692,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titulov usporiadaných na prehliadanie so zameraním na čítanie.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -730,7 +729,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Nenašli sa žiadne $label';
+    return 'No $label found';
   }
 
   @override
@@ -749,13 +748,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get readStatus => 'Prečítajte si';
 
   @override
-  String get watched => 'Pozreté';
+  String get watched => 'Sledované';
 
   @override
   String get unread => 'Neprečítané';
 
   @override
-  String get unwatched => 'Nepozreté';
+  String get unwatched => 'Nepozerané';
 
   @override
   String get seriesStatus => 'Stav série';
@@ -767,45 +766,43 @@ class AppLocalizationsSk extends AppLocalizations {
   String get books => 'knihy';
 
   @override
-  String get latestBooks => 'Najnovšie knihy';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Najnovšie audioknihy';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kníh',
-      many: '$count knihy',
-      few: '$count knihy',
-      one: '1 kniha',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Kniha';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiokniha';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent % prečítané';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'zostáva $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Čítať';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Počúvať';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -843,12 +840,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count častí';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Prvé vydanie $year';
+    return 'First published $year';
   }
 
   @override
@@ -863,7 +860,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count kníh';
+    return '$count books';
   }
 
   @override
@@ -875,7 +872,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count autorov';
+    return '$count Authors';
   }
 
   @override
@@ -883,10 +880,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiokníh',
-      many: '$count audioknihy',
-      few: '$count audioknihy',
-      one: '1 audiokniha',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -901,7 +896,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get failedToLoad => 'Načítanie zlyhalo';
 
   @override
-  String get delete => 'Vymazať';
+  String get delete => 'Odstrániť';
 
   @override
   String get save => 'Uložiť';
@@ -922,7 +917,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get nextUp => 'Ďalej nahor';
 
   @override
-  String get seasons => 'Série';
+  String get seasons => 'Ročné obdobia';
 
   @override
   String get chapters => 'kapitoly';
@@ -934,7 +929,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get movies => 'Filmy';
 
   @override
-  String get musicVideos => 'Hudobné videá';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Iné';
@@ -949,11 +944,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tableOfContents => 'Obsah';
 
   @override
-  String get tracklist => 'Zoznam skladieb';
+  String get tracklist => 'Tracklist';
 
   @override
   String discNumber(int number) {
-    return 'Disk $number';
+    return 'Disc $number';
   }
 
   @override
@@ -979,7 +974,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Vydané $year';
+    return 'Published $year';
   }
 
   @override
@@ -990,54 +985,52 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezón',
-      many: '$count sezóny',
-      few: '$count sezóny',
-      one: '1 sezóna',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Skončí o $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Položky';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Bonusy';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Zo zákulisia';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Vystrihnuté scény';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Krátke dokumenty';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Rozhovory';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scény';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Krátke filmy';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Ukážky';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'zostáva $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Skončí za $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1051,11 +1044,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Pokračovať od $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Prehrať';
+  String get play => 'Hrať';
 
   @override
   String get startOver => 'Začať odznova';
@@ -1079,10 +1072,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get version => 'Verzia';
 
   @override
-  String get cast => 'Preniesť';
+  String get cast => 'Obsadenie';
 
   @override
-  String get trailer => 'Ukážka';
+  String get trailer => 'Trailer';
 
   @override
   String get finished => 'Dokončené';
@@ -1151,7 +1144,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Odstrániť stiahnuté skladby pre „$title“?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1166,17 +1159,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Nenačítali sa žiadne $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Sťahuje sa $title ($count položiek)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Naozaj chcete odstrániť „$name“ zo servera? Túto akciu nie je možné vrátiť späť.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1187,7 +1180,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Nepodporovaný formát knihy: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1197,7 +1190,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get subtitleTrack => 'Titulková stopa';
 
   @override
-  String get none => 'Žiadne';
+  String get none => 'žiadne';
 
   @override
   String get downloadSubtitlesLabel => 'Stiahnite si titulky...';
@@ -1214,7 +1207,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Titulky stiahnuté a vybraté: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1223,7 +1216,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Nenašli sa žiadne vzdialené titulky pre jazyk $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1231,7 +1224,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Verzia $number';
+    return 'Version $number';
   }
 
   @override
@@ -1251,7 +1244,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Sťahuje sa $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1259,7 +1252,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Odstrániť lokálne súbory pre $typeLabel?\n\nUvoľní sa tým miesto v úložisku. Neskôr ich môžete stiahnuť znova.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1275,25 +1268,25 @@ class AppLocalizationsSk extends AppLocalizations {
   String get director => 'RIADITEĽ';
 
   @override
-  String get directors => 'REŽISÉRI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENÁRISTA';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENÁRISTI';
+  String get writers => 'SPISOVATELIA';
 
   @override
   String get studio => 'ŠTÚDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count ďalších';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count epizód';
+    return '$count Episodes';
   }
 
   @override
@@ -1303,12 +1296,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Epizóda $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Kapitola $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1316,10 +1309,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count skladieb',
-      many: '$count skladby',
-      few: '$count skladby',
-      one: '1 skladba',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1329,27 +1320,25 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapitol',
-      many: '$count kapitoly',
-      few: '$count kapitoly',
-      one: '1 kapitola',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Narodenie $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Úmrtie $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Vek $age';
+    return 'Age $age';
   }
 
   @override
@@ -1359,20 +1348,20 @@ class AppLocalizationsSk extends AppLocalizations {
   String get readMore => 'Prečítajte si viac';
 
   @override
-  String get shuffle => 'Náhodne';
+  String get shuffle => 'Zamiešať';
 
   @override
-  String get shuffleAllMusic => 'Prehrať všetku hudbu náhodne';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Prihláste sa do Moonfin v telefóne';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Server je nedostupný';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count stiahnutí';
+    return '$count downloads';
   }
 
   @override
@@ -1380,7 +1369,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1391,32 +1380,32 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Akcia vzdialených titulkov ($action) vyžaduje pre tohto používateľa oprávnenie Jellyfin na správu titulkov.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Táto položka sa na serveri nenašla pre akciu vzdialených titulkov ($action).';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Akcia vzdialených titulkov ($action) zlyhala: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Akcia vzdialených titulkov ($action) zlyhala (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Nepodarilo sa vykonať akciu $action pre vzdialené titulky.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'všetky stiahnuté epizódy pre „$name“';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1447,17 +1436,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Akcia $label zlyhala: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Nepodarilo sa nastaviť hlasitosť odosielania: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Ovládanie $label';
+    return '$label Controls';
   }
 
   @override
@@ -1467,14 +1456,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get unavailable => 'nedostupné';
 
   @override
-  String get pause => 'Pozastaviť';
+  String get pause => 'Pauza';
 
   @override
   String get syncPosition => 'Synchronizovať pozíciu';
 
   @override
   String stopCast(String label) {
-    return 'Zastaviť $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1482,7 +1471,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Skladba $number';
+    return 'Track $number';
   }
 
   @override
@@ -1499,7 +1488,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sekúnd';
+    return '$seconds seconds';
   }
 
   @override
@@ -1514,11 +1503,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automaticky';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
-    return '$mbps Mb/s';
+    return '$mbps Mbps';
   }
 
   @override
@@ -1529,12 +1518,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1553,7 +1542,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get playback => 'Prehrávanie';
 
   @override
-  String get playMethod => 'Spôsob prehrávania';
+  String get playMethod => 'Play Method';
 
   @override
   String get directPlay => 'Priame prehrávanie';
@@ -1568,7 +1557,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get transcodeReasons => 'Dôvody transkódovania';
 
   @override
-  String get player => 'Prehrávač';
+  String get player => 'Hráč';
 
   @override
   String get container => 'Kontajner';
@@ -1592,7 +1581,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get videoBitrate => 'Bitová rýchlosť videa';
 
   @override
-  String get track => 'Stopa';
+  String get track => 'Sledovať';
 
   @override
   String get channels => 'Kanály';
@@ -1614,12 +1603,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Chyba relácie $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Nepodarilo sa načítať podrobnosti o knihe: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1628,7 +1617,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Tento formát (.$extension) sa zatiaľ nedá zobraziť v aplikácii.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1641,17 +1630,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Nepodarilo sa otvoriť čítačku v aplikácii: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Záložka je už uložená na $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Záložka pridaná: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1663,7 +1652,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Strana $number';
+    return 'Page $number';
   }
 
   @override
@@ -1674,12 +1663,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Formát: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent % prečítané';
+    return '$percent% read';
   }
 
   @override
@@ -1703,7 +1692,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Obnoviť priblíženie (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1726,7 +1715,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Nepodarilo sa aktualizovať stav prečítania: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1758,7 +1747,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Táto platforma nedokáže spustiť vstavaný dokumentový engine pre súbory $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1797,7 +1786,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Nepodarilo sa načítať TV program: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1808,22 +1797,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Ďalej: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'zostáva $minutes min';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'zostáva $hours h';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'zostáva $hours h $minutes min';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1846,29 +1835,29 @@ class AppLocalizationsSk extends AppLocalizations {
   String get favoriteChannel => 'Obľúbený kanál';
 
   @override
-  String get record => 'Nahrať';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Zrušiť nahrávanie';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Nahrávanie programu je naplánované';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Nahrávanie zrušené';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Nepodarilo sa vytvoriť nahrávku';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Sledovať';
+  String get watch => 'Sledujte';
 
   @override
   String get close => 'Zavrieť';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Nepodarilo sa prehrať $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1894,7 +1883,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Zrušiť naplánované nahrávanie „$name“?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1921,7 +1910,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Zastaviť nahrávanie „$name“?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1936,12 +1925,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Žiadne výsledky pre „$query“';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Vyhľadávanie zlyhalo: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1982,12 +1971,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Odstrániť „$name“ a súvisiace súbory?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count skladieb';
+    return '$count tracks';
   }
 
   @override
@@ -1998,16 +1987,16 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Nepodarilo sa načítať album: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Pre album $name sa nenašli žiadne stiahnuté skladby.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'Séria';
+  String get season => 'Sezóna';
 
   @override
   String get errorLoadingEpisodes => 'Chyba pri načítavaní epizód';
@@ -2020,7 +2009,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Odstrániť „$name“?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2035,7 +2024,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Epizóda $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2049,7 +2038,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sezóna $number';
+    return 'Season $number';
   }
 
   @override
@@ -2065,7 +2054,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Odstrániť všetky stiahnuté epizódy v $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2073,10 +2062,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizód',
-      many: '$count epizódy',
-      few: '$count epizódy',
-      one: '1 epizóda',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2111,7 +2098,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Odstrániť $count stiahnutých položiek?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2125,7 +2112,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'z limitu $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2209,7 +2196,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count možností';
+    return '$count options';
   }
 
   @override
@@ -2303,11 +2290,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Stránky s detailmi, riadky na domovskej obrazovke a hlasitosť';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
-    return '$value %';
+    return '$value%';
   }
 
   @override
@@ -2318,18 +2305,18 @@ class AppLocalizationsSk extends AppLocalizations {
       'Prehrať pri prehliadaní domovskej obrazovky';
 
   @override
-  String get loopThemeMusic => 'Opakovať tematickú hudbu';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Prehrávať skladbu dokola namiesto jedného prehratia';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Podrobnosti rozostrenie pozadia';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2345,23 +2332,23 @@ class AppLocalizationsSk extends AppLocalizations {
   String get playerZoomMode => 'Režim priblíženia prehrávača';
 
   @override
-  String get settingsScrollWheelAction => 'Koliesko myši';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Vyberte, čo sa má diať pri rolovaní kolieskom myši nad videom počas prehrávania.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Vypnuté';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Posun (dopredu/dozadu)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Hlasitosť';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Hlasitosť';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2376,7 +2363,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get refreshRateSwitching => 'Prepínanie obnovovacej frekvencie';
 
   @override
-  String get disabled => 'Vypnuté';
+  String get disabled => 'Zakázané';
 
   @override
   String get scaleOnTv => 'Mierka v televízii';
@@ -2415,37 +2402,37 @@ class AppLocalizationsSk extends AppLocalizations {
   String get defaultAudioLanguage => 'Predvolený jazyk zvuku';
 
   @override
-  String get fallbackAudioLanguage => 'Záložný jazyk zvuku';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Uprednostniť predvolenú zvukovú stopu';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Uprednostniť pôvodnú zvukovú stopu pred lokalizovaným dabingom.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Uprednostniť stopy s audio popisom';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Uprednostniť stopy s audio popisom pred bežnými stopami.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Prekódovanie (zvuk)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Priamy stream (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Prekódovanie (bitový tok alebo rozlíšenie)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Prekódovanie (video a zvuk)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Prekódovanie (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (predvolené nastavenie servera)';
@@ -2505,7 +2492,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get polish => 'poľský';
 
   @override
-  String get ac3Passthrough => 'Passthrough AC3';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
   String get dtsPassthrough => 'Priechod DTS';
@@ -2522,28 +2509,27 @@ class AppLocalizationsSk extends AppLocalizations {
       'Povoliť zvuk TrueHD (nemusí fungovať na všetkých platformách)';
 
   @override
-  String get settingsAudioOutputMode => 'Režim zvukového výstupu';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Vyberte, ako sa má zvuk dekódovať. AVR Passthrough posiela surové streamy Dolby/DTS do vášho receivera, Automaticky alebo Downmix dekódujú lokálne.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Záložný zvukový kodek';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Vyberte cieľový formát na prekódovanie viackanálového zvuku, keď zdrojový stream nie je možné priamo prehrať ani preposlať.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Automaticky zistiť\n(odporúčané)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(predvolené)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2552,27 +2538,26 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(bezstratový)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(len stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(efektívny)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(bezstratový)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maximálny počet zvukových kanálov';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Nastavte maximálny počet kanálov vašej zvukovej zostavy. Viackanálové streamy, ktoré tento limit prekročia, sa zmixujú alebo prekódujú.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Automaticky zistiť\n(predvolené hardvérom)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2584,7 +2569,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvadrofónny';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2599,67 +2584,67 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (pokročilé)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough kodekov';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Povoľte iba formáty, ktoré podporuje váš AVR alebo HDMI zariadenie.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Posielať bitstream Dolby Digital Plus (EAC3) do externého dekodéra.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Posielať bitstream Dolby Atmos cez EAC3 (JOC) do externého dekodéra.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Posielať bitstream DTS-HD MA (vrátane jadra DTS) do externého dekodéra.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Posielať bitstream Dolby TrueHD s metadátami Atmos do externého dekodéra.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Zistené zvukové schopnosti';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Zatiaľ nie je k dispozícii žiadna snímka schopností za behu.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Trasa';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekódovanie';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Trasa pre HD zvuk';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2674,51 +2659,50 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Reproduktor';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Slúchadlá';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostika';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Úroveň videa';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Rozsah videa';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodek titulkov';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Povolené zvukové kodeky';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Zvukové kodeky HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Zvukové kodeky HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'passthrough audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Aktívna zvuková trasa';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Podpora HD zvuku na trase';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nočný režim';
@@ -2767,7 +2751,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2782,14 +2766,14 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Po $episodes epizódach / $hours h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
   String get resumeAndSkip => 'Obnoviť a preskočiť';
 
   @override
-  String get resumeRewind => 'Pretočenie pri pokračovaní';
+  String get resumeRewind => 'Resume Rewind';
 
   @override
   String get unpauseRewind => 'Zrušiť pretáčanie dozadu';
@@ -2857,45 +2841,45 @@ class AppLocalizationsSk extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Prispôsobte vzhľad titulkov';
 
   @override
-  String get subtitleMode => 'Režim titulkov';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Označené';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Vždy';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Cudzojazyčné';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Vynútené';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Prehrá stopy, ktoré sú v metadátach mediálneho súboru interne označené ako „default“ alebo „forced“.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automaticky načíta a zobrazí titulky pri každom spustení videa.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automaticky zapne titulky, ak je predvolená zvuková stopa v cudzom jazyku.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Načíta iba titulky výslovne označené príznakom „forced“.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Úplne vypne automatické načítanie titulkov.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Záložný jazyk titulkov';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Stream titulkov';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Rýchla hnedá líška preskočí lenivého psa';
@@ -2943,7 +2927,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get global => 'globálne';
 
   @override
-  String get desktop => 'Počítač';
+  String get desktop => 'Desktop';
 
   @override
   String get mobile => 'Mobil';
@@ -2953,17 +2937,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Načítali sa nastavenia profilu $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Nepodarilo sa načítať nastavenia profilu $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Lokálne nastavenia sa synchronizovali s profilom $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3100,10 +3084,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť knižnice na paneli s nástrojmi';
 
   @override
-  String get navbarAlwaysExpanded => 'Vždy zobrazovať popisy v navigácii';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Zobraziť tlačidlo Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Nepriehľadnosť navigačnej lišty';
@@ -3121,7 +3105,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get purple => 'Fialová';
 
   @override
-  String get teal => 'Modrozelená';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'námorníctvo';
@@ -3142,7 +3126,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get slate => 'Bridlica';
 
   @override
-  String get indigo => 'Indigová';
+  String get indigo => 'Indigo';
 
   @override
   String get libraryDisplay => 'Zobrazenie knižnice';
@@ -3179,19 +3163,18 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť možnosť prehliadania priečinkov';
 
   @override
-  String get groupItemsIntoCollections => 'Zoskupiť položky do kolekcií';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Skryť položky knižnice patriace do kolekcie pri prehliadaní knižníc';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Upozornenie o zoskupovaní knižnice';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Ak chcete použiť toto nastavenie, uistite sa, že sú v nastaveniach zobrazenia vašej knižnice na serveri Jellyfin alebo Emby zapnuté možnosti „Group movies into collections“ alebo „Group shows into collections“.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Viditeľnosť knižnice';
@@ -3220,7 +3203,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count vybratých';
+    return '$count selected';
   }
 
   @override
@@ -3287,7 +3270,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noneExcluded => 'Žiadne vylúčené';
 
   @override
-  String get autoAdvance => 'Automatický posun';
+  String get autoAdvance => 'Auto Advance';
 
   @override
   String get autoAdvanceSlides => 'Automaticky prejsť na ďalšiu snímku';
@@ -3303,10 +3286,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Automatické prehrávanie upútavok na paneli médií po 3 sekundách';
 
   @override
-  String get trailerAudio => 'Zvuk ukážok';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Zapnúť zvuk ukážok v mediálnom paneli';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Ukážka epizódy';
@@ -3347,7 +3330,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get resumeAudio => 'Obnoviť zvuk';
 
   @override
-  String get resumeBooks => 'Pokračovať v knihách';
+  String get resumeBooks => 'Resume Books';
 
   @override
   String get activeRecordings => 'Aktívne nahrávky';
@@ -3383,11 +3366,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Skombinujte oba riadky do jednej domácej sekcie';
 
   @override
-  String get fullScreenRows => 'Rozšírené riadky na domovskej obrazovke';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Obmedziť domovskú obrazovku na 1 riadok naraz';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Typ obrázka na riadok';
@@ -3402,7 +3384,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get lastUser => 'Posledný používateľ';
 
   @override
-  String get currentUser => 'Aktuálny používateľ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vždy overiť';
@@ -3509,10 +3491,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobrazenie hodín počas šetriča obrazovky';
 
   @override
-  String get clockModeStatic => 'Statické';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Poskakujúce';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritici)';
@@ -3583,7 +3565,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Povoľte a zmeňte poradie zdrojov hodnotení zobrazovaných v aplikácii';
 
   @override
-  String get pluginLabel => 'Doplnok Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin zistený';
@@ -3601,14 +3583,14 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVerzia: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
   String get availableServices => 'Dostupné služby';
 
   @override
-  String get serverPluginSync => 'Synchronizácia serverového pluginu';
+  String get serverPluginSync => 'Server Plugin Sync';
 
   @override
   String get syncSettingsWithPlugin =>
@@ -3655,13 +3637,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get networks => 'siete';
 
   @override
-  String get seerrDiscoveryRows => 'Objavovacie riadky Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Obnovte predvolené hodnoty riadkov';
 
   @override
-  String get enableSeerr => 'Povoliť Seerr';
+  String get enableSeerr => 'Povoliť Serr';
 
   @override
   String get showSeerrInNavigation =>
@@ -3678,46 +3660,47 @@ class AppLocalizationsSk extends AppLocalizations {
   String get hideAdultContent => 'Skryť obsah pre dospelých vo výsledkoch';
 
   @override
-  String get seerrNotificationsSection => 'Upozornenia';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Upozornenia na nové žiadosti';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Upozorniť ma, keď niekto odošle žiadosť';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Aktualizácie žiadostí';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Schválené, zamietnuté a pridané do vašej knižnice';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Aktualizácie problémov';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nové problémy, odpovede a riešenia';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Prihlásený ako: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Stránka objavovania Seerr';
+  String get discoverRows => 'Objavte riadky';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Povoľte riadky, ktoré chcete vidieť na hlavnej stránke Seerr. Presunutím zmeníte poradie. Vlastné poradie sa synchronizuje s doplnkom Moonbase.';
+      'Presunutím zmeníte poradie. Povoliť alebo zakázať riadky. Povolená synchronizácia poradia riadkov s doplnkom Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Povoľte riadky, ktoré chcete vidieť na hlavnej stránke Seerr. Presunutím zmeníte poradie. Vlastné poradie sa synchronizuje s doplnkom Moonbase.';
+      'Presunutím zmeníte poradie. Povoliť alebo zakázať riadky.';
 
   @override
-  String get enabled => 'Zapnuté';
+  String get enabled => 'Povolené';
 
   @override
   String get hidden => 'Skryté';
@@ -3727,7 +3710,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Verzia $version';
+    return 'Version $version';
   }
 
   @override
@@ -3777,7 +3760,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Dostupná aktualizácia: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3789,7 +3772,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Verzia v$version je dostupná';
+    return 'v$version Available';
   }
 
   @override
@@ -3853,7 +3836,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get imageCacheCleared => 'Vyrovnávacia pamäť obrázkov je vymazaná';
 
   @override
-  String get clear => 'Vymazať';
+  String get clear => 'Jasné';
 
   @override
   String get browse => 'Prehľadávať';
@@ -3869,15 +3852,15 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Sťahuje sa · $percent %';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importuje sa';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count položiek';
+    return '$count Items';
   }
 
   @override
@@ -3897,7 +3880,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Požiadal $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3914,12 +3897,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Zrušiť žiadosť o „$title“?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Zrušiť $count žiadostí o „$title“?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3934,12 +3917,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Rozpočet: $amount \$';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Tržby: $amount \$';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3949,7 +3932,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Požiadať o $type';
+    return 'Request $type';
   }
 
   @override
@@ -3978,14 +3961,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get showMore => 'Zobraziť viac';
 
   @override
-  String get appearances => 'Účinkovanie';
+  String get appearances => 'Vystúpenia';
 
   @override
   String get crewSection => 'Posádka';
 
   @override
   String ageValue(int age) {
-    return 'vek $age';
+    return 'age $age';
   }
 
   @override
@@ -4016,149 +3999,148 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deletedStatus => 'Odstránené';
 
   @override
-  String get failedStatus => 'Zlyhalo';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Spracováva sa';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Upravil $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Dokončené';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'O tento titul už bolo požiadané';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Dosiahli ste limit žiadostí';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Tento titul je na zozname blokovaných';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Nezostali žiadne sezóny, o ktoré možno požiadať';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Nemáte oprávnenie na vytvorenie tejto žiadosti';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Žiadosti';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problémy';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Najnovšie';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Naposledy upravené';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Žiadne problémy';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Zostáva $remaining z $limit žiadostí o filmy';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Zostáva $remaining z $limit žiadostí o sezóny';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Súčasť kolekcie $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Zobraziť kolekciu';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Požiadať o kolekciu';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmov · $available dostupných';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Požiadať o $count filmov';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Odosiela sa žiadosť $current z $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Požiadané o $count filmov';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Požiadané o $ok z $total filmov';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Všetky filmy sú už dostupné alebo požiadané';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Nahlásiť problém';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Zvuk';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'V čom je problém?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Všetky epizódy';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizóda';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Otvorené';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Vyriešené';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Vyriešiť';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Znova otvoriť';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Nahlásil $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentárov';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Pridať komentár';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Odstrániť tento problém?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Odoslať hlásenie';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Skóre TMDB';
@@ -4173,7 +4155,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get revenueLabel => 'Výnosy';
 
   @override
-  String get runtimeLabel => 'Dĺžka';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'Rozpočet';
@@ -4182,7 +4164,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get originalLanguageLabel => 'Pôvodný jazyk';
 
   @override
-  String get seasonsLabel => 'Série';
+  String get seasonsLabel => 'Ročné obdobia';
 
   @override
   String get episodesLabel => 'Epizódy';
@@ -4197,7 +4179,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get address => 'Adresa';
 
   @override
-  String get analytics => 'Analytika';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalóg';
@@ -4230,7 +4212,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get forward => 'Vpred';
 
   @override
-  String get general => 'Všeobecné';
+  String get general => 'generál';
 
   @override
   String get go => 'Choď';
@@ -4284,10 +4266,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get revoke => 'Odvolať';
 
   @override
-  String get role => 'Rola';
+  String get role => 'Role';
 
   @override
-  String get root => 'Koreň';
+  String get root => 'Root';
 
   @override
   String get run => 'Bežať';
@@ -4311,7 +4293,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get status => 'Stav';
 
   @override
-  String get stop => 'Zastaviť';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Streamovanie';
@@ -4344,10 +4326,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get branding => 'Branding';
 
   @override
-  String get adminDrawerDashboard => 'Nástenka';
+  String get adminDrawerDashboard => 'Dashboard';
 
   @override
-  String get adminDrawerAnalytics => 'Analytika';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Nastavenia';
@@ -4362,19 +4344,19 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminDrawerLibraries => 'Knižnice';
 
   @override
-  String get adminDrawerDisplay => 'Zobrazenie';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metadáta';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Nastavenia NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Prekódovanie';
 
   @override
-  String get adminDrawerResume => 'Pokračovať';
+  String get adminDrawerResume => 'Obnoviť';
 
   @override
   String get adminDrawerStreaming => 'Streamovanie';
@@ -4432,22 +4414,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Dostupné aktualizácie pluginov: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Pluginy vyžadujúce reštart: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Zlyhané naplánované úlohy: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Nedávne varovania/chyby: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4506,7 +4488,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Chyba: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4533,7 +4515,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Príkaz zlyhal: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4555,13 +4537,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get sessionForward => 'Vpred';
 
   @override
-  String get sessionNext => 'Ďalšie';
+  String get sessionNext => 'Ďalej';
 
   @override
-  String get sessionVolumeDown => 'Hlas. –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Hlas. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4570,7 +4552,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get nowPlaying => 'Prehráva sa';
 
   @override
-  String get volume => 'Hlasitosť';
+  String get volume => 'Objem';
 
   @override
   String get actions => 'Akcie';
@@ -4582,7 +4564,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audioCodec => 'Audio kodek';
 
   @override
-  String get hwAccel => 'HW akcelerácia';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Dokončenie';
@@ -4597,14 +4579,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminClearDates => 'Vymazať dátumy';
 
   @override
-  String get adminActivitySeverityAll => 'Všetky závažnosti';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Rozsah dátumov';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Nepodarilo sa načítať denník aktivity: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4621,7 +4603,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Nepodarilo sa aktualizovať zariadenie: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4632,28 +4614,28 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť zariadenie: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Odstrániť zariadenie „$name“? Používateľ sa bude musieť na tomto zariadení znova prihlásiť.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Odstrániť všetky zariadenia';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Odstrániť $count zariadení? Dotknutí používatelia sa budú musieť znova prihlásiť. Vaše aktuálne zariadenie to neovplyvní.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Zariadenia odstránené';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Niektoré zariadenia boli odstránené, $count sa odstrániť nepodarilo.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4682,7 +4664,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Nepodarilo sa spustiť skenovanie: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4693,12 +4675,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Knižnica bola premenovaná na „$name“';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Nepodarilo sa premenovať: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4706,17 +4688,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Knižnica „$name“ bola odstránená';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť knižnicu: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Nepodarilo sa pridať cestu: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4724,12 +4706,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Odstrániť „$path“ z tejto knižnice?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Nepodarilo sa odstrániť cestu: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4737,7 +4719,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť možnosti: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4768,259 +4750,251 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminMetadataCountryHint => 'napr. USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Cesty';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Možnosti';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Sťahovače';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Ukladače metadát';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Sťahovače titulkov';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Sťahovače textov piesní';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Sťahovače metadát: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Načítavače obrázkov: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Tento server neponúka žiadne sťahovače pre tento typ knižnice.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Všeobecné';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metadáta';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Vložené informácie';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Titulky';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Obrázky';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Seriály';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Hudba';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmy';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Zapnúť monitorovanie v reálnom čase';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Zisťovať zmeny súborov a automaticky ich spracovať.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Považovať archívy za mediálne súbory';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Zobrazovať fotografie';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Ukladať obrázky do mediálnych priečinkov';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatická obnova metadát';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nikdy';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Predvolené';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Zobrazenie';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Zobrazenie knižnice';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Zobraziť priečinkové zobrazenie s čistými mediálnymi priečinkami';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Zobrazovať špeciály v sezónach, v ktorých boli odvysielané';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Zoskupiť filmy do kolekcií';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Zoskupiť seriály do kolekcií';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Zobrazovať externý obsah v návrhoch';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Správanie dátumu pridania';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Použiť dátum pridania z';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Dátum naskenovania do knižnice';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Dátum vytvorenia súboru';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadáta a obrázky';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Preferovaný jazyk metadát';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitoly';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Dĺžka zástupných kapitol (sekundy)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Dĺžka kapitol vygenerovaných pre médiá, ktoré žiadne nemajú. Nastavením na 0 túto možnosť vypnete.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Rozlíšenie obrázkov kapitol';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Nastavenia NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadáta NFO sú kompatibilné s Kodi a podobnými klientmi. Nastavenia platia pre všetky knižnice, ktoré ukladajú metadáta NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Používateľ, pre ktorého sa v súboroch NFO ukladajú údaje o sledovaní';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Ukladať cesty k obrázkom do súborov NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Zapnúť náhradu ciest pre cesty k obrázkom v NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopírovať obrázky extrafanart do priečinka extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Žiadne';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dní';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Použiť vložené názvy';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => 'Použiť vložené názvy pre bonusy';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Použiť vložené informácie o epizódach';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Povoliť vložené titulky';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Povoliť všetky';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Len textové';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Len obrázkové';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Žiadne';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Preskočiť sťahovanie, ak sú prítomné vložené titulky';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Preskočiť sťahovanie, ak zvuková stopa zodpovedá jazyku sťahovania';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Vyžadovať presnú zhodu titulkov';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Ukladať titulky do mediálnych priečinkov';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Extrahovať obrázky kapitol';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extrahovať obrázky kapitol počas skenovania knižnice';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Zapnúť extrakciu obrázkov trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extrahovať obrázky trickplay počas skenovania knižnice';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Ukladať obrázky trickplay do mediálnych priečinkov';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Automaticky zlúčiť seriály rozdelené do viacerých priečinkov';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Zobrazovaný názov nultej sezóny';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Zapnúť skenovanie LUFS na normalizáciu hlasitosti';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Uprednostniť neštandardnú značku interpretov';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Automaticky pridávať filmy do kolekcií';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Vyžaduje sa názov knižnice';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Nepodarilo sa vytvoriť knižnicu: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5047,27 +5021,27 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Zakázať používateľa $name? Nebude sa môcť prihlásiť.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Povoliť používateľa $name? Bude sa môcť znova prihlásiť.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Používateľ „$name“ bol zakázaný';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Používateľ „$name“ bol povolený';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Nepodarilo sa aktualizovať pravidlá používateľa: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5084,7 +5058,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Nepodarilo sa vytvoriť používateľa: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5104,7 +5078,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5115,7 +5089,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Zlyhalo: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5131,7 +5105,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminDeleteUser => 'Odstrániť používateľa';
 
   @override
-  String get admin => 'Správca';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5252,145 +5226,143 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminEnableAllChannels => 'Povoliť prístup ku všetkým kanálom';
 
   @override
-  String get adminParentalControl => 'Rodičovská kontrola';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Maximálne povolené rodičovské hodnotenie';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Obsah s vyšším hodnotením bude pred týmto používateľom skrytý.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Žiadne';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokovať položky bez hodnotenia alebo s nerozpoznaným hodnotením';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Knihy';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanály';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Živá televízia';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmy';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Hudba';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Ukážky';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriály';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Plány prístupu';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Povoliť prístup len počas nižšie naplánovaných časov. Ak nie je nastavený žiadny plán, prístup je povolený celý deň.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Pridať plán';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Deň';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Začiatok';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Koniec';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Každý deň';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Pracovný deň';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Víkend';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Nedeľa';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Pondelok';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Utorok';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Streda';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Štvrtok';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Piatok';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sobota';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Povolené značky';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Zobrazí sa iba obsah s týmito značkami. Ak chcete povoliť všetko, nechajte pole prázdne.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokované značky';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Obsah s týmito značkami bude pred týmto používateľom skrytý.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Pridať značku';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Povolené zariadenia';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Povolené kanály';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Poskytovateľ overenia';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Poskytovateľ obnovenia hesla';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Maximálny počet neúspešných prihlásení pred zamknutím';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Nastavte 0 pre predvolenú hodnotu alebo -1 na vypnutie zamykania.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Prístup k SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Povoliť vytváranie skupín a pripájanie sa k nim';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Povoliť pripájanie sa k skupinám';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Bez prístupu';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Povoliť odstraňovanie obsahu z';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5398,22 +5370,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Server vrátil HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Naozaj chcete odstrániť používateľa $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Používateľ „$name“ bol odstránený';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť používateľa: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5434,7 +5406,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Nepodarilo sa vytvoriť kľúč: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5445,7 +5417,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Odvolať kľúč pre $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5453,7 +5425,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Nepodarilo sa odvolať kľúč: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5473,29 +5445,29 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nVytvorené: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Vytvoriť zálohu';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Vyberte, čo sa má do zálohy zahrnúť.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Databáza';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Vždy zahrnuté';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metadáta';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Titulky';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Obrázky trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Vytvára sa záloha...';
@@ -5505,7 +5477,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Nepodarilo sa vytvoriť zálohu: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5518,7 +5490,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Nepodarilo sa načítať manifest: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5529,7 +5501,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Nepodarilo sa obnoviť zálohu: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5561,17 +5533,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Uložené do $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť súbor: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Nepodarilo sa načítať $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5582,7 +5554,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Nepodarilo sa načítať úlohy: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5594,17 +5566,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Nepodarilo sa spustiť úlohu: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Nepodarilo sa zastaviť úlohu: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Nepodarilo sa načítať úlohu: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5612,12 +5584,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Nepodarilo sa odstrániť spúšťač: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Nepodarilo sa pridať spúšťač: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5643,7 +5615,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours hod.';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5654,7 +5626,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Nepodarilo sa prepnúť plugin: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5662,27 +5634,27 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Naozaj chcete odinštalovať „$name“?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Nepodarilo sa odinštalovať plugin: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Nepodarilo sa nainštalovať balík: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Nepodarilo sa nainštalovať aktualizáciu: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Nepodarilo sa načítať pluginy: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5694,12 +5666,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Nainštalovať aktualizáciu (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Nepodarilo sa načítať katalóg: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5721,17 +5693,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '„$name“ bude odstránený po reštarte servera';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Nepodarilo sa odinštalovať: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Aktualizuje sa „$name“ na v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5740,7 +5712,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Nepodarilo sa načítať plugin: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5748,7 +5720,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Verzia $version';
+    return 'Version $version';
   }
 
   @override
@@ -5768,17 +5740,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Naozaj chcete odstrániť „$name“?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť repozitáre: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Nepodarilo sa načítať repozitáre: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5795,12 +5767,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Nepodarilo sa načítať nastavenia pluginu: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Nepodarilo sa otvoriť $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6031,10 +6003,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ports => 'Porty';
 
   @override
-  String get adminHttpPort => 'Port HTTP';
+  String get adminHttpPort => 'HTTP port';
 
   @override
-  String get adminHttpsPort => 'Port HTTPS';
+  String get adminHttpsPort => 'HTTPS port';
 
   @override
   String get adminPublicHttpsPort => 'Verejný port HTTPS';
@@ -6043,7 +6015,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminBaseUrl => 'Základná adresa URL';
 
   @override
-  String get adminBaseUrlHint => 'napr. /jellyfin';
+  String get adminBaseUrlHint => 'napr. /medúza';
 
   @override
   String get https => 'HTTPS';
@@ -6070,7 +6042,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminCertificatePath => 'Cesta k certifikátu';
 
   @override
-  String get whitelist => 'Zoznam povolených';
+  String get whitelist => 'Whitelist';
 
   @override
   String get blacklist => 'Čierna listina';
@@ -6083,12 +6055,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Nepodarilo sa načítať metadáta: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť metadáta: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6108,7 +6080,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Nepodarilo sa obnoviť metadáta: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6122,7 +6094,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Vzdialené vyhľadávanie zlyhalo: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6136,7 +6108,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Nepodarilo sa aktualizovať typ obsahu: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6152,12 +6124,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Obrázok $imageType bol aktualizovaný';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Nepodarilo sa stiahnuť obrázok: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6168,27 +6140,27 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Obrázok $imageType bol nahraný';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Nepodarilo sa nahrať obrázok: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Odstrániť obrázok $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Obrázok $imageType bol odstránený';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť obrázok: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6199,68 +6171,67 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Vyhľadávanie tunerov zlyhalo: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Pridať tuner';
 
   @override
-  String get adminEditTuner => 'Upraviť tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Súbor alebo URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP adresa tunera';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Zrozumiteľný názov';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limit súčasných pripojení';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Maximálny počet streamov, ktoré tuner naraz povolí. Nastavením na 0 zrušíte obmedzenie.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Záložný maximálny bitový tok streamovania';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importovať iba obľúbené kanály';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Povoliť hardvérové prekódovanie';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Povoliť prekódovací kontajner fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Povoliť zdieľanie streamov';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Zapnúť opakovanie streamu';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorovať DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Čítať vstup v natívnej snímkovej frekvencii';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Upraviť poskytovateľa';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6269,50 +6240,50 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Súbor alebo URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Predpona filmov';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategórie filmov';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Viacero kategórií oddeľte zvislou čiarou.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategórie pre deti';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategórie správ';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategórie športu';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Používateľské meno';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Heslo';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Krajina';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Vyberte krajinu';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'PSČ';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Získať zoznamy';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Zoznamy';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Zapnúť všetky tunery';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Typ tunera';
@@ -6322,7 +6293,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Nepodarilo sa pridať tuner: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6336,12 +6307,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Nepodarilo sa pridať poskytovateľa: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Nepodarilo sa odstrániť tuner: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6349,16 +6320,16 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Nepodarilo sa resetovať tuner: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Tento typ tunera nepodporuje resetovanie.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Nepodarilo sa odstrániť poskytovateľa: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6377,45 +6348,43 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Cesta záznamu série';
 
   @override
-  String get adminMovieRecordingPath => 'Cesta na nahrávanie filmov';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Počet dní údajov programu';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automaticky';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dní';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Cesta k aplikácii na dodatočné spracovanie';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Argumenty dodatočného spracovania';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Ukladať metadáta NFO nahrávok';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Ukladať obrázky nahrávok';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Časovanie';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Cesty nahrávok';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Dodatočné spracovanie';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Údaje programu: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6424,7 +6393,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť nastavenia: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6443,7 +6412,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Nepodarilo sa aktualizovať mapovania: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6460,14 +6429,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminGuideProviders => 'Poskytovatelia sprievodcov';
 
   @override
-  String get adminRefreshGuideData => 'Obnoviť údaje programu';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Obnova údajov programu sa spustila';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Úloha obnovy programu nie je na tomto serveri dostupná.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Pridať poskytovateľa';
@@ -6478,26 +6447,26 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Cesta nahrávok: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Cesta seriálov: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Rezerva pred: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Rezerva po: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Vyhľadávanie tunerov';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Mapovania kanálov';
@@ -6525,7 +6494,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Obnoviť zálohu $name teraz?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6571,27 +6540,27 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'pred $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'pred $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'pred $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Nepodarilo sa načítať $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count zhôd';
+    return '$count matches';
   }
 
   @override
@@ -6601,7 +6570,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Editor metadát';
 
   @override
-  String get adminMetadataIdentify => 'Identifikovať';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Typ';
@@ -6676,7 +6645,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminMetadataEditPerson => 'Upraviť osobu';
 
   @override
-  String get adminMetadataRole => 'Rola';
+  String get adminMetadataRole => 'Role';
 
   @override
   String get adminMetadataImagePrimary => 'Primárne';
@@ -6701,22 +6670,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Obrázok $imageType bol aktualizovaný';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Obrázok $imageType bol nahraný';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Obrázok $imageType bol odstránený';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Nepodarilo sa stiahnuť obrázok: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6725,12 +6694,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Nepodarilo sa nahrať obrázok: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Odstrániť obrázok $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6739,12 +6708,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť obrázok: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Vybrať obrázok $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6777,7 +6746,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Dostupná aktualizácia: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6801,7 +6770,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Nainštalovať aktualizáciu (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6813,7 +6782,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return 'Inštaluje sa „$name“...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6833,7 +6802,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Nastavenia $name';
+    return '$name Settings';
   }
 
   @override
@@ -6873,7 +6842,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Nepodarilo sa načítať repozitáre: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6881,7 +6850,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Naozaj chcete odstrániť „$name“?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6889,7 +6858,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Nepodarilo sa uložiť repozitáre: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6963,10 +6932,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminNetworkingPorts => 'Porty';
 
   @override
-  String get adminNetworkingHttpPort => 'Port HTTP';
+  String get adminNetworkingHttpPort => 'HTTP port';
 
   @override
-  String get adminNetworkingHttpsPort => 'Port HTTPS';
+  String get adminNetworkingHttpsPort => 'HTTPS port';
 
   @override
   String get adminNetworkingEnableHttps => 'Povoliť HTTPS';
@@ -6987,7 +6956,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminNetworkingProxyHint => 'napr. 10.0.0.1';
 
   @override
-  String get adminNetworkingWhitelist => 'Zoznam povolených';
+  String get adminNetworkingWhitelist => 'Whitelist';
 
   @override
   String get adminNetworkingBlacklist => 'Čierna listina';
@@ -7017,21 +6986,19 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Povoliť úvodnú obrazovku';
 
   @override
-  String get adminBrandingSplashUpload => 'Nahrať obrázok';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'Úvodná obrazovka bola aktualizovaná';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Nepodarilo sa nahrať úvodnú obrazovku';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Úvodná obrazovka bola odstránená';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Žiadna vlastná úvodná obrazovka';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hardvérová akcelerácia';
@@ -7047,125 +7014,121 @@ class AppLocalizationsSk extends AppLocalizations {
       'Povoliť hardvérové ​​dekódovanie pre:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Zariadenie QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Zapnúť vylepšený dekodér NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Uprednostniť natívny systémový hardvérový dekodér';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Farebná hĺbka hardvérového dekódovania';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bitové dekódovanie HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bitové dekódovanie VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      '8/10-bitové dekódovanie HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      '12-bitové dekódovanie HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hardvérové kódovanie';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Povoliť kódovanie HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Povoliť kódovanie AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Zapnúť nízkoenergetický kodér Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Zapnúť nízkoenergetický kodér Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Mapovanie tónov';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Zapnúť mapovanie tónov';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Zapnúť mapovanie tónov VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Zapnúť mapovanie tónov VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritmus mapovania tónov';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Režim mapovania tónov';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Rozsah mapovania tónov';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturácia mapovania tónov';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Špička mapovania tónov';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter mapovania tónov';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'Jas mapovania tónov VPP';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast mapovania tónov VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Predvoľby a kvalita';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Predvoľba kodéra';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF kódovania H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF kódovania H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metóda odstránenia prekladania';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Zdvojnásobiť snímkovú frekvenciu pri odstraňovaní prekladania';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Zvuk';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Zapnúť kódovanie zvuku VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Zosilnenie zmiešaného zvuku';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritmus zmiešania do stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Maximálna veľkosť fronty multiplexovania';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Automaticky';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kódovanie';
@@ -7285,10 +7248,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminTaskNeverRun => 'Nikdy neutekaj';
 
   @override
-  String get adminTaskStop => 'Zastaviť';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Spustené úlohy';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Bežať';
@@ -7310,17 +7273,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Denne o $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Každý $day o $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Každých $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7358,10 +7321,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hodín',
-      many: '$count hodiny',
-      few: '$count hodiny',
-      one: '1 hodina',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7389,17 +7350,17 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'pred $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'pred $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'pred $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7407,22 +7368,22 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day. $month.';
+    return '$month/$day';
   }
 
   @override
@@ -7436,50 +7397,49 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Základná adresa URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'napr. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'napr. /medúza';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Verejný port HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Vyžadovať HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Presmerovať všetky vzdialené požiadavky na HTTPS. Nemá účinok, ak server nemá platný certifikát.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Heslo certifikátu';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Nastavenia IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Zapnúť IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Zapnúť IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Zapnúť automatické mapovanie portov';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Siete LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Zoznam IP adries alebo podsietí CIDR oddelených čiarkou alebo novým riadkom, ktoré sa považujú za lokálnu sieť.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publikované URI servera';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Priraďte podsieť alebo adresu k publikovanej URL, napr. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Cesta k certifikátu';
@@ -7509,11 +7469,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Tlmenie škrtiacej klapky';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Oneskorenie obmedzenia (sekundy)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Povoliť extrakciu titulkov za behu';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimálne percento obnovenia';
@@ -7562,30 +7522,29 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Nepodarilo sa aktualizovať typ obsahu: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Prah pomalej odozvy (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Zapnúť varovania o pomalej odozve';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Povoliť Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metadáta';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Cesty';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Výkon';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cesta vyrovnávacej pamäte';
@@ -7597,7 +7556,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminGeneralServerName => 'Názov servera';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Preferovaný jazyk zobrazenia';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nepodarilo sa načítať nastavenia';
@@ -7607,12 +7566,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Nepodarilo sa aktualizovať mapovania: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Časový limit: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7649,10 +7608,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# účastníkov',
-      many: '# účastníka',
-      few: '# účastníci',
-      one: '# účastník',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7696,7 +7653,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Položka $index';
+    return 'Item $index';
   }
 
   @override
@@ -7744,12 +7701,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName sa pripojil do skupiny SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName opustil skupinu SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7762,7 +7719,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Synchronizuje sa prehrávanie so skupinou $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7801,10 +7758,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'nájdených # riadkov',
-      many: 'nájdených # riadka',
-      few: 'nájdené # riadky',
-      one: 'nájdený # riadok',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7845,20 +7800,20 @@ class AppLocalizationsSk extends AppLocalizations {
   String get offlineSavedMedia => 'Uložené médiá';
 
   @override
-  String get offlineBannerTitle => 'Ste offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Zobrazujú sa vaše stiahnuté položky';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Stiahnuté';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Server je nedostupný';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Prehráva sa zo stiahnutých položiek, kým sa server nevráti';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7874,12 +7829,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Ovládanie odosielania zlyhalo: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Ovládanie $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7890,7 +7845,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Zastaviť $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7913,12 +7868,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Zadajte $length-miestny PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Zadajte svoj $length-miestny PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7931,21 +7886,22 @@ class AppLocalizationsSk extends AppLocalizations {
   String get pinForgot => 'Zabudli ste PIN?';
 
   @override
-  String get pinClear => 'Vymazať';
+  String get pinClear => 'Jasné';
 
   @override
-  String get pinBackspace => 'Vymazať';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Žiadosť Quick Connect bola schválená.';
+  String get quickConnectAuthorized =>
+      'Žiadosť o rýchle pripojenie bola schválená.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Kód Quick Connect je neplatný alebo jeho platnosť vypršala.';
+      'Kód rýchleho pripojenia je neplatný alebo jeho platnosť vypršala.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect nie je na tomto serveri podporovaný.';
+      'Rýchle pripojenie nie je na tomto serveri podporované.';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7953,19 +7909,19 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect je na tomto serveri zakázaný.';
+      'Rýchle pripojenie je na tomto serveri zakázané.';
 
   @override
   String get quickConnectForbidden =>
-      'Váš účet nemôže autorizovať túto žiadosť Quick Connect.';
+      'Váš účet nemôže autorizovať túto žiadosť o rýchle pripojenie.';
 
   @override
   String get quickConnectNotFound =>
-      'Kód Quick Connect sa nenašiel. Skúste nový kód.';
+      'Kód rýchleho pripojenia sa nenašiel. Skúste nový kód.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect zlyhal: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7976,7 +7932,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Príkaz zlyhal: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8005,7 +7961,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Nepodarilo sa spustiť odosielanie: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8017,7 +7973,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Nie sú k dispozícii žiadne zariadenia na vzdialené prehrávanie.\n\nV systéme iOS môžu byť ciele AirPlay v simulátore nedostupné.';
 
   @override
-  String get trackActionPlayNext => 'Prehrať ako ďalšie';
+  String get trackActionPlayNext => 'Play Next';
 
   @override
   String get trackActionAddToQueue => 'Pridať do poradia';
@@ -8032,7 +7988,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trackActionDeleteFromPlaylist => 'Odstrániť zo zoznamu skladieb';
 
   @override
-  String get trackActionMoveUp => 'Posunúť nahor';
+  String get trackActionMoveUp => 'Move Up';
 
   @override
   String get trackActionMoveDown => 'Posunúť nadol';
@@ -8051,7 +8007,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Sťahuje sa $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8062,7 +8018,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Nepodarilo sa odstrániť stiahnutý súbor';
 
   @override
-  String get shuffleBy => 'Zamiešať podľa';
+  String get shuffleBy => 'Shuffle By';
 
   @override
   String get shuffleSelectLibrary => 'Vyberte možnosť Knižnica';
@@ -8127,21 +8083,21 @@ class AppLocalizationsSk extends AppLocalizations {
   String get upNext => 'Ďalej';
 
   @override
-  String get playNext => 'Prehrať ako ďalšie';
+  String get playNext => 'Play Next';
 
   @override
   String get stillWatchingContent =>
       'Prehrávanie bolo pozastavené. ešte stále pozeráš?';
 
   @override
-  String get stillWatchingStop => 'Zastaviť';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Pokračovať';
 
   @override
   String skipSegment(String segment) {
-    return 'Preskočiť $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8152,12 +8108,12 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Sťahuje sa $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Sťahuje sa $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8219,13 +8175,13 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Skryť z Pokračovať v sledovaní';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Skryť z Nasleduje';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Pridať do kolekcie';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8280,15 +8236,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsAlphabetical => 'Abecedne';
 
   @override
-  String get settingsConnectionSection => 'PRIPOJENIE';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Povoliť vlastnoručne podpísané certifikáty';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Dôverovať serverom s vlastnoručne podpísanými certifikátmi TLS alebo s certifikátmi zo súkromnej certifikačnej autority. Zapnite len pre servery, ktoré spravujete. Vypne sa tým overovanie certifikátov pre všetky pripojenia.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'SÚKROMIE A BEZPEČNOSŤ';
@@ -8304,11 +8259,11 @@ class AppLocalizationsSk extends AppLocalizations {
       'Akcenty tém, pozadia, ukazovatele sledovanosti a hudba tém';
 
   @override
-  String get settingsDetailsScreen => 'Obrazovka s detailmi';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Štýl, rozostrenie pozadia a správanie kariet';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Domovská stránka';
@@ -8346,11 +8301,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Zobraziť tlačidlo Seerr v navigačnom paneli';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vždy zobrazovať textové popisy v hornom navigačnom paneli';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8418,7 +8373,8 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsSupportMoonfin => 'Podporte Moonfina';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Kúpte vývojárovi kávu';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'PRÁVNE';
@@ -8452,10 +8408,8 @@ class AppLocalizationsSk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licenčných oznámení',
-      many: '# licenčného oznámenia',
-      few: '# licenčné oznámenia',
-      one: '# licenčné oznámenie',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8503,17 +8457,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiť úvody a závery?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Odpočítavanie mediálnych segmentov';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Ukazovateľ priebehu';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Časovač';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Žiadne';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Vyzvať používateľa';
@@ -8537,8 +8490,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Ako by sa malo video upraviť, aby sa zmestilo na obrazovku.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv =>
-      'Prehrávací engine (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8548,13 +8500,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (odporúčané)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (staršie)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (staršie)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (odporúčané)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Záložná';
@@ -8653,7 +8605,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get settingsLiveTvDirect => 'Živá televízia priamo';
+  String get settingsLiveTvDirect => 'Live TV Direct';
 
   @override
   String get settingsLiveTvDirectSubtitle =>
@@ -8747,760 +8699,749 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nedávno vydané – $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Automaticky prehrať ďalšiu epizódu';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Automaticky prehrať ďalšiu epizódu, keď je dostupná.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Preskakovať ticho';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Automaticky preskakovať tiché zvukové úseky, ak to stream podporuje.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Povoliť externé zvukové efekty';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Umožniť aplikáciám s ekvalizérom a efektmi (napr. Wavelet) pripojiť sa k prehrávacím reláciám Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Vypnúť tunelovanie';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Vynútiť netunelované prehrávanie. Užitočné na zariadeniach s výpadkami zvuku a videa pri tunelovaní.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Zapnúť tunelovanie';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Pokročilé. Smeruje zvuk a video cez prepojenú hardvérovú cestu. Predvolene vypnuté, pretože na niektorých zariadeniach spôsobuje výpadky zvuku a videa.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Mapovať Dolby Vision profil 7 na HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Prehrávať streamy Dolby Vision profil 7 ako HEVC kompatibilné s HDR10 na zariadeniach bez podpory Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Použiť vložené štýly titulkov';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Použiť farby, písma a umiestnenie vložené v stope titulkov. Vypnutím sa použijú vaše predvoľby štýlu titulkov.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Použiť vložené veľkosti písma titulkov';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Použiť veľkosti písma vložené v stope titulkov. Vypnutím sa použije veľkosť titulkov z vašich predvolieb štýlu.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Zobraziť podrobnosti o médiu';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Zobraziť podrobnosti o vybratej položke v hornej časti stránok knižnice.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Skryť pozadia pri prehliadaní?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Použiť podrobné podnadpisy';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Zobraziť podrobný alebo minimalistický podriadok na stránkach knižnice.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Odstrániť uloženú tému?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Odstrániť „$themeName“ z vyrovnávacej pamäte tohto zariadenia?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Obchod s témami';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Prehliadajte a ukladajte komunitné témy';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Uložte tému, aby ste ju mohli používať ako ostatné uložené témy.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Momentálne nie sú k dispozícii žiadne témy.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Obchod s témami sa nepodarilo načítať. Skontrolujte pripojenie a skúste to znova.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Uložiť';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Uložiť a použiť';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Uložené';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Túto tému sa nepodarilo načítať.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Téma „$themeName“ bola uložená.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Téma „$themeName“ bola odstránená z tohto zariadenia.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Tému „$themeName“ sa nepodarilo odstrániť.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Uložené témy';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Toto sú témy stiahnuté z pluginu Moonfin pre aktuálny server. Odstránením sa zmaže len táto lokálna kópia.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Pre tento server sa nenašli žiadne uložené témy.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Aktuálne aktívna';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Odstrániť uloženú tému';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Spravujte stiahnuté témy pluginu na tomto zariadení';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Editor tém';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'Otvoriť editor tém Moonfin v prehliadači';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Domovská obrazovka';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Dolný panel';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasický';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderný';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Domovské riadky';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Zobrazenie domovských riadkov';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sekcie domovských riadkov';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Prepínače domovských riadkov';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Zapnite alebo vypnite kategórie domovských riadkov podľa knižníc';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Zapnutím nasledujúcich prepínačov zobrazíte riadky v domovských sekciách.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasický zachováva typ obrázka a informačnú vrstvu pre každý riadok. Moderný používa riadky s prechodom z portrétu na pozadie.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Zobraziť riadky obľúbených';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Zobraziť riadky Obľúbené filmy, Obľúbené seriály a ďalšie obľúbené v domovských sekciách.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Zoradenie riadkov obľúbených';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Zoraďte riadky obľúbených podľa dátumu pridania, dátumu vydania, abecedy a ďalších kritérií.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Zobraziť riadky kolekcií';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Zobraziť riadky kolekcií v domovských sekciách.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Zoradenie riadkov kolekcií';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Zoraďte riadky kolekcií podľa dátumu pridania, dátumu vydania, abecedy a ďalších kritérií.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Zobraziť riadky žánrov';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Zobraziť riadky žánrov v domovských sekciách.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Zoradenie riadkov žánrov';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Zoraďte riadky žánrov podľa dátumu pridania, dátumu vydania, abecedy a ďalších kritérií.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Položky v riadkoch žánrov';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Zobraziť v riadkoch žánrov filmy, seriály alebo oboje.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Zobraziť riadky playlistov';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Zobraziť riadky playlistov v domovských sekciách.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Zoradenie riadkov playlistov';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Zoraďte riadky playlistov podľa dátumu pridania, dátumu vydania, abecedy a ďalších kritérií.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Zobraziť zvukové riadky';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Zobraziť zvukové riadky v domovských sekciách.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Zoradenie zvukových riadkov';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Zoraďte zvukové riadky podľa dátumu pridania, dátumu vydania, abecedy a ďalších kritérií.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Zvukové playlisty';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Vzhľad';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Rozloženie';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Téma';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Klávesnica';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Tlačidlá';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Vykresľovanie';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfigurácia MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Externá prehrávacia aplikácia';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Nastavením externého prehrávača povolíte možnosť prehrania dlhým stlačením';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Zobraziť výber aplikácie pri spustení prehrávania.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Načítavajú sa nainštalované prehrávače...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Pripojenie';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Cieľ prekódovania zvuku';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Podporované na tomto zariadení';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Nepodporované na tomto zariadení';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Posielať bitstream DTS:X (DTS UHD) do externého dekodéra.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD s Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Správanie prehrávača médií';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Vylepšenia prehrávania';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Vždy zapnuté.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Nahradiť tlačidlo Preskočiť outro zobrazením Nasleduje';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Zobraziť vrstvu Nasleduje namiesto tlačidla Preskočiť outro.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Smerovanie prehrávača';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Uprednostniť softvérové dekodéry';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Použiť FFmpeg (zvuk) a libgav1 (AV1) pred hardvérovými dekodérmi. Vypnite, ak prestane fungovať zvukový passthrough cez HDMI.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Otvárať prehrávanie videa vo vybratej externej aplikácii na Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatické radenie do fronty';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Uprednostniť titulky SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Pri automatickom výbere uprednostniť stopy titulkov SDH/CC.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Webová diagnostika';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Webová diagnostika Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Na tejto stránke môžete diagnostikovať problémy s pripojením v prehliadači (CORS, zmiešaný obsah a nastavenia zisťovania).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Zistené zlyhanie pre zmiešaný obsah';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Zistené zlyhanie CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin zistil, že stránka HTTPS sa pokúša volať URL servera cez HTTP. Prehliadače túto požiadavku zablokujú skôr, než sa dostane na váš server.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin zistil zlyhanie požiadavky na úrovni prehliadača, ktoré býva spôsobené chýbajúcimi hlavičkami CORS alebo preflight na mediálnom serveri.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Cieľová URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Podrobnosti: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'Aktuálny kontext behu';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schéma';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Režim pluginu';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Skenovanie WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Vynútená URL servera';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Predvolená URL servera';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL proxy na zisťovanie';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'nie je nakonfigurované';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Zmiešaný obsah';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Táto stránka je načítaná cez HTTPS, ale jedna alebo viac nakonfigurovaných URL používa HTTP. Prehliadače blokujú volania z HTTPS stránok na HTTP API.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Riešenie: sprístupnite mediálny server alebo proxy koncový bod cez HTTPS, alebo načítavajte Moonfin cez HTTP len v dôveryhodných lokálnych sieťach.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'V aktuálnych nastaveniach behu sa nezistila žiadna zjavná konfigurácia so zmiešaným obsahom.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Kontrolný zoznam CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Povoľte origin prehliadača v Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Zahrňte Authorization, X-Emby-Authorization a X-Emby-Token do Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Sprístupnite Content-Range a Accept-Ranges pre streamovanie a posúvanie.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Na požiadavky OPTIONS preflight vracajte 204.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Ukážka hlavičiek (štýl nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Poznámka';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Táto diagnostická trasa je určená pre webové zostavy. Ak ju vidíte na inej platforme, tieto kontroly nemusia platiť.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Späť na výber servera';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Odhlásiť všetkých používateľov';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Povolenie pre mikrofón je natrvalo zamietnuté. Zapnite ho v systémových nastaveniach.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Hlasové vyhľadávanie vyžaduje povolenie pre mikrofón.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nerozumeli sme. Skúste to znova.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nezistila sa žiadna reč.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Chyba mikrofónu.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Hlasové vyhľadávanie vyžaduje internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Hlasová služba je zaneprázdnená. Skúste to znova.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Povolenie pre mikrofón je natrvalo zamietnuté.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Povolenie pre mikrofón je zamietnuté.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Rozpoznávanie reči nie je na tomto zariadení dostupné.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Otvoriť výber výstupu iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Výber výstupu AirPlay nie je na tomto zariadení dostupný.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videá';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programy';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Skladby';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Fotoalbumy';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotografie';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Osoby';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Nedávno vydané epizódy';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Pozrieť znova';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Hosťovské účinkovania';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Účinkovania (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Podiel štábu (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Pozerať so skupinou';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Chyby';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Varovania';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Otvoriť v prehliadači';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Vstavaný prehliadač nie je na tejto platforme dostupný.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Naozaj chcete reštartovať server?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Naozaj chcete vypnúť server? Budete ho musieť spustiť ručne.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Interné';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Nečinné';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nenašli sa žiadni používatelia';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Vášmu hľadaniu nezodpovedajú žiadni používatelia';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nenašli sa žiadne zariadenia';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Aktuálnym filtrom nezodpovedajú žiadne zariadenia';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Heslo je nastavené';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nie je nastavené žiadne heslo';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Vzdialený prístup';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Len lokálne';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Nepodarilo sa načítať analytiku médií';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Súhrnná analytika naprieč všetkými mediálnymi knižnicami.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Najlepší interpreti';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Najlepší autori';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Najlepší prispievatelia';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knižníc',
-      many: '$count knižnice',
-      few: '$count knižnice',
-      one: '1 knižnica',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Pre tento výber zatiaľ nie sú k dispozícii žiadne súhrny indexovaných médií.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Podrobnosti o knižnici';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Rozpis knižníc';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'Nie sú k dispozícii žiadne knižnice.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Správa servera';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Údaje';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Vyrovnávacia pamäť obrázkov';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Vyrovnávacia pamäť';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Denníky';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metadáta';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Prekódovanie';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Tento server nevrátil žiadne cesty.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent % využité';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Aktivita používateľov';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Systémové udalosti';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Vyžaduje pozornosť';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Prehrávanie';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Zariadenia';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Pokročilé';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Pluginy';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Živá televízia';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Domáce videá';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Zmiešaný obsah';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Domáce videá a fotografie';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Zmiešané filmy a seriály';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9512,150 +9453,150 @@ class AppLocalizationsSk extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nenašli sa žiadne nahrávky';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'V archíve .$extension sa nenašli žiadne obrázkové strany.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Vstavané vykresľovanie zlyhalo ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Vykresľovanie EPUB zlyhalo ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Chýba lokálny súbor pre čítačku: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status pri otváraní údajov knihy z $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nie je dostupný žiadny čitateľný koncový bod knihy';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Nepodporovaný formát komiksového archívu: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Plugin na rozbaľovanie CBR nie je na tejto platforme dostupný.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Nepodarilo sa rozbaliť archív .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Rozbaľovanie CB7 nie je na tejto platforme dostupné.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Plugin na rozbaľovanie CB7 nie je na tejto platforme dostupný.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Zavrieť panel žánrov';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Načítava sa náhodný výber...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'NÁHODNE Z KNIŽNICE';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'NÁHODNÝ VÝBER';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'NÁHODNE PODĽA ŽÁNRU';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatické prepínanie HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Automaticky zapnúť HDR pri prehrávaní HDR videa a po ukončení obnoviť režim zobrazenia.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Na celej obrazovke';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Zmeniť obrázok';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Chýba';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Limity prekódovania';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Vymazať všetky obrázky?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Naozaj chcete vymazať všetky stiahnuté obrázky?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Potvrdiť vymazanie';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Naozaj chcete vymazať položku „$itemType“?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Nahrať?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Rozlíšenie: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Zobrazovať len obrázky v jazyku rozhrania';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Potvrdiť vymazanie všetkého';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Obrázok bol úspešne nahraný!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Nepodarilo sa nahrať obrázok: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Nepodarilo sa nastaviť obrázok: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Nepodarilo sa odstrániť obrázok: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Nepodarilo sa vymazať všetky obrázky: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Áno';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plagát';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Pozadia';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9664,31 +9605,31 @@ class AppLocalizationsSk extends AppLocalizations {
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatúra';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika disku';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Snímka obrazovky';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Predná strana obalu';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Zadná strana obalu';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika ponuky';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plagát';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'pozadie';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
   String get confirmItemBanner => 'banner';
@@ -9697,114 +9638,114 @@ class AppLocalizationsSk extends AppLocalizations {
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatúra';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafika disku';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'snímka obrazovky';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'predná strana obalu';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'zadná strana obalu';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafika ponuky';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Všetky';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Vysoké (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Stredné (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Nízke (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Zdroje';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitoly';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Záložky';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Poznámky';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Fronta';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Časová os';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Časová os je prázdna';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Celá kniha';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Zameraná časová os';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportovať záložky';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportovať poznámky';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportovať všetko';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exportované do $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Export zlyhal: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Text';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Pridať záložku';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Pridať poznámku';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Upraviť poznámku';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Napíšte poznámku k tomuto momentu';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Časovač vypnutia';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Vypnuté';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Koniec kapitoly';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Vlastné';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'zostáva $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9819,51 +9760,51 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Rýchlosť prehrávania';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Zostáva';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Uplynulo';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Späť o $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Vpred o $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Predchádzajúca kapitola';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Ďalšia kapitola';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitola $current z $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Žiadne kapitoly';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Zatiaľ žiadne záložky';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Zatiaľ žiadne poznámky';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Záložka pridaná na $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Obnoviť na 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9871,255 +9812,249 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Uložiť';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Zrušiť';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Vymazať';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Predvoľby titulkov';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Zmeňte režimy titulkov, predvolené jazyky, vzhľad a možnosti vykresľovania.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Vykresľovanie titulkov';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Možnosti zobrazenia';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Dátum vydania (vzostupne)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Dátum vydania (zostupne)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Zoskupiť podiely';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Zoskupiť viacero rolí';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Upozornenie na prístup na zápis do knižnice';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Ako to opraviť:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Udeľte servisnému používateľovi Jellyfin (napr. jellyfin alebo Docker PUID/PGID) oprávnenia na zápis do priečinkov vašej mediálnej knižnice na serveri.\n\n2. Alebo v nástenke Jellyfin prejdite do sekcie Libraries, upravte túto knižnicu a vypnite možnosť „Save artwork into media folders“, aby sa obrázky ukladali do internej databázy Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Zavrieť';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Vaša knižnica „$libraryName“ je nastavená tak, aby ukladala obrázky priamo do mediálnych priečinkov (možnosť „Save artwork into media folders“ je zapnutá). Jellyfin však otestoval prístup na zápis a nemá oprávnenie zapisovať súbory do tohto adresára:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Zdá sa, že Jellyfin nedokázal aktualizovať obrázky. Vaša knižnica je nastavená tak, aby ukladala obrázky priamo do mediálnych priečinkov (možnosť „Save artwork into media folders“ je zapnutá). Táto chyba sa zvyčajne vyskytuje, keď serverový proces Jellyfin nemá oprávnenie zapisovať súbory do vašich mediálnych adresárov.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Externé zoznamy';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Prehrať znova';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informácie o súbore';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Veľkosť: $size  •  Formát: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Zobraziť všetky zvukové stopy ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Zobraziť všetky stopy titulkov ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Kontroluje sa možnosť priameho prehrávania...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Možnosť priameho prehrávania: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Vynútené';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Prehrávač nepodporuje formát kontajnera.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Kodek videa nie je podporovaný.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Kodek zvuku nie je podporovaný.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Formát titulkov nie je podporovaný (vyžaduje vypálenie do obrazu).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Profil zvuku nie je podporovaný.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Profil videa nie je podporovaný.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Úroveň videa nie je podporovaná.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Toto zariadenie nepodporuje rozlíšenie videa.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Bitová hĺbka videa nie je podporovaná.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Snímková frekvencia videa nie je podporovaná.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Bitový tok súboru prekračuje limit streamovania prehrávača.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Bitový tok videa prekračuje limit streamovania.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Bitový tok zvuku prekračuje limit streamovania.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Počet zvukových kanálov nie je podporovaný.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Abecedne';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Poradie vydania (vzostupne)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Poradie vydania (zostupne)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Vlastné (ťahaním myšou)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Možnosti zoradenia playlistu';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Obnoviť zoradenie';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Pozrieť znova S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Pozrieť playlist znova';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nenašli sa žiadne titulky.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Ovládanie správcu';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Vykresľovací engine (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller je moderný GPU renderer Flutteru pre plynulejšie animácie a menej trhania. Na niektorých TV boxoch a starších GPU môže spôsobovať chyby zobrazenia alebo čierne video; v takom prípade ho vypnite. Automatický vyberie najlepšiu predvoľbu pre vaše zariadenie. Zmena sa prejaví po reštarte Moonfin.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatický';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Zapnuté';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Vypnuté';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Vyžaduje sa reštart';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin sa musí reštartovať, aby sa zmenil vykresľovací engine. Zatvorte teraz aplikáciu a znova ju otvorte.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Zatvoriť aplikáciu';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Obnoviť knižnicu';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Obnoviť všetky knižnice';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Dátum pridania (najstaršie prvé)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Dátum pridania (najnovšie prvé)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Abecedne (A – Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Abecedne (Z – A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Načítava sa analytika servera... $percentage %';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Podľa zdroja';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filmov';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 seriálov';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Najpopulárnejšie filmy na IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Najpopulárnejšie seriály na IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Najhoršie hodnotené filmy na IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Najlepšie hodnotené anglické filmy na IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -9,30 +9,30 @@ class AppLocalizationsSl extends AppLocalizations {
   AppLocalizationsSl([String locale = 'sl']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Mesečeva plavutka';
 
   @override
-  String get accountPreferences => 'NASTAVITVE RAČUNA';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Jezik vmesnika';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Privzeto sistemsko';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Prijavite se';
 
   @override
-  String get empty => 'Prazno';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Povezovanje s strežnikom $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Hitra povezava';
 
   @override
   String get password => 'Geslo';
@@ -61,12 +61,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ni na voljo: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ni na voljo ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin različica $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -107,7 +107,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Ali želite odstraniti »$serverName« s seznama strežnikov?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -142,62 +142,62 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema aplikacije';
 
   @override
-  String get detailScreenStyle => 'Slog zaslona s podrobnostmi';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasični je izvirna sredinska postavitev Moonfin. Sodobni je odzivna filmska postavitev.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasični';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Sodobni';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Razširjeni zavihki';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Samodejno prikaži vsebino zavihka med brskanjem po zavihkih. Izklopite, če želite zavihke odpirati in zapirati ročno.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Prikaz tehničnih podrobnosti?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Prikaži kodek, ločljivost in podatke o pretoku v povzetku pasice';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistem priporočil';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Uporabite algoritem Moonfin priporoča za lokalno knjižnico ali spletne metrike podobnosti TMDb. Opomba: spletna priporočila zahtevajo integracijo Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin priporoča';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Podobnost TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Uporaba omejitve starševske ocene?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Omeji predloge funkcije Moonfin priporoča glede na starševsko oceno ciljne vsebine';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Slog vmesnika';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Samodejni se prilagodi vaši napravi. Izberite Apple ali Material, če želite vsiliti videz.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Samodejni';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,42 +206,41 @@ class AppLocalizationsSl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kakovost stekla';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Samodejna izbere najboljši učinek stekla za to napravo. Polna vsili pravo zabrisanost, Zmanjšana uporabi lahko steklo, ki varčuje z močjo GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Samodejna';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Polna';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Zmanjšana';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Preklapljajte med Moonfin in Neon Pulse brez ponovnega zagona aplikacije';
 
   @override
-  String get customThemeTitle => 'Tema po meri';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Teme po meri spremenijo vizualne elemente po celotnem Moonfinu. Izberite možnost, ki ustreza vašemu slogu.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme =>
-      'Prednostno uporabi sistemsko tipkovnico';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Za vnos besedila privzeto uporabi način vnosa vaše naprave';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Mesečeva plavutka';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -255,18 +254,18 @@ class AppLocalizationsSl extends AppLocalizations {
       'Oblikovanje Synthwave z magenta sijajem, cian besedilom in močnejšim kromiranim kontrastom';
 
   @override
-  String get themeGlass => 'Steklo';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Slog tekočega stekla z drsečim gradientnim ozadjem, motnimi površinami in modrim poudarkom Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bitni junak';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro slog pikselske grafike z izrazito paleto, oglatimi robovi, ostrimi sencami in pikselsko pisavo';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -316,7 +315,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Povezava z $target ni mogoča';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -329,35 +328,35 @@ class AppLocalizationsSl extends AppLocalizations {
   String get exit => 'Izhod';
 
   @override
-  String get gameMenu => 'Meni';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Zaustavljeno';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Shrani stanje';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Igre';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Naloži stanje';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Hitro naprej';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Nastavitve emulatorja';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'To jedro nima nastavljivih možnosti.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Pridržite za odpiranje menija';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Igranje iger na tej napravi še ni podprto.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -380,13 +379,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get schedule => 'Urnik';
 
   @override
-  String get series => 'Serije';
+  String get series => 'serija';
 
   @override
   String get noItemsFound => 'Ni elementov';
 
   @override
-  String get home => 'Domov';
+  String get home => 'domov';
 
   @override
   String get browseAll => 'Prebrskaj vse';
@@ -431,7 +430,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Mape ni bilo mogoče naložiti: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -439,7 +438,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count elementov';
+    return '$count items';
   }
 
   @override
@@ -456,7 +455,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count elementov';
+    return '$count Items';
   }
 
   @override
@@ -497,7 +496,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Žanri';
+    return '$name — Genres';
   }
 
   @override
@@ -510,7 +509,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get albumArtists => 'Izvajalci albuma';
 
   @override
-  String get artists => 'Izvajalci';
+  String get artists => 'Umetniki';
 
   @override
   String get bookmarks => 'Zaznamki';
@@ -535,17 +534,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'pred $count min';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'pred $count h';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'pred $count d';
+    return '${count}d ago';
   }
 
   @override
@@ -556,7 +555,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'Izberite, katere vsebinske vire želite prikazati v Odkrivanju.';
 
   @override
-  String get apply => 'Uporabi';
+  String get apply => 'Prijavite se';
 
   @override
   String get openLink => 'Odprite povezavo';
@@ -580,7 +579,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count naslovov';
+    return '$count titles';
   }
 
   @override
@@ -605,7 +604,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get listen => 'poslušaj';
 
   @override
-  String get resume => 'Nadaljuj';
+  String get resume => 'Nadaljevanje';
 
   @override
   String get failedToLoadLibrary => 'Nalaganje knjižnice ni uspelo';
@@ -667,17 +666,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count avtorjev';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count žanrov';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent % dokončano';
+    return '$percent% completed';
   }
 
   @override
@@ -694,7 +693,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count naslovov, urejenih za brskanje s poudarkom na branju.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -731,7 +730,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Ni rezultatov: $label';
+    return 'No $label found';
   }
 
   @override
@@ -750,7 +749,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get readStatus => 'Preberi';
 
   @override
-  String get watched => 'Ogledano';
+  String get watched => 'Gledal';
 
   @override
   String get unread => 'Neprebrano';
@@ -768,45 +767,43 @@ class AppLocalizationsSl extends AppLocalizations {
   String get books => 'knjige';
 
   @override
-  String get latestBooks => 'Najnovejše knjige';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Najnovejše zvočne knjige';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knjig',
-      few: '$count knjige',
-      two: '$count knjigi',
-      one: '1 knjiga',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Knjiga';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Zvočna knjiga';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent % prebrano';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'še $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Beri';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Poslušaj';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Avtor';
@@ -844,12 +841,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count razdelkov';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Prva izdaja $year';
+    return 'First published $year';
   }
 
   @override
@@ -864,7 +861,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count knjig';
+    return '$count books';
   }
 
   @override
@@ -875,7 +872,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count avtorjev';
+    return '$count Authors';
   }
 
   @override
@@ -883,10 +880,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count zvočnih knjig',
-      few: '$count zvočne knjige',
-      two: '$count zvočni knjigi',
-      one: '1 zvočna knjiga',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -922,7 +917,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nextUp => 'Naprej';
 
   @override
-  String get seasons => 'Sezone';
+  String get seasons => 'letni časi';
 
   @override
   String get chapters => 'Poglavja';
@@ -934,7 +929,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get movies => 'Filmi';
 
   @override
-  String get musicVideos => 'Glasbeni videi';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'drugo';
@@ -953,7 +948,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disk $number';
+    return 'Disc $number';
   }
 
   @override
@@ -977,7 +972,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Izdano $year';
+    return 'Published $year';
   }
 
   @override
@@ -988,54 +983,52 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sezon',
-      few: '$count sezone',
-      two: '$count sezoni',
-      one: '1 sezona',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Konec ob $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Elementi';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Dodatki';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Izza kulis';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Izbrisani prizori';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Kratki dokumentarci';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjuji';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Prizori';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kratki filmi';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Napovedniki';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'še $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Konec čez $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,11 +1042,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Nadaljuj od $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Predvajaj';
+  String get play => 'Igraj';
 
   @override
   String get startOver => 'Začni znova';
@@ -1077,7 +1070,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get version => 'Različica';
 
   @override
-  String get cast => 'Predvajaj v napravi';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Napovednik';
@@ -1149,7 +1142,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Ali želite izbrisati prenesene skladbe za »$title«?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1164,17 +1157,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Ni naloženih elementov: $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Prenašanje $title ($count elementov)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Ali ste prepričani, da želite izbrisati »$name« s strežnika? Tega dejanja ni mogoče razveljaviti.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1185,7 +1178,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Nepodprta oblika knjige: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1195,7 +1188,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get subtitleTrack => 'Skladba s podnapisi';
 
   @override
-  String get none => 'Brez';
+  String get none => 'Noben';
 
   @override
   String get downloadSubtitlesLabel => 'Prenesi podnapise ...';
@@ -1211,7 +1204,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Podnapisi preneseni in izbrani: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1220,7 +1213,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Za jezik $language ni najdenih oddaljenih podnapisov.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1228,7 +1221,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Različica $number';
+    return 'Version $number';
   }
 
   @override
@@ -1250,7 +1243,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Prenašanje $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1258,7 +1251,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Ali želite izbrisati lokalne datoteke za $typeLabel?\n\nS tem boste sprostili prostor v shrambi. Pozneje jih lahko znova prenesete.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1274,25 +1267,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
-  String get directors => 'REŽISERJI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENARIST';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARISTI';
+  String get writers => 'PISATELJICE';
 
   @override
   String get studio => 'GARSONJERA';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count več';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count epizod';
+    return '$count Episodes';
   }
 
   @override
@@ -1302,12 +1295,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Epizoda $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Poglavje $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1315,10 +1308,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count skladb',
-      few: '$count skladbe',
-      two: '$count skladbi',
-      one: '1 skladba',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1328,27 +1319,25 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count poglavij',
-      few: '$count poglavja',
-      two: '$count poglavji',
-      one: '1 poglavje',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Rojstvo $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Smrt $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Starost $age';
+    return 'Age $age';
   }
 
   @override
@@ -1361,17 +1350,17 @@ class AppLocalizationsSl extends AppLocalizations {
   String get shuffle => 'Naključno';
 
   @override
-  String get shuffleAllMusic => 'Naključno predvajaj vso glasbo';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Prijavite se v Moonfin na telefonu';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Strežnik ni dosegljiv';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count prenosov';
+    return '$count downloads';
   }
 
   @override
@@ -1379,7 +1368,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kan.';
+    return '${count}ch';
   }
 
   @override
@@ -1390,32 +1379,32 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Dejanje oddaljenih podnapisov ($action) za tega uporabnika zahteva dovoljenje Jellyfin za upravljanje podnapisov.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Tega elementa ni bilo mogoče najti na strežniku za dejanje oddaljenih podnapisov ($action).';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Dejanje oddaljenih podnapisov ($action) ni uspelo: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Dejanje oddaljenih podnapisov ($action) ni uspelo (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Dejanja $action za oddaljene podnapise ni bilo mogoče izvesti.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'vse prenesene epizode za »$name«';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1447,17 +1436,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Dejanje $label ni uspelo: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Glasnosti predvajanja na napravi ni bilo mogoče nastaviti: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Upravljanje $label';
+    return '$label Controls';
   }
 
   @override
@@ -1474,7 +1463,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Ustavi $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1482,7 +1471,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Skladba $number';
+    return 'Track $number';
   }
 
   @override
@@ -1499,14 +1488,14 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sekund';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'Dolgo pritisnite za odklepanje';
 
   @override
-  String get off => 'Izklopljeno';
+  String get off => 'Izključeno';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1518,7 +1507,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String bitrateValueMbps(int mbps) {
-    return '$mbps Mb/s';
+    return '$mbps Mbps';
   }
 
   @override
@@ -1529,12 +1518,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1568,7 +1557,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get transcodeReasons => 'Razlogi za prekodiranje';
 
   @override
-  String get player => 'Predvajalnik';
+  String get player => 'Igralec';
 
   @override
   String get container => 'Posoda';
@@ -1592,7 +1581,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get videoBitrate => 'Bitna hitrost videa';
 
   @override
-  String get track => 'Skladba';
+  String get track => 'Track';
 
   @override
   String get channels => 'Kanali';
@@ -1614,12 +1603,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Napaka seje $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Podrobnosti knjige ni bilo mogoče naložiti: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1628,7 +1617,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Te oblike (.$extension) še ni mogoče prikazati v aplikaciji.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1641,17 +1630,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Bralnika v aplikaciji ni bilo mogoče odpreti: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Zaznamek je na mestu $label že shranjen.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Zaznamek dodan: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1663,7 +1652,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Stran $number';
+    return 'Page $number';
   }
 
   @override
@@ -1674,12 +1663,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Oblika: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent % prebrano';
+    return '$percent% read';
   }
 
   @override
@@ -1702,7 +1691,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Ponastavi povečavo (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1725,7 +1714,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Stanja branja ni bilo mogoče posodobiti: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1757,7 +1746,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ta platforma ne podpira vgrajenega pogona za dokumente za datoteke $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1796,7 +1785,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Sporeda ni bilo mogoče naložiti: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1807,22 +1796,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Sledi: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'še $minutes min';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'še $hours h';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'še $hours h $minutes min';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1846,29 +1835,29 @@ class AppLocalizationsSl extends AppLocalizations {
   String get favoriteChannel => 'Najljubši kanal';
 
   @override
-  String get record => 'Snemaj';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Prekliči snemanje';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Snemanje oddaje je načrtovano';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Snemanje preklicano';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Posnetka ni mogoče ustvariti';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Glej';
+  String get watch => 'Pazi';
 
   @override
   String get close => 'Zapri';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Predvajanje $name ni uspelo';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1894,11 +1883,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Ali želite preklicati načrtovano snemanje »$name«?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Ne';
+  String get no => 'št';
 
   @override
   String get yesCancel => 'Da, Prekliči';
@@ -1922,7 +1911,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Ali želite ustaviti snemanje »$name«?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1937,12 +1926,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Ni rezultatov za »$query«';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Iskanje ni uspelo: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1983,12 +1972,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Ali želite odstraniti »$name« in pripadajoče datoteke?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count skladb';
+    return '$count tracks';
   }
 
   @override
@@ -1999,12 +1988,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Albuma ni bilo mogoče naložiti: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Za album $name ni najdenih prenesenih skladb.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2021,7 +2010,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Ali želite odstraniti »$name«?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2036,7 +2025,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Epizoda $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2050,7 +2039,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sezona $number';
+    return 'Season $number';
   }
 
   @override
@@ -2066,7 +2055,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Ali želite izbrisati vse prenesene epizode v $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2074,10 +2063,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count epizod',
-      few: '$count epizode',
-      two: '$count epizodi',
-      one: '1 epizoda',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2112,7 +2099,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Ali želite izbrisati $count prenesenih elementov?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2126,7 +2113,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'od omejitve $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2169,7 +2156,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mediaRequestIntegration => 'Integracija medijske zahteve';
 
   @override
-  String get switchServer => 'Zamenjaj strežnik';
+  String get switchServer => 'Switch Server';
 
   @override
   String get signOut => 'Odjava';
@@ -2211,7 +2198,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count možnosti';
+    return '$count options';
   }
 
   @override
@@ -2305,11 +2292,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Strani s podrobnostmi, vrstice na domači strani in glasnost';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
-    return '$value %';
+    return '$value%';
   }
 
   @override
@@ -2320,18 +2307,18 @@ class AppLocalizationsSl extends AppLocalizations {
       'Igrajte med brskanjem po začetnem zaslonu';
 
   @override
-  String get loopThemeMusic => 'Ponavljaj tematsko glasbo';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Skladbo predvajaj v zanki namesto enkrat';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Zameglitev ozadja podrobnosti';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2347,23 +2334,23 @@ class AppLocalizationsSl extends AppLocalizations {
   String get playerZoomMode => 'Način povečave predvajalnika';
 
   @override
-  String get settingsScrollWheelAction => 'Kolesce miške';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Izberite, kaj se zgodi ob drsenju s kolescem miške nad videom med predvajanjem.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Izklopljeno';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Iskanje (naprej/nazaj)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Glasnost';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Glasnost';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2372,13 +2359,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get autoCrop => 'Samodejno obrezovanje';
 
   @override
-  String get stretch => 'Raztegni';
+  String get stretch => 'Stretch';
 
   @override
   String get refreshRateSwitching => 'Preklop hitrosti osveževanja';
 
   @override
-  String get disabled => 'Onemogočeno';
+  String get disabled => 'Onemogočen';
 
   @override
   String get scaleOnTv => 'Lestvica na TV';
@@ -2417,39 +2404,37 @@ class AppLocalizationsSl extends AppLocalizations {
   String get defaultAudioLanguage => 'Privzeti jezik zvoka';
 
   @override
-  String get fallbackAudioLanguage => 'Nadomestni jezik zvoka';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Prednostno uporabi privzeto zvočno sled';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Prednostno uporabi izvirno zvočno sled namesto lokalizirane sinhronizacije.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'Prednostno uporabi sledi z zvočnim opisom';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Prednostno uporabi sledi z zvočnim opisom namesto običajnih sledi.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Prekodiranje (zvok)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Neposredni pretok (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Prekodiranje (bitna hitrost ali ločljivost)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Prekodiranje (video in zvok)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Prekodiranje (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Samodejno (privzeto za strežnik)';
@@ -2488,7 +2473,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get arabic => 'arabščina';
 
   @override
-  String get hindi => 'Hindijščina';
+  String get hindi => 'Hindi';
 
   @override
   String get dutch => 'nizozemščina';
@@ -2526,28 +2511,27 @@ class AppLocalizationsSl extends AppLocalizations {
       'Omogoči zvok TrueHD (morda ne deluje na vseh platformah)';
 
   @override
-  String get settingsAudioOutputMode => 'Način zvočnega izhoda';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Izberite, kako se zvok dekodira. AVR Passthrough pošilja surove pretoke Dolby/DTS v vaš sprejemnik, Samodejno ali Downmix dekodirata lokalno.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Nadomestni zvočni kodek';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Izberite ciljno obliko za prekodiranje večkanalnega zvoka, kadar izvornega pretoka ni mogoče predvajati neposredno ali posredovati naprej.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Samodejno zaznaj\n(priporočeno)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(privzeto)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2556,27 +2540,26 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(brez izgub)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(samo stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(učinkovit)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(brez izgub)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Največje število zvočnih kanalov';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Nastavite največje število kanalov vaše zvočne postavitve. Večkanalni pretoki, ki presegajo to omejitev, bodo zmiksani ali prekodirani.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Samodejno zaznaj\n(privzeto za strojno opremo)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2588,7 +2571,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kvadrofonija';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2603,67 +2586,67 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (napredno)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough kodekov';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Omogočite samo oblike, ki jih podpira vaš AVR ali naprava HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Pošlji bitni tok Dolby Digital Plus (EAC3) v zunanji dekodirnik.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Pošlji bitni tok Dolby Atmos prek EAC3 (JOC) v zunanji dekodirnik.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Pošlji bitni tok DTS-HD MA (vključno z jedrom DTS) v zunanji dekodirnik.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Pošlji bitni tok Dolby TrueHD z metapodatki Atmos v zunanji dekodirnik.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Zaznane zvočne zmožnosti';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Posnetek zmožnosti med izvajanjem še ni na voljo.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Pot';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekodiranje';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Pot za zvok HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2678,50 +2661,50 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Zvočnik';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Slušalke';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kan. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostika';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Raven videa';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Obseg videa';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodek podnapisov';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Dovoljeni zvočni kodeki';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Zvočni kodeki HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Zvočni kodeki HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'passthrough audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktivna zvočna pot';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Podpora za zvok HD na poti';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nočni način';
@@ -2770,7 +2753,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value s';
+    return '${value}s';
   }
 
   @override
@@ -2785,7 +2768,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Po $episodes epizodah / $hours h';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2826,7 +2809,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get selectMpvConf => 'Izberite mpv.conf';
 
   @override
-  String get pathToMpvConf => '/pot/do/mpv.conf';
+  String get pathToMpvConf => '/path/to/mpv.conf';
 
   @override
   String get subtitleStyleDescription =>
@@ -2860,45 +2843,45 @@ class AppLocalizationsSl extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Prilagodite videz podnapisov';
 
   @override
-  String get subtitleMode => 'Način podnapisov';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Označeni';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Vedno';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Tujejezični';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Vsiljeni';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Predvaja sledi, ki so v metapodatkih predstavnostne datoteke interno označene kot »default« ali »forced«.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Samodejno naloži in prikaže podnapise ob vsakem zagonu videa.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Samodejno vklopi podnapise, če je privzeta zvočna sled v tujem jeziku.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Naloži samo podnapise, ki so izrecno označeni z zastavico »forced«.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Popolnoma onemogoči samodejno nalaganje podnapisov.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Nadomestni jezik podnapisov';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Pretok podnapisov';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Hitra rjava lisica skoči čez lenega psa';
@@ -2932,7 +2915,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get green => 'zelena';
 
   @override
-  String get cyan => 'Cian';
+  String get cyan => 'Cyan';
 
   @override
   String get red => 'Rdeča';
@@ -2957,17 +2940,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Nastavitve profila $profile so naložene.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Nastavitev profila $profile ni bilo mogoče naložiti.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Lokalne nastavitve so sinhronizirane s profilom $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3047,7 +3030,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get clearAllDownloads => 'Počisti vse prenose';
 
   @override
-  String get original => 'Izvirna';
+  String get original => 'Original';
 
   @override
   String get changeDownloadLocation => 'Spremenite lokacijo prenosa';
@@ -3102,11 +3085,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Prikaži knjižnice v orodni vrstici';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Vedno prikaži oznake v navigacijski vrstici';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Prikaži gumb Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Neprosojnost krmarne vrstice';
@@ -3124,7 +3106,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get purple => 'Vijolična';
 
   @override
-  String get teal => 'Modrozelena';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Mornarica';
@@ -3181,19 +3163,18 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Pokaži možnost brskanja po mapah';
 
   @override
-  String get groupItemsIntoCollections => 'Združi elemente v zbirke';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Med brskanjem po knjižnicah skrij elemente, ki pripadajo zbirki';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Obvestilo o združevanju knjižnice';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Za uporabo te nastavitve poskrbite, da sta v nastavitvah prikaza vaše knjižnice na strežniku Jellyfin ali Emby omogočeni možnosti »Group movies into collections« in/ali »Group shows into collections«.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Vidnost knjižnice';
@@ -3222,7 +3203,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count izbranih';
+    return '$count selected';
   }
 
   @override
@@ -3252,13 +3233,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Izbirajte med različnimi slogi medijske vrstice ali pa medijsko vrstico izklopite';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Mesečeva plavutka';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Izklopljeno';
+  String get mediaBarModeOff => 'Izključeno';
 
   @override
   String get enableMediaBar => 'Omogoči vrstico z mediji';
@@ -3306,11 +3287,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Samodejno predvajanje napovednikov v medijski vrstici po 3 sekundah';
 
   @override
-  String get trailerAudio => 'Zvok napovednikov';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Omogoči zvok napovednikov v predstavnostni vrstici';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Predogled epizode';
@@ -3387,11 +3367,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get combineBothRows => 'Združite obe vrstici v en sam domači del';
 
   @override
-  String get fullScreenRows => 'Razširjene vrstice na domači strani';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Omeji domačo stran na 1 vrstico naenkrat';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Vrsta slike na vrstico';
@@ -3406,7 +3385,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get lastUser => 'Zadnji uporabnik';
 
   @override
-  String get currentUser => 'Trenutni uporabnik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vedno preveri pristnost';
@@ -3513,10 +3492,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Prikaz ure med ohranjevalnikom zaslona';
 
   @override
-  String get clockModeStatic => 'Statična';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Odbijajoča se';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritiki)';
@@ -3586,7 +3565,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'Omogočite in preuredite vire ocen, prikazane v celotni aplikaciji';
 
   @override
-  String get pluginLabel => 'Vtičnik Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Vtičnik zaznan';
@@ -3604,7 +3583,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nRazličica: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3658,7 +3637,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get networks => 'Omrežja';
 
   @override
-  String get seerrDiscoveryRows => 'Vrstice za odkrivanje Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Ponastavi vrstice na privzete';
@@ -3681,43 +3660,44 @@ class AppLocalizationsSl extends AppLocalizations {
   String get hideAdultContent => 'Skrij vsebino za odrasle v rezultatih';
 
   @override
-  String get seerrNotificationsSection => 'Obvestila';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Obvestila o novih zahtevah';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Obvesti me, ko nekdo odda zahtevo';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Posodobitve zahtev';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Odobreno, zavrnjeno in dodano v vašo knjižnico';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Posodobitve težav';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nove težave, odgovori in rešitve';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Prijavljeni kot: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Stran za odkrivanje Seerr';
+  String get discoverRows => 'Odkrijte vrstice';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Omogočite vrstice, ki jih želite videti na glavni strani Seerr. Povlecite za prerazporeditev. Prilagojeni vrstni red se sinhronizira z vtičnikom Moonbase.';
+      'Povlecite za prerazporeditev. Omogoči ali onemogoči vrstice. Omogočen vrstni red se sinhronizira z vtičnikom Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Omogočite vrstice, ki jih želite videti na glavni strani Seerr. Povlecite za prerazporeditev. Prilagojeni vrstni red se sinhronizira z vtičnikom Moonbase.';
+      'Povlecite za prerazporeditev. Omogoči ali onemogoči vrstice.';
 
   @override
   String get enabled => 'Omogočeno';
@@ -3730,7 +3710,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Različica $version';
+    return 'Version $version';
   }
 
   @override
@@ -3781,7 +3761,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Na voljo je posodobitev: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3793,7 +3773,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Različica v$version je na voljo';
+    return 'v$version Available';
   }
 
   @override
@@ -3856,7 +3836,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get imageCacheCleared => 'Predpomnilnik slik je počiščen';
 
   @override
-  String get clear => 'Počisti';
+  String get clear => 'jasno';
 
   @override
   String get browse => 'Prebrskaj';
@@ -3872,15 +3852,15 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Prenašanje · $percent %';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Uvažanje';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count elementov';
+    return '$count Items';
   }
 
   @override
@@ -3900,7 +3880,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Zahteval $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3917,12 +3897,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Ali želite preklicati zahtevo za »$title«?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Ali želite preklicati $count zahtev za »$title«?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3937,12 +3917,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Proračun: $amount \$';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Prihodek: $amount \$';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3952,7 +3932,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Zahtevaj $type';
+    return 'Request $type';
   }
 
   @override
@@ -3988,7 +3968,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'starost $age';
+    return 'age $age';
   }
 
   @override
@@ -4019,146 +3999,148 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deletedStatus => 'Izbrisano';
 
   @override
-  String get failedStatus => 'Neuspešno';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'V obdelavi';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Spremenil $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Zaključeno';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ta naslov je bil že zahtevan';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Dosežena je omejitev zahtev';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Ta naslov je na seznamu blokiranih';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Ni več sezon, ki bi jih lahko zahtevali';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Nimate dovoljenja za to zahtevo';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Zahteve';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Težave';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Najnovejše';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Nazadnje spremenjeno';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Ni težav';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Na voljo je še $remaining od $limit zahtev za filme';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Na voljo je še $remaining od $limit zahtev za sezone';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Del zbirke $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Prikaži zbirko';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Zahtevaj zbirko';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmov · $available na voljo';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Zahtevaj $count filmov';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Pošiljanje zahteve $current od $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Zahtevanih $count filmov';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Zahtevanih $ok od $total filmov';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'Vsi filmi so že na voljo ali zahtevani';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Prijavi težavo';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Zvok';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'V čem je težava?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Vse epizode';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Epizoda';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Odprto';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Rešeno';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Reši';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Znova odpri';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Prijavil $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komentarjev';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Dodaj komentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Ali želite izbrisati to težavo?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Pošlji prijavo';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Rezultat TMDB';
@@ -4173,7 +4155,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get revenueLabel => 'Prihodki';
 
   @override
-  String get runtimeLabel => 'Trajanje';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'Proračun';
@@ -4182,7 +4164,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get originalLanguageLabel => 'Izvirni jezik';
 
   @override
-  String get seasonsLabel => 'Sezone';
+  String get seasonsLabel => 'letni časi';
 
   @override
   String get episodesLabel => 'Epizode';
@@ -4251,7 +4233,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get networking => 'Mreženje';
 
   @override
-  String get next => 'Naslednji';
+  String get next => 'Naprej';
 
   @override
   String get path => 'Pot';
@@ -4275,7 +4257,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get refresh => 'Osveži';
 
   @override
-  String get remote => 'Daljinski upravljalnik';
+  String get remote => 'Daljinsko';
 
   @override
   String get rename => 'Preimenuj';
@@ -4287,13 +4269,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get role => 'Vloga';
 
   @override
-  String get root => 'Koren';
+  String get root => 'Root';
 
   @override
   String get run => 'Teči';
 
   @override
-  String get search => 'Išči';
+  String get search => 'Iskanje';
 
   @override
   String get select => 'Izberite';
@@ -4311,7 +4293,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get status => 'Stanje';
 
   @override
-  String get stop => 'Ustavi';
+  String get stop => 'Stop';
 
   @override
   String get streaming => 'Pretakanje';
@@ -4320,7 +4302,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get time => 'Čas';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Prevara';
 
   @override
   String get uninstall => 'Odstrani';
@@ -4338,7 +4320,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get unmute => 'Vklop zvoka';
 
   @override
-  String get mute => 'Izklopi zvok';
+  String get mute => 'Mute';
 
   @override
   String get branding => 'Znamčenje';
@@ -4362,25 +4344,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminDrawerLibraries => 'Knjižnice';
 
   @override
-  String get adminDrawerDisplay => 'Prikaz';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Metapodatki';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Nastavitve NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Prekodiranje';
 
   @override
-  String get adminDrawerResume => 'Nadaljuj';
+  String get adminDrawerResume => 'Nadaljevanje';
 
   @override
   String get adminDrawerStreaming => 'Pretakanje';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Prevara';
 
   @override
   String get adminDrawerDevices => 'Naprave';
@@ -4432,22 +4414,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Na voljo posodobitve vtičnikov: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Vtičniki, ki zahtevajo ponovni zagon: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Neuspešna načrtovana opravila: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Nedavna opozorila/napake: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4506,7 +4488,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Napaka: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4533,7 +4515,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Ukaz ni uspel: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4555,13 +4537,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get sessionForward => 'Naprej';
 
   @override
-  String get sessionNext => 'Naslednji';
+  String get sessionNext => 'Naprej';
 
   @override
-  String get sessionVolumeDown => 'Glas. –';
+  String get sessionVolumeDown => 'Vol –';
 
   @override
-  String get sessionVolumeUp => 'Glas. +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4582,7 +4564,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audioCodec => 'Avdio kodek';
 
   @override
-  String get hwAccel => 'Strojno pospeševanje';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Dokončanje';
@@ -4597,14 +4579,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminClearDates => 'Jasni datumi';
 
   @override
-  String get adminActivitySeverityAll => 'Vse stopnje resnosti';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Časovno obdobje';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Dnevnika dejavnosti ni bilo mogoče naložiti: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4621,7 +4603,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Naprave ni bilo mogoče posodobiti: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4632,28 +4614,28 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Naprave ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Ali želite odstraniti napravo »$name«? Uporabnik se bo moral na tej napravi znova prijaviti.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Izbriši vse naprave';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Ali želite odstraniti $count naprav? Prizadeti uporabniki se bodo morali znova prijaviti. To ne vpliva na vašo trenutno napravo.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Naprave odstranjene';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Nekatere naprave so odstranjene, $count jih ni bilo mogoče odstraniti.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4682,7 +4664,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Pregleda ni bilo mogoče zagnati: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4693,12 +4675,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Knjižnica je preimenovana v »$name«';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Preimenovanje ni uspelo: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4706,17 +4688,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Knjižnica »$name« je izbrisana';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Knjižnice ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Poti ni bilo mogoče dodati: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4724,12 +4706,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Ali želite odstraniti »$path« iz te knjižnice?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Poti ni bilo mogoče odstraniti: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4737,7 +4719,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Možnosti ni bilo mogoče shraniti: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4769,258 +4751,251 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminMetadataCountryHint => 'npr. ZDA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Poti';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Možnosti';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Prenosniki';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Shranjevalniki metapodatkov';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Prenosniki podnapisov';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Prenosniki besedil';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Prenosniki metapodatkov: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Pridobivalniki slik: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ta strežnik za to vrsto knjižnice ne ponuja nobenih prenosnikov.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Splošno';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Metapodatki';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Vgrajeni podatki';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Podnapisi';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Slike';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serije';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Glasba';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmi';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Omogoči spremljanje v realnem času';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Zaznaj spremembe datotek in jih samodejno obdelaj.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Obravnavaj arhive kot predstavnostne datoteke';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Prikaži fotografije';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Shrani slikovno gradivo v predstavnostne mape';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Samodejno osveževanje metapodatkov';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Nikoli';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Privzeto';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Prikaz';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Prikaz knjižnice';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Prikaži pogled map z navadnimi predstavnostnimi mapami';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Prikaži posebne epizode v sezonah, v katerih so bile predvajane';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Združi filme v zbirke';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Združi serije v zbirke';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Prikaži zunanjo vsebino med predlogi';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Ravnanje z datumom dodajanja';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Uporabi datum dodajanja iz';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Datum pregleda v knjižnico';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum nastanka datoteke';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metapodatki in slike';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Prednostni jezik metapodatkov';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Poglavja';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Trajanje nadomestnih poglavij (sekunde)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Dolžina poglavij, ustvarjenih za vsebine, ki jih nimajo. Nastavite na 0, da to onemogočite.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Ločljivost slik poglavij';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Nastavitve NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metapodatki NFO so združljivi s Kodi in podobnimi odjemalci. Nastavitve veljajo za vse knjižnice, ki shranjujejo metapodatke NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Uporabnik, za katerega se v datotekah NFO shranjujejo podatki o gledanju';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Shrani poti do slik v datoteke NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Omogoči zamenjavo poti za poti do slik v NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopiraj slike extrafanart v mapo extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Brez';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dni';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Uporabi vgrajene naslove';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Uporabi vgrajene naslove za dodatke';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Uporabi vgrajene podatke o epizodah';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Dovoli vgrajene podnapise';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Dovoli vse';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Samo besedilne';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Samo slikovne';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Brez';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Preskoči prenos, če so prisotni vgrajeni podnapisi';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Preskoči prenos, če se zvočna sled ujema z jezikom prenosa';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Zahtevaj popolno ujemanje podnapisov';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Shrani podnapise v predstavnostne mape';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Izlušči slike poglavij';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Izlušči slike poglavij med pregledom knjižnice';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Omogoči luščenje slik trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Izlušči slike trickplay med pregledom knjižnice';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Shrani slike trickplay v predstavnostne mape';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Samodejno združi serije, ki so razpršene po več mapah';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Prikazano ime ničte sezone';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Omogoči pregled LUFS za normalizacijo glasnosti';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Prednostno uporabi nestandardno oznako izvajalcev';
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => 'Samodejno dodajaj filme v zbirke';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Zahtevano je ime knjižnice';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Knjižnice ni bilo mogoče ustvariti: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5046,27 +5021,27 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Ali želite onemogočiti uporabnika $name? Ne bo se mogel prijaviti.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Ali želite omogočiti uporabnika $name? Znova se bo lahko prijavil.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Uporabnik »$name« je onemogočen';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Uporabnik »$name« je omogočen';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Pravilnika uporabnika ni bilo mogoče posodobiti: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5083,7 +5058,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Uporabnika ni bilo mogoče ustvariti: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5103,7 +5078,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Shranjevanje ni uspelo: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5114,7 +5089,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Ni uspelo: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5137,7 +5112,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'Administratorji imajo popoln dostop do strežnika. Dodelite previdno.';
 
   @override
-  String get administrator => 'Skrbnik';
+  String get administrator => 'Administrator';
 
   @override
   String get adminHiddenUser => 'Skrit uporabnik';
@@ -5248,144 +5223,143 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminEnableAllChannels => 'Omogoči dostop do vseh kanalov';
 
   @override
-  String get adminParentalControl => 'Starševski nadzor';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Najvišja dovoljena starševska ocena';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Vsebina z višjo oceno bo temu uporabniku skrita.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Brez';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blokiraj elemente brez ocene ali z neprepoznano oceno';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Knjige';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanali';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV v živo';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmi';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Glasba';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Napovedniki';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serije';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Urniki dostopa';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Dovoli dostop samo med spodaj načrtovanimi časi. Če urnik ni nastavljen, je dostop dovoljen ves dan.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Dodaj urnik';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dan';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Začetek';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Konec';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Vsak dan';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Delovnik';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Vikend';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Nedelja';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Ponedeljek';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Torek';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Sreda';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Četrtek';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Petek';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sobota';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Dovoljene oznake';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Prikazana je samo vsebina s temi oznakami. Pustite prazno, če želite dovoliti vse.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blokirane oznake';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Vsebina s temi oznakami bo temu uporabniku skrita.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Dodaj oznako';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Omogočene naprave';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Omogočeni kanali';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Ponudnik overjanja';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Ponudnik ponastavitve gesla';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Največje število neuspelih prijav pred zaklepom';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Nastavite 0 za privzeto vrednost ali -1, da zaklep onemogočite.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Dostop do SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Dovoli ustvarjanje skupin in pridruževanje';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Dovoli pridruževanje skupinam';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Brez dostopa';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Dovoli brisanje vsebine iz';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5393,22 +5367,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Strežnik je vrnil HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Ali ste prepričani, da želite izbrisati uporabnika $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Uporabnik »$name« je izbrisan';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Uporabnika ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5429,7 +5403,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Ključa ni bilo mogoče ustvariti: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5440,7 +5414,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Ali želite preklicati ključ za $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5448,7 +5422,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Ključa ni bilo mogoče preklicati: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5468,30 +5442,29 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Žeton: $token\\nUstvarjeno: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Ustvari varnostno kopijo';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Izberite, kaj naj vsebuje varnostna kopija.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Zbirka podatkov';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Vedno vključeno';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Metapodatki';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Podnapisi';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Slike trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Ustvarjanje varnostne kopije ...';
@@ -5502,7 +5475,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Varnostne kopije ni bilo mogoče ustvariti: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5516,7 +5489,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Manifesta ni bilo mogoče naložiti: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5527,7 +5500,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Varnostne kopije ni bilo mogoče obnoviti: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5560,17 +5533,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Shranjeno v $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Datoteke ni bilo mogoče shraniti: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Ni bilo mogoče naložiti $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5581,7 +5554,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Opravil ni bilo mogoče naložiti: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5593,17 +5566,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Opravila ni bilo mogoče zagnati: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Opravila ni bilo mogoče ustaviti: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Opravila ni bilo mogoče naložiti: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5611,12 +5584,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Sprožilca ni bilo mogoče odstraniti: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Sprožilca ni bilo mogoče dodati: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5642,7 +5615,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ur';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5653,7 +5626,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Vtičnika ni bilo mogoče preklopiti: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5661,27 +5634,27 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Ali ste prepričani, da želite odstraniti »$name«?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Vtičnika ni bilo mogoče odstraniti: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Paketa ni bilo mogoče namestiti: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Posodobitve ni bilo mogoče namestiti: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Vtičnikov ni bilo mogoče naložiti: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5693,12 +5666,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Namesti posodobitev (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Kataloga ni bilo mogoče naložiti: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5720,17 +5693,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '»$name« bo odstranjen po ponovnem zagonu strežnika';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Odstranitev ni uspela: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Posodabljanje »$name« na v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5739,7 +5712,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Vtičnika ni bilo mogoče naložiti: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5747,7 +5720,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Različica $version';
+    return 'Version $version';
   }
 
   @override
@@ -5767,17 +5740,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Ali ste prepričani, da želite odstraniti »$name«?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Repozitorijev ni bilo mogoče shraniti: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Repozitorijev ni bilo mogoče naložiti: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5794,12 +5767,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Nastavitev vtičnika ni mogoče naložiti: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Ni bilo mogoče odpreti $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6041,7 +6014,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminBaseUrl => 'Osnovni URL';
 
   @override
-  String get adminBaseUrlHint => 'npr. /jellyfin';
+  String get adminBaseUrlHint => 'npr. /želefina';
 
   @override
   String get https => 'HTTPS';
@@ -6081,12 +6054,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Metapodatkov ni bilo mogoče naložiti: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Metapodatkov ni bilo mogoče shraniti: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6107,7 +6080,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Metapodatkov ni bilo mogoče osvežiti: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6122,7 +6095,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Oddaljeno iskanje ni uspelo: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6136,7 +6109,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Vrste vsebine ni bilo mogoče posodobiti: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6151,12 +6124,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Slika $imageType je posodobljena';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Slike ni bilo mogoče prenesti: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6167,27 +6140,27 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Slika $imageType je naložena';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Slike ni bilo mogoče naložiti: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Izbriši sliko $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Slika $imageType je izbrisana';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Slike ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6198,68 +6171,67 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Iskanje sprejemnikov ni uspelo: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Dodaj sprejemnik';
 
   @override
-  String get adminEditTuner => 'Uredi sprejemnik';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Sprejemnik M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Datoteka ali URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP naslov sprejemnika';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Razumljivo ime';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Omejitev hkratnih povezav';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Največje število pretokov, ki jih sprejemnik dovoli hkrati. Nastavite na 0 za neomejeno.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Nadomestna največja bitna hitrost pretakanja';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Uvozi samo priljubljene kanale';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Dovoli strojno prekodiranje';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Dovoli vsebnik za prekodiranje fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Dovoli deljenje pretokov';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Omogoči ponavljanje pretoka';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Prezri DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Beri vhod z izvorno hitrostjo sličic';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Uredi ponudnika';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6268,49 +6240,50 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Datoteka ali URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Predpona filmov';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategorije filmov';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => 'Več kategorij ločite z navpičnico.';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategorije za otroke';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategorije novic';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategorije športa';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Uporabniško ime';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Geslo';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Država';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Izberite državo';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Poštna številka';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Pridobi sporede';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Sporedi';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Omogoči vse sprejemnike';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Vrsta sprejemnika';
@@ -6320,7 +6293,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Sprejemnika ni bilo mogoče dodati: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6334,12 +6307,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Ponudnika ni bilo mogoče dodati: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Sprejemnika ni bilo mogoče odstraniti: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6347,16 +6320,16 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Sprejemnika ni bilo mogoče ponastaviti: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ta vrsta sprejemnika ne podpira ponastavitve.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Ponudnika ni bilo mogoče odstraniti: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6375,44 +6348,43 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Pot snemanja serije';
 
   @override
-  String get adminMovieRecordingPath => 'Pot za snemanje filmov';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Število dni podatkov sporeda';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Samodejno';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dni';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Pot do aplikacije za naknadno obdelavo';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumenti naknadne obdelave';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Shrani metapodatke NFO posnetkov';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Shrani slike posnetkov';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Časovna uskladitev';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Poti posnetkov';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Naknadna obdelava';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Podatki sporeda: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6420,7 +6392,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Nastavitev ni bilo mogoče shraniti: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6438,7 +6410,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Preslikav ni bilo mogoče posodobiti: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6455,15 +6427,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminGuideProviders => 'Ponudniki vodnikov';
 
   @override
-  String get adminRefreshGuideData => 'Osveži podatke sporeda';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Osveževanje podatkov sporeda se je začelo';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Opravilo za osveževanje sporeda na tem strežniku ni na voljo.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Dodaj ponudnika';
@@ -6473,26 +6444,26 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Pot posnetkov: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Pot serij: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Rezerva pred: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Rezerva po: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Iskanje sprejemnikov';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Preslikave kanalov';
@@ -6521,7 +6492,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Ali želite zdaj obnoviti varnostno kopijo $name?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6545,7 +6516,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminLiveTvTitle => 'Administracija televizije v živo';
 
   @override
-  String get adminApply => 'Uporabi';
+  String get adminApply => 'Prijavite se';
 
   @override
   String get adminNotSet => 'Ni nastavljeno';
@@ -6567,27 +6538,27 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'pred $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'pred $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'pred $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Ni bilo mogoče naložiti $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count zadetkov';
+    return '$count matches';
   }
 
   @override
@@ -6597,7 +6568,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Urejevalnik metapodatkov';
 
   @override
-  String get adminMetadataIdentify => 'Prepoznaj';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Vrsta';
@@ -6697,22 +6668,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Slika $imageType je posodobljena';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Slika $imageType je naložena';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Slika $imageType je izbrisana';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Slike ni bilo mogoče prenesti: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6721,12 +6692,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Slike ni bilo mogoče naložiti: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Izbriši sliko $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6735,12 +6706,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Slike ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Izberi sliko $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6773,7 +6744,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Na voljo je posodobitev: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6797,7 +6768,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Namesti posodobitev (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6809,7 +6780,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '»$name« se namešča...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6829,7 +6800,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Nastavitve $name';
+    return '$name Settings';
   }
 
   @override
@@ -6869,7 +6840,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Repozitorijev ni bilo mogoče naložiti: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6877,7 +6848,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Ali ste prepričani, da želite odstraniti »$name«?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6885,7 +6856,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Repozitorijev ni bilo mogoče shraniti: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7013,20 +6984,19 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Omogoči začetni zaslon';
 
   @override
-  String get adminBrandingSplashUpload => 'Naloži sliko';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Uvodni zaslon je posodobljen';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Uvodnega zaslona ni bilo mogoče naložiti';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Uvodni zaslon je odstranjen';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Ni uvodnega zaslona po meri';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Strojni pospešek';
@@ -7042,128 +7012,121 @@ class AppLocalizationsSl extends AppLocalizations {
       'Omogoči dekodiranje strojne opreme za:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Naprava QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Omogoči izboljšani dekodirnik NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Prednostno uporabi izvorni sistemski strojni dekodirnik';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Barvna globina strojnega dekodiranja';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bitno dekodiranje HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bitno dekodiranje VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      '8/10-bitno dekodiranje HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      '12-bitno dekodiranje HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Strojno kodiranje';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Dovoli kodiranje HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Dovoli kodiranje AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Omogoči Intelov nizkoenergijski kodirnik H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Omogoči Intelov nizkoenergijski kodirnik HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Preslikava tonov';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Omogoči preslikavo tonov';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Omogoči preslikavo tonov VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Omogoči preslikavo tonov VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritem preslikave tonov';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Način preslikave tonov';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Obseg preslikave tonov';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Zmanjšanje nasičenosti pri preslikavi tonov';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Vrh preslikave tonov';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter preslikave tonov';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Svetlost preslikave tonov VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast preslikave tonov VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Prednastavitve in kakovost';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Prednastavitev kodirnika';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF kodiranja H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF kodiranja H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Način razpletanja';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Podvoji hitrost sličic pri razpletanju';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Zvok';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Omogoči zvočno kodiranje VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Ojačitev zmiksanega zvoka';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Algoritem zmiksanja v stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Največja velikost vrste za multipleksiranje';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Samodejno';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Kodiranje';
@@ -7283,10 +7246,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminTaskNeverRun => 'Nikoli ne teci';
 
   @override
-  String get adminTaskStop => 'Ustavi';
+  String get adminTaskStop => 'Stop';
 
   @override
-  String get adminRunningTasks => 'Opravila v teku';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Teči';
@@ -7308,17 +7271,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Dnevno ob $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Vsak $day ob $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Vsakih $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7356,10 +7319,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ur',
-      few: '$count ure',
-      two: '$count uri',
-      one: '1 ura',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7387,17 +7348,17 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'pred $days d';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'pred $hours h';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'pred $minutes min';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7405,22 +7366,22 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours h';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day. $month.';
+    return '$month/$day';
   }
 
   @override
@@ -7434,50 +7395,49 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Osnovni URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'npr. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'npr. /želefina';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Javna vrata HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Zahtevaj HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Preusmeri vse oddaljene zahteve na HTTPS. Nima učinka, če strežnik nima veljavnega potrdila.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Geslo potrdila';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Nastavitve IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Omogoči IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Omogoči IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Omogoči samodejno preslikavo vrat';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Omrežja LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Z vejico ali novo vrstico ločen seznam IP naslovov ali podomrežij CIDR, ki se obravnavajo kot lokalno omrežje.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Objavljeni URI-ji strežnika';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Preslikajte podomrežje ali naslov na objavljen URL, npr. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Pot potrdila';
@@ -7507,11 +7467,11 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Medpomnilnik plina';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Zakasnitev omejevanja (sekunde)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Dovoli sprotno luščenje podnapisov';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Najmanjši odstotek nadaljevanja';
@@ -7561,30 +7521,29 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Vrste vsebine ni bilo mogoče posodobiti: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Prag počasnega odziva (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Omogoči opozorila o počasnem odzivu';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Omogoči Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Strežnik';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Metapodatki';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Poti';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Zmogljivost';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Pot predpomnilnika';
@@ -7596,7 +7555,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminGeneralServerName => 'Ime strežnika';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Prednostni jezik prikaza';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nastavitev ni bilo mogoče naložiti';
@@ -7606,12 +7565,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Preslikav ni bilo mogoče posodobiti: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Časovna omejitev: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7648,10 +7607,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# udeležencev',
-      few: '# udeleženci',
-      two: '# udeleženca',
-      one: '# udeleženec',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7695,7 +7652,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Element $index';
+    return 'Item $index';
   }
 
   @override
@@ -7743,12 +7700,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName se je pridružil skupini SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName je zapustil skupino SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7760,7 +7717,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Sinhroniziranje predvajanja s skupino $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7798,10 +7755,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'odkritih # vrstic',
-      few: 'odkrite # vrstice',
-      two: 'odkriti # vrstici',
-      one: 'odkrita # vrstica',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7836,26 +7791,26 @@ class AppLocalizationsSl extends AppLocalizations {
   String get offlineFileNotAvailable => 'Datoteka ni na voljo';
 
   @override
-  String get offlineSwitchServer => 'Zamenjaj strežnik';
+  String get offlineSwitchServer => 'Switch Server';
 
   @override
   String get offlineSavedMedia => 'Shranjeni mediji';
 
   @override
-  String get offlineBannerTitle => 'Niste povezani';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Prikazani so vaši prenosi';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Prenosi';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Strežnik ni dosegljiv';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Predvajanje iz prenosov, dokler se ne vrne';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7871,12 +7826,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Upravljanje predvajanja na napravi ni uspelo: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Upravljanje $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7887,7 +7842,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Ustavi $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7910,12 +7865,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Vnesite $length-mestno kodo PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Vnesite svojo $length-mestno kodo PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7928,41 +7883,41 @@ class AppLocalizationsSl extends AppLocalizations {
   String get pinForgot => 'Ste pozabili PIN?';
 
   @override
-  String get pinClear => 'Počisti';
+  String get pinClear => 'jasno';
 
   @override
   String get pinBackspace => 'vračalka';
 
   @override
-  String get quickConnectAuthorized => 'Zahteva Quick Connect je odobrena.';
+  String get quickConnectAuthorized => 'Zahteva za hitro povezavo je odobrena.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Koda Quick Connect je neveljavna ali potekla.';
+      'Koda za hitro povezavo je neveljavna ali potekla.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect ni podprt na tem strežniku.';
+      'Hitra povezava ni podprta na tem strežniku.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Kode Quick Connect ni bilo mogoče avtorizirati.';
+      'Kode za hitro povezavo ni bilo mogoče avtorizirati.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect je na tem strežniku onemogočen.';
+      'Hitra povezava je na tem strežniku onemogočena.';
 
   @override
   String get quickConnectForbidden =>
-      'Vaš račun ne more odobriti te zahteve Quick Connect.';
+      'Vaš račun ne more odobriti te zahteve za hitro povezavo.';
 
   @override
   String get quickConnectNotFound =>
-      'Kode Quick Connect ni bilo mogoče najti. Poskusite z novo kodo.';
+      'Kode za hitro povezavo ni bilo mogoče najti. Poskusi z novo kodo.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ni uspel: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7973,7 +7928,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Ukaz ni uspel: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8002,7 +7957,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Predvajanja na napravi ni bilo mogoče začeti: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8048,7 +8003,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Prenašanje $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8130,14 +8085,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get stillWatchingContent => 'Predvajanje je zaustavljeno. še gledaš?';
 
   @override
-  String get stillWatchingStop => 'Ustavi';
+  String get stillWatchingStop => 'Stop';
 
   @override
   String get stillWatchingContinue => 'Nadaljuj';
 
   @override
   String skipSegment(String segment) {
-    return 'Preskoči $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8148,12 +8103,12 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Prenašanje $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Prenašanje $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8190,7 +8145,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Dovoli vrtenje';
 
   @override
-  String get playerTooltipPrevious => 'Prejšnji';
+  String get playerTooltipPrevious => 'Prejšnja';
 
   @override
   String get playerTooltipSeekBack => 'Išči nazaj';
@@ -8215,13 +8170,13 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Skrij iz Nadaljuj z gledanjem';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Skrij iz Sledi';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Dodaj v zbirko';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8276,14 +8231,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsAlphabetical => 'Abecedno';
 
   @override
-  String get settingsConnectionSection => 'POVEZAVA';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Dovoli samopodpisana potrdila';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Zaupaj strežnikom s samopodpisanimi potrdili TLS ali potrdili zasebnega overitelja. Omogočite samo za strežnike, ki jih upravljate sami. S tem onemogočite preverjanje potrdil za vse povezave.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ZASEBNOST IN VARNOST';
@@ -8299,11 +8254,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'Tematski poudarki, ozadja, indikatorji gledanja in tematska glasba';
 
   @override
-  String get settingsDetailsScreen => 'Zaslon s podrobnostmi';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Slog, zabrisanost ozadja in vedenje zavihkov';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Domača stran';
@@ -8341,11 +8296,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Prikaži gumb Seerr v navigacijski vrstici';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Vedno prikaži besedilne oznake v zgornji navigacijski vrstici';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8413,7 +8368,8 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsSupportMoonfin => 'Podprite Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Kupite razvijalcu kavo';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'PRAVNO';
@@ -8447,10 +8403,8 @@ class AppLocalizationsSl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licenčnih obvestil',
-      few: '# licenčna obvestila',
-      two: '# licenčni obvestili',
-      one: '# licenčno obvestilo',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8500,17 +8454,16 @@ class AppLocalizationsSl extends AppLocalizations {
       'Preskočiti uvodne in končne elemente?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Odštevanje predstavnostnih odsekov';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Vrstica napredka';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Časovnik';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Brez';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Poziv uporabniku';
@@ -8545,13 +8498,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (priporočeno)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (starejši)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (podedovano)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (priporočeno)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Nadomestni Dolby Vision';
@@ -8620,7 +8573,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'Bitstream AC3 na zunanji dekoder';
 
   @override
-  String get settingsCinemaMode => 'Kinodvorana';
+  String get settingsCinemaMode => 'Cinema Mode';
 
   @override
   String get settingsCinemaModeSubtitle =>
@@ -8742,763 +8695,749 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nedavno izdano – $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Samodejno predvajaj naslednjo epizodo';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Samodejno predvajaj naslednjo epizodo, ko je na voljo.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Preskakuj tišino';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Samodejno preskoči tihe zvočne odseke, kadar to pretok podpira.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Dovoli zunanje zvočne učinke';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Aplikacijam z izenačevalnikom in učinki (npr. Wavelet) dovoli povezavo s predvajalnimi sejami Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Onemogoči tuneliranje';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Vsili predvajanje brez tuneliranja. Uporabno na napravah s prekinitvami zvoka in slike pri tuneliranju.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Omogoči tuneliranje';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Napredno. Zvok in sliko usmeri po povezani strojni poti. Privzeto izklopljeno, ker na nekaterih napravah povzroča izpade zvoka in slike.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Preslikaj Dolby Vision profil 7 v HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Pretoke Dolby Vision profil 7 predvajaj kot HEVC, združljiv s HDR10, na napravah brez podpore za Dolby Vision.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Uporabi vgrajene sloge podnapisov';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Uporabi barve, pisave in postavitev, vgrajene v sled podnapisov. Onemogočite, če želite uporabiti svoje nastavitve sloga podnapisov.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Uporabi vgrajene velikosti pisave podnapisov';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Uporabi namige o velikosti pisave, vgrajene v sled podnapisov. Onemogočite, če želite uporabiti velikost podnapisov iz svojih nastavitev sloga.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Prikaži podrobnosti vsebine';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Prikaži podrobnosti izbranega elementa na vrhu strani knjižnice.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Skrij ozadja med brskanjem?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Uporabi podrobne podnaslove';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Prikaži podrobno ali minimalno podvrstico na straneh knjižnice.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle =>
-      'Ali želite izbrisati shranjeno temo?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Ali želite odstraniti »$themeName« iz predpomnilnika te naprave?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Trgovina s temami';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Brskajte po temah skupnosti in jih shranjujte';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Shranite temo, da jo boste lahko uporabljali kot druge shranjene teme.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Trenutno ni na voljo nobene teme.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Trgovine s temami ni bilo mogoče naložiti. Preverite povezavo in poskusite znova.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Shrani';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Shrani in uporabi';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Shranjeno';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Te teme ni bilo mogoče naložiti.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Tema »$themeName« je shranjena.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Tema »$themeName« je izbrisana iz te naprave.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Teme »$themeName« ni bilo mogoče izbrisati.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Shranjene teme';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'To so teme, prenesene iz vtičnika Moonfin za trenutni strežnik. Z brisanjem odstranite samo to lokalno kopijo.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Za ta strežnik ni bilo najdenih shranjenih tem.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Trenutno aktivna';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Izbriši shranjeno temo';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Upravljajte prenesene teme vtičnika na tej napravi';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Urejevalnik tem';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Odprite urejevalnik tem Moonfin v brskalniku';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Domači zaslon';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Spodnja vrstica';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasični';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Sodobni';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Vrstice na domači strani';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Prikaz vrstic na domači strani';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Razdelki vrstic na domači strani';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Stikala vrstic na domači strani';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Omogočite ali onemogočite kategorije vrstic na domači strani glede na knjižnice';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Z vklopom spodnjih stikal prikažete vrstice v razdelkih domače strani.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasični ohrani vrsto slike in informacijsko prekrivko za vsako vrstico. Sodobni uporablja vrstice s prehodom iz pokončne slike v ozadje.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Prikaži vrstice priljubljenih';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'V razdelkih domače strani prikaži vrstice Priljubljeni filmi, Priljubljene serije in druge priljubljene.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Razvrščanje vrstic priljubljenih';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Vrstice priljubljenih razvrstite po datumu dodajanja, datumu izida, po abecedi in drugih merilih.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Prikaži vrstice zbirk';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'V razdelkih domače strani prikaži vrstice zbirk.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Razvrščanje vrstic zbirk';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Vrstice zbirk razvrstite po datumu dodajanja, datumu izida, po abecedi in drugih merilih.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Prikaži vrstice žanrov';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'V razdelkih domače strani prikaži vrstice žanrov.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Razvrščanje vrstic žanrov';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Vrstice žanrov razvrstite po datumu dodajanja, datumu izida, po abecedi in drugih merilih.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Elementi v vrsticah žanrov';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'V vrsticah žanrov prikaži filme, serije ali oboje.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Prikaži vrstice seznamov predvajanja';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'V razdelkih domače strani prikaži vrstice seznamov predvajanja.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Razvrščanje vrstic seznamov predvajanja';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Vrstice seznamov predvajanja razvrstite po datumu dodajanja, datumu izida, po abecedi in drugih merilih.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Prikaži zvočne vrstice';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'V razdelkih domače strani prikaži zvočne vrstice.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Razvrščanje zvočnih vrstic';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Zvočne vrstice razvrstite po datumu dodajanja, datumu izida, po abecedi in drugih merilih.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Zvočni seznami predvajanja';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Videz';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Postavitev';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tipkovnica';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Gumbi';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Izrisovanje';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfiguracija MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Zunanja aplikacija za predvajanje';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Nastavite zunanji predvajalnik, da omogočite možnost predvajanja z dolgim pritiskom';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Ob začetku predvajanja prikaži izbirnik aplikacij.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Nalaganje nameščenih predvajalnikov...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Povezava';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Cilj prekodiranja zvoka';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Podprto na tej napravi';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Ni podprto na tej napravi';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'Passthrough DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Pošlji bitni tok DTS:X (DTS UHD) v zunanji dekodirnik.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Passthrough TrueHD z Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Vedenje predvajalnika';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Izboljšave predvajanja';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Vedno vklopljeno.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Zamenjaj gumb Preskoči odjavno špico s prikazom Sledi';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Namesto gumba Preskoči odjavno špico prikaži prekrivko Sledi.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Usmerjanje predvajalnika';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders =>
-      'Prednostno uporabi programske dekodirnike';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Uporabi FFmpeg (zvok) in libgav1 (AV1) pred strojnimi dekodirniki. Onemogočite, če preneha delovati zvočni passthrough prek HDMI.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Predvajanje videa odpri v izbrani zunanji aplikaciji na Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Samodejno uvrščanje v vrsto';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Prednostno uporabi podnapise SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Pri samodejni izbiri daj prednost sledem podnapisov SDH/CC.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Spletna diagnostika';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Spletna diagnostika Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Na tej strani lahko diagnosticirate težave s povezljivostjo v brskalniku (CORS, mešana vsebina in nastavitve odkrivanja).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Zaznana napaka zaradi mešane vsebine';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Zaznana napaka CORS/preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin je zaznal, da stran HTTPS poskuša klicati URL strežnika prek HTTP. Brskalniki to zahtevo blokirajo, preden doseže vaš strežnik.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin je zaznal napako zahteve na ravni brskalnika, ki jo običajno povzročijo manjkajoče glave CORS ali preflight na predstavnostnem strežniku.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Ciljni URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Podrobnosti: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Trenutni kontekst izvajanja';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Shema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Način vtičnika';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Pregled WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Vsiljeni URL strežnika';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Privzeti URL strežnika';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl =>
-      'URL posredniškega strežnika za odkrivanje';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'ni nastavljeno';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Mešana vsebina';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Ta stran je naložena prek HTTPS, vendar en ali več nastavljenih URL-jev uporablja HTTP. Brskalniki stranem HTTPS preprečujejo klice na vmesnike API prek HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Rešitev: predstavnostni strežnik ali posredniško končno točko ponudite prek HTTPS ali pa Moonfin nalagajte prek HTTP samo v zaupanja vrednih lokalnih omrežjih.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'V trenutnih nastavitvah izvajanja ni zaznane očitne konfiguracije z mešano vsebino.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Kontrolni seznam CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Dovolite origin brskalnika v Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• V Access-Control-Allow-Headers vključite Authorization, X-Emby-Authorization in X-Emby-Token.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Izpostavite Content-Range in Accept-Ranges za pretakanje in iskanje po posnetku.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Na zahteve OPTIONS preflight odgovarjajte s 204.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
-  String get webDiagnosticsHeaderSnippetTitle => 'Primer glav (slog nginx)';
+  String get webDiagnosticsHeaderSnippetTitle =>
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Opomba';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Ta diagnostična pot je namenjena spletnim gradnjam. Če to vidite na drugi platformi, ta preverjanja morda ne veljajo.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Nazaj na izbiro strežnika';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Odjavi vse uporabnike';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Dovoljenje za mikrofon je trajno zavrnjeno. Omogočite ga v sistemskih nastavitvah.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Glasovno iskanje zahteva dovoljenje za mikrofon.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nismo razumeli. Poskusite znova.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected =>
-      'Zaznanega ni bilo nobenega govora.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Napaka mikrofona.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Glasovno iskanje potrebuje internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Glasovna storitev je zasedena. Poskusite znova.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Dovoljenje za mikrofon je trajno zavrnjeno.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Dovoljenje za mikrofon je zavrnjeno.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Prepoznavanje govora na tej napravi ni na voljo.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Odpri izbirnik izhoda iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Izbirnik izhoda AirPlay na tej napravi ni na voljo.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videi';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Oddaje';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Skladbe';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Foto albumi';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotografije';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Osebe';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Nedavno izdane epizode';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Poglej znova';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Gostujoči nastopi';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Nastopi (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Prispevki ekipe (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Glej s skupino';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Napake';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Opozorila';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Odpri v brskalniku';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Vgrajeni brskalnik na tej platformi ni na voljo.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Ali ste prepričani, da želite znova zagnati strežnik?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Ali ste prepričani, da želite zaustaviti strežnik? Znova ga boste morali zagnati ročno.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Notranje';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Nedejavno';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Ni najdenih uporabnikov';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Vašemu iskanju ne ustreza noben uporabnik';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Ni najdenih naprav';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Trenutnim filtrom ne ustreza nobena naprava';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Geslo je nastavljeno';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nastavljenega ni nobenega gesla';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Oddaljeni dostop';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Samo lokalno';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Analitike vsebin ni bilo mogoče naložiti';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Združena analitika po vseh predstavnostnih knjižnicah.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Najboljši izvajalci';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Najboljši avtorji';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Najboljši sodelujoči';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count knjižnic',
-      few: '$count knjižnice',
-      two: '$count knjižnici',
-      one: '1 knjižnica',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Za to izbiro še ni na voljo nobenih seštevkov indeksiranih vsebin.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Podrobnosti knjižnice';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Razčlenitev knjižnic';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Na voljo ni nobene knjižnice.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Upravljanje strežnika';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Podatki';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Predpomnilnik slik';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Predpomnilnik';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Dnevniki';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Metapodatki';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Prekodiranje';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'Ta strežnik ni vrnil nobenih poti.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent % porabljeno';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Dejavnost uporabnikov';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Sistemski dogodki';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Zahteva pozornost';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Strežnik';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Predvajanje';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Naprave';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Napredno';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Vtičniki';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV v živo';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Domači videi';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Mešana vsebina';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Domači videi in fotografije';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Mešani filmi in serije';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9510,301 +9449,299 @@ class AppLocalizationsSl extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Ni najdenih posnetkov';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'V arhivu .$extension ni najdenih slikovnih strani.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Vgrajeno izrisovanje ni uspelo ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Izrisovanje EPUB ni uspelo ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Manjka lokalna datoteka za bralnik: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status pri odpiranju podatkov knjige iz $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Na voljo ni nobene berljive končne točke knjige';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Nepodprta oblika stripovskega arhiva: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Vtičnik za razširjanje CBR na tej platformi ni na voljo.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Arhiva .cbr ni bilo mogoče razširiti.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Razširjanje CB7 na tej platformi ni na voljo.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Vtičnik za razširjanje CB7 na tej platformi ni na voljo.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Zapri ploščo žanrov';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Nalaganje naključnega izbora...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'NAKLJUČNO IZ KNJIŽNICE';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'NAKLJUČNI IZBOR';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'NAKLJUČNO PO ŽANRU';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Samodejno preklapljanje HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Samodejno omogoči HDR pri predvajanju videa HDR in ob izhodu obnovi način prikaza.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Na celotnem zaslonu';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Zamenjaj slikovno gradivo';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Manjka';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Omejitve prekodiranja';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton =>
-      'Ali želite počistiti vse slikovno gradivo?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Ali ste prepričani, da želite počistiti vse preneseno slikovno gradivo?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Potrdi čiščenje';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Ali ste prepričani, da želite počistiti element »$itemType«?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Naložiti?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Ločljivost: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Prikaži samo slikovno gradivo v jeziku vmesnika';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Potrdi čiščenje vsega';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Slika je bila uspešno naložena!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Slike ni bilo mogoče naložiti: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Slike ni bilo mogoče nastaviti: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Slike ni bilo mogoče izbrisati: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Vsega slikovnega gradiva ni bilo mogoče počistiti: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Da';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Plakat';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Ozadja';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Pasica';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotip';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Sličica';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafika';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika diska';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Zaslonska slika';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Sprednja stran ovitka';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Zadnja stran ovitka';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika menija';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'plakat';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ozadje';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'pasica';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotip';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'sličica';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafika';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafika diska';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'zaslonska slika';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'sprednja stran ovitka';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'zadnja stran ovitka';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafika menija';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Vse';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Visoka (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Srednja (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Nizka (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Viri';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Poglavja';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Zaznamki';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Zapiski';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Vrsta';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Časovnica';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Časovnica je prazna';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Celotna knjiga';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Osredotočena časovnica';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Izvozi zaznamke';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Izvozi zapiske';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Izvozi vse';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Izvoženo v $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Izvoz ni uspel: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Besedilo';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Dodaj zaznamek';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Dodaj zapisek';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Uredi zapisek';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Zapišite zapisek za ta trenutek';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Časovnik spanja';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Izklopljeno';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Konec poglavja';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Po meri';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'še $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9819,51 +9756,51 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Hitrost predvajanja';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Preostalo';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Preteklo';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Nazaj za $seconds s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Naprej za $seconds s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Prejšnje poglavje';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Naslednje poglavje';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Poglavje $current od $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Ni poglavij';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Zaenkrat ni zaznamkov';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Zaenkrat ni zapiskov';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Zaznamek dodan na $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Ponastavi na 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9871,249 +9808,249 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Shrani';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Prekliči';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Izbriši';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Nastavitve podnapisov';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Spremenite načine podnapisov, privzete jezike, videz in možnosti izrisovanja.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Izrisovanje podnapisov';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Možnosti prikaza';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Datum izida (naraščajoče)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Datum izida (padajoče)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Združi prispevke';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Združi več vlog';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Opozorilo o pisalnem dostopu do knjižnice';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Kako to odpraviti:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Storitvenemu uporabniku Jellyfin (npr. jellyfin ali Docker PUID/PGID) dodelite pravice za pisanje v mape vaše predstavnostne knjižnice na strežniku.\n\n2. Ali pa v nadzorni plošči Jellyfin pojdite v razdelek Libraries, uredite to knjižnico in onemogočite možnost »Save artwork into media folders«, da se slikovno gradivo shranjuje v notranjo zbirko podatkov Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Opusti';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Vaša knjižnica »$libraryName« je nastavljena tako, da shranjuje slikovno gradivo neposredno v predstavnostne mape (možnost »Save artwork into media folders« je omogočena). Vendar je Jellyfin preizkusil pisalni dostop in nima dovoljenja za pisanje datotek v ta imenik:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Videti je, da Jellyfin ni uspel posodobiti slikovnega gradiva. Vaša knjižnica je nastavljena tako, da shranjuje slikovno gradivo neposredno v predstavnostne mape (možnost »Save artwork into media folders« je omogočena). Ta napaka se običajno pojavi, kadar strežniški proces Jellyfin nima dovoljenja za pisanje datotek v vaše predstavnostne imenike.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Zunanji seznami';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Predvajaj znova';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Podatki o datoteki';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Velikost: $size  •  Oblika: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Prikaži vse zvočne sledi ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Prikaži vse sledi podnapisov ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Preverjanje zmožnosti neposrednega predvajanja...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Zmožnost neposrednega predvajanja: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Vsiljeno';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Predvajalnik ne podpira oblike vsebnika.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Video kodek ni podprt.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Zvočni kodek ni podprt.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Oblika podnapisov ni podprta (zahteva vžig v sliko).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Zvočni profil ni podprt.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Video profil ni podprt.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Raven videa ni podprta.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Ta naprava ne podpira ločljivosti videa.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Bitna globina videa ni podprta.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Hitrost sličic videa ni podprta.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Bitna hitrost datoteke presega omejitev pretakanja predvajalnika.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Bitna hitrost videa presega omejitev pretakanja.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Bitna hitrost zvoka presega omejitev pretakanja.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Število zvočnih kanalov ni podprto.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Po abecedi';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Vrstni red izida (naraščajoče)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Vrstni red izida (padajoče)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Po meri (povleci in spusti)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Možnosti razvrščanja seznama predvajanja';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Ponastavi razvrščanje';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Poglej znova S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Znova predvajaj seznam predvajanja';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Ni najdenih podnapisov.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Skrbniško upravljanje';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Pogon za izrisovanje (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller je sodobni GPU-izrisovalnik Flutterja za tekočejše animacije in manj zatikanja. Na nekaterih TV-škatlah in starejših grafičnih karticah lahko povzroči napake v prikazu ali črno sliko; v tem primeru ga izklopite. Samodejno izbere najboljšo privzeto nastavitev za vašo napravo. Za uveljavitev znova zaženite Moonfin.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Samodejno';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Vklopljeno';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Izklopljeno';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Zahtevan je ponovni zagon';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin se mora znova zagnati, da spremeni pogon za izrisovanje. Zaprite aplikacijo in jo znova odprite.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Zapri aplikacijo';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Osveži knjižnico';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Osveži vse knjižnice';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Datum dodajanja (najprej najstarejši)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Datum dodajanja (najprej najnovejši)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Po abecedi (A do Ž)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Po abecedi (Ž do A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Nalaganje analitike strežnika... $percentage %';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Ujemaj z virom';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 filmov';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 serij';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Najbolj priljubljeni filmi na IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Najbolj priljubljene serije na IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Najslabše ocenjeni filmi na IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Najbolje ocenjeni angleški filmi na IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -9,30 +9,30 @@ class AppLocalizationsSq extends AppLocalizations {
   AppLocalizationsSq([String locale = 'sq']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Fina e hënës';
 
   @override
-  String get accountPreferences => 'PREFERENCAT E LLOGARISË';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Gjuha e ndërfaqes';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Parazgjedhja e sistemit';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Hyni';
 
   @override
-  String get empty => 'Bosh';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Po lidhet me $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Lidhja e shpejtë';
 
   @override
   String get password => 'Fjalëkalimi';
@@ -51,7 +51,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get waitingForAuthorization => 'Në pritje të autorizimit...';
 
   @override
-  String get back => 'Prapa';
+  String get back => 'Mbrapa';
 
   @override
   String get serverUnavailable => 'Serveri është i padisponueshëm';
@@ -61,12 +61,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect nuk ofrohet: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect nuk ofrohet ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin versioni $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Të hiqet \"$serverName\" nga serverët tuaj?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -142,62 +142,62 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema e aplikacionit';
 
   @override
-  String get detailScreenStyle => 'Stili i ekranit të detajeve';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasik është paraqitja origjinale e centruar e Moonfin. Moderne është një paraqitje kinematike përshtatëse.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasik';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Moderne';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Skedat e zgjeruara';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Shfaq automatikisht përmbajtjen e skedës gjatë shfletimit të skedave. Çaktivizoje për të hapur dhe mbyllur secilën skedë manualisht.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Të shfaqen detajet teknike?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Shfaq kodekun, rezolucionin dhe informacionin e transmetimit në përmbledhjen e banerit';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistemi i rekomandimeve';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Përdor algoritmin e bibliotekës lokale Moonfin Recommends ose Metrikat e Ngjashmërisë online të TMDb. Shënim: rekomandimet online kërkojnë integrimin me Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Ngjashmëria TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Të zbatohet kufiri i klasifikimit prindëror?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Kufizo sugjerimet e Moonfin Recommends sipas klasifikimit prindëror të medias së synuar';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Stili i ndërfaqes';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatik përshtatet me pajisjen tuaj. Zgjidh Apple ose Material për të imponuar një pamje.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatik';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,41 +206,41 @@ class AppLocalizationsSq extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Cilësia e xhamit';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto zgjedh efektin më të mirë të xhamit për këtë pajisje. I plotë imponon turbullim real; I reduktuar përdor një xham të lehtë që kursen energjinë e GPU-së.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'I plotë';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'I reduktuar';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Kalo midis Moonfin dhe Neon Pulse pa e rifilluar aplikacionin';
 
   @override
-  String get customThemeTitle => 'Temë e personalizuar';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Temat e personalizuara ndryshojnë elementet vizuale në të gjithë Moonfin. Zgjidh një nga këto opsione që t\'i përshtatet stilit tuaj.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Parapëlqe tastierën e sistemit';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Përdor si parazgjedhje metodën e futjes së pajisjes tuaj për shkrimin e tekstit';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Fina e hënës';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -254,18 +254,18 @@ class AppLocalizationsSq extends AppLocalizations {
       'Stilim Synthwave me shkëlqim magenta, tekst cian dhe kontrast më të fortë kromi';
 
   @override
-  String get themeGlass => 'Xham';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Stilim me xham të lëngshëm, sfond me gradient lëvizës, sipërfaqe të ngrira dhe theks blu Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'Heroi 8-bit';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Stilim retro me pixel-art, paletë të trashë, korniza blloqesh, hije të forta dhe font pikselësh';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => 'Hyni me llogarinë tuaj Emby Connect';
@@ -314,7 +314,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Nuk mund të lidhet me $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,36 +327,35 @@ class AppLocalizationsSq extends AppLocalizations {
   String get exit => 'Dilni';
 
   @override
-  String get gameMenu => 'Menyja';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Në pauzë';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Ruaj gjendjen';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Lojëra';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Ngarko gjendjen';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Përshpejto';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Cilësimet e emulatorit';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Kjo bërthamë nuk ka opsione të rregullueshme.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Mbaj shtypur për të hapur menynë';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Luajtja e lojërave nuk mbështetet ende në këtë pajisje.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -379,13 +378,13 @@ class AppLocalizationsSq extends AppLocalizations {
   String get schedule => 'Orari';
 
   @override
-  String get series => 'Serialet';
+  String get series => 'Seria';
 
   @override
   String get noItemsFound => 'Nuk u gjet asnjë artikull';
 
   @override
-  String get home => 'Kreu';
+  String get home => 'Shtëpi';
 
   @override
   String get browseAll => 'Shfleto të gjitha';
@@ -431,7 +430,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Ngarkimi i dosjes dështoi: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -439,7 +438,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count artikuj';
+    return '$count items';
   }
 
   @override
@@ -456,7 +455,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Artikuj';
+    return '$count Items';
   }
 
   @override
@@ -493,11 +492,11 @@ class AppLocalizationsSq extends AppLocalizations {
   String get large => 'I madh';
 
   @override
-  String get extraLarge => 'Shumë i madh';
+  String get extraLarge => 'Extra Large';
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Zhanret';
+    return '$name — Genres';
   }
 
   @override
@@ -536,17 +535,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count min më parë';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count orë më parë';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count ditë më parë';
+    return '${count}d ago';
   }
 
   @override
@@ -557,7 +556,7 @@ class AppLocalizationsSq extends AppLocalizations {
       'Zgjidh se cili subjekt ushqehet për të shfaqur në \"Zbulo\".';
 
   @override
-  String get apply => 'Zbato';
+  String get apply => 'Aplikoni';
 
   @override
   String get openLink => 'Hap lidhjen';
@@ -581,7 +580,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count tituj';
+    return '$count titles';
   }
 
   @override
@@ -607,7 +606,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get listen => 'Dëgjo';
 
   @override
-  String get resume => 'Vazhdo';
+  String get resume => 'Rezyme';
 
   @override
   String get failedToLoadLibrary => 'Ngarkimi i bibliotekës dështoi';
@@ -669,17 +668,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count autorë';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count zhanre';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% e përfunduar';
+    return '$percent% completed';
   }
 
   @override
@@ -696,7 +695,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count tituj të renditur për shfletim me leximin në plan të parë.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -733,7 +732,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Nuk u gjet asnjë $label';
+    return 'No $label found';
   }
 
   @override
@@ -752,13 +751,13 @@ class AppLocalizationsSq extends AppLocalizations {
   String get readStatus => 'Lexoni';
 
   @override
-  String get watched => 'Të shikuara';
+  String get watched => 'Shikuar';
 
   @override
   String get unread => 'Të palexuara';
 
   @override
-  String get unwatched => 'Të pashikuara';
+  String get unwatched => 'I pashikuar';
 
   @override
   String get seriesStatus => 'Statusi i Serisë';
@@ -770,43 +769,43 @@ class AppLocalizationsSq extends AppLocalizations {
   String get books => 'libra';
 
   @override
-  String get latestBooks => 'Librat më të fundit';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Audiolibrat më të fundit';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count libra',
-      one: '1 libër',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Libër';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Audiolibër';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% i lexuar';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time të mbetura';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Lexo';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Dëgjo';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autori';
@@ -837,19 +836,19 @@ class AppLocalizationsSq extends AppLocalizations {
   String get internetArchive => 'Arkivi i Internetit';
 
   @override
-  String get rssFeed => 'Burim RSS';
+  String get rssFeed => 'RSS Feed';
 
   @override
   String get downloadZip => 'Shkarko Zip';
 
   @override
   String sectionCountLabel(int count) {
-    return '$count seksione';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Botuar për herë të parë më $year';
+    return 'First published $year';
   }
 
   @override
@@ -864,7 +863,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count libra';
+    return '$count books';
   }
 
   @override
@@ -876,7 +875,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Autorë';
+    return '$count Authors';
   }
 
   @override
@@ -884,8 +883,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiolibra',
-      one: '1 audiolibër',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -900,7 +899,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get failedToLoad => 'Ngarkimi dështoi';
 
   @override
-  String get delete => 'Fshi';
+  String get delete => 'Fshije';
 
   @override
   String get save => 'Ruaj';
@@ -909,7 +908,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get moreLikeThis => 'Më shumë si kjo';
 
   @override
-  String get castAndCrew => 'Aktorët dhe ekipi';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Mbledhja';
@@ -918,10 +917,10 @@ class AppLocalizationsSq extends AppLocalizations {
   String get episodes => 'Episodet';
 
   @override
-  String get nextUp => 'Në vijim';
+  String get nextUp => 'Next Up';
 
   @override
-  String get seasons => 'Sezonet';
+  String get seasons => 'Stinët';
 
   @override
   String get chapters => 'Kapitujt';
@@ -933,7 +932,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get movies => 'Filmat';
 
   @override
-  String get musicVideos => 'Videoklipe muzikore';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Të tjera';
@@ -952,7 +951,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disku $number';
+    return 'Disc $number';
   }
 
   @override
@@ -977,7 +976,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Botuar më $year';
+    return 'Published $year';
   }
 
   @override
@@ -988,52 +987,52 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Sezone',
-      one: '1 Sezon',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Përfundon në $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Artikuj';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Ekstra';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Prapa skenave';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Skena të fshira';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Dokumentarë të shkurtër';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervista';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Skena';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Filma të shkurtër';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailerat';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time të mbetura';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Përfundon pas $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1047,7 +1046,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Vazhdo nga $position';
+    return 'Resume from $position';
   }
 
   @override
@@ -1075,10 +1074,10 @@ class AppLocalizationsSq extends AppLocalizations {
   String get version => 'Versioni';
 
   @override
-  String get cast => 'Transmeto';
+  String get cast => 'Cast';
 
   @override
-  String get trailer => 'Trailer';
+  String get trailer => 'Rimorkio';
 
   @override
   String get finished => 'Përfunduar';
@@ -1146,7 +1145,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Të fshihen pistat e shkarkuara për \"$title\"?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1161,17 +1160,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Asnjë $itemLabel nuk u ngarkua';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Po shkarkohet $title ($count artikuj)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Jeni i sigurt që doni të fshini \"$name\" nga serveri? Ky veprim nuk mund të zhbëhet.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1183,7 +1182,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Format libri i pambështetur: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1210,7 +1209,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Titra u shkarkua dhe u zgjodh: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1219,7 +1218,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Nuk u gjetën titra online për $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1227,7 +1226,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Versioni $number';
+    return 'Version $number';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Po shkarkohet $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1255,7 +1254,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Të fshihen skedarët lokalë për $typeLabel?\n\nKjo do të lirojë hapësirë ruajtjeje. Mund t\'i rishkarkoni më vonë.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1271,25 +1270,25 @@ class AppLocalizationsSq extends AppLocalizations {
   String get director => 'DREJTOR';
 
   @override
-  String get directors => 'REGJISORËT';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SKENARISTI';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SKENARISTËT';
+  String get writers => 'SHKRIMTARËT';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count të tjera';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count Episode';
+    return '$count Episodes';
   }
 
   @override
@@ -1299,12 +1298,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Episodi $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Kapitulli $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1312,8 +1311,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pista',
-      one: '1 pistë',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1323,25 +1322,25 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapituj',
-      one: '1 kapitull',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Lindur më $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Vdiq më $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Mosha $age';
+    return 'Age $age';
   }
 
   @override
@@ -1351,20 +1350,20 @@ class AppLocalizationsSq extends AppLocalizations {
   String get readMore => 'Lexo më shumë';
 
   @override
-  String get shuffle => 'Përziej';
+  String get shuffle => 'Përzierje';
 
   @override
-  String get shuffleAllMusic => 'Luaj rastësisht të gjithë muzikën';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Hyni në Moonfin në telefonin tuaj';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Serveri juaj nuk arrihet';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count shkarkime';
+    return '$count downloads';
   }
 
   @override
@@ -1372,7 +1371,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kanale';
+    return '${count}ch';
   }
 
   @override
@@ -1383,32 +1382,32 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '$action i titrave online kërkon lejen e menaxhimit të titrave në Jellyfin për këtë përdorues.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Ky artikull nuk u gjet në server për $action e titrave online.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '$action i titrave online dështoi: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '$action i titrave online dështoi (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Nuk u arrit të $action titrat online.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'të gjitha episodet e shkarkuara për \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1440,17 +1439,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Veprimi $label dështoi: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Vendosja e volumit të transmetimit dështoi: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Kontrollet e $label';
+    return '$label Controls';
   }
 
   @override
@@ -1460,14 +1459,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get unavailable => 'I padisponueshëm';
 
   @override
-  String get pause => 'Pauzë';
+  String get pause => 'Ndalo';
 
   @override
   String get syncPosition => 'Pozicioni i sinkronizimit';
 
   @override
   String stopCast(String label) {
-    return 'Ndalo $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1475,7 +1474,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Pista $number';
+    return 'Track $number';
   }
 
   @override
@@ -1492,14 +1491,14 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sekonda';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'Shtypni gjatë për ta zhbllokuar';
 
   @override
-  String get off => 'Fikur';
+  String get off => 'Joaktiv';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1561,7 +1560,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get transcodeReasons => 'Arsyet e transkodimit';
 
   @override
-  String get player => 'Luajtësi';
+  String get player => 'Lojtar';
 
   @override
   String get container => 'Enë';
@@ -1607,12 +1606,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Gabim në sesionin $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Ngarkimi i detajeve të librit dështoi: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1621,7 +1620,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Ky format (.$extension) nuk mund të paraqitet ende brenda aplikacionit.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1634,17 +1633,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Hapja e lexuesit brenda aplikacionit dështoi: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Faqeshënuesi është ruajtur tashmë te $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Faqeshënuesi u shtua: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1656,7 +1655,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Faqja $number';
+    return 'Page $number';
   }
 
   @override
@@ -1667,12 +1666,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Formati: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% i lexuar';
+    return '$percent% read';
   }
 
   @override
@@ -1696,7 +1695,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Rivendos zmadhimin (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1719,7 +1718,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Përditësimi i gjendjes së leximit dështoi: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1753,7 +1752,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Kjo platformë nuk mund të presë motorin e integruar të dokumenteve për skedarët $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1792,7 +1791,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Ngarkimi i udhëzuesit dështoi: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1803,22 +1802,22 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Tjetra: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min të mbetura';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours orë të mbetura';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours orë e $minutes min të mbetura';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1841,29 +1840,29 @@ class AppLocalizationsSq extends AppLocalizations {
   String get favoriteChannel => 'Kanali i preferuar';
 
   @override
-  String get record => 'Regjistro';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Anulo regjistrimin';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Programi u caktua për regjistrim';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Regjistrimi u anulua';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Regjistrimi nuk mund të krijohet';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Shiko';
+  String get watch => 'Shikoni';
 
   @override
-  String get close => 'Mbyll';
+  String get close => 'Mbylle';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Luajtja e $name dështoi';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1889,11 +1888,11 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Të anulohet regjistrimi i planifikuar i \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Jo';
+  String get no => 'Nr';
 
   @override
   String get yesCancel => 'Po, Anulo';
@@ -1917,7 +1916,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Të ndalohet regjistrimi i \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1932,19 +1931,19 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Asnjë rezultat për \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Kërkimi dështoi: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Lloji i llogarisë Seerr';
+  String get seerrAccountType => 'Lloji i llogarisë Seer';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1978,12 +1977,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Të hiqet \"$name\" dhe skedarët e tij?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count pista';
+    return '$count tracks';
   }
 
   @override
@@ -1994,12 +1993,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Ngarkimi i albumit dështoi: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Nuk u gjetën pista të shkarkuara për $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2016,7 +2015,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Të hiqet \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2031,7 +2030,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Episodi $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2045,7 +2044,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sezoni $number';
+    return 'Season $number';
   }
 
   @override
@@ -2061,7 +2060,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Të fshihen të gjitha episodet e shkarkuara në $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2069,8 +2068,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episode',
-      one: '1 episod',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2105,7 +2104,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Të fshihen $count artikuj të shkarkuar?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2119,7 +2118,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'nga kufiri $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2205,7 +2204,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count opsione';
+    return '$count options';
   }
 
   @override
@@ -2300,7 +2299,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Faqet e detajeve, rreshtat e kreut dhe volumi';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2314,11 +2313,11 @@ class AppLocalizationsSq extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Luaj kur shfleton ekranin bazë';
 
   @override
-  String get loopThemeMusic => 'Përsërit muzikën e temës';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Përsërit pistën në vend që ta luash vetëm një herë';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detajet turbullimi i sfondit';
@@ -2341,23 +2340,23 @@ class AppLocalizationsSq extends AppLocalizations {
   String get playerZoomMode => 'Modaliteti i zmadhimit të lojtarit';
 
   @override
-  String get settingsScrollWheelAction => 'Rrota e miut';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Zgjidh çfarë bën rrotullimi i rrotës së miut mbi video gjatë luajtjes.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Fikur';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Lëviz (përpara / prapa)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Volumi';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Volumi';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Përshtatet';
@@ -2372,7 +2371,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get refreshRateSwitching => 'Ndërrimi i shpejtësisë së rifreskimit';
 
   @override
-  String get disabled => 'Çaktivizuar';
+  String get disabled => 'I paaftë';
 
   @override
   String get scaleOnTv => 'Shkallë në TV';
@@ -2411,38 +2410,37 @@ class AppLocalizationsSq extends AppLocalizations {
   String get defaultAudioLanguage => 'Gjuha e parazgjedhur e audios';
 
   @override
-  String get fallbackAudioLanguage => 'Gjuha rezervë e audios';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Parapëlqe pistën audio të parazgjedhur';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Parapëlqe pistën audio origjinale para dublimit të lokalizuar.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Parapëlqe pistat me përshkrim audio';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Parapëlqe pistat me përshkrim audio para pistave normale.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodim (Audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Transmetim i drejtpërdrejtë (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodim (Bitrate ose rezolucion)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodim (Video dhe audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodim (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (Serveri i parazgjedhur)';
@@ -2481,7 +2479,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get arabic => 'arabisht';
 
   @override
-  String get hindi => 'Hindisht';
+  String get hindi => 'Hindi';
 
   @override
   String get dutch => 'holandeze';
@@ -2502,7 +2500,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get polish => 'polonisht';
 
   @override
-  String get ac3Passthrough => 'Kalim i drejtpërdrejtë AC3';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
   String get dtsPassthrough => 'Kalimi DTS';
@@ -2519,29 +2517,27 @@ class AppLocalizationsSq extends AppLocalizations {
       'Aktivizo audion TrueHD (mund të mos funksionojë në të gjitha platformat)';
 
   @override
-  String get settingsAudioOutputMode => 'Modaliteti i daljes audio';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Zgjidh se si dekodohet audioja. Kalimi i drejtpërdrejtë AVR dërgon transmetime të papërpunuara Dolby/DTS te marrësi juaj; Auto ose Downmix dekodon lokalisht.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough =>
-      'Kalim i drejtpërdrejtë AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Kodeku rezervë i audios';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Zgjidh formatin e synuar për të transkoduar audion shumëkanalëshe kur transmetimi burimor nuk mund të luhet drejtpërdrejt ose të kalojë i papërpunuar.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Zbulim automatik\n(Rekomandohet)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Parazgjedhur)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2550,27 +2546,26 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Pa humbje)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Vetëm stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efikas)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Pa humbje)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Kanalet maksimale audio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Konfiguro kanalet maksimale të sistemit tuaj audio. Transmetimet shumëkanalëshe që e tejkalojnë këtë kufi do të përzihen poshtë ose do të transkodohen.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Zbulim automatik\n(Parazgjedhja e harduerit)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2579,91 +2574,85 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Rrethues';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kuadrafonik';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Rrethues';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Rrethues';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Rrethues';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Rrethues';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced =>
-      'Kalim i drejtpërdrejtë (I avancuar)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough =>
-      'Kalim i drejtpërdrejtë i kodekut';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Aktivizo vetëm formatet që mbështet AVR-ja ose pajisja juaj HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Kalim i drejtpërdrejtë EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough =>
-      'Kalim i drejtpërdrejtë EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough =>
-      'Kalim i drejtpërdrejtë DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough =>
-      'Kalim i drejtpërdrejtë DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Kalim i drejtpërdrejtë TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough =>
-      'Kalim i drejtpërdrejtë TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dërgo bitstream Dolby Digital Plus (EAC3) te dekoduesi i jashtëm.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Dërgo bitstream Dolby Atmos përmes EAC3 (JOC) te dekoduesi i jashtëm.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Dërgo bitstream DTS-HD MA (përfshin DTS core) te dekoduesi i jashtëm.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Dërgo bitstream Dolby TrueHD me metadata Atmos te dekoduesi i jashtëm.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Aftësitë audio të zbuluara';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Ende nuk ofrohet asnjë fotografi e aftësive në kohë ekzekutimi.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Rruga';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Dekodimi';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Kalim i drejtpërdrejtë';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Rrugë audio HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2678,50 +2667,50 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Altoparlant';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Kufje';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kanale PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostikimi';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Niveli i videos';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Gama e videos';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodeku i titrave';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Kodekët audio të lejuar';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Kodekët audio HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Kodekët audio HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'kalim i drejtpërdrejtë audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Rruga aktive audio';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Mbështetja e audios HD në rrugë';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Modaliteti i natës';
@@ -2785,7 +2774,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Pas $episodes episodesh / $hours orësh';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2860,45 +2849,45 @@ class AppLocalizationsSq extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Personalizo pamjen e titrave';
 
   @override
-  String get subtitleMode => 'Modaliteti i titrave';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Të shënuara';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Gjithmonë';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Të huaja';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Të detyruara';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Luan pistat që janë shënuar brenda metadatave të skedarit media si \"të parazgjedhura\" ose \"të detyruara\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Ngarkon dhe shfaq automatikisht titrat sa herë që fillon një video.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Aktivizon automatikisht titrat nëse pista audio e parazgjedhur është në një gjuhë të huaj.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Ngarkon vetëm titrat e etiketuara shprehimisht me shenjën e metadatave \"të detyruara\".';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Çaktivizon plotësisht ngarkimin automatik të titrave.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Gjuha rezervë e titrave';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Transmetimi i titrave';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2932,7 +2921,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get green => 'E gjelbër';
 
   @override
-  String get cyan => 'Cian';
+  String get cyan => 'Cyan';
 
   @override
   String get red => 'E kuqe';
@@ -2957,17 +2946,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'U ngarkuan cilësimet e profilit $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Ngarkimi i cilësimeve të profilit $profile dështoi.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Cilësimet lokale u sinkronizuan me profilin $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3085,7 +3074,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get navigationStyle => 'Stili i lundrimit';
 
   @override
-  String get topBar => 'Shiriti i sipërm';
+  String get topBar => 'Top Bar';
 
   @override
   String get leftSidebar => 'Shiriti anësor i majtë';
@@ -3104,11 +3093,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq bibliotekat në shiritin e veglave';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Shfaq gjithmonë etiketat e shiritit të navigimit';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Shfaq butonin Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opaciteti i Navbarit';
@@ -3126,7 +3114,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get purple => 'Vjollcë';
 
   @override
-  String get teal => 'Gurkali';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'Marina';
@@ -3144,7 +3132,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get darkGreen => 'Jeshile e errët';
 
   @override
-  String get slate => 'Rrasë';
+  String get slate => 'Slate';
 
   @override
   String get indigo => 'Lejla';
@@ -3159,7 +3147,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get thumbnailLabel => 'Miniatura';
 
   @override
-  String get bannerLabel => 'Baner';
+  String get bannerLabel => 'Banner';
 
   @override
   String get overridePerLibrarySettings => 'Anuloni cilësimet për bibliotekë';
@@ -3183,19 +3171,18 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq opsionin e shfletimit të dosjeve';
 
   @override
-  String get groupItemsIntoCollections => 'Grupo artikujt në koleksione';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Fshih artikujt e bibliotekës të lidhur me koleksionin gjatë shfletimit të bibliotekave';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Njoftim për grupimin e bibliotekës';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Për të përdorur këtë cilësim, sigurohuni që cilësimet e bibliotekës \"Grupo filmat në koleksione\" dhe/ose \"Grupo serialet në koleksione\" të jenë aktivizuar te cilësimet e Shfaqjes së bibliotekës tuaj në serverin tuaj Jellyfin ose Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Dukshmëria e Bibliotekës';
@@ -3224,7 +3211,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count të zgjedhur';
+    return '$count selected';
   }
 
   @override
@@ -3254,13 +3241,13 @@ class AppLocalizationsSq extends AppLocalizations {
       'Zgjidhni midis stileve të ndryshme të shiritit të medias ose çaktivizoni shiritin e medias';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Fina e hënës';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Fikur';
+  String get mediaBarModeOff => 'Joaktiv';
 
   @override
   String get enableMediaBar => 'Aktivizo shiritin e medias';
@@ -3307,11 +3294,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Luaj automatikisht rimorkio në shiritin e medias pas 3 sekondash';
 
   @override
-  String get trailerAudio => 'Audioja e trailerit';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Aktivizo audion për trailerët në shiritin e medias';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Pamja paraprake e episodit';
@@ -3390,11 +3376,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Kombinoni të dy rreshtat në një seksion të vetëm shtëpiak';
 
   @override
-  String get fullScreenRows => 'Rreshtat e zgjeruar të kreut';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Kufizo rreshtat e kreut në 1 rresht për ekran';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Lloji i imazhit për rresht';
@@ -3409,7 +3394,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get lastUser => 'Përdoruesi i fundit';
 
   @override
-  String get currentUser => 'Përdoruesi aktual';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentifiko gjithmonë';
@@ -3477,7 +3462,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get libraryArt => 'Arti i Bibliotekës';
 
   @override
-  String get logo => 'Logoja';
+  String get logo => 'Logo';
 
   @override
   String get clock => 'Ora';
@@ -3518,10 +3503,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq orën gjatë ruajtjes së ekranit';
 
   @override
-  String get clockModeStatic => 'Statik';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Kërcyes';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Domate të kalbura (Kritikë)';
@@ -3594,7 +3579,7 @@ class AppLocalizationsSq extends AppLocalizations {
       'Aktivizo dhe rirendit burimet e vlerësimit të shfaqura në të gjithë aplikacionin';
 
   @override
-  String get pluginLabel => 'Shtojca Moonbase';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'U zbulua shtojca';
@@ -3612,7 +3597,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nVersioni: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3666,7 +3651,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get networks => 'Rrjetet';
 
   @override
-  String get seerrDiscoveryRows => 'Rreshtat e zbulimit Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Rivendosni rreshtat në parazgjedhje';
@@ -3680,7 +3665,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get seerrUnavailable =>
-      'Nuk ofrohet sepse mbështetja për Seerr në shtojcën e serverit është e çaktivizuar.';
+      'I padisponueshëm sepse mbështetja e Serr-it të shtojcës së serverit është çaktivizuar.';
 
   @override
   String get nsfwFilter => 'Filtri NSFW';
@@ -3689,44 +3674,44 @@ class AppLocalizationsSq extends AppLocalizations {
   String get hideAdultContent => 'Fshih përmbajtjen për të rritur në rezultate';
 
   @override
-  String get seerrNotificationsSection => 'Njoftimet';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Njoftime për kërkesa të reja';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Njoftomë kur dikush dërgon një kërkesë';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Përditësime të kërkesave';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Të miratuara, të refuzuara dhe të shtuara në bibliotekën tuaj';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Përditësime të problemeve';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Probleme të reja, përgjigje dhe zgjidhje';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'I identifikuar si: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Faqja e zbulimit Seerr';
+  String get discoverRows => 'Zbuloni Rreshtat';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktivizo rreshtat që dëshiron të shohësh në faqen kryesore të Seerr. Tërhiq për t\'i rirenditur. Renditja e personalizuar sinkronizohet me Moonbase.';
+      'Tërhiqeni për ta rirenditur. Aktivizo ose çaktivizo rreshtat. Sinkronizimi i rendit të rreshtit të aktivizuar me shtesën Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktivizo rreshtat që dëshiron të shohësh në faqen kryesore të Seerr. Tërhiq për t\'i rirenditur. Renditja e personalizuar sinkronizohet me Moonbase.';
+      'Tërhiqeni për ta rirenditur. Aktivizo ose çaktivizo rreshtat.';
 
   @override
   String get enabled => 'Aktivizuar';
@@ -3739,7 +3724,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Versioni $version';
+    return 'Version $version';
   }
 
   @override
@@ -3789,7 +3774,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Përditësim i disponueshëm: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3801,7 +3786,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version është i disponueshëm';
+    return 'v$version Available';
   }
 
   @override
@@ -3843,8 +3828,7 @@ class AppLocalizationsSq extends AppLocalizations {
       'Madhësia e posterit, lloji i imazhit, pamja e dosjes';
 
   @override
-  String get mdbListTmdbRatingSources =>
-      'MDBList, TMDB dhe burimet e vlerësimeve';
+  String get mdbListTmdbRatingSources => 'MDBLlist, TMDB dhe burime vlerësimi';
 
   @override
   String gbValue(String value) {
@@ -3866,7 +3850,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get imageCacheCleared => 'Memoria e fshehtë e imazheve u pastrua';
 
   @override
-  String get clear => 'Pastro';
+  String get clear => 'E qartë';
 
   @override
   String get browse => 'Shfletoni';
@@ -3882,19 +3866,19 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Po shkarkohet · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Po importohet';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count Artikuj';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Cilësimet e Seerr';
+  String get seerrSettings => 'Cilësimet e shikuesit';
 
   @override
   String get requestMore => 'Kërkoni më shumë';
@@ -3910,7 +3894,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Kërkuar nga $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3927,12 +3911,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Të anulohet kërkesa për \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Të anulohen $count kërkesa për \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3947,12 +3931,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Buxheti: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Të ardhurat: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3962,7 +3946,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Kërko $type';
+    return 'Request $type';
   }
 
   @override
@@ -3998,7 +3982,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'mosha $age';
+    return 'age $age';
   }
 
   @override
@@ -4029,102 +4013,102 @@ class AppLocalizationsSq extends AppLocalizations {
   String get deletedStatus => 'Fshirë';
 
   @override
-  String get failedStatus => 'Dështoi';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Në përpunim';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Modifikuar nga $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Përfunduar';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Ky titull është kërkuar tashmë';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'U arrit kufiri i kërkesave';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Ky titull është në listën e bllokuar';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Nuk ka mbetur asnjë sezon për të kërkuar';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Nuk keni leje për ta bërë këtë kërkesë';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Kërkesat';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problemet';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Më të rejat';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Modifikuar së fundmi';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Asnjë problem';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Kanë mbetur $remaining nga $limit kërkesa filmash';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Kanë mbetur $remaining nga $limit kërkesa sezonesh';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Pjesë e $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Shiko koleksionin';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Kërko koleksionin';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filma · $available të disponueshëm';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Kërko $count filma';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Po kërkohet $current nga $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'U kërkuan $count filma';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'U kërkuan $ok nga $total filma';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Të gjithë filmat janë tashmë të disponueshëm ose të kërkuar';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Raporto problem';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4133,44 +4117,44 @@ class AppLocalizationsSq extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Cili është problemi?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Të gjitha episodet';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Episodi';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'E hapur';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'I zgjidhur';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Zgjidh';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Rihap';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Raportuar nga $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count komente';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Shto një koment';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Të fshihet ky problem?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Dërgo raportin';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Rezultati i TMDB';
@@ -4194,7 +4178,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get originalLanguageLabel => 'Gjuha origjinale';
 
   @override
-  String get seasonsLabel => 'Sezonet';
+  String get seasonsLabel => 'Stinët';
 
   @override
   String get episodesLabel => 'Episodet';
@@ -4203,7 +4187,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get access => 'Qasja';
 
   @override
-  String get add => 'Shto';
+  String get add => 'Shtoni';
 
   @override
   String get address => 'Adresa';
@@ -4242,7 +4226,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get forward => 'Përpara';
 
   @override
-  String get general => 'Të përgjithshme';
+  String get general => 'Gjeneral';
 
   @override
   String get go => 'Shkoni';
@@ -4332,7 +4316,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get time => 'Koha';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Mashtrime';
 
   @override
   String get uninstall => 'Çinstaloni';
@@ -4350,10 +4334,10 @@ class AppLocalizationsSq extends AppLocalizations {
   String get unmute => 'Hiq zërin';
 
   @override
-  String get mute => 'Pa zë';
+  String get mute => 'Hesht';
 
   @override
-  String get branding => 'Markimi';
+  String get branding => 'Branding';
 
   @override
   String get adminDrawerDashboard => 'Paneli';
@@ -4365,7 +4349,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminDrawerSettings => 'Cilësimet';
 
   @override
-  String get adminDrawerBranding => 'Markimi';
+  String get adminDrawerBranding => 'Branding';
 
   @override
   String get adminDrawerUsers => 'Përdoruesit';
@@ -4374,25 +4358,25 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotekat';
 
   @override
-  String get adminDrawerDisplay => 'Shfaqja';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Cilësimet NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transkodimi';
 
   @override
-  String get adminDrawerResume => 'Vazhdo';
+  String get adminDrawerResume => 'Rezyme';
 
   @override
   String get adminDrawerStreaming => 'Transmetim';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Mashtrime';
 
   @override
   String get adminDrawerDevices => 'Pajisjet';
@@ -4416,7 +4400,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminDrawerScheduledTasks => 'Detyrat e planifikuara';
 
   @override
-  String get adminDrawerPlugins => 'Shtojcat';
+  String get adminDrawerPlugins => 'Plugins';
 
   @override
   String get adminDrawerRepositories => 'Depot';
@@ -4444,22 +4428,22 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Përditësime shtojcash të disponueshme: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Shtojca që kërkojnë rinisje: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Detyra të planifikuara që dështuan: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Hyrje të fundit paralajmërimi/gabimi: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4518,7 +4502,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Gabim: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4546,7 +4530,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Komanda dështoi: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4559,7 +4543,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminSetVolume => 'Vendos volumin';
 
   @override
-  String get sessionPrev => 'Mëparshme';
+  String get sessionPrev => 'Prev';
 
   @override
   String get sessionRewind => 'Ktheje prapa';
@@ -4583,7 +4567,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get nowPlaying => 'Tani po luhet';
 
   @override
-  String get volume => 'Volumi';
+  String get volume => 'Vëllimi';
 
   @override
   String get actions => 'Veprimet';
@@ -4595,7 +4579,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audioCodec => 'Kodiku i audios';
 
   @override
-  String get hwAccel => 'Përshpejtim HW';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Përfundimi';
@@ -4610,14 +4594,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminClearDates => 'Datat e qarta';
 
   @override
-  String get adminActivitySeverityAll => 'Të gjitha nivelet';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Intervali i datave';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Ngarkimi i regjistrit të aktivitetit dështoi: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4634,7 +4618,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Përditësimi i pajisjes dështoi: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4645,28 +4629,28 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Fshirja e pajisjes dështoi: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Të hiqet pajisja \'$name\'? Përdoruesi do të duhet të hyjë sërish në këtë pajisje.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Fshi të gjitha pajisjet';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Të hiqen $count pajisje? Përdoruesit e prekur do të duhet të hyjnë sërish. Pajisja juaj aktuale nuk preket.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Pajisjet u hoqën';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'U hoqën disa pajisje; $count nuk u hoqën dot.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4695,7 +4679,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Nisja e skanimit dështoi: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4706,12 +4690,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Biblioteka u riemërtua në \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Riemërtimi dështoi: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4719,17 +4703,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Biblioteka \"$name\" u fshi';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Fshirja e bibliotekës dështoi: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Shtimi i shtegut dështoi: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4737,12 +4721,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Të hiqet \"$path\" nga kjo bibliotekë?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Heqja e shtegut dështoi: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4750,7 +4734,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Ruajtja e opsioneve dështoi: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4783,259 +4767,251 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminMetadataCountryHint => 'p.sh. SHBA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Shtigjet';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Opsionet';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Shkarkuesit';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Ruajtësit e metadatave';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Shkarkuesit e titrave';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Shkarkuesit e teksteve';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Shkarkuesit e metadatave: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Marrësit e imazheve: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Ky server nuk ofron asnjë shkarkues për këtë lloj biblioteke.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Të përgjithshme';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Informacion i integruar';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Titrat';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Imazhet';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serialet';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muzika';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmat';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktivizo monitorimin në kohë reale';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Zbulo ndryshimet e skedarëve dhe përpunoji automatikisht.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Trajto arkivat si skedarë media';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Shfaq fotot';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Ruaj grafikat në dosjet e medias';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Rifreskim automatik i metadatave';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Asnjëherë';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'E parazgjedhur';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Shfaqja';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Shfaqja e bibliotekës';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Shfaq një pamje dosjesh për të treguar dosjet e thjeshta të medias';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Shfaq specialet brenda sezoneve në të cilat u transmetuan';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Grupo filmat në koleksione';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Grupo serialet në koleksione';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Shfaq përmbajtje të jashtme në sugjerime';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Sjellja e datës së shtimit';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Përdor datën e shtimit nga';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Data e skanimit në bibliotekë';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Data e krijimit të skedarit';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata dhe imazhe';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Gjuha e parapëlqyer e metadatave';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitujt';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Kohëzgjatja e kapitujve fiktivë (sekonda)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Gjatësia e kapitujve që gjenerohen për media që nuk ka. Vendos 0 për ta çaktivizuar.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Rezolucioni i imazhit të kapitullit';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Cilësimet NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadata NFO është e pajtueshme me Kodi dhe klientë të ngjashëm. Cilësimet zbatohen për të gjitha bibliotekat që ruajnë metadata NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Përdoruesi për të cilin ruhen të dhënat e shikimit në skedarët NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Ruaj shtigjet e imazheve brenda skedarëve NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktivizo zëvendësimin e shtegut për shtigjet e imazheve NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopjo imazhet extrafanart në një dosje extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Asnjë';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ditë';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Përdor titujt e integruar';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Përdor titujt e integruar për ekstrat';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Përdor informacionin e integruar të episodeve';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Lejo titrat e integruara';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Lejo të gjitha';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Vetëm tekst';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Vetëm imazh';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Asnjë';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Anashkalo shkarkimin nëse ka titra të integruara';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Anashkalo shkarkimin nëse pista audio përputhet me gjuhën e shkarkimit';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Kërko një përputhje të përsosur të titrave';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => 'Ruaj titrat në dosjet e medias';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Nxirr imazhet e kapitujve';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Nxirr imazhet e kapitujve gjatë skanimit të bibliotekës';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktivizo nxjerrjen e imazheve Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Nxirr imazhet Trickplay gjatë skanimit të bibliotekës';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Ruaj imazhet Trickplay në dosjet e medias';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Bashko automatikisht serialet që janë shpërndarë nëpër disa dosje';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Emri i shfaqjes së sezonit zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Aktivizo skanimin LUFS për normalizimin e audios';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Parapëlqe etiketën jostandarde të artistëve';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Shto automatikisht filmat në koleksione';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Kërkohet emri i bibliotekës';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Krijimi i bibliotekës dështoi: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5062,27 +5038,27 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Të çaktivizohet $name? Nuk do të mund të hyjë.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Të aktivizohet $name? Do të mund të hyjë sërish.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Përdoruesi \"$name\" u çaktivizua';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Përdoruesi \"$name\" u aktivizua';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Përditësimi i politikës së përdoruesit dështoi: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5099,7 +5075,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Krijimi i përdoruesit dështoi: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5121,7 +5097,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Ruajtja dështoi: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5132,7 +5108,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Dështoi: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5148,7 +5124,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminDeleteUser => 'Fshi përdoruesin';
 
   @override
-  String get admin => 'Administrator';
+  String get admin => 'Admin';
 
   @override
   String get adminFullAccessWarning =>
@@ -5268,146 +5244,143 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktivizo qasjen në të gjitha kanalet';
 
   @override
-  String get adminParentalControl => 'Kontrolli prindëror';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Klasifikimi maksimal prindëror i lejuar';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Përmbajtja me klasifikim më të lartë do t\'i fshihet këtij përdoruesi.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Asnjë';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blloko artikujt pa informacion klasifikimi ose me klasifikim të panjohur';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Libra';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanale';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV drejtpërdrejt';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filma';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muzikë';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailerat';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Seriale';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Oraret e aksesit';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Lejo aksesin vetëm gjatë orareve të planifikuara më poshtë. Aksesi lejohet gjatë gjithë ditës kur nuk është caktuar asnjë orar.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Shto orar';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dita';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Fillimi';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Fundi';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Çdo ditë';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Ditë jave';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Fundjavë';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'E diel';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'E hënë';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'E martë';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'E mërkurë';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'E enjte';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'E premte';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'E shtunë';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Etiketat e lejuara';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Shfaqet vetëm përmbajtja me këto etiketa. Lëre bosh për të lejuar të gjitha.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Etiketat e bllokuara';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Përmbajtja me këto etiketa i fshihet këtij përdoruesi.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Shto etiketë';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Pajisjet e aktivizuara';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Kanalet e aktivizuara';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Ofruesi i vërtetimit';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Ofruesi i rivendosjes së fjalëkalimit';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Numri maksimal i tentativave të dështuara para bllokimit';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Vendos 0 për parazgjedhjen, ose -1 për të çaktivizuar bllokimin.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Aksesi në SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Lejo krijimin e grupeve dhe bashkimin me to';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Lejo bashkimin me grupe';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Pa akses';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Lejo fshirjen e përmbajtjes nga';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5415,22 +5388,22 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Serveri ktheu HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Jeni i sigurt që doni të fshini $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Përdoruesi \"$name\" u fshi';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Fshirja e përdoruesit dështoi: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5451,7 +5424,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Krijimi i çelësit dështoi: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5463,7 +5436,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Të revokohet çelësi për $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5471,7 +5444,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Revokimi i çelësit dështoi: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5491,30 +5464,29 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nKrijuar: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Krijo kopje rezervë';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Zgjidh çfarë të përfshihet në kopjen rezervë.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Baza e të dhënave';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Përfshihet gjithmonë';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Titrat';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Imazhet Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Po krijon kopje rezervë...';
@@ -5524,7 +5496,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Krijimi i kopjes rezervë dështoi: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5533,12 +5505,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Manifesti: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Ngarkimi i manifestit dështoi: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5549,7 +5521,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Rikthimi i kopjes rezervë dështoi: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5582,17 +5554,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'U ruajt te $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Ruajtja e skedarit dështoi: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Ngarkimi i $fileName dështoi';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5603,7 +5575,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Ngarkimi i detyrave dështoi: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5615,17 +5587,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Nisja e detyrës dështoi: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Ndalimi i detyrës dështoi: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Ngarkimi i detyrës dështoi: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5633,12 +5605,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Heqja e nxitësit dështoi: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Shtimi i nxitësit dështoi: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5664,7 +5636,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours orë';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5675,7 +5647,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Ndryshimi i gjendjes së shtojcës dështoi: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5683,27 +5655,27 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Jeni i sigurt që doni të çinstaloni \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Çinstalimi i shtojcës dështoi: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Instalimi i paketës dështoi: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Instalimi i përditësimit dështoi: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Ngarkimi i shtojcave dështoi: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5715,12 +5687,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Instalo përditësimin (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Ngarkimi i katalogut dështoi: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5742,17 +5714,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" do të hiqet pas rinisjes së serverit';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Çinstalimi dështoi: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Po përditësohet \"$name\" në v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5761,7 +5733,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Ngarkimi i shtojcës dështoi: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5769,7 +5741,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Versioni $version';
+    return 'Version $version';
   }
 
   @override
@@ -5789,17 +5761,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Jeni i sigurt që doni të hiqni \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Ruajtja e depove dështoi: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Ngarkimi i depove dështoi: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5816,12 +5788,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Cilësimet e shtojcës nuk mund të ngarkohen: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Nuk u hap dot $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5948,11 +5920,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminThrottleBuffering => 'Mbyllja e mbytjes';
 
   @override
-  String get adminTrickplaySaved => 'Cilësimet e Trickplay u ruajtën';
+  String get adminTrickplaySaved =>
+      'Cilësimet e luajtjes së mashtrimit u ruajtën';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Ngarkimi i cilësimeve të Trickplay dështoi';
+      'Ngarkimi i cilësimeve të luajtjes së mashtrimit dështoi';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6107,12 +6080,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Ngarkimi i metadatave dështoi: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Ruajtja e metadatave dështoi: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6133,7 +6106,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Rifreskimi i metadatave dështoi: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6148,7 +6121,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Kërkimi në largësi dështoi: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6162,7 +6135,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Përditësimi i llojit të përmbajtjes dështoi: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6177,12 +6150,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Imazhi $imageType u përditësua';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Shkarkimi i imazhit dështoi: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6193,27 +6166,27 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Imazhi $imageType u ngarkua';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Ngarkimi i imazhit dështoi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Fshi imazhin $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Imazhi $imageType u fshi';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Fshirja e imazhit dështoi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6224,70 +6197,67 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Zbulimi i tunerit dështoi: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Shto sintonizues';
 
   @override
-  String get adminEditTuner => 'Redakto tunerin';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Skedar ose URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Adresa IP e tunerit';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Emri miqësor';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Agjenti i përdoruesit';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Kufiri i lidhjeve të njëkohshme';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Numri maksimal i transmetimeve që lejon tuneri njëkohësisht. Vendos 0 për të pakufizuar.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Bitrate-i maksimal rezervë i transmetimit';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Importo vetëm kanalet e preferuara';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Lejo transkodimin harduerik';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Lejo kontejnerin e transkodimit fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Lejo ndarjen e transmetimit';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'Aktivizo përsëritjen e transmetimit';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Shpërfill DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Lexo hyrjen me shpejtësinë origjinale të kuadrove';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Redakto ofruesin';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6296,50 +6266,50 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Skedar ose URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Parashtesa e filmit';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategoritë e filmave';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Ndaji kategoritë e shumta me një vijë vertikale.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategoritë për fëmijë';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategoritë e lajmeve';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategoritë sportive';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Emri i përdoruesit';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Fjalëkalimi';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Shteti';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Zgjidh një shtet';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Kodi postar';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Merr listimet';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Listimet';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktivizo të gjithë tunerët';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Lloji i sintonizuesit';
@@ -6349,7 +6319,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Shtimi i tunerit dështoi: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6363,12 +6333,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Shtimi i ofruesit dështoi: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Heqja e tunerit dështoi: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6376,16 +6346,16 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Rivendosja e tunerit dështoi: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ky lloj tuneri nuk mbështet rivendosjen.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Heqja e ofruesit dështoi: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6404,44 +6374,43 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Rruga e regjistrimit të serisë';
 
   @override
-  String get adminMovieRecordingPath => 'Shtegu i regjistrimit të filmave';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Ditët e të dhënave të udhëzuesit';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatik';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ditë';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Shtegu i aplikacionit të pas-përpunimit';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argumentet e pas-përpunuesit';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Ruaj metadatat NFO të regjistrimit';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Ruaj imazhet e regjistrimit';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Koha';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Shtigjet e regjistrimit';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Pas-përpunimi';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Të dhënat e udhëzuesit: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6450,7 +6419,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Ruajtja e cilësimeve dështoi: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6467,7 +6436,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Përditësimi i hartëzimeve dështoi: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6485,15 +6454,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminGuideProviders => 'Ofruesit e udhëzuesve';
 
   @override
-  String get adminRefreshGuideData => 'Rifresko të dhënat e udhëzuesit';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Rifreskimi i të dhënave të udhëzuesit filloi';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Detyra e rifreskimit të udhëzuesit nuk ofrohet në këtë server.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Shto Ofrues';
@@ -6504,22 +6472,22 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Shtegu i regjistrimit: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Shtegu i serialeve: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Mbushje para: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Mbushje pas: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6551,7 +6519,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Të rikthehet tani kopja rezervë $name?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6575,7 +6543,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminLiveTvTitle => 'Administrimi i TV drejtpërdrejt';
 
   @override
-  String get adminApply => 'Zbato';
+  String get adminApply => 'Aplikoni';
 
   @override
   String get adminNotSet => 'Nuk është vendosur';
@@ -6597,27 +6565,27 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes min më parë';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours orë më parë';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days ditë më parë';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Ngarkimi i $fileName dështoi';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count përputhje';
+    return '$count matches';
   }
 
   @override
@@ -6627,7 +6595,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Redaktori i meta të dhënave';
 
   @override
-  String get adminMetadataIdentify => 'Identifiko';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Lloji';
@@ -6669,7 +6637,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminMetadataFieldCriticRating => 'Vlerësimi kritik';
 
   @override
-  String get adminMetadataFieldTagline => 'Slogani';
+  String get adminMetadataFieldTagline => 'Tagline';
 
   @override
   String get adminMetadataFieldOverview => 'Vështrim i përgjithshëm';
@@ -6699,7 +6667,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminMetadataAddPerson => 'Shto person';
 
   @override
-  String get adminMetadataEditPerson => 'Redakto personin';
+  String get adminMetadataEditPerson => 'Edit Person';
 
   @override
   String get adminMetadataRole => 'Roli';
@@ -6714,7 +6682,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminMetadataImageLogo => 'Logo';
 
   @override
-  String get adminMetadataImageBanner => 'Baner';
+  String get adminMetadataImageBanner => 'Banner';
 
   @override
   String get adminMetadataImageThumb => 'Gishti i madh';
@@ -6727,22 +6695,22 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Imazhi $imageType u përditësua';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Imazhi $imageType u ngarkua';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Imazhi $imageType u fshi';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Shkarkimi i imazhit dështoi: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6751,12 +6719,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Ngarkimi i imazhit dështoi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Fshi imazhin $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6765,12 +6733,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Fshirja e imazhit dështoi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Zgjidh imazhin $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6803,7 +6771,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Përditësim i disponueshëm: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6826,7 +6794,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Instalo përditësimin (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6838,7 +6806,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" po instalohet...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6858,7 +6826,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Cilësimet e $name';
+    return '$name Settings';
   }
 
   @override
@@ -6898,7 +6866,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Ngarkimi i depove dështoi: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6906,7 +6874,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Jeni i sigurt që doni të hiqni \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6914,7 +6882,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Ruajtja e depove dështoi: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7023,7 +6991,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminNetworkingAddEntry => 'Shto hyrje';
 
   @override
-  String get adminBrandingTitle => 'Markimi';
+  String get adminBrandingTitle => 'Branding';
 
   @override
   String get adminBrandingLoginDisclaimer => 'Mohim identifikimi';
@@ -7043,20 +7011,19 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktivizo spërkatjen e ekranit';
 
   @override
-  String get adminBrandingSplashUpload => 'Ngarko imazh';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Ekrani i nisjes u përditësua';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Ngarkimi i ekranit të nisjes dështoi';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Ekrani i nisjes u hoq';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Pa ekran nisjeje të personalizuar';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Përshpejtimi i harduerit';
@@ -7072,128 +7039,118 @@ class AppLocalizationsSq extends AppLocalizations {
       'Aktivizo dekodimin e harduerit për:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Pajisja QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Aktivizo dekoduesin e përmirësuar NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Parapëlqe dekoduesin harduerik origjinal të sistemit';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Thellësia e ngjyrës për dekodimin harduerik';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Dekodim HEVC 10-bit';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Dekodim VP9 10-bit';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'Dekodim HEVC RExt 8/10-bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'Dekodim HEVC RExt 12-bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Kodimi harduerik';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Lejo kodimin HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Lejo kodimin AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktivizo koduesin Intel H.264 me konsum të ulët';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktivizo koduesin Intel HEVC me konsum të ulët';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Hartëzimi i toneve';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktivizo hartëzimin e toneve';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Aktivizo hartëzimin e toneve VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktivizo hartëzimin e toneve VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoritmi i hartëzimit të toneve';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode =>
-      'Modaliteti i hartëzimit të toneve';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Gama e hartëzimit të toneve';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Çngopja e hartëzimit të toneve';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Kulmi i hartëzimit të toneve';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam =>
-      'Parametri i hartëzimit të toneve';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Ndriçimi i hartëzimit të toneve VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrasti i hartëzimit të toneve VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Paracaktimet dhe cilësia';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Paracaktimi i koduesit';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF i kodimit H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF i kodimit H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Metoda e çndërthurjes';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Dyfisho shpejtësinë e kuadrove gjatë çndërthurjes';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktivizo kodimin audio VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost =>
-      'Forcimi i përzierjes poshtë të audios';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm =>
-      'Algoritmi i përzierjes poshtë në stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Madhësia maksimale e radhës së multipleksimit';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7319,7 +7276,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminTaskStop => 'Ndalo';
 
   @override
-  String get adminRunningTasks => 'Detyrat në ekzekutim';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Vraponi';
@@ -7341,17 +7298,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Çdo ditë në $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Çdo $day në $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Çdo $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7389,8 +7346,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count orë',
-      one: '1 orë',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7418,17 +7375,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days ditë më parë';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours orë më parë';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes min më parë';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7436,17 +7393,17 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours orë';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days ditë';
+    return '${days}d';
   }
 
   @override
@@ -7456,7 +7413,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'Konfiguro gjenerimin e imazheve Trickplay për miniaturat e paraparjes gjatë lëvizjes.';
+      'Konfiguro gjenerimin e imazheve të luajtjes për miniaturë të pamjes paraprake të kërkimit.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Porta publike HTTPS';
@@ -7471,44 +7428,43 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Porta publike HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Kërko HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Ridrejto të gjitha kërkesat në largësi drejt HTTPS. Nuk ka efekt nëse serveri nuk ka certifikatë të vlefshme.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Fjalëkalimi i certifikatës';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Cilësimet e IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktivizo IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktivizo IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Aktivizo hartëzimin automatik të portave';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Rrjetet LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Listë adresash IP ose nënrrjetesh CIDR, të ndara me presje ose rreshta, që trajtohen si pjesë e rrjetit lokal.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI-të e publikuara të serverit';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Harto një nënrrjet ose adresë te një URL e publikuar, p.sh. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Rruga e certifikatës';
@@ -7539,11 +7495,11 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Mbyllja e mbytjes';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Vonesa e kufizimit (sekonda)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Lejo nxjerrjen e titrave në çast';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Përqindja minimale e rinisë';
@@ -7594,7 +7550,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Përditësimi i llojit të përmbajtjes dështoi: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7602,23 +7558,22 @@ class AppLocalizationsSq extends AppLocalizations {
       'Pragu i ngadaltë i përgjigjes (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktivizo paralajmërimet për përgjigje të ngadalta';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktivizo Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Serveri';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Shtigjet';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Performanca';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Rruga e cache-it';
@@ -7630,7 +7585,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminGeneralServerName => 'Emri i serverit';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Gjuha e parapëlqyer e shfaqjes';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Ngarkimi i cilësimeve dështoi';
@@ -7640,12 +7595,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Përditësimi i hartëzimeve dështoi: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Kufiri kohor: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7682,8 +7637,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# pjesëmarrës',
-      one: '# pjesëmarrës',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7727,7 +7682,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Artikulli $index';
+    return 'Item $index';
   }
 
   @override
@@ -7775,12 +7730,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName u bashkua me grupin SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName u largua nga grupi SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7792,7 +7747,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Po sinkronizohet luajtja me $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7830,8 +7785,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rreshta të zbuluar',
-      one: '# rresht i zbuluar',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7872,20 +7827,20 @@ class AppLocalizationsSq extends AppLocalizations {
   String get offlineSavedMedia => 'Media e ruajtur';
 
   @override
-  String get offlineBannerTitle => 'Jeni jashtë linje';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Po shfaqen shkarkimet tuaja';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Shkarkimet';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Serveri juaj nuk arrihet';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Po luhet nga shkarkimet derisa të rikthehet';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7901,12 +7856,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Kontrolli i transmetimit dështoi: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Kontrollet e $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7917,7 +7872,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Ndalo $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7940,12 +7895,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Vendosni një PIN me $length shifra';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Vendosni PIN-in tuaj me $length shifra';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7958,41 +7913,42 @@ class AppLocalizationsSq extends AppLocalizations {
   String get pinForgot => 'Keni harruar kodin PIN?';
 
   @override
-  String get pinClear => 'Pastro';
+  String get pinClear => 'E qartë';
 
   @override
-  String get pinBackspace => 'Kthim prapa';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Kërkesa Quick Connect u autorizua.';
+  String get quickConnectAuthorized =>
+      'Kërkesa për Lidhje të Shpejtë e autorizuar.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Kodi Quick Connect është i pavlefshëm ose ka skaduar.';
+      'Kodi i Lidhjes së Shpejtë është i pavlefshëm ose i skaduar.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect nuk mbështetet në këtë server.';
+      'Lidhja e shpejtë nuk mbështetet në këtë server.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Autorizimi i kodit Quick Connect dështoi.';
+      'Autorizimi i kodit të Lidhjes së Shpejtë dështoi.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect është i çaktivizuar në këtë server.';
+      'Lidhja e shpejtë është çaktivizuar në këtë server.';
 
   @override
   String get quickConnectForbidden =>
-      'Llogaria juaj nuk mund ta autorizojë këtë kërkesë Quick Connect.';
+      'Llogaria juaj nuk mund ta autorizojë këtë kërkesë për Lidhje të Shpejtë.';
 
   @override
   String get quickConnectNotFound =>
-      'Kodi Quick Connect nuk u gjet. Provo një kod të ri.';
+      'Kodi i lidhjes së shpejtë nuk u gjet. Provoni një kod të ri.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect dështoi: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -8003,7 +7959,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Komanda dështoi: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8032,7 +7988,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Nisja e transmetimit dështoi: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8078,7 +8034,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Po shkarkohet $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8123,7 +8079,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get imageTypeThumbnail => 'Miniatura';
 
   @override
-  String get imageTypeBanner => 'Baner';
+  String get imageTypeBanner => 'Banner';
 
   @override
   String get playlistAddFailed => 'Shtimi në listën e luajtjes dështoi';
@@ -8167,7 +8123,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return 'Kapërce $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8178,12 +8134,12 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Po shkarkohet $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Po shkarkohet $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8220,7 +8176,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Lejo rrotullimin';
 
   @override
-  String get playerTooltipPrevious => 'E mëparshmja';
+  String get playerTooltipPrevious => 'E mëparshme';
 
   @override
   String get playerTooltipSeekBack => 'Kërkoni prapa';
@@ -8245,13 +8201,13 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Fshih nga \"Vazhdo shikimin\"';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Fshih nga \"Në vijim\"';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Shto në koleksion';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8306,15 +8262,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetike';
 
   @override
-  String get settingsConnectionSection => 'LIDHJA';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Lejo certifikatat e vetënënshkruara';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Beso serverët që përdorin certifikata TLS të vetënënshkruara ose me CA private. Aktivizoje vetëm për serverët që kontrollon vetë. Kjo çaktivizon vlerësimin e certifikatave për të gjitha lidhjet.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACIA DHE SIGURIA';
@@ -8330,11 +8285,11 @@ class AppLocalizationsSq extends AppLocalizations {
       'Thekse temash, sfonde, tregues të shikuar dhe muzikë me temë';
 
   @override
-  String get settingsDetailsScreen => 'Ekrani i detajeve';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stili, turbullimi i sfondit dhe sjellja e skedave';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Faqja kryesore';
@@ -8372,11 +8327,11 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Shfaq butonin Seerr në shiritin e navigimit';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Shfaq gjithmonë etiketat e tekstit në shiritin e sipërm të navigimit';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8445,7 +8400,8 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsSupportMoonfin => 'Mbështet Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Dhuro një kafe për zhvilluesin';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'LIGJORE';
@@ -8479,8 +8435,8 @@ class AppLocalizationsSq extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# njoftime licencash',
-      one: '# njoftim licence',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8530,17 +8486,16 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Të kapërcehen hyrjet dhe daljet?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Numërimi mbrapsht i segmentit të medias';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Shiriti i progresit';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Kohëmatësi';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Asnjë';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Përdoruesi i shpejtë';
@@ -8575,13 +8530,13 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (rekomandohet)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (i vjetër)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (trashëgimia)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (rekomandohet)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Rikthim i Dolby Vision';
@@ -8771,762 +8726,749 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName të publikuara së fundmi';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Luaj automatikisht episodin tjetër';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Luaj automatikisht episodin tjetër kur është i disponueshëm.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Kapërce heshtjen';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Kapërce automatikisht segmentet e heshtura audio kur mbështeten nga transmetimi.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Lejo efektet e jashtme audio';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Lejo aplikacionet e ekualizuesit dhe efekteve (p.sh. Wavelet) të lidhen me sesionet e luajtjes Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Çaktivizo tunelizimin';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Detyro luajtjen pa tunelizim. E dobishme në pajisje me shkëputje audio/video gjatë tunelizimit.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Aktivizo tunelizimin';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'I avancuar. Kalon audion dhe videon përmes një shtegu harduerik të bashkuar. I çaktivizuar si parazgjedhje sepse shkakton ndërprerje audio/video në disa pajisje.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Harto profilin 7 të Dolby Vision në HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Luaj transmetimet e profilit 7 të Dolby Vision si HEVC të pajtueshëm me HDR10 në pajisjet jo-DV.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Përdor stilet e integruara të titrave';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Zbato ngjyrat, fontet dhe pozicionimin e integruar në pistën e titrave. Çaktivizoje për të përdorur preferencat e tua të stilit të titrave.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Përdor madhësitë e integruara të fontit të titrave';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Zbato sugjerimet e madhësisë së fontit të integruara në pistën e titrave. Çaktivizoje për të përdorur madhësinë e titrave nga preferencat e tua të stilit.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Shfaq detajet e medias';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Shfaq detajet e artikullit të zgjedhur në krye të faqeve të Bibliotekës.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Të fshihen sfondet gjatë shfletimit?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Përdor nëntituj të detajuar';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Shfaq nënrresht të detajuar ose minimal në faqet e Bibliotekës.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Të fshihet tema e ruajtur?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Të hiqet \"$themeName\" nga memoria e fshehtë e kësaj pajisjeje?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Dyqani i temave';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Shfleto dhe ruaj temat e komunitetit';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Ruaj një temë për ta përdorur si temat e tua të tjera të ruajtura.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Për momentin nuk ofrohet asnjë temë.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Dyqani i temave nuk u ngarkua dot. Kontrollo lidhjen dhe provo sërish.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Ruaj';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Ruaj dhe zbato';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'U ruajt';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Kjo temë nuk u ngarkua dot.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" u ruajt.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" u fshi nga kjo pajisje.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" nuk u fshi dot.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Temat e ruajtura';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Këto janë tema të shkarkuara nga shtojca Moonfin për serverin aktual. Fshirja heq vetëm këtë kopje lokale.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Nuk u gjet asnjë temë e ruajtur për këtë server.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Aktualisht aktive';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Fshi temën e ruajtur';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Menaxho temat e shkarkuara të shtojcës në këtë pajisje';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Redaktuesi i temave';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Hap Redaktuesin e temave të Moonfin në shfletuesin tuaj';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Ekrani kryesor';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Shiriti i poshtëm';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasik';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Moderne';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Rreshtat e kreut';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Shfaqja e rreshtave të kreut';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Seksionet e rreshtave të kreut';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Çelësat e rreshtave të kreut';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Aktivizo ose çaktivizo kategoritë e rreshtave të kreut të bazuara në bibliotekë';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktivizo çelësat e mëposhtëm për të shfaqur rreshtat në Seksionet e kreut.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasik ruan llojin e imazhit për çdo rresht dhe mbishtresën e informacionit. Moderne përdor rreshta nga portreti te sfondi.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Shfaq rreshtat e të preferuarave';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Shfaq Filmat e preferuar, Serialet dhe rreshta të tjerë të preferuar në Seksionet e kreut.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Renditja e rreshtit të të preferuarave';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Rendit rreshtat e të preferuarave sipas datës së shtimit, datës së publikimit, alfabetit dhe më shumë.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Shfaq rreshtat e koleksioneve';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Shfaq rreshtat e Koleksioneve në Seksionet e kreut.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Renditja e rreshtit të koleksioneve';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Rendit rreshtat e Koleksioneve sipas datës së shtimit, datës së publikimit, alfabetit dhe më shumë.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Shfaq rreshtat e zhanreve';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Shfaq rreshtat e Zhanreve në Seksionet e kreut.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Renditja e rreshtit të zhanreve';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Rendit rreshtat e Zhanreve sipas datës së shtimit, datës së publikimit, alfabetit dhe më shumë.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Artikujt e rreshtit të zhanreve';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Shfaq Filma, Seriale ose të dyja në rreshtat e Zhanreve.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Shfaq rreshtat e listave të luajtjes';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Shfaq rreshtat e Listave të luajtjes në Seksionet e kreut.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting =>
-      'Renditja e rreshtit të listave të luajtjes';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Rendit rreshtat e Listave të luajtjes sipas datës së shtimit, datës së publikimit, alfabetit dhe më shumë.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Shfaq rreshtat audio';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Shfaq rreshtat Audio në Seksionet e kreut.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Renditja e rreshtave audio';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Rendit rreshtat audio sipas datës së shtimit, datës së publikimit, alfabetit dhe më shumë.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Listat e luajtjes audio';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Pamja';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Paraqitja';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tastiera';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Butonat';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Renderimi';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Konfigurimi i MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Aplikacioni i luajtësit të jashtëm';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Cakto luajtësin e jashtëm për të aktivizuar opsionin e luajtjes me shtypje të gjatë';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Shfaq zgjedhësin e aplikacioneve kur fillon luajtja.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Po ngarkohen luajtësit e instaluar...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Lidhja';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Formati i synuar i transkodimit audio';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'Kalim i drejtpërdrejtë';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Mbështetet në këtë pajisje';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Nuk mbështetet në këtë pajisje';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough =>
-      'Kalim i drejtpërdrejtë DTS:X (DTS UHD)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Dërgo bitstream DTS:X (DTS UHD) te dekoduesi i jashtëm.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Kalim i drejtpërdrejtë TrueHD me Atmos (JOC)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Sjellja e luajtësit të medias';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Përmirësimet e luajtjes';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Gjithmonë aktiv.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Zëvendëso \"Kapërce fundin\" me shfaqjen \"Në vijim\"';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Shfaq mbishtresën \"Në vijim\" në vend të butonit \"Kapërce fundin\".';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Drejtimi i luajtësit';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Parapëlqe dekoduesit softuerikë';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Përdor FFmpeg (audio) dhe libgav1 (AV1) para dekoduesve harduerikë. Çaktivizoje nëse kalimi i drejtpërdrejtë i audios HDMI prishet.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Hap luajtjen e videos në aplikacionin e jashtëm të zgjedhur në Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Radhitja automatike';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Parapëlqe titrat SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Jepu përparësi pistave të titrave SDH/CC gjatë zgjedhjes automatike.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Diagnostikimi i uebit';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Diagnostikimi i uebit të Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Përdore këtë faqe për të diagnostikuar problemet e lidhjes së shfletuesit (CORS, përmbajtje e përzier dhe cilësimet e zbulimit).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'U zbulua dështim për shkak të përmbajtjes së përzier';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'U zbulua dështim CORS/Preflight';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin zbuloi një faqe HTTPS që po përpiqet të thërrasë një URL serveri HTTP. Shfletuesit e bllokojnë këtë kërkesë para se të arrijë te serveri juaj.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin zbuloi një dështim kërkese në nivel shfletuesi, që zakonisht shkaktohet nga mungesa e kokave CORS ose preflight në serverin e medias.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL-ja e synuar: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detaji: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Konteksti aktual i ekzekutimit';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Origjina';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Skema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Modaliteti i shtojcës';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Skanimi WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL-ja e detyruar e serverit';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl =>
-      'URL-ja e parazgjedhur e serverit';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL-ja e proxy-t të zbulimit';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'nuk është konfiguruar';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Përmbajtje e përzier';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Kjo faqe është ngarkuar përmes HTTPS, por një ose më shumë URL të konfiguruara janë HTTP. Shfletuesit i bllokojnë faqet HTTPS që thërrasin API HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Zgjidhja: shërbeje serverin e medias ose pikëmbarimin e proxy-t përmes HTTPS, ose ngarkoje Moonfin përmes HTTP vetëm në rrjete lokale të besuara.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Nuk u zbulua asnjë konfigurim i dukshëm me përmbajtje të përzier nga cilësimet aktuale të ekzekutimit.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Lista e kontrollit CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Lejo origjinën e shfletuesit në Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Përfshi Authorization, X-Emby-Authorization dhe X-Emby-Token në Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Ekspozo Content-Range dhe Accept-Ranges për transmetimin dhe sjelljen e lëvizjes.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Kthe 204 për kërkesat preflight OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Shembull fragmenti kokash (stil nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Shënim';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Kjo rrugë diagnostikimi është menduar për ndërtimet e uebit. Nëse po e shihni në një platformë tjetër, këto kontrolle mund të mos zbatohen.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Kthehu te zgjedhja e serverit';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Dil nga të gjithë përdoruesit';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Leja e mikrofonit është refuzuar përgjithmonë. Aktivizoje te cilësimet e sistemit.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Leja e mikrofonit kërkohet për kërkimin me zë.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Nuk u kuptua. Provo sërish.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Nuk u zbulua asnjë e folur.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Gabim i mikrofonit.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Kërkimi me zë ka nevojë për internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Shërbimi i zërit është i zënë. Provo sërish.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Leja e mikrofonit është refuzuar përgjithmonë.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Leja e mikrofonit është refuzuar.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Njohja e të folurit nuk ofrohet në këtë pajisje.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Hap zgjedhësin e rrugëve të iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Zgjedhësi i rrugëve AirPlay nuk ofrohet në këtë pajisje.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Video';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Programet';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Këngët';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Albumet e fotove';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotot';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Personat';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Episodet e publikuara së fundmi';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Shiko sërish';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Paraqitje si i ftuar';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Paraqitjet (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Kontributet e ekipit (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Shiko me grupin';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Gabimet';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Paralajmërimet';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Disku';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Hap në shfletues';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Shfletuesi i integruar nuk ofrohet në këtë platformë.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Jeni i sigurt që doni ta rinisni serverin?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Jeni i sigurt që doni ta fikni serverin? Do t\'ju duhet ta rinisni manualisht.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'I brendshëm';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Në pritje';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Nuk u gjet asnjë përdorues';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Asnjë përdorues nuk përputhet me kërkimin tuaj';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Nuk u gjet asnjë pajisje';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Asnjë pajisje nuk përputhet me filtrat aktualë';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Fjalëkalimi u caktua';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Nuk është konfiguruar asnjë fjalëkalim';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Akses në largësi';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Vetëm lokal';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Ngarkimi i analitikës së medias dështoi';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Analitikë e kombinuar për të gjitha bibliotekat e medias.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Artistët kryesorë';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Autorët kryesorë';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Kontribuuesit kryesorë';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Biblioteka',
-      one: '1 Bibliotekë',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Ende nuk ofrohen totale të medias së indeksuar për këtë përzgjedhje.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Detajet e bibliotekës';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Ndarja e bibliotekës';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Nuk ofrohet asnjë bibliotekë.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administrimi i serverit';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Të dhënat';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Memoria e fshehtë e imazheve';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Memoria e fshehtë';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Regjistrat';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transkodimi';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Ky server nuk ktheu asnjë shteg serveri.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% të përdorura';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Aktiviteti i përdoruesve';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Ngjarjet e sistemit';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Kërkon vëmendje';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Serveri';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Luajtja';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Pajisjet';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Të avancuara';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Shtojcat';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV drejtpërdrejt';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Video shtëpiake';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Përmbajtje e përzier';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Video dhe foto shtëpiake';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Filma dhe seriale të përzier';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9538,299 +9480,299 @@ class AppLocalizationsSq extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Nuk u gjet asnjë regjistrim';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Nuk u gjet asnjë faqe imazhi brenda arkivit .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Renderuesi i integruar dështoi ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Renderuesi EPUB dështoi ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Mungon skedari lokal për lexuesin: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status gjatë hapjes së të dhënave të librit nga $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Nuk ofrohet asnjë pikëmbarim i lexueshëm libri';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Format arkivi komiku i pambështetur: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Shtojca e nxjerrjes CBR nuk ofrohet në këtë platformë.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Nxjerrja e arkivit .cbr dështoi.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Nxjerrja CB7 nuk ofrohet në këtë platformë.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Shtojca e nxjerrjes CB7 nuk ofrohet në këtë platformë.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Mbyll panelin e zhanreve';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Po ngarkohet luajtja rastësore...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'LUAJTJE RASTËSORE E BIBLIOTEKËS';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'LUAJTJE RASTËSORE';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'LUAJTJE RASTËSORE E ZHANREVE';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Ndërrimi automatik i HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Aktivizo automatikisht HDR për luajtjen e videove HDR dhe rikthe modalitetin e ekranit në dalje.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Kur është në ekran të plotë';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Ndrysho grafikën';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Mungon';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Kufijtë e transkodimit';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Të pastrohen të gjitha grafikat?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Jeni i sigurt që doni të pastroni të gjitha grafikat e shkarkuara?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Konfirmo pastrimin';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Jeni i sigurt që doni ta pastroni këtë $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Të ngarkohet?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Rezolucioni: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Shfaq grafikat vetëm në gjuhën e ndërfaqes';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Konfirmo pastrimin e të gjithave';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Imazhi u ngarkua me sukses!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Ngarkimi i imazhit dështoi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Caktimi i imazhit dështoi: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Fshirja e imazhit dështoi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Pastrimi i të gjitha grafikave dështoi: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Po';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Sfonde';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Baner';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniaturë';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafikë';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Grafika e diskut';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Pamje ekrani';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Kapaku i kutisë';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Kapaku i pasmë i kutisë';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Grafika e menysë';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'sfond';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'baner';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniaturë';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafikë';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'grafikë disku';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'pamje ekrani';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'kapak kutie';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'kapak i pasmë kutie';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'grafikë menyje';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Të gjitha';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'E lartë (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Mesatare (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'E ulët (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Burimet';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitujt';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Faqeshënuesit';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Shënimet';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Radha';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Vija kohore';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Vija kohore është bosh';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'I gjithë libri';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Vija kohore e fokusuar';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Eksporto faqeshënuesit';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Eksporto shënimet';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Eksporto të gjitha';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'U eksportua te $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Eksportimi dështoi: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Tekstet';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Shto faqeshënues';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Shto shënim';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Redakto shënimin';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Shkruaj një shënim për këtë moment';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Kohëmatësi i gjumit';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Fikur';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Fundi i kapitullit';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'I personalizuar';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining të mbetura';
+    return '$remaining left';
   }
 
   @override
@@ -9845,51 +9787,51 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Shpejtësia e luajtjes';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Të mbetura';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Të kaluara';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Prapa ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Përpara ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Kapitulli i mëparshëm';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Kapitulli tjetër';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitulli $current nga $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Pa kapituj';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Ende pa faqeshënues';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Ende pa shënime';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Faqeshënuesi u shtua te $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Rivendos në 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9897,258 +9839,249 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Ruaj';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Anulo';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Fshi';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Preferencat e titrave';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Ndrysho modalitetet e titrave, gjuhët e parazgjedhura, pamjen dhe opsionet e renderimit.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Renderimi i titrave';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Opsionet e shfaqjes';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Data e publikimit (Në rritje)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Data e publikimit (Në zbritje)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Grupo kontributet';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Grupo rolet e shumta';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Paralajmërim për aksesin e shkrimit në bibliotekë';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Si ta rregulloni këtë:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Jepini leje shkrimi përdoruesit të shërbimit Jellyfin (p.sh. jellyfin ose PUID/PGID i Docker) për dosjet e bibliotekës suaj të medias në server.\n\n2. Ose shkoni te Paneli i Jellyfin -> Bibliotekat, redaktoni këtë bibliotekë dhe çaktivizoni \'Ruaj grafikat në dosjet e medias\' për t\'i ruajtur grafikat në bazën e brendshme të të dhënave të Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Mbyll';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Biblioteka juaj \'$libraryName\' është konfiguruar t\'i ruajë grafikat drejtpërdrejt në dosjet e medias (\'Ruaj grafikat në dosjet e medias\' është aktiv). Megjithatë, Jellyfin testoi aksesin e shkrimit dhe nuk ka leje të shkruajë skedarë në këtë direktori:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Duket se Jellyfin nuk arriti t\'i përditësojë grafikat. Biblioteka juaj është konfiguruar t\'i ruajë grafikat drejtpërdrejt në dosjet e medias (\'Ruaj grafikat në dosjet e medias\' është aktiv). Ky gabim zakonisht ndodh kur procesi i serverit Jellyfin nuk ka leje të shkruajë skedarë në direktoritë tuaja të medias.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Lista të jashtme';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Luaj sërish';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Informacioni i skedarit';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Madhësia: $size  •  Formati: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Shfaq të gjitha ($count) pistat audio';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Shfaq të gjitha ($count) pistat e titrave';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Po kontrollohet aftësia e luajtjes së drejtpërdrejtë...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel =>
-      'Aftësia e luajtjes së drejtpërdrejtë: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Të detyruara';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Formati i kontejnerit nuk mbështetet nga luajtësi.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Kodeku i videos nuk mbështetet.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Kodeku i audios nuk mbështetet.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Formati i titrave nuk mbështetet (kërkon djegie mbi video).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Profili i audios nuk mbështetet.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Profili i videos nuk mbështetet.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Niveli i videos nuk mbështetet.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Rezolucioni i videos nuk mbështetet nga kjo pajisje.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Thellësia e bitit të videos nuk mbështetet.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Shpejtësia e kuadrove të videos nuk mbështetet.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Bitrate-i i skedarit e tejkalon kufirin e transmetimit të luajtësit.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Bitrate-i i videos e tejkalon kufirin e transmetimit.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Bitrate-i i audios e tejkalon kufirin e transmetimit.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Numri i kanaleve audio nuk mbështetet.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetike';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Renditja e publikimit (Në rritje)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Renditja e publikimit (Në zbritje)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'E personalizuar (Tërhiq dhe lësho)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions =>
-      'Opsionet e renditjes së listës së luajtjes';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Rivendos renditjen';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Shiko sërish S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Shiko sërish listën e luajtjes';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Nuk u gjet asnjë titër.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Kontrollet e administratorit';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Motori i renderimit (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller është renderuesi modern i GPU-së i Flutter për animacione më të buta dhe më pak ndërprerje. Në disa TV box dhe GPU të vjetra mund të shkaktojë defekte ose video të zezë; çaktivizoje nëse i vëren. Automatik zgjedh parazgjedhjen më të mirë për pajisjen tuaj. Rinis Moonfin për ta zbatuar.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatik';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Ndezur';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Fikur';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Kërkohet rinisje';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin duhet të rinisë për të ndryshuar motorin e renderimit. Mbylle aplikacionin tani, pastaj hape sërish për ta zbatuar.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Mbyll aplikacionin tani';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Rifresko bibliotekën';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Rifresko të gjitha bibliotekat';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Data e shtimit (Më të vjetrat në fillim)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest =>
-      'Data e shtimit (Më të rejat në fillim)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetike (A deri Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetike (Z deri A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Po ngarkohet analitika e serverit... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Përputh me burimin';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => '250 filmat më të mirë në IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => '250 serialet më të mira në IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Filmat më popullorë në IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Serialet më popullore në IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Filmat me vlerësimin më të ulët në IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Filmat anglisht më të vlerësuar në IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -9,30 +9,30 @@ class AppLocalizationsSr extends AppLocalizations {
   AppLocalizationsSr([String locale = 'sr']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Моонфин';
 
   @override
-  String get accountPreferences => 'ПОДЕШАВАЊА НАЛОГА';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Језик интерфејса';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Подразумевано за систем';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Пријавите се';
 
   @override
-  String get empty => 'Празно';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Повезивање са сервером $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Куицк Цоннецт';
 
   @override
   String get password => 'Лозинка';
@@ -61,12 +61,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect није доступан: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect није доступан ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin верзија $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -99,14 +99,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get addServer => 'Додај сервер';
 
   @override
-  String get embyConnect => 'Emby Connect';
+  String get embyConnect => '__АРБ_ТЕРМ_0__ Повежи се';
 
   @override
   String get removeServer => 'Уклони сервер';
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Уклонити „$serverName” са листе сервера?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -122,7 +122,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get serverAddress => 'Адреса сервера';
 
   @override
-  String get serverAddressHint => 'https://your-server.example.com';
+  String get serverAddressHint => 'хттпс://ваш-сервер.екампле.цом';
 
   @override
   String get connect => 'Повежите се';
@@ -132,7 +132,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get secureStorageUnavailableMessage =>
-      'Moonfin није могао да приступи системском привеску за кључеве. Пријава може да се настави, али безбедно чување токена можда неће бити доступно док не откључате привезак.';
+      '__АРБ_ТЕРМ_0__ није могао да приступи вашем системском прстену за кључеве. Пријављивање може да се настави, али безбедно складиштење токена можда неће бити доступно док се привезак за кључеве не откључа.';
 
   @override
   String get ok => 'ОК';
@@ -141,62 +141,62 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsAppearanceTheme => 'Апп Тхеме';
 
   @override
-  String get detailScreenStyle => 'Стил екрана са детаљима';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Класични је оригинални центрирани Moonfin распоред. Модерни је прилагодљив биоскопски распоред.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Класични';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Модерни';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Проширене картице';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Аутоматски приказуј садржај картице док прегледате картице. Искључите за ручно отварање и затварање сваке картице.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Приказати техничке детаље?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Прикажи кодек, резолуцију и податке о стриму у сажетку на банеру';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Систем препорука';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Користите алгоритам локалне библиотеке Moonfin Recommends или онлајн TMDb метрике сличности. Напомена: онлајн препоруке захтевају Seerr интеграцију.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb сличност';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Применити ограничење родитељске оцене?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ограничи предлоге функције Moonfin Recommends према родитељској оцени изабраног садржаја';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стил интерфејса';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Аутоматски се прилагођава вашем уређају. Изаберите Apple или Material за жељени изглед.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Аутоматски';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,44 +205,45 @@ class AppLocalizationsSr extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Квалитет стакла';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Аутоматски бира најбољи ефекат стакла за овај уређај. Пуни намеће право замућење, а Смањени користи лагано стакло које штеди GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Аутоматски';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Пуни';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Смањени';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
-      'Примените потпуно прилагођену тему и бирајте између корисничког интерфејса инспирисаног Apple-ом или Material-ом.';
+      'Пребацивање између __АРБ_ТЕРМ_1__ и __АРБ_ТЕРМ_0__ без поновног покретања апликације';
 
   @override
-  String get customThemeTitle => 'Прилагођена тема';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Прилагођене теме мењају визуелне елементе у целом Moonfin-у. Изаберите једну од ових опција која одговара вашем стилу.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Преферирај системску тастатуру';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'За унос текста подразумевано користи метод уноса вашег уређаја';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Моонфин';
 
   @override
-  String get themeMoonfinSubtitle => 'Оригинални, чист Moonfin изглед.';
+  String get themeMoonfinSubtitle =>
+      'Тренутни __АРБ_ТЕРМ_0__ изглед који сте сви заволели';
 
   @override
   String get themeNeonPulse => 'Неон Пулсе';
@@ -252,22 +253,22 @@ class AppLocalizationsSr extends AppLocalizations {
       'Синтхваве стил са магента сјајем, цијан текстом и јачим хромираним контрастом';
 
   @override
-  String get themeGlass => 'Стакло';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Стил течног стакла са покретном градијентном позадином, матираним површинама и Apple-плавим акцентом';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-битни херој';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретро pixel-art стил са израженом палетом, блоковским ивицама, оштрим сенкама и пиксел фонтом';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
-      'Пријавите се својим Emby Connect налогом';
+      'Пријавите се са својим __АРБ_ТЕРМ_0__ налогом за повезивање';
 
   @override
   String get emailOrUsername => 'Е-маил или корисничко име';
@@ -280,23 +281,23 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get noLinkedServers =>
-      'Ниједан сервер није повезан са овим Emby Connect налогом';
+      'Ниједан сервер није повезан са овим __АРБ_ТЕРМ_0__ налогом за повезивање';
 
   @override
   String get invalidEmbyConnectCredentials =>
-      'Неисправни Emby Connect подаци за пријаву';
+      'Неважећи __АРБ_ТЕРМ_0__ акредитиви за повезивање';
 
   @override
   String get invalidEmbyConnectLogin =>
-      'Неисправно Emby Connect корисничко име или лозинка';
+      'Неважеће __АРБ_ТЕРМ_0__ корисничко име или лозинка за повезивање';
 
   @override
   String get embyConnectExchangeNotSupported =>
-      'Сервер не подржава Emby Connect размену';
+      'Сервер не подржава __АРБ_ТЕРМ_0__ размену за повезивање';
 
   @override
   String get embyConnectNetworkError =>
-      'Мрежна грешка при повезивању са Emby Connect-ом или изабраним сервером';
+      'Мрежна грешка при контактирању __АРБ_ТЕРМ_0__ Цоннецт или изабраног сервера';
 
   @override
   String get loadingLinkedServers => 'Учитавање повезаних сервера...';
@@ -313,11 +314,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Повезивање са $target није успело';
+    return 'Unable to connect to $target';
   }
 
   @override
-  String get exitApp => 'Изаћи из Moonfin-а?';
+  String get exitApp => 'Изаћи из __АРБ_ТЕРМ_0__?';
 
   @override
   String get exitAppConfirmation => 'Да ли сте сигурни да желите да изађете?';
@@ -326,35 +327,35 @@ class AppLocalizationsSr extends AppLocalizations {
   String get exit => 'Изађи';
 
   @override
-  String get gameMenu => 'Мени';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Паузирано';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Сачувај стање';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Игре';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Учитај стање';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Убрзано напред';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Подешавања емулатора';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Ово језгро нема подесивих опција.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Држите за отварање менија';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Покретање игара још није подржано на овом уређају.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Ниједан почетни ред није могао да се учита';
@@ -376,13 +377,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get schedule => 'Распоред';
 
   @override
-  String get series => 'Серије';
+  String get series => 'Сериес';
 
   @override
   String get noItemsFound => 'Нема пронађених ставки';
 
   @override
-  String get home => 'Почетна';
+  String get home => 'Хоме';
 
   @override
   String get browseAll => 'Прегледај све';
@@ -426,7 +427,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Учитавање фасцикле није успело: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -434,14 +435,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count ставки',
-      few: '$count ставке',
-      one: '$count ставка',
-    );
-    return '$_temp0';
+    return '$count items';
   }
 
   @override
@@ -458,14 +452,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count ставки',
-      few: '$count ставке',
-      one: '$count ставка',
-    );
-    return '$_temp0';
+    return '$count Items';
   }
 
   @override
@@ -506,7 +493,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — жанрови';
+    return '$name — Genres';
   }
 
   @override
@@ -519,7 +506,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get albumArtists => 'Албум Артистс';
 
   @override
-  String get artists => 'Извођачи';
+  String get artists => 'Уметници';
 
   @override
   String get bookmarks => 'Боокмаркс';
@@ -545,17 +532,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'пре $count мин';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'пре $count ч';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'пре $count д';
+    return '${count}d ago';
   }
 
   @override
@@ -566,7 +553,7 @@ class AppLocalizationsSr extends AppLocalizations {
       'Изаберите које садржаје тема желите да прикажете у Дисцовер-у.';
 
   @override
-  String get apply => 'Примени';
+  String get apply => 'Пријавите се';
 
   @override
   String get openLink => 'Отворите везу';
@@ -586,18 +573,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get librivoxDescription =>
-      'Популарни наслови у јавном власништву са LibriVox-а.';
+      'Популарни наслови јавног домена из __АРБ_ТЕРМ_0__.';
 
   @override
   String titlesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count наслова',
-      few: '$count наслова',
-      one: '$count наслов',
-    );
-    return '$_temp0';
+    return '$count titles';
   }
 
   @override
@@ -683,31 +663,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count аутора',
-      few: '$count аутора',
-      one: '$count аутор',
-    );
-    return '$_temp0';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count жанрова',
-      few: '$count жанра',
-      one: '$count жанр',
-    );
-    return '$_temp0';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% завршено';
+    return '$percent% completed';
   }
 
   @override
@@ -724,14 +690,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count наслова распоређено за прегледање са нагласком на читању.',
-      few: '$count наслова распоређена за прегледање са нагласком на читању.',
-      one: '$count наслов распоређен за прегледање са нагласком на читању.',
-    );
-    return '$_temp0';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -754,7 +713,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get trendingTitlesOpenLibrary =>
-      'Популарни наслови по темама са сервиса Open Library.';
+      'Наслови у тренду према теми из __АРБ_ТЕРМ_0__.';
 
   @override
   String get noBookmarkedItems => 'Још нема обележених ставки';
@@ -768,7 +727,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Нема резултата за $label';
+    return 'No $label found';
   }
 
   @override
@@ -787,13 +746,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get readStatus => 'Читај';
 
   @override
-  String get watched => 'Одгледано';
+  String get watched => 'Гледао';
 
   @override
   String get unread => 'Непрочитано';
 
   @override
-  String get unwatched => 'Неодгледано';
+  String get unwatched => 'Негледан';
 
   @override
   String get seriesStatus => 'Статус серије';
@@ -805,44 +764,43 @@ class AppLocalizationsSr extends AppLocalizations {
   String get books => 'Књиге';
 
   @override
-  String get latestBooks => 'Најновије књиге';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Најновије аудио-књиге';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count књига',
-      few: '$count књиге',
-      one: '$count књига',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Књига';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудио-књига';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'још $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Читај';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слушај';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Аутор';
@@ -858,7 +816,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get noLibrivoxDescription =>
-      'LibriVox још увек нема опис за овај наслов.';
+      '__АРБ_ТЕРМ_0__ још увек није дао опис за овај наслов.';
 
   @override
   String get readers => 'Реадерс';
@@ -867,7 +825,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get openLinks => 'Отворите везе';
 
   @override
-  String get librivoxPage => 'LibriVox страница';
+  String get librivoxPage => '__АРБ_ТЕРМ_0__ Страница';
 
   @override
   String get internetArchive => 'Интернет Арцхиве';
@@ -880,24 +838,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count одељака',
-      few: '$count одељка',
-      one: '$count одељак',
-    );
-    return '$_temp0';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Први пут објављено $year.';
+    return 'First published $year';
   }
 
   @override
   String get noOpenLibraryOverview =>
-      'Open Library још увек нема преглед за овај наслов.';
+      'Још увек није доступан преглед од __АРБ_ТЕРМ_0__ за овај наслов.';
 
   @override
   String get subjects => 'Субјекти';
@@ -907,14 +858,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count књига',
-      few: '$count књиге',
-      one: '$count књига',
-    );
-    return '$_temp0';
+    return '$count books';
   }
 
   @override
@@ -925,14 +869,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count аутора',
-      few: '$count аутора',
-      one: '$count аутор',
-    );
-    return '$_temp0';
+    return '$count Authors';
   }
 
   @override
@@ -940,9 +877,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудио-књига',
-      few: '$count аудио-књиге',
-      one: '$count аудио-књига',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -957,7 +893,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get failedToLoad => 'Учитавање није успело';
 
   @override
-  String get delete => 'Обриши';
+  String get delete => 'Избриши';
 
   @override
   String get save => 'Сачувај';
@@ -978,7 +914,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get nextUp => 'Нект Уп';
 
   @override
-  String get seasons => 'Сезоне';
+  String get seasons => 'Годишња доба';
 
   @override
   String get chapters => 'поглавља';
@@ -990,7 +926,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get movies => 'Филмови';
 
   @override
-  String get musicVideos => 'Музички спотови';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Остало';
@@ -1009,7 +945,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Диск $number';
+    return 'Disc $number';
   }
 
   @override
@@ -1034,7 +970,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Објављено $year.';
+    return 'Published $year';
   }
 
   @override
@@ -1045,53 +981,52 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count сезона',
-      few: '$count сезоне',
-      one: '$count сезона',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Завршава се у $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Ставке';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Додаци';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Иза сцене';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Избрисане сцене';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Кратки прилози';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Интервјуи';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцене';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Кратки филмови';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Најаве';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return 'још $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Завршава се за $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1105,11 +1040,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Настави од $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Пусти';
+  String get play => 'Играј';
 
   @override
   String get startOver => 'Почни испочетка';
@@ -1133,10 +1068,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get version => 'Версион';
 
   @override
-  String get cast => 'Пребаци';
+  String get cast => 'Цаст';
 
   @override
-  String get trailer => 'Најава';
+  String get trailer => 'Траилер';
 
   @override
   String get finished => 'Завршено';
@@ -1205,7 +1140,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Обрисати преузете песме за „$title”?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1220,17 +1155,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Нема учитаних ставки: $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Преузимање: $title ($count ставки)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Да ли сте сигурни да желите да обришете „$name” са сервера? Ова радња се не може опозвати.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1242,7 +1177,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Неподржани формат књиге: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1259,7 +1194,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get searchOpenSubtitlesPlugin =>
-      'Претражите помоћу OpenSubtitles додатка';
+      'Претражујте помоћу додатка __АРБ_ТЕРМ_0__';
 
   @override
   String get downloadSubtitles => 'Довнлоад Субтитлес';
@@ -1269,16 +1204,16 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Титл преузет и изабран: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
   String get subtitleDownloadedPending =>
-      'Титл је преузет. Може проћи тренутак док се не појави, док Jellyfin освежава ставку.';
+      'Поднаслов је преузет. Може потрајати тренутак да се појави док __АРБ_ТЕРМ_0__ освежи ставку.';
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Нису пронађени мрежни титлови за $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1286,7 +1221,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Верзија $number';
+    return 'Version $number';
   }
 
   @override
@@ -1308,7 +1243,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Преузимање: $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1316,7 +1251,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Обрисати локалне датотеке за $typeLabel?\n\nТиме ћете ослободити простор за складиштење. Можете их поново преузети касније.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1332,32 +1267,25 @@ class AppLocalizationsSr extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕДИТЕЉИ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТА';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТИ';
+  String get writers => 'ВРИТЕРС';
 
   @override
   String get studio => 'СТУДИО';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count више';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count епизода',
-      few: '$count епизоде',
-      one: '$count епизода',
-    );
-    return '$_temp0';
+    return '$count Episodes';
   }
 
   @override
@@ -1367,12 +1295,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Епизода $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Поглавље $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1380,9 +1308,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count песама',
-      few: '$count песме',
-      one: '$count песма',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1392,26 +1319,25 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count поглавља',
-      few: '$count поглавља',
-      one: '$count поглавље',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Рођење: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Смрт: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Старост: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1421,27 +1347,20 @@ class AppLocalizationsSr extends AppLocalizations {
   String get readMore => 'Прочитајте више';
 
   @override
-  String get shuffle => 'Насумично';
+  String get shuffle => 'Схуффле';
 
   @override
-  String get shuffleAllMusic => 'Насумично пусти сву музику';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Пријавите се на Moonfin на телефону';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Сервер није доступан';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count преузимања',
-      few: '$count преузимања',
-      one: '$count преузимање',
-    );
-    return '$_temp0';
+    return '$count downloads';
   }
 
   @override
@@ -1449,7 +1368,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count кан.';
+    return '${count}ch';
   }
 
   @override
@@ -1460,32 +1379,32 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Радња „$action” за мрежне титлове захтева Jellyfin дозволу за управљање титловима за овог корисника.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Ова ставка није пронађена на серверу за радњу „$action” са мрежним титловима.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Радња „$action” за мрежне титлове није успела: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Радња „$action” за мрежне титлове није успела (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Радња „$action” за мрежне титлове није успела.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'све преузете епизоде за „$name”';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1515,17 +1434,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Радња „$label” није успела: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Подешавање јачине звука за Cast није успело: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Контроле – $label';
+    return '$label Controls';
   }
 
   @override
@@ -1542,7 +1461,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Заустави $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1550,38 +1469,31 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Песма $number';
+    return 'Track $number';
   }
 
   @override
   String get remotePlayback => 'Ремоте Плаибацк';
 
   @override
-  String get castingToGoogleCast => 'Пребацивање на Google Cast';
+  String get castingToGoogleCast => 'Пребацивање на __АРБ_ТЕРМ_0__';
 
   @override
-  String get castingViaAirPlay => 'Пребацивање преко AirPlay-а';
+  String get castingViaAirPlay => 'Пребацивање преко __АРБ_ТЕРМ_0__';
 
   @override
-  String get castingViaDlna => 'Пребацивање преко DLNA';
+  String get castingViaDlna => 'Пребацивање преко __АРБ_ТЕРМ_0__';
 
   @override
   String secondsCount(int seconds) {
-    String _temp0 = intl.Intl.pluralLogic(
-      seconds,
-      locale: localeName,
-      other: '$seconds секунди',
-      few: '$seconds секунде',
-      one: '$seconds секунда',
-    );
-    return '$_temp0';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'Дуго притисните за откључавање';
 
   @override
-  String get off => 'Искључено';
+  String get off => 'Офф';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1604,12 +1516,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value ms';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value ms';
+    return '+${value}ms';
   }
 
   @override
@@ -1643,7 +1555,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get transcodeReasons => 'Трансцоде Реасонс';
 
   @override
-  String get player => 'Плејер';
+  String get player => 'Плаиер';
 
   @override
   String get container => 'Контејнер';
@@ -1667,7 +1579,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get videoBitrate => 'Видео Битрате';
 
   @override
-  String get track => 'Нумера';
+  String get track => 'Трацк';
 
   @override
   String get channels => 'Канали';
@@ -1689,12 +1601,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Грешка $protocol сесије';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Учитавање података о књизи није успело: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1703,7 +1615,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Овај формат (.$extension) још не може да се прикаже у апликацији.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1716,17 +1628,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Отварање читача у апликацији није успело: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Обележивач је већ сачуван на $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Обележивач додат: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1738,7 +1650,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Страница $number';
+    return 'Page $number';
   }
 
   @override
@@ -1749,12 +1661,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Формат: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
@@ -1778,7 +1690,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Ресетуј зумирање (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1801,7 +1713,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Ажурирање статуса читања није успело: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1833,7 +1745,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ова платформа не може да покрене уграђени механизам за документе за $extension датотеке.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1872,7 +1784,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Учитавање ТВ водича није успело: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1883,22 +1795,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Следеће: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'још $minutes мин';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'још $hours ч';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'још $hours ч $minutes мин';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1921,19 +1833,19 @@ class AppLocalizationsSr extends AppLocalizations {
   String get favoriteChannel => 'Омиљени канал';
 
   @override
-  String get record => 'Сними';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Откажи снимање';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Емисија је заказана за снимање';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Снимање је отказано';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Није могуће направити снимак';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Гледај';
@@ -1943,7 +1855,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Репродукција канала $name није успела';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1969,11 +1881,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Отказати заказано снимање емисије „$name”?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Не';
+  String get no => 'бр';
 
   @override
   String get yesCancel => 'Да, откажи';
@@ -1997,7 +1909,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Зауставити снимање серије „$name”?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -2012,19 +1924,19 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Нема резултата за „$query”';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Претраживање није успело: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Тип Seerr налога';
+  String get seerrAccountType => 'Сеерр Тип налога';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -2058,19 +1970,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Уклонити „$name” и припадајуће датотеке?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count песама',
-      few: '$count песме',
-      one: '$count песма',
-    );
-    return '$_temp0';
+    return '$count tracks';
   }
 
   @override
@@ -2081,12 +1986,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Учитавање албума није успело: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Нема преузетих песама за $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2103,22 +2008,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Уклонити „$name”?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Е$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Епизода $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2132,12 +2037,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Сезона $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2148,7 +2053,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Обрисати све преузете епизоде у $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2156,9 +2061,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count епизода',
-      few: '$count епизоде',
-      one: '$count епизода',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2193,14 +2097,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Обрисати $count преузетих ставки?',
-      few: 'Обрисати $count преузете ставке?',
-      one: 'Обрисати $count преузету ставку?',
-    );
-    return '$_temp0';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2214,7 +2111,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'од ограничења $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2299,14 +2196,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count опција',
-      few: '$count опције',
-      one: '$count опција',
-    );
-    return '$_temp0';
+    return '$count options';
   }
 
   @override
@@ -2399,7 +2289,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Странице са детаљима, редови на почетном екрану и јачина звука';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2414,18 +2304,18 @@ class AppLocalizationsSr extends AppLocalizations {
       'Играјте када прегледате почетни екран';
 
   @override
-  String get loopThemeMusic => 'Понављај тематску музику';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Понављај песму уместо једнократне репродукције';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Детаљи Замућење позадине';
 
   @override
   String pixelValue(int value) {
-    return '$value px';
+    return '${value}px';
   }
 
   @override
@@ -2441,23 +2331,23 @@ class AppLocalizationsSr extends AppLocalizations {
   String get playerZoomMode => 'Режим зумирања играча';
 
   @override
-  String get settingsScrollWheelAction => 'Точкић миша';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Изаберите шта ради померање точкића миша преко видеа током репродукције.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Искључено';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Премотавање (напред / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Јачина звука';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Јачина звука';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Фит';
@@ -2511,37 +2401,37 @@ class AppLocalizationsSr extends AppLocalizations {
   String get defaultAudioLanguage => 'Подразумевани аудио језик';
 
   @override
-  String get fallbackAudioLanguage => 'Резервни језик звука';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Преферирај подразумевани аудио-запис';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Преферирај оригинални аудио-запис уместо локализоване синхронизације.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Преферирај записе са аудио-описом';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Преферирај записе са аудио-описом уместо уобичајених записа.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскодирање (звук)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Директни стрим (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскодирање (проток или резолуција)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскодирање (видео и звук)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскодирање (видео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Аутоматски (подразумевано на серверу)';
@@ -2607,7 +2497,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get dtsPassthrough => 'ДТС Пасстхроугх';
 
   @override
-  String get trueHdSupport => 'TrueHD подршка';
+  String get trueHdSupport => 'ТруеХД подршка';
 
   @override
   String get enableDtsPassthrough =>
@@ -2615,31 +2505,30 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get enableTrueHdAudio =>
-      'Омогући TrueHD аудио (можда неће радити на свим платформама)';
+      'Омогућите ТруеХД аудио (можда неће радити на свим платформама)';
 
   @override
-  String get settingsAudioOutputMode => 'Режим излаза звука';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Изаберите како се звук декодира. AVR Passthrough шаље необрађене Dolby/DTS стримове вашем пријемнику, док Auto или Downmix декодирају локално.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Резервни аудио-кодек';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Изаберите циљни формат за транскодирање вишеканалног звука када изворни стрим не може директно да се репродукује нити да се проследи.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Аутоматско откривање\n(препоручено)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(подразумевано)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2648,27 +2537,26 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(без губитака)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(само стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ефикасан)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(без губитака)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максималан број аудио-канала';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Подесите максималан број канала ваше аудио-конфигурације. Вишеканални стримови који премашују ово ограничење биће сведени на мањи број канала или транскодирани.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Аутоматско откривање\n(хардверски подразумевано)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2680,7 +2568,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 квадрофонија';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2695,14 +2583,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (напредно)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough кодека';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Омогућите само формате које подржава ваш AVR или HDMI уређај.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
   String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
@@ -2724,38 +2612,38 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Шаљи Dolby Digital Plus (EAC3) bitstream спољном декодеру.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Шаљи Dolby Atmos преко EAC3 (JOC) bitstream спољном декодеру.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Шаљи DTS-HD MA bitstream (укључује DTS core) спољном декодеру.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Шаљи Dolby TrueHD bitstream са Atmos метаподацима спољном декодеру.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Откривене аудио-могућности';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Снимак могућности током извршавања још није доступан.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Рута';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Декодирање';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD аудио-рута';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2770,50 +2658,50 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Звучник';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Слушалице';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count кан. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Дијагностика';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Видео ниво';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Видео опсег';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Кодек титлова';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Дозвољени аудио-кодеци';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS аудио-кодеци';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 аудио-кодеци';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Активна аудио-рута';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Подршка руте за HD звук';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Ноћни режим';
@@ -2822,21 +2710,22 @@ class AppLocalizationsSr extends AppLocalizations {
   String get compressDynamicRange => 'Компримирајте динамички опсег';
 
   @override
-  String get advancedMpv => 'Напредни mpv';
+  String get advancedMpv => 'Напредно __АРБ_ТЕРМ_0__';
 
   @override
-  String get enableCustomMpvConf => 'Омогући прилагођени mpv.conf';
+  String get enableCustomMpvConf => 'Омогући прилагођени __АРБ_ТЕРМ_0__.цонф';
 
   @override
   String get applyMpvConfBeforePlayback =>
-      'Примени кориснички mpv.conf пре почетка репродукције';
+      'Примените кориснички наведен __АРБ_ТЕРМ_0__.цонф пре него што репродукција почне';
 
   @override
-  String get unsafeAdvancedMpvOptions => 'Небезбедне напредне mpv опције';
+  String get unsafeAdvancedMpvOptions =>
+      'Небезбедне напредне __АРБ_ТЕРМ_0__ опције';
 
   @override
   String get unsafeMpvOptionsDescription =>
-      'Дозволите шири скуп mpv опција. Може нарушити репродукцију.';
+      'Дозволи шири скуп __АРБ_ТЕРМ_0__ опција. Може нарушити понашање при репродукцији.';
 
   @override
   String get hardwareDecoding => 'Хардверско декодирање';
@@ -2862,7 +2751,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value с';
+    return '${value}s';
   }
 
   @override
@@ -2877,7 +2766,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'После $episodes епизода / $hours ч';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2908,17 +2797,17 @@ class AppLocalizationsSr extends AppLocalizations {
   String get skipForwardLength => 'Дужина прескакања унапред';
 
   @override
-  String get customMpvConfPath => 'Путања до прилагођеног mpv.conf';
+  String get customMpvConfPath => 'Прилагођена путања __АРБ_ТЕРМ_0__.цонф';
 
   @override
   String get notSetMpvConf =>
-      'Није постављено. Moonfin ће покушати са подразумеваним mpv.conf у app/data фасциклама.';
+      'Није постављено. __АРБ_ТЕРМ_0__ ће покушати са подразумеваним __АРБ_ТЕРМ_1__.цонф у фолдерима апп/дата.';
 
   @override
-  String get selectMpvConf => 'Изаберите mpv.conf';
+  String get selectMpvConf => 'Изаберите __АРБ_ТЕРМ_0__.цонф';
 
   @override
-  String get pathToMpvConf => '/путања/до/mpv.conf';
+  String get pathToMpvConf => '/путања/до/__АРБ_ТЕРМ_0__.цонф';
 
   @override
   String get subtitleStyleDescription =>
@@ -2952,45 +2841,45 @@ class AppLocalizationsSr extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Прилагодите изглед титла';
 
   @override
-  String get subtitleMode => 'Режим титлова';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Означени';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Увек';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Страни језик';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Принудни';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Репродукује записе који су у метаподацима медијске датотеке означени као „default” или „forced”.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Аутоматски учитава и приказује титлове сваки пут када видео почне.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Аутоматски укључује титлове ако је подразумевани аудио-запис на страном језику.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Учитава само титлове изричито означене ознаком „forced” у метаподацима.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Потпуно онемогућава аутоматско учитавање титлова.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Резервни језик титлова';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Стрим титлова';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Брза смеђа лисица прескаче лењог пса';
@@ -3049,17 +2938,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Учитана су подешавања профила $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Учитавање подешавања профила $profile није успело.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Локална подешавања синхронизована су са профилом $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3130,7 +3019,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get downloadsVisibleToOtherApps =>
-      'Downloads/Moonfin — видљиво другим апликацијама';
+      'Преузимања/__АРБ_ТЕРМ_0__ — видљиво другим апликацијама';
 
   @override
   String get dangerZone => 'Зона опасности';
@@ -3160,7 +3049,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get saveToDownloadsFolderDescription =>
-      'Преузети медији ће бити сачувани у Downloads/Moonfin на вашем уређају. Ове датотеке ће бити видљиве другим апликацијама, као што су галерија или музички плејер.\n\nПостојећа преузимања ће остати на тренутној локацији.';
+      'Преузети медији ће бити сачувани у Преузимања/__АРБ_ТЕРМ_0__ на вашем уређају. Ове датотеке ће бити видљиве другим апликацијама као што су ваша галерија или музички плејер.\n\nПостојећа преузимања ће остати на тренутној локацији.';
 
   @override
   String get enable => 'Омогући';
@@ -3195,10 +3084,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Прикажи библиотеке на траци са алаткама';
 
   @override
-  String get navbarAlwaysExpanded => 'Увек прошири натписе навигационе траке';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Прикажи Seerr дугме';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Прозирност навигационе траке';
@@ -3272,26 +3161,25 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showFolderBrowsingOption => 'Прикажи опцију прегледања фолдера';
 
   @override
-  String get groupItemsIntoCollections => 'Групиши ставке у колекције';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Сакриј ставке библиотеке повезане са колекцијом при прегледању библиотека';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Обавештење о груписању библиотеке';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Да бисте користили ово подешавање, проверите да ли су подешавања библиотеке „Групиши филмове у колекције” и/или „Групиши серије у колекције” омогућена у подешавањима приказа ваше библиотеке на Jellyfin или Emby серверу.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Видљивост библиотеке';
 
   @override
   String get libraryVisibilityDescription =>
-      'Укључите или искључите видљивост на почетној страници по библиотеци. Поново покрените Moonfin да би промене ступиле на снагу.';
+      'Укључите/искључите видљивост почетне странице по библиотеци. Поново покрените __АРБ_ТЕРМ_0__ да би промене ступиле на снагу.';
 
   @override
   String get showInNavigation => 'Прикажи у навигацији';
@@ -3313,14 +3201,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count изабрано',
-      few: '$count изабране',
-      one: '$count изабрана',
-    );
-    return '$_temp0';
+    return '$count selected';
   }
 
   @override
@@ -3347,16 +3228,16 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get mediaBarModeDescription =>
-      'Изаберите један од стилова медијске траке или је искључите';
+      'Изаберите између __АРБ_ТЕРМ_0__, МакД или искључите медијску траку';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Моонфин';
 
   @override
   String get mediaBarModeMakd => 'МакД';
 
   @override
-  String get mediaBarModeOff => 'Искључено';
+  String get mediaBarModeOff => 'Офф';
 
   @override
   String get enableMediaBar => 'Омогући траку медија';
@@ -3403,10 +3284,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Аутоматска репродукција трејлера на траци са медијима након 3 секунде';
 
   @override
-  String get trailerAudio => 'Звук најава';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Омогући звук за најаве у медијској траци';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Преглед епизоде';
@@ -3483,10 +3364,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get combineBothRows => 'Комбинујте оба реда у један кућни одељак';
 
   @override
-  String get fullScreenRows => 'Проширени редови почетног екрана';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => 'Ограничи на 1 ред по екрану';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тип слике по реду';
@@ -3501,7 +3382,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get lastUser => 'Последњи корисник';
 
   @override
-  String get currentUser => 'Тренутни корисник';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Увек аутентификујте';
@@ -3576,7 +3457,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes мин';
+    return '$minutes min';
   }
 
   @override
@@ -3607,10 +3488,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Прикажите сат током чувара екрана';
 
   @override
-  String get clockModeStatic => 'Статични';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Одбијајући';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Роттен Томатоес (критичари)';
@@ -3619,10 +3500,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get rottenTomatoesAudience => 'Роттен Томатоес (публика)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'ИМДб';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'ТМДБ';
 
   @override
   String get metacritic => 'Метацритиц';
@@ -3631,7 +3512,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get metacriticUser => 'Метацритиц (корисник)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'Тракт';
 
   @override
   String get letterboxd => 'Леттербокд';
@@ -3652,7 +3533,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get additionalRatings => 'Додатне оцене';
 
   @override
-  String get showMdbListAndTmdbRatings => 'Прикажи MDBList и TMDB оцене';
+  String get showMdbListAndTmdbRatings => 'Прикажи МДБЛист и ТМДБ оцене';
 
   @override
   String get ratingLabels => 'Ратинг Лабелс';
@@ -3680,7 +3561,7 @@ class AppLocalizationsSr extends AppLocalizations {
       'Омогућите и промените редослед извора оцена приказаних у целој апликацији';
 
   @override
-  String get pluginLabel => 'Moonbase додатак';
+  String get pluginLabel => 'Додатак';
 
   @override
   String get pluginDetected => 'Додатак је откривен';
@@ -3698,7 +3579,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nВерзија: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3752,22 +3633,22 @@ class AppLocalizationsSr extends AppLocalizations {
   String get networks => 'Мреже';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr редови откривања';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults =>
       'Ресетујте редове на подразумеване вредности';
 
   @override
-  String get enableSeerr => 'Омогући Seerr';
+  String get enableSeerr => 'Омогући Сеерр';
 
   @override
   String get showSeerrInNavigation =>
-      'Прикажи Seerr у навигацији (захтева додатак за сервер)';
+      'Прикажи Сеерр у навигацији (захтева додатак за сервер)';
 
   @override
   String get seerrUnavailable =>
-      'Није доступно јер је подршка за Seerr у серверском додатку онемогућена.';
+      'Није доступно јер је подршка за серверски додатак Сеерр онемогућена.';
 
   @override
   String get nsfwFilter => 'НСФВ филтер';
@@ -3776,43 +3657,44 @@ class AppLocalizationsSr extends AppLocalizations {
   String get hideAdultContent => 'Сакриј садржај за одрасле у резултатима';
 
   @override
-  String get seerrNotificationsSection => 'Обавештења';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Обавештења о новим захтевима';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Обавести ме када неко пошаље захтев';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Ажурирања захтева';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Одобрено, одбијено и додато у вашу библиотеку';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Ажурирања проблема';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Нови проблеми, одговори и решења';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Пријављени сте као: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr страница за откривање';
+  String get discoverRows => 'Откријте редове';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Изаберите редове који се приказују на Seerr почетној страници. Превуците да промените редослед. Прилагођени редослед се синхронизује са Moonbase-ом.';
+      'Превуците да бисте променили редослед. Омогућите или онемогућите редове. Омогућен редослед редова се синхронизује са додатком __АРБ_ТЕРМ_0__.';
 
   @override
   String get discoverRowsDescription =>
-      'Омогућите редове које желите да видите на Seerr почетној страници. Превуците да промените редослед. Прилагођени редослед се синхронизује са Moonbase-ом.';
+      'Превуците да бисте променили редослед. Омогућите или онемогућите редове.';
 
   @override
   String get enabled => 'Омогућено';
@@ -3825,7 +3707,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Верзија $version';
+    return 'Version $version';
   }
 
   @override
@@ -3835,7 +3717,8 @@ class AppLocalizationsSr extends AppLocalizations {
   String get sourceCode => 'Изворни код';
 
   @override
-  String get sourceCodeUrl => 'https://github.com/Moonfin-Client/Moonfin-Core';
+  String get sourceCodeUrl =>
+      'хттпс://гитхуб.цом/Моонфин-Цлиент/Мобиле-Десктоп';
 
   @override
   String get checkForUpdatesNow => 'Проверите да ли постоје ажурирања одмах';
@@ -3876,7 +3759,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Доступно ажурирање: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3887,7 +3770,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Доступна верзија v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3929,7 +3812,7 @@ class AppLocalizationsSr extends AppLocalizations {
       'Величина постера, тип слике, приказ фасцикле';
 
   @override
-  String get mdbListTmdbRatingSources => 'MDBList, TMDB и извори оцена';
+  String get mdbListTmdbRatingSources => 'МДБЛист, ТМДБ и извори рејтинга';
 
   @override
   String gbValue(String value) {
@@ -3951,7 +3834,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get imageCacheCleared => 'Кеш слика је очишћен';
 
   @override
-  String get clear => 'Очисти';
+  String get clear => 'Јасно';
 
   @override
   String get browse => 'Прегледај';
@@ -3967,26 +3850,19 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Преузимање · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Увоз';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count ставки',
-      few: '$count ставке',
-      one: '$count ставка',
-    );
-    return '$_temp0';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr подешавања';
+  String get seerrSettings => 'Сеерр Сеттингс';
 
   @override
   String get requestMore => 'Захтевајте више';
@@ -3998,11 +3874,11 @@ class AppLocalizationsSr extends AppLocalizations {
   String get cancelRequest => 'Откажи захтев';
 
   @override
-  String get playInMoonfin => 'Пусти у Moonfin-у';
+  String get playInMoonfin => 'Играј у __АРБ_ТЕРМ_0__';
 
   @override
   String requestedByName(String name) {
-    return 'Затражио/ла: $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -4019,19 +3895,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Отказати захтев за „$title”?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Отказати $count захтева за „$title”?',
-      few: 'Отказати $count захтева за „$title”?',
-      one: 'Отказати $count захтев за „$title”?',
-    );
-    return '$_temp0';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -4039,19 +3908,19 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get itemNotFoundInLibrary =>
-      'Ставка није пронађена у вашој Moonfin библиотеци';
+      'Ставка није пронађена у вашој библиотеци __АРБ_ТЕРМ_0__';
 
   @override
   String get errorSearchingLibrary => 'Грешка при претраживању библиотеке';
 
   @override
   String budgetAmount(String amount) {
-    return 'Буџет: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Приход: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -4061,7 +3930,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Затражи $type';
+    return 'Request $type';
   }
 
   @override
@@ -4090,14 +3959,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showMore => 'Прикажи више';
 
   @override
-  String get appearances => 'Појављивања';
+  String get appearances => 'Наступи';
 
   @override
   String get crewSection => 'Посада';
 
   @override
   String ageValue(int age) {
-    return 'старост $age';
+    return 'age $age';
   }
 
   @override
@@ -4128,171 +3997,151 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deletedStatus => 'Избрисано';
 
   @override
-  String get failedStatus => 'Неуспешно';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'У обради';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Изменио/ла: $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завршено';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Овај наслов је већ затражен';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Достигнуто је ограничење захтева';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Овај наслов је на листи блокираних';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Нема више сезона које се могу затражити';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Немате дозволу за слање овог захтева';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Захтеви';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Проблеми';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Најновије';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Последња измена';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Нема проблема';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Преостало $remaining од $limit захтева за филмове';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Преостало $remaining од $limit захтева за сезоне';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Део колекције $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Прикажи колекцију';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Затражи колекцију';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total филмова · $available доступно';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Затражи $count филмова',
-      few: 'Затражи $count филма',
-      one: 'Затражи $count филм',
-    );
-    return '$_temp0';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Слање захтева $current од $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: 'Затражено $count филмова',
-      few: 'Затражена $count филма',
-      one: 'Затражен $count филм',
-    );
-    return '$_temp0';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Затражено $ok од $total филмова';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Сви филмови су већ доступни или затражени';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Пријави проблем';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Видео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Звук';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Шта није у реду?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Све епизоде';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Епизода';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Отворено';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Решено';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Реши';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Поново отвори';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Пријавио/ла: $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count коментара',
-      few: '$count коментара',
-      one: '$count коментар',
-    );
-    return '$_temp0';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Додајте коментар';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Обрисати овај проблем?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Пошаљи пријаву';
+  String get submitReport => 'Submit Report';
 
   @override
-  String get tmdbScore => 'TMDB оцена';
+  String get tmdbScore => 'ТМДБ Сцоре';
 
   @override
   String get releaseDateLabel => 'Датум изласка';
@@ -4313,7 +4162,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get originalLanguageLabel => 'Оригинал Лангуаге';
 
   @override
-  String get seasonsLabel => 'Сезоне';
+  String get seasonsLabel => 'Годишња доба';
 
   @override
   String get episodesLabel => 'Епизоде';
@@ -4361,7 +4210,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get forward => 'Напред';
 
   @override
-  String get general => 'Опште';
+  String get general => 'генерал';
 
   @override
   String get go => 'Иди';
@@ -4406,7 +4255,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get refresh => 'Освежи';
 
   @override
-  String get remote => 'Даљински управљач';
+  String get remote => 'Ремоте';
 
   @override
   String get rename => 'Преименуј';
@@ -4424,7 +4273,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get run => 'Трчи';
 
   @override
-  String get search => 'Претражи';
+  String get search => 'Тражи';
 
   @override
   String get select => 'Изаберите';
@@ -4442,7 +4291,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Заустави';
+  String get stop => 'Стани';
 
   @override
   String get streaming => 'Стреаминг';
@@ -4451,7 +4300,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get time => 'Време';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Трицкплаи';
 
   @override
   String get uninstall => 'Деинсталирај';
@@ -4469,7 +4318,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get unmute => 'Укључи звук';
 
   @override
-  String get mute => 'Искључи звук';
+  String get mute => 'Муте';
 
   @override
   String get branding => 'Брендирање';
@@ -4493,13 +4342,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminDrawerLibraries => 'Библиотеке';
 
   @override
-  String get adminDrawerDisplay => 'Приказ';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метаподаци';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO подешавања';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Трансцодинг';
@@ -4511,7 +4360,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminDrawerStreaming => 'Стреаминг';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Трицкплаи';
 
   @override
   String get adminDrawerDevices => 'Уређаји';
@@ -4563,22 +4412,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Доступна ажурирања додатака: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Додаци који захтевају поновно покретање: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Неуспели заказани задаци: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Недавна упозорења/грешке: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4637,7 +4486,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Грешка: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4645,7 +4494,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get adminServerRebootMessage =>
-      'Поновно покретање сервера је у току, поново покрените Moonfin';
+      'Рестарт сервера је у току, поново покрените __АРБ_ТЕРМ_0__';
 
   @override
   String get adminActiveSessions => 'Активне сесије';
@@ -4664,7 +4513,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Наредба није успела: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4701,7 +4550,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get nowPlaying => 'Сада се игра';
 
   @override
-  String get volume => 'Јачина звука';
+  String get volume => 'Волуме';
 
   @override
   String get actions => 'Акције';
@@ -4728,14 +4577,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminClearDates => 'Очистите датуме';
 
   @override
-  String get adminActivitySeverityAll => 'Сви нивои озбиљности';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Опсег датума';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Учитавање дневника активности није успело: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4752,7 +4601,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Ажурирање уређаја није успело: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4763,38 +4612,28 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Брисање уређаја није успело: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Уклонити уређај „$name”? Корисник ће морати поново да се пријави на овом уређају.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Обриши све уређаје';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other:
-          'Уклонити $count уређаја? Обухваћени корисници мораће поново да се пријаве. Ваш тренутни уређај није обухваћен.',
-      few:
-          'Уклонити $count уређаја? Обухваћени корисници мораће поново да се пријаве. Ваш тренутни уређај није обухваћен.',
-      one:
-          'Уклонити $count уређај? Обухваћени корисници мораће поново да се пријаве. Ваш тренутни уређај није обухваћен.',
-    );
-    return '$_temp0';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Уређаји су уклоњени';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Неки уређаји су уклоњени; $count није било могуће уклонити.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4823,7 +4662,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Покретање скенирања није успело: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4834,12 +4673,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Библиотека је преименована у „$name”';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Преименовање није успело: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4847,17 +4686,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Библиотека „$name” је обрисана';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Брисање библиотеке није успело: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Додавање путање није успело: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4865,12 +4704,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Уклонити „$path” из ове библиотеке?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Уклањање путање није успело: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4878,7 +4717,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Чување опција није успело: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4909,265 +4748,251 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminMetadataCountryHint => 'нпр. САД, ДЕ, ФР';
 
   @override
-  String get adminLibraryTabPaths => 'Путање';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Опције';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Преузимачи';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Чување метаподатака';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Преузимачи титлова';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Преузимачи текстова песама';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Преузимачи метаподатака: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Преузимање слика: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Овај сервер не нуди преузимаче за ову врсту библиотеке.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Опште';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метаподаци';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Уграђени подаци';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Титлови';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Слике';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Серије';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музика';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Филмови';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Омогући надзор у реалном времену';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Откриј промене датотека и аутоматски их обради.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Третирај архиве као медијске датотеке';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Прикажи фотографије';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Сачувај графику у медијске фасцикле';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Аутоматско освежавање метаподатака';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Никад';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Подразумевано';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Приказ';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Приказ библиотеке';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Прикажи приказ фасцикли за обичне медијске фасцикле';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Прикажи специјалне епизоде унутар сезона у којима су емитоване';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Групиши филмове у колекције';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Групиши серије у колекције';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Прикажи спољни садржај у предлозима';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Понашање датума додавања';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Користи датум додавања из';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Датум скенирања у библиотеку';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Датум креирања датотеке';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метаподаци и слике';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Жељени језик метаподатака';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Поглавља';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Трајање заменског поглавља (секунде)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Дужина поглавља која се генеришу за медије без њих. Поставите на 0 за онемогућавање.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Резолуција слике поглавља';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO подешавања';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO метаподаци су компатибилни са Kodi-јем и сличним клијентима. Подешавања се примењују на све библиотеке које чувају NFO метаподатке.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Корисник чији се подаци о гледању чувају у NFO датотекама';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Сачувај путање слика у NFO датотекама';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Омогући замену путања за путање слика у NFO датотекама';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Копирај extrafanart слике у фасциклу extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ништа';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    String _temp0 = intl.Intl.pluralLogic(
-      days,
-      locale: localeName,
-      other: '$days дана',
-      few: '$days дана',
-      one: '$days дан',
-    );
-    return '$_temp0';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Користи уграђене наслове';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Користи уграђене наслове за додатке';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Користи уграђене податке о епизодама';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Дозволи уграђене титлове';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Дозволи све';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Само текст';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Само слика';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ништа';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Прескочи преузимање ако постоје уграђени титлови';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Прескочи преузимање ако се аудио-запис подудара са језиком преузимања';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Захтевај савршено подударање титлова';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Сачувај титлове у медијске фасцикле';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Издвоји слике поглавља';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Издвоји слике поглавља током скенирања библиотеке';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Омогући издвајање trickplay слика';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Издвоји trickplay слике током скенирања библиотеке';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Сачувај trickplay слике у медијске фасцикле';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Аутоматски споји серије распоређене у више фасцикли';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Приказани назив сезоне нула';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Омогући LUFS скенирање за нормализацију звука';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Преферирај нестандардну ознаку извођача';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Аутоматски додај филмове у колекције';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Назив библиотеке је обавезан';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Креирање библиотеке није успело: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5194,27 +5019,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Онемогућити корисника $name? Неће моћи да се пријави.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Омогућити корисника $name? Моћи ће поново да се пријави.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Корисник „$name” је онемогућен';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Корисник „$name” је омогућен';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Ажурирање правила корисника није успело: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5231,7 +5056,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Креирање корисника није успело: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5251,7 +5076,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Чување није успело: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5262,7 +5087,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Неуспешно: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5399,144 +5224,143 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminEnableAllChannels => 'Омогућите приступ свим каналима';
 
   @override
-  String get adminParentalControl => 'Родитељски надзор';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Највиша дозвољена родитељска оцена';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Садржај са вишом оценом биће сакривен овом кориснику.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ништа';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блокирај ставке без оцене или са непрепознатом оценом';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Књиге';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Канали';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ТВ уживо';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Филмови';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музика';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Најаве';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Серије';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Распореди приступа';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Дозволи приступ само током доле наведених термина. Ако распоред није постављен, приступ је дозвољен цео дан.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Додај распоред';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Дан';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Почетак';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Крај';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Сваки дан';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Радни дан';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Викенд';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Недеља';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Понедељак';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Уторак';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Среда';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Четвртак';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Петак';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Субота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Дозвољене ознаке';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Приказује се само садржај са овим ознакама. Оставите празно да бисте дозволили све.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Блокиране ознаке';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Садржај са овим ознакама сакривен је овом кориснику.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Додај ознаку';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Омогућени уређаји';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Омогућени канали';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Провајдер аутентификације';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Провајдер ресетовања лозинке';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максималан број неуспелих покушаја пријаве пре закључавања';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Поставите на 0 за подразумевано или -1 за онемогућавање закључавања.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay приступ';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Дозволи креирање група и придруживање групама';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Дозволи придруживање групама';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Без приступа';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Дозволи брисање садржаја из';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5544,22 +5368,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Сервер је вратио HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Да ли сте сигурни да желите да обришете корисника $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Корисник „$name” је обрисан';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Брисање корисника није успело: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5580,7 +5404,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Креирање кључа није успело: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5591,7 +5415,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Опозвати кључ за $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5599,7 +5423,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Опозивање кључа није успело: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5619,30 +5443,29 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nКреирано: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Направи резервну копију';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Изаберите шта ће бити укључено у резервну копију.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База података';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Увек укључено';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метаподаци';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Титлови';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay слике';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Прављење резервне копије...';
@@ -5652,7 +5475,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Прављење резервне копије није успело: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5661,12 +5484,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Манифест: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Учитавање манифеста није успело: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5677,7 +5500,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Враћање резервне копије није успело: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5709,17 +5532,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Сачувано у $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Чување датотеке није успело: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Учитавање датотеке $fileName није успело';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5730,7 +5553,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Учитавање задатака није успело: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5742,17 +5565,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Покретање задатка није успело: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Заустављање задатка није успело: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Учитавање задатка није успело: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5760,12 +5583,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Уклањање окидача није успело: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Додавање окидача није успело: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5791,7 +5614,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours ч';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5802,7 +5625,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Промена стања додатка није успела: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5810,27 +5633,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Да ли сте сигурни да желите да деинсталирате „$name”?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Деинсталација додатка није успела: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Инсталација пакета није успела: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Инсталација ажурирања није успела: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Учитавање додатака није успело: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5842,12 +5665,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Инсталирај ажурирање (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Учитавање каталога није успело: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5869,17 +5692,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '„$name” биће уклоњен након поновног покретања сервера';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Деинсталација није успела: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Ажурирање „$name” на v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5888,7 +5711,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Учитавање додатка није успело: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5896,7 +5719,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Верзија $version';
+    return 'Version $version';
   }
 
   @override
@@ -5916,21 +5739,21 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Да ли сте сигурни да желите да уклоните „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Чување репозиторијума није успело: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Учитавање репозиторијума није успело: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
-  String get adminRepositoryNameHint => 'нпр. Jellyfin Stable';
+  String get adminRepositoryNameHint => 'нпр. __АРБ_ТЕРМ_0__ Стабилно';
 
   @override
   String get adminRepositoryUrl => 'УРЛ спремишта';
@@ -5943,12 +5766,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Није могуће учитати подешавања додатка: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Није могуће отворити $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6072,11 +5895,11 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminThrottleBuffering => 'Пуферовање гаса';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay подешавања су сачувана';
+  String get adminTrickplaySaved => 'Подешавања трицкплаиа су сачувана';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Учитавање Trickplay подешавања није успело';
+      'Учитавање подешавања трицкплаиа није успело';
 
   @override
   String get adminEnableHardwareAcceleration => 'Омогућите хардверско убрзање';
@@ -6190,7 +6013,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminBaseUrl => 'Основни УРЛ';
 
   @override
-  String get adminBaseUrlHint => 'нпр. /jellyfin';
+  String get adminBaseUrlHint => 'нпр. /јеллифин';
 
   @override
   String get https => 'ХТТПС';
@@ -6230,12 +6053,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Учитавање метаподатака није успело: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Чување метаподатака није успело: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6256,7 +6079,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Освежавање метаподатака није успело: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6270,7 +6093,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Удаљена претрага није успела: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6284,7 +6107,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Ажурирање врсте садржаја није успело: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6299,12 +6122,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Слика $imageType је ажурирана';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Преузимање слике није успело: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6315,27 +6138,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Слика $imageType је отпремљена';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Отпремање слике није успело: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Обриши слику $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Слика $imageType је обрисана';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Брисање слике није успело: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6346,68 +6169,67 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Откривање тјунера није успело: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Додај тјунер';
 
   @override
-  String get adminEditTuner => 'Уреди тјунер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U тјунер';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Датотека или URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP адреса тјунера';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Приказани назив';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Кориснички агент';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Ограничење истовремених веза';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максималан број стримова које тјунер дозвољава истовремено. Поставите на 0 за неограничено.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Резервни максимални проток стриминга';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Увези само омиљене канале';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Дозволи хардверско транскодирање';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Дозволи fMP4 контејнер за транскодирање';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Дозволи дељење стрима';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Омогући понављање стрима';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Занемари DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Читај улаз при изворној брзини кадрова';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Уреди провајдера';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6416,50 +6238,50 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Датотека или URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Префикс филма';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Категорије филмова';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Више категорија одвојите усправном цртом.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Категорије за децу';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Категорије вести';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Категорије спорта';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Корисничко име';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Лозинка';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Држава';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Изаберите државу';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Поштански број';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Преузми програмски распоред';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Програмски распоред';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Омогући све тјунере';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тип тјунера';
@@ -6469,7 +6291,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Додавање тјунера није успело: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6483,12 +6305,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Додавање провајдера није успело: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Уклањање тјунера није успело: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6496,16 +6318,16 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Ресетовање тјунера није успело: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Ова врста тјунера не подржава ресетовање.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Уклањање провајдера није успело: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6524,51 +6346,43 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Путања за снимање серије';
 
   @override
-  String get adminMovieRecordingPath => 'Путања за снимање филмова';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Број дана података ТВ водича';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Аутоматски';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    String _temp0 = intl.Intl.pluralLogic(
-      days,
-      locale: localeName,
-      other: '$days дана',
-      few: '$days дана',
-      one: '$days дан',
-    );
-    return '$_temp0';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Путања апликације за накнадну обраду';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Аргументи за накнадну обраду';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Сачувај NFO метаподатке снимка';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Сачувај слике снимка';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Временска подешавања';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Путање снимања';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Накнадна обрада';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Подаци ТВ водича: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6576,7 +6390,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Чување подешавања није успело: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6594,7 +6408,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Ажурирање мапирања није успело: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6611,15 +6425,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminGuideProviders => 'Водич Провајдери';
 
   @override
-  String get adminRefreshGuideData => 'Освежи податке ТВ водича';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Освежавање података ТВ водича је покренуто';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Задатак освежавања ТВ водича није доступан на овом серверу.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Додај провајдера';
@@ -6630,22 +6443,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Путања снимања: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Путања серија: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Додатак пре: $minutes мин';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Додатак после: $minutes мин';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6678,7 +6491,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Вратити резервну копију $name сада?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6702,7 +6515,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminLiveTvTitle => 'ТВ администрација уживо';
 
   @override
-  String get adminApply => 'Примени';
+  String get adminApply => 'Пријавите се';
 
   @override
   String get adminNotSet => 'Није постављено';
@@ -6724,34 +6537,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'пре $minutes мин';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'пре $hours ч';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'пре $days д';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Учитавање датотеке $fileName није успело';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count подударања',
-      few: '$count подударања',
-      one: '$count подударање',
-    );
-    return '$_temp0';
+    return '$count matches';
   }
 
   @override
@@ -6761,7 +6567,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Уређивач метаподатака';
 
   @override
-  String get adminMetadataIdentify => 'Идентификуј';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тип';
@@ -6861,22 +6667,22 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Слика $imageType је ажурирана';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Слика $imageType је отпремљена';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Слика $imageType је обрисана';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Преузимање слике није успело: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6885,12 +6691,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Отпремање слике није успело: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Обриши слику $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6899,12 +6705,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Брисање слике није успело: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Изаберите слику $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6937,7 +6743,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Доступно ажурирање: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6961,7 +6767,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Инсталирај ажурирање (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6973,7 +6779,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '„$name” се инсталира...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6993,7 +6799,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Подешавања – $name';
+    return '$name Settings';
   }
 
   @override
@@ -7033,7 +6839,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Учитавање репозиторијума није успело: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -7041,7 +6847,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Да ли сте сигурни да желите да уклоните „$name”?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -7049,7 +6855,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Чување репозиторијума није успело: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7072,7 +6878,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminReposUrl => 'УРЛ спремишта';
 
   @override
-  String get adminReposNameHint => 'нпр. Jellyfin Stable';
+  String get adminReposNameHint => 'нпр. __АРБ_ТЕРМ_0__ Стабилно';
 
   @override
   String get adminPluginSettingsInvalidUrl => 'Неважећи УРЛ';
@@ -7176,20 +6982,19 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Омогућите почетни екран';
 
   @override
-  String get adminBrandingSplashUpload => 'Отпреми слику';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Уводни екран је ажуриран';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Отпремање уводног екрана није успело';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Уводни екран је уклоњен';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Нема прилагођеног уводног екрана';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Хардверско убрзање';
@@ -7205,126 +7010,121 @@ class AppLocalizationsSr extends AppLocalizations {
       'Омогући хардверско декодирање за:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV уређај';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Омогући побољшани NVDEC декодер';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Преферирај изворни хардверски декодер система';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Дубина боје хардверског декодирања';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-битно HEVC декодирање';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-битно VP9 декодирање';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-битно декодирање';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-битно декодирање';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Хардверско кодирање';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Дозволи HEVC кодирање';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Дозволи AV1 кодирање';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Омогући Intel H.264 кодер ниске потрошње';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Омогући Intel HEVC кодер ниске потрошње';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Мапирање тонова';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Омогући мапирање тонова';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Омогући VPP мапирање тонова';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Омогући VideoToolbox мапирање тонова';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Алгоритам мапирања тонова';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Режим мапирања тонова';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Опсег мапирања тонова';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Десатурација мапирања тонова';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Вршна вредност мапирања тонова';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Параметар мапирања тонова';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Осветљеност VPP мапирања тонова';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Контраст VPP мапирања тонова';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality =>
-      'Предефинисана подешавања и квалитет';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Предефинисано подешавање кодера';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF за H.264 кодирање';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF за H.265 (HEVC) кодирање';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метод уклањања испреплетаности';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Удвостручи брзину кадрова при уклањању испреплетаности';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Звук';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Омогући VBR кодирање звука';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Појачање downmix-а звука';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгоритам стерео downmix-а';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максимална величина реда за муксовање';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Аутоматски';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Енцодинг';
@@ -7443,10 +7243,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminTaskNeverRun => 'Никад не трчи';
 
   @override
-  String get adminTaskStop => 'Заустави';
+  String get adminTaskStop => 'Стани';
 
   @override
-  String get adminRunningTasks => 'Задаци у току';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Трчи';
@@ -7468,17 +7268,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Сваког дана у $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Сваког $day у $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Сваких $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7516,9 +7316,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count сати',
-      few: '$count сата',
-      one: '$count сат',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7546,17 +7345,17 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'пре $days д';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'пре $hours ч';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'пре $minutes мин';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7564,27 +7363,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes мин';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours ч';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days д';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month.';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Подесите генерисање Trickplay слика за сличице прегледа при премотавању.';
+      'Конфигуришите генерисање трицкплаи слика за тражење сличица за преглед.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Јавни ХТТПС порт';
@@ -7593,50 +7392,49 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Основни УРЛ';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'нпр. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'нпр. /јеллифин';
 
   @override
   String get adminNetworkingHttps => 'ХТТПС';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Јавни HTTP порт';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Захтевај HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Преусмери све удаљене захтеве на HTTPS. Нема ефекта ако сервер нема важећи сертификат.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Лозинка сертификата';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP подешавања';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Омогући IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Омогући IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Омогући аутоматско мапирање портова';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN мреже';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Листа IP адреса или CIDR подмрежа које се сматрају делом локалне мреже, одвојених зарезом или новим редом.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Објављени URI-ји сервера';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Мапирајте подмрежу или адресу на објављени URL, нпр. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Путања сертификата';
@@ -7666,11 +7464,11 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Пуферовање гаса';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Одлагање ограничавања (секунде)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Дозволи издвајање титлова у ходу';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Минимални проценат биографије';
@@ -7719,30 +7517,29 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Ажурирање врсте садржаја није успело: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => 'Праг спорог одзива (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Омогући упозорења о спорим одговорима';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Омогући Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метаподаци';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Путање';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Перформансе';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Путања кеша';
@@ -7754,7 +7551,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminGeneralServerName => 'Име сервера';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Жељени језик приказа';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Учитавање подешавања није успело';
@@ -7764,12 +7561,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Ажурирање мапирања није успело: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Временско ограничење: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7782,33 +7579,32 @@ class AppLocalizationsSr extends AppLocalizations {
   String get syncPlay => 'SyncPlay';
 
   @override
-  String get syncPlayDisabledTitle => 'SyncPlay је онемогућен';
+  String get syncPlayDisabledTitle => '__АРБ_ТЕРМ_0__ онемогућен';
 
   @override
   String get syncPlayDisabledMessage =>
-      'Омогућите SyncPlay у подешавањима да бисте користили синхронизовану репродукцију.';
+      'Омогућите __АРБ_ТЕРМ_0__ у подешавањима да бисте користили синхронизовану репродукцију.';
 
   @override
   String get syncPlayServerUnsupportedTitle => 'Сервер није подржан';
 
   @override
   String get syncPlayServerUnsupportedMessage =>
-      'SyncPlay захтева Jellyfin сервер. Тренутни сервер га не подржава.';
+      '__АРБ_ТЕРМ_0__ захтева __АРБ_ТЕРМ_1__ сервер. Тренутни сервер то не подржава.';
 
   @override
-  String get syncPlayGroupFallbackName => 'SyncPlay група';
+  String get syncPlayGroupFallbackName => '__АРБ_ТЕРМ_0__ Група';
 
   @override
-  String get syncPlayGroupTooltip => 'SyncPlay група';
+  String get syncPlayGroupTooltip => '__АРБ_ТЕРМ_0__ група';
 
   @override
   String syncPlayParticipantCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# учесника',
-      few: '# учесника',
-      one: '# учесник',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7852,7 +7648,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Ставка $index';
+    return 'Item $index';
   }
 
   @override
@@ -7865,7 +7661,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get syncPlayGroupName => 'Назив групе';
 
   @override
-  String get syncPlayDefaultGroupName => 'Моја SyncPlay група';
+  String get syncPlayDefaultGroupName => 'Моја __АРБ_ТЕРМ_0__ група';
 
   @override
   String get syncPlayCreateGroup => 'Креирајте групу';
@@ -7877,11 +7673,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get syncPlayNoGroupsAvailable => 'Нема доступних група';
 
   @override
-  String get syncPlayJoinGroupQuestion => 'Придружити се SyncPlay групи?';
+  String get syncPlayJoinGroupQuestion =>
+      'Желите ли да се придружите групи __АРБ_ТЕРМ_0__?';
 
   @override
   String get syncPlayJoinGroupWarning =>
-      'Придруживање SyncPlay групи може заменити тренутни ред за репродукцију. Наставити?';
+      'Придруживање __АРБ_ТЕРМ_0__ групи може да замени ваш тренутни ред за репродукцију. Наставити?';
 
   @override
   String get syncPlayJoin => 'Придружите се';
@@ -7900,24 +7697,24 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName се придружио/ла SyncPlay групи';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName је напустио/ла SyncPlay групу';
+    return '$userName left SyncPlay group';
   }
 
   @override
-  String get syncPlayAccessDeniedTitle => 'Приступ SyncPlay-у је одбијен';
+  String get syncPlayAccessDeniedTitle => '__АРБ_ТЕРМ_0__ приступ одбијен';
 
   @override
   String get syncPlayAccessDeniedMessage =>
-      'Немате приступ једној или више ставки у овој SyncPlay групи. Замолите власника групе да провери дозволе библиотеке или да изабере други ред.';
+      'Немате приступ једној или више ставки у овој __АРБ_ТЕРМ_0__ групи. Замолите власника групе да провери дозволе библиотеке или одабере други ред.';
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Синхронизација репродукције са групом $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7925,27 +7722,27 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get dolbyVisionDirectPlayFailedTitle =>
-      'Директна репродукција Dolby Vision садржаја није успела';
+      '__АРБ_ТЕРМ_0__ Директна репродукција није успела';
 
   @override
   String get dolbyVisionDirectPlayFailedMessage =>
-      'Директна репродукција овог Dolby Vision тока није могла да почне. Покушати поново уз транскодирање на серверу?';
+      'Директна репродукција није успела да почне за овај __АРБ_ТЕРМ_0__ стрим. Покушати поново да користите транскодирање сервера?';
 
   @override
   String get retryWithTranscode => 'Покушајте поново са транскодом';
 
   @override
-  String get dolbyVisionNotSupportedTitle => 'Dolby Vision није подржан';
+  String get dolbyVisionNotSupportedTitle => '__АРБ_ТЕРМ_0__ Није подржано';
 
   @override
   String get dolbyVisionNotSupportedMessage =>
-      'Овај уређај не може директно да декодира Dolby Vision садржај. Користите HDR10 као резервну опцију или затражите транскодирање на серверу.';
+      'Овај уређај не може директно да декодира садржај __АРБ_ТЕРМ_0__. Користите __АРБ_ТЕРМ_1__ резервни или затражите транскодирање сервера.';
 
   @override
   String get rememberMyChoice => 'Запамти мој избор';
 
   @override
-  String get playHdr10Fallback => 'Пусти HDR10 резервну верзију';
+  String get playHdr10Fallback => 'Пусти __АРБ_ТЕРМ_0__ резервни део';
 
   @override
   String get requestTranscode => 'Захтевај транскодирање';
@@ -7955,9 +7752,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# редова откривено',
-      few: '# реда откривена',
-      one: '# ред откривен',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7998,20 +7794,20 @@ class AppLocalizationsSr extends AppLocalizations {
   String get offlineSavedMedia => 'Сачувани медији';
 
   @override
-  String get offlineBannerTitle => 'Ван мреже сте';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Приказују се ваша преузимања';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Преузимања';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Сервер није доступан';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Репродукција из преузимања док се не врати';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8020,19 +7816,19 @@ class AppLocalizationsSr extends AppLocalizations {
   String get castAirPlay => 'AirPlay';
 
   @override
-  String get castDlna => 'DLNA';
+  String get castDlna => '__АРБ_ТЕРМ_0__';
 
   @override
   String get castRemotePlayback => 'Ремоте Плаибацк';
 
   @override
   String castControlFailed(String error) {
-    return 'Cast контрола није успела: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Контроле – $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -8043,7 +7839,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Заустави $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -8067,12 +7863,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Унесите $length-цифрени PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Унесите свој $length-цифрени PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -8085,41 +7881,41 @@ class AppLocalizationsSr extends AppLocalizations {
   String get pinForgot => 'Заборавили сте ПИН?';
 
   @override
-  String get pinClear => 'Очисти';
+  String get pinClear => 'Јасно';
 
   @override
   String get pinBackspace => 'Бацкспаце';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect захтев је одобрен.';
+  String get quickConnectAuthorized => 'Захтев за брзо повезивање је одобрен.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect код је неважећи или је истекао.';
+      'Код за брзо повезивање је неважећи или је истекао.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect није подржан на овом серверу.';
+      'Брзо повезивање није подржано на овом серверу.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Ауторизација Quick Connect кода није успела.';
+      'Ауторизација кода за брзо повезивање није успела.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect је онемогућен на овом серверу.';
+      'Брзо повезивање је онемогућено на овом серверу.';
 
   @override
   String get quickConnectForbidden =>
-      'Ваш налог не може да одобри овај Quick Connect захтев.';
+      'Ваш налог не може да одобри овај захтев за брзо повезивање.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect код није пронађен. Пробајте нови код.';
+      'Код за брзо повезивање није пронађен. Пробајте нови код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect није успео: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -8130,7 +7926,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Наредба није успела: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8159,7 +7955,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Покретање Cast-а није успело: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8168,7 +7964,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get noRemoteDevicesIos =>
-      'Нема доступних уређаја за даљинску репродукцију.\n\nНа iOS-у, AirPlay уређаји можда неће бити доступни у симулатору.';
+      'Нема доступних уређаја за даљинску репродукцију.\n\nНа иОС-у, __АРБ_ТЕРМ_0__ циљеви можда неће бити доступни у симулатору.';
 
   @override
   String get trackActionPlayNext => 'Плаи Нект';
@@ -8206,7 +8002,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Преузимање: $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8288,14 +8084,14 @@ class AppLocalizationsSr extends AppLocalizations {
       'Репродукција је паузирана. Да ли још увек гледаш?';
 
   @override
-  String get stillWatchingStop => 'Заустави';
+  String get stillWatchingStop => 'Стани';
 
   @override
   String get stillWatchingContinue => 'Настави';
 
   @override
   String skipSegment(String segment) {
-    return 'Прескочи $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8306,12 +8102,12 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Преузимање $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Преузимање: $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8373,13 +8169,13 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Сакриј из одељка „Наставите са гледањем”';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Сакриј из одељка „Следеће”';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Додај у колекцију';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8406,15 +8202,15 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsDynamicContentSubtitle => 'Медиа Бар и визуелни слојеви';
 
   @override
-  String get settingsPlaybackSyncplay => 'Репродукција и SyncPlay';
+  String get settingsPlaybackSyncplay => 'Репродукција и __АРБ_ТЕРМ_0__';
 
   @override
   String get settingsPlaybackSyncplaySubtitle =>
-      'Аудио/видео подешавања, титлови, преузимања и SyncPlay контроле';
+      'Аудио/видео подешавања, титлови, преузимања и контроле __АРБ_ТЕРМ_0__';
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'Синхронизација додатака, Seerr, оцене и још много тога';
+      'Синхронизација додатака, Сеерр, оцене и још много тога';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8433,15 +8229,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsAlphabetical => 'Абецедно';
 
   @override
-  String get settingsConnectionSection => 'ВЕЗА';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Дозволи самопотписане сертификате';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Веруј серверима који користе самопотписане сертификате или сертификате приватног CA. Омогућите само за сервере које контролишете. Овим се онемогућава провера сертификата за све везе.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ПРИВАТНОСТ И БЕЗБЕДНОСТ';
@@ -8457,11 +8252,11 @@ class AppLocalizationsSr extends AppLocalizations {
       'Акценти теме, позадине, индикатори гледања и тематска музика';
 
   @override
-  String get settingsDetailsScreen => 'Екран са детаљима';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стил, замућење позадине и понашање картица';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Почетна страница';
@@ -8499,15 +8294,15 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Прикажи Seerr дугме у навигационој траци';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Увек приказуј текстуалне натписе у горњој навигационој траци';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
-      'Укључите или искључите видљивост на почетној страници по библиотеци. Поново покрените Moonfin да би промене ступиле на снагу.';
+      'Укључите/искључите видљивост почетне странице по библиотеци. Поново покрените __АРБ_ТЕРМ_0__ да би промене ступиле на снагу.';
 
   @override
   String get settingsMediaBarAndLocalPreviews =>
@@ -8524,7 +8319,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'Moonbase омогућава интеграције на страни сервера, укључујући додатне изворе оцена, Seerr захтеве и синхронизована подешавања.';
+      '__АРБ_ТЕРМ_0__ покреће интеграције на страни сервера укључујући додатне изворе оцењивања, Сеерр захтеве и синхронизоване поставке.';
 
   @override
   String get settingsOfflineDownloads => 'Оффлине Довнлоадс';
@@ -8557,22 +8352,23 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsReportAnIssueSubtitle =>
-      'Отворите праћење проблема на GitHub-у';
+      'Отворите алатку за праћење проблема на __АРБ_ТЕРМ_0__';
 
   @override
-  String get settingsJoinDiscord => 'Придружите се Discord-у';
+  String get settingsJoinDiscord => 'Придружите се __АРБ_ТЕРМ_0__';
 
   @override
   String get settingsJoinDiscordSubtitle => 'Разговарајте са заједницом';
 
   @override
-  String get settingsJoinTheDiscord => 'Придружите се Discord серверу';
+  String get settingsJoinTheDiscord => 'Придружите се __АРБ_ТЕРМ_0__';
 
   @override
-  String get settingsSupportMoonfin => 'Подржите Moonfin';
+  String get settingsSupportMoonfin => 'Подршка __АРБ_ТЕРМ_0__';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Частите програмера кафом';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ЛЕГАЛ';
@@ -8589,14 +8385,14 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsPrivacyPolicySubtitle =>
-      'Како Moonfin рукује вашим подацима';
+      'Како __АРБ_ТЕРМ_0__ рукује вашим подацима';
 
   @override
   String get settingsCheckForUpdates => 'Проверите ажурирања';
 
   @override
   String get settingsCheckForUpdatesSubtitle =>
-      'Проверите да ли постоји ново Moonfin издање';
+      'Проверите најновије издање __АРБ_ТЕРМ_0__';
 
   @override
   String get settingsPoweredByFlutter => 'Поверед би Флуттер';
@@ -8606,9 +8402,8 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# лиценцних обавештења',
-      few: '# лиценцна обавештења',
-      one: '# лиценцно обавештење',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8658,16 +8453,16 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескочити уводе и резултате?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Одбројавање медијског сегмента';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Трака напретка';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Одбројавање';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ништа';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Промпт Усер';
@@ -8698,30 +8493,31 @@ class AppLocalizationsSr extends AppLocalizations {
       'Изаберите подразумевани механизам за репродукцију на Андроид ТВ уређајима. Промене се примењују на следећу сесију репродукције.';
 
   @override
-  String get settingsPlaybackEngineMedia3Recommended => 'Media3 (препоручено)';
+  String get settingsPlaybackEngineMedia3Recommended =>
+      '__АРБ_ТЕРМ_0__ (препоручено)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (застарело)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
-  String get settingsPlaybackEngineMpvLegacy => 'mpv (застарело)';
+  String get settingsPlaybackEngineMpvLegacy => '__АРБ_ТЕРМ_0__ (наслеђе)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (препоручено)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
-  String get settingsDolbyVisionFallback => 'Dolby Vision резервна опција';
+  String get settingsDolbyVisionFallback => '__АРБ_ТЕРМ_0__ Замена';
 
   @override
   String get settingsDolbyVisionFallbackDescription =>
-      'Понашање за Dolby Vision наслове на уређајима без Dolby Vision декодирања.';
+      'Понашање за __АРБ_ТЕРМ_0__ наслове на уређајима без __АРБ_ТЕРМ_0__ декодирања.';
 
   @override
   String get settingsAskEachTime => 'Питајте сваки пут';
 
   @override
   String get settingsPreferHdr10Fallback =>
-      'Дај предност HDR10 резервној опцији';
+      'Дајте предност __АРБ_ТЕРМ_0__ резервном';
 
   @override
   String get settingsPreferServerTranscode =>
@@ -8729,11 +8525,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsDolbyVisionProfile7DirectPlay =>
-      'Директна репродукција Dolby Vision профила 7';
+      '__АРБ_ТЕРМ_0__ Профил 7 Директна игра';
 
   @override
   String get settingsDolbyVisionProfile7DirectPlayDescription =>
-      'Одређује да ли се токови слоја побољшања Dolby Vision профила 7 директно репродукују.';
+      'Контролише да ли __АРБ_ТЕРМ_0__ токови слоја побољшања профила 7 треба да усмеравају репродукцију.';
 
   @override
   String get settingsAutoAftkrtEnabled => 'Аутоматски (АФТКРТ омогућен)';
@@ -8817,21 +8613,21 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsOpenGroupsSubtitle =>
-      'Направите SyncPlay групе, придружите им се или управљајте њима';
+      'Креирајте, придружите се групама __АРБ_ТЕРМ_0__ или управљајте њима';
 
   @override
-  String get settingsSyncplayEnabled => 'SyncPlay омогућен';
+  String get settingsSyncplayEnabled => '__АРБ_ТЕРМ_0__ Омогућено';
 
   @override
   String get settingsSyncplayEnabledSubtitle =>
       'Омогућите функције групног гледања';
 
   @override
-  String get settingsSyncplayButton => 'SyncPlay дугме';
+  String get settingsSyncplayButton => '__АРБ_ТЕРМ_0__ Дугме';
 
   @override
   String get settingsSyncplayButtonSubtitle =>
-      'Прикажи SyncPlay дугме у навигационој траци';
+      'Прикажите дугме __АРБ_ТЕРМ_0__ на траци за навигацију';
 
   @override
   String get settingsSyncplayAdvancedCorrection => 'Адванцед Цоррецтион';
@@ -8874,7 +8670,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsSyncplayMinimumSkipDelay => 'Минимално кашњење прескакања';
 
   @override
-  String get settingsSyncplayExtraOffset => 'Додатни SyncPlay помак';
+  String get settingsSyncplayExtraOffset => '__АРБ_ТЕРМ_0__ Додатни помак';
 
   @override
   String get onNow => 'Он Нов';
@@ -8897,757 +8693,749 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Недавно објављено – $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Аутоматски пусти следећу епизоду';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Аутоматски пусти следећу епизоду када је доступна.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Прескочи тишину';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Аутоматски прескочи тихе делове звука када их стрим подржава.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Дозволи спољне звучне ефекте';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Дозволи апликацијама за еквилизацију и ефекте (нпр. Wavelet) да се повежу са Media3 сесијама репродукције.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Онемогући тунеловање';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Принуди репродукцију без тунеловања. Корисно на уређајима са прекидима звука/видеа при тунеловању.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Омогући тунеловање';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Напредно. Усмерава звук и видео кроз повезану хардверску путању. Подразумевано искључено јер на неким уређајима изазива испадање звука/видеа.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Мапирај Dolby Vision профил 7 у HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Репродукуј Dolby Vision профил 7 стримове као HDR10-компатибилни HEVC на уређајима без DV-а.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Користи уграђене стилове титлова';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Примени боје, фонтове и положај уграђене у запис титлова. Искључите да бисте уместо тога користили сопствена подешавања стила титлова.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Користи уграђене величине фонта титлова';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Примени препоруке величине фонта уграђене у запис титлова. Искључите да бисте користили величину титлова из сопствених подешавања стила.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Прикажи детаље медија';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Прикажи детаље изабране ставке на врху страница библиотеке.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Сакрити позадинске слике при прегледању?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Користи детаљне поднаслове';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Прикажи детаљан или минималан подред на страницама библиотеке.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Обрисати сачувану тему?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Уклонити „$themeName” из кеша овог уређаја?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Продавница тема';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Прегледајте и сачувајте теме заједнице';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Сачувајте тему да бисте је користили као и остале сачуване теме.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Тренутно нема доступних тема.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Учитавање Продавнице тема није успело. Проверите везу и покушајте поново.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Сачувај';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Сачувај и примени';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Сачувано';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Ову тему није било могуће учитати.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Сачувано: „$themeName”.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '„$themeName” је обрисана са овог уређаја.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Није могуће обрисати „$themeName”.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Сачуване теме';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Ово су теме преузете из Moonfin додатка за тренутни сервер. Брисањем се уклања само ова локална копија.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'За овај сервер нису пронађене сачуване теме.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Тренутно активна';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Обриши сачувану тему';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Управљајте преузетим темама додатка на овом уређају';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Уређивач тема';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Отворите Moonfin Уређивач тема у прегледачу';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Почетни екран';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Доња трака';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Класични';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Модерни';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Редови почетног екрана';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Приказ редова почетног екрана';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Одељци редова почетног екрана';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Прекидачи редова почетног екрана';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Омогућите или онемогућите категорије редова почетног екрана засноване на библиотеци';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Омогућите следеће прекидаче за приказ редова у одељцима почетног екрана.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Класични задржава врсту слике по реду и информациони слој. Модерни користи редове од портрета до позадинске слике.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Прикажи редове омиљених';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Прикажи омиљене филмове, серије и остале редове омиљених у одељцима почетног екрана.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Сортирање редова омиљених';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Сортирајте редове омиљених према датуму додавања, датуму изласка, абецедно и више.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Прикажи редове колекција';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Прикажи редове колекција у одељцима почетног екрана.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Сортирање редова колекција';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Сортирајте редове колекција према датуму додавања, датуму изласка, абецедно и више.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Прикажи редове жанрова';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Прикажи редове жанрова у одељцима почетног екрана.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Сортирање редова жанрова';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Сортирајте редове жанрова према датуму додавања, датуму изласка, абецедно и више.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Ставке редова жанрова';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Прикажи филмове, серије или обоје у редовима жанрова.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Прикажи редове плејлиста';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Прикажи редове плејлиста у одељцима почетног екрана.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Сортирање редова плејлиста';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Сортирајте редове плејлиста према датуму додавања, датуму изласка, абецедно и више.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Прикажи аудио-редове';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Прикажи аудио-редове у одељцима почетног екрана.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Сортирање аудио-редова';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Сортирајте аудио-редове према датуму додавања, датуму изласка, абецедно и више.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудио-плејлисте';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Изглед';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Распоред';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тема';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Тастатура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Дугмад';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Приказивање';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV конфигурација';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Спољна апликација за репродукцију';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Поставите спољни плејер да бисте омогућили опцију репродукције дугим притиском';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Прикажи избор апликације при покретању репродукције.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Учитавање инсталираних плејера...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Веза';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Циљни формат транскодирања звука';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Подржано на овом уређају';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Није подржано на овом уређају';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Шаљи DTS:X (DTS UHD) bitstream спољном декодеру.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD са Atmos-ом (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Понашање медијског плејера';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Побољшања репродукције';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Увек укључено.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Замени прескакање одјавне шпице приказом „Следеће”';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Прикажи слој „Следеће” уместо дугмета за прескакање одјавне шпице.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Усмеравање плејера';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Преферирај софтверске декодере';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Користи FFmpeg (звук) и libgav1 (AV1) пре хардверских декодера. Искључите ако HDMI audio passthrough престане да ради.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Отвори репродукцију видеа у изабраној спољној апликацији на Android TV-у.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Аутоматско додавање у ред';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Преферирај SDH титлове';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Дај предност SDH/CC записима титлова при аутоматском избору.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Веб дијагностика';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin веб дијагностика';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Користите ову страницу за дијагностику проблема са повезивањем прегледача (CORS, мешовити садржај и подешавања откривања).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Откривен квар због мешовитог садржаја';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Откривен квар CORS-а/preflight захтева';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin је открио да HTTPS страница покушава да позове HTTP URL сервера. Прегледачи блокирају тај захтев пре него што стигне до вашег сервера.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin је открио квар захтева на нивоу прегледача који обично изазивају недостајућа CORS или preflight заглавља на медијском серверу.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Циљни URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Детаљи: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Тренутни контекст извршавања';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Извор';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Шема';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Режим додатка';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC скенирање';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Принудни URL сервера';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Подразумевани URL сервера';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl =>
-      'URL прокси сервера за откривање';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'није конфигурисано';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Мешовити садржај';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Ова страница се учитава преко HTTPS-а, али је један или више конфигурисаних URL-ова HTTP. Прегледачи блокирају HTTPS страницама позивање HTTP API-ја.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Решење: послужите свој медијски сервер или прокси крајњу тачку преко HTTPS-а или учитајте Moonfin преко HTTP-а само на поузданим локалним мрежама.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Из тренутних подешавања извршавања није откривена очигледна конфигурација мешовитог садржаја.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS контролна листа';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Дозволите извор прегледача у Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Укључите Authorization, X-Emby-Authorization и X-Emby-Token у Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Изложите Content-Range и Accept-Ranges за стриминг и премотавање.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Вратите 204 на OPTIONS preflight захтеве.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Пример исечка заглавља (nginx стил)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Напомена';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Ова дијагностичка рута намењена је веб верзијама. Ако ово видите на другој платформи, ове провере се можда не примењују.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Назад на избор сервера';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Одјави све кориснике';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Дозвола за микрофон је трајно одбијена. Омогућите је у подешавањима система.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'За гласовну претрагу потребна је дозвола за микрофон.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Нисмо то ухватили. Покушајте поново.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Говор није откривен.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Грешка микрофона.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Гласовна претрага захтева интернет.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Гласовна услуга је заузета. Покушајте поново.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Дозвола за микрофон је трајно одбијена.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Дозвола за микрофон је одбијена.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Препознавање говора није доступно на овом уређају.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Отвори iOS избор излаза';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay избор излаза није доступан на овом уређају.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Видео-записи';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Емисије';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Песме';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Фото-албуми';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Фотографије';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Особе';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Недавно објављене епизоде';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Погледајте поново';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Гостујуће улоге';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Појављивања (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Доприноси екипе (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Гледај са групом';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Грешке';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Упозорења';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Диск';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Отвори у прегледачу';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Уграђени прегледач није доступан на овој платформи.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Да ли сте сигурни да желите поново да покренете сервер?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Да ли сте сигурни да желите да искључите сервер? Мораћете ручно да га покренете поново.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Интерно';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Неактивно';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Нема пронађених корисника';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Ниједан корисник не одговара претрази';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Нема пронађених уређаја';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Ниједан уређај не одговара тренутним филтерима';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Лозинка је постављена';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Лозинка није конфигурисана';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Удаљени приступ';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Само локално';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Учитавање медијске аналитике није успело';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Обједињена аналитика свих медијских библиотека.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Најбољи извођачи';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Најбољи аутори';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Највећи доприносиоци';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count библиотека',
-      few: '$count библиотеке',
-      one: '$count библиотека',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'За овај избор још нису доступни укупни износи индексираних медија.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Детаљи библиотеке';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Рашчламба библиотеке';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Нема доступних библиотека.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Администрација сервера';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Подаци';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Кеш слика';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Кеш';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Дневници';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'Метаподаци';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Транскодирање';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Овај сервер није вратио ниједну путању.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% искоришћено';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Активност корисника';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Догађаји система';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Захтева пажњу';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Сервер';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Репродукција';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Уређаји';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Напредно';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Додаци';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'ТВ уживо';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Кућни видео-записи';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Мешовити садржај';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Кућни видео-записи и фотографије';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Мешовити филмови и серије';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9659,299 +9447,299 @@ class AppLocalizationsSr extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Нема пронађених снимака';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'У .$extension архиви нису пронађене странице са сликама.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Уграђени приказивач није успео ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB приказивач није успео ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Недостаје локална датотека за читач: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status при отварању података књиге са $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Нема доступне крајње тачке за читање књиге';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Неподржани формат архиве стрипа: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Додатак за издвајање CBR-а није доступан на овој платформи.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Издвајање .cbr архиве није успело.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Издвајање CB7-а није доступно на овој платформи.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Додатак за издвајање CB7-а није доступан на овој платформи.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Затвори панел жанрова';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Учитавање насумичне репродукције...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'НАСУМИЧНО ИЗ БИБЛИОТЕКЕ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'НАСУМИЧАН ИЗБОР';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'НАСУМИЧНО ПО ЖАНРОВИМА';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Аутоматско пребацивање на HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Аутоматски омогући HDR за репродукцију HDR видеа и врати режим приказа при изласку.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'У целом екрану';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Промени графику';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Недостаје';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Ограничења транскодирања';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Обрисати сву графику?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Да ли сте сигурни да желите да обришете сву преузету графику?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Потврди брисање';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Да ли сте сигурни да желите да обришете ово: $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Отпремити?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Резолуција: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Прикажи само графику на језику интерфејса';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Потврди брисање свега';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Слика је успешно отпремљена!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Отпремање слике није успело: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Постављање слике није успело: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Брисање слике није успело: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Брисање све графике није успело: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Да';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Позадинске слике';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Банер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Логотип';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Сличица';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Графика';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Графика диска';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Снимак екрана';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Предња страна кутије';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задња страна кутије';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Графика менија';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'позадинска слика';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'банер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'логотип';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'сличица';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'графика';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'графика диска';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'снимак екрана';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'предња страна кутије';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задња страна кутије';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'графика менија';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Све';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Висока (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Средња (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Ниска (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Извори';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Поглавља';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Обележивачи';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Белешке';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Ред';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Временска линија';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Временска линија је празна';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Цела књига';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Фокусирана временска линија';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Извези обележиваче';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Извези белешке';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Извези све';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Извезено у $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Извоз није успео: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Текст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Додај обележивач';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Додај белешку';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Уреди белешку';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напишите белешку за овај тренутак';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Тајмер за спавање';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Искључено';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Крај поглавља';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Прилагођено';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'још $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9959,58 +9747,58 @@ class AppLocalizationsSr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count мин',
-      one: '1 мин',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Брзина репродукције';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Преостало';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Протекло';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $seconds с';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Напред $seconds с';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Претходно поглавље';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Следеће поглавље';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Поглавље $current од $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Нема поглавља';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Још нема обележивача';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Још нема бележака';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Обележивач додат на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Врати на 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -10018,249 +9806,249 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Сачувај';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Откажи';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Обриши';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Подешавања титлова';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Промените режиме титлова, подразумеване језике, изглед и опције приказа.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Приказ титлова';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Опције приказа';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Датум изласка (растуће)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Датум изласка (опадајуће)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Груписање доприноса';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Групиши више улога';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Упозорење о приступу за писање у библиотеку';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Како то решити:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Доделите дозволе за писање кориснику Jellyfin услуге (нпр. jellyfin или Docker PUID/PGID) за фасцикле ваше медијске библиотеке на серверу.\n\n2. Или идите на Jellyfin контролну таблу -> Библиотеке, уредите ову библиотеку и онемогућите „Сачувај графику у медијске фасцикле” како би се графика чувала у Jellyfin-овој интерној бази података.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Одбаци';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Ваша библиотека „$libraryName” конфигурисана је да чува графику директно у медијским фасциклама (укључена је опција „Сачувај графику у медијске фасцикле”). Међутим, Jellyfin је тестирао приступ за писање и нема дозволу да уписује датотеке у овај директоријум:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Изгледа да Jellyfin није успео да ажурира графику. Ваша библиотека је конфигурисана да чува графику директно у медијским фасциклама (укључена је опција „Сачувај графику у медијске фасцикле”). Ова грешка се обично јавља када процес Jellyfin сервера нема дозволу да уписује датотеке у ваше медијске директоријуме.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Спољне листе';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Понови';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Подаци о датотеци';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Величина: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Прикажи све аудио-записе ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Прикажи све титлове ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Провера могућности директне репродукције...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Могућност директне репродукције: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Принудни';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Плејер не подржава формат контејнера.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Видео кодек није подржан.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудио-кодек није подржан.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Формат титлова није подржан (захтева утискивање).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Аудио-профил није подржан.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Видео профил није подржан.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Видео ниво није подржан.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Овај уређај не подржава резолуцију видеа.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Дубина боје видеа није подржана.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Брзина кадрова видеа није подржана.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Проток датотеке премашује ограничење стриминга плејера.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Проток видеа премашује ограничење стриминга.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Проток звука премашује ограничење стриминга.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Број аудио-канала није подржан.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Азбучно';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Редослед изласка (растуће)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Редослед изласка (опадајуће)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Прилагођено (превуци и отпусти)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Опције сортирања плејлисте';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Ресетуј сортирање';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Поново погледај С$season:Е$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Поново погледај плејлисту';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Нису пронађени титлови.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Администраторске контроле';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Механизам приказа (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller је Flutter-ов модерни GPU приказивач за глаткије анимације и мање застајкивања. На неким ТВ уређајима и старијим GPU-овима може изазвати сметње или црни видео; искључите га ако то приметите. Аутоматски бира најбоље подешавање за ваш уређај. Поново покрените Moonfin да бисте применили промену.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Аутоматски';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Укључено';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Искључено';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Потребно је поновно покретање';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin мора поново да се покрене да би се променио механизам приказа. Затворите апликацију сада, а затим је поново отворите да бисте применили промену.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Затвори апликацију сада';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Освежи библиотеку';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Освежи све библиотеке';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Датум додавања (најстарије прво)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Датум додавања (најновије прво)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Азбучно (А–Ш)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Азбучно (Ш–А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Учитавање аналитике сервера... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Као извор';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 филмова';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 ТВ серија';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb најпопуларнији филмови';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb најпопуларније ТВ серије';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb најлошије оцењени филмови';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb најбоље оцењени енглески филмови';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -12,27 +12,27 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'KONTOINSTÄLLNINGAR';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Gränssnittsspråk';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Systemstandard';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Logga in';
 
   @override
-  String get empty => 'Tom';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Ansluter till $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Snabbanslutning';
 
   @override
   String get password => 'Losenord';
@@ -61,12 +61,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect är inte tillgängligt: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect är inte tillgängligt ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Ta bort \"$serverName\" från dina servrar?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsAppearanceTheme => 'App-tema';
 
   @override
-  String get detailScreenStyle => 'Stil för detaljsida';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klassisk är Moonfins ursprungliga centrerade layout. Modern är en responsiv, filmisk layout.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klassisk';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Expanderade flikar';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Visa flikinnehåll automatiskt när du bläddrar bland flikarna. Stäng av för att öppna och stänga varje flik manuellt.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Visa tekniska detaljer?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Visa codec, upplösning och streaminformation i bannersammanfattningen';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Rekommendationssystem';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Använd Moonfin Recommends lokala biblioteksalgoritm eller TMDb:s likhetsmått online. Obs: Onlinerekommendationer kräver Seerr-integration.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-likhet';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Begränsa efter åldersgräns?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Begränsa förslag från Moonfin Recommends efter målmediets åldersgräns';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Gränssnittsstil';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatiskt matchar din enhet. Välj Apple eller Material för att framtvinga ett utseende.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatiskt';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,11 +205,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glaskvalitet';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto väljer den bästa glaseffekten för den här enheten. Full framtvingar äkta oskärpa; Reducerad använder ett lättviktigt glas som sparar GPU-kraft.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
@@ -218,25 +218,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Reducerad';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Växla mellan Moonfin och Neon Pulse utan att starta om appen';
 
   @override
-  String get customThemeTitle => 'Anpassat tema';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Anpassade teman ändrar visuella element i hela Moonfin. Välj ett av alternativen som passar din stil.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Föredra systemtangentbord';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Använd enhetens inmatningsmetod som standard för textinmatning';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -257,14 +257,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid glass-stil med drivande gradientbakgrund, frostade ytor och Apple-blå accentfärg';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixelkonst med kraftig palett, blockiga kanter, hårda skuggor och pixelteckensnitt';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +313,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Kan inte ansluta till $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -326,36 +326,35 @@ class AppLocalizationsSv extends AppLocalizations {
   String get exit => 'Utgång';
 
   @override
-  String get gameMenu => 'Meny';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Pausad';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Spara tillstånd';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Spel';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Ladda tillstånd';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Snabbspolning framåt';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Emulatorinställningar';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Den här kärnan har inga justerbara alternativ.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Håll in för att öppna menyn';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Spel stöds inte på den här enheten än.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Inga hemmarader kunde laddas';
@@ -368,7 +367,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get retryHomeRows => 'Försök Hemrader igen';
 
   @override
-  String get guide => 'Tablå';
+  String get guide => 'Guide';
 
   @override
   String get recordings => 'Inspelningar';
@@ -377,7 +376,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get schedule => 'Schema';
 
   @override
-  String get series => 'Serier';
+  String get series => 'Serie';
 
   @override
   String get noItemsFound => 'Inga föremål hittades';
@@ -426,7 +425,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Kunde inte läsa in mappen: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -434,7 +433,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count objekt';
+    return '$count items';
   }
 
   @override
@@ -451,7 +450,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count objekt';
+    return '$count Items';
   }
 
   @override
@@ -482,7 +481,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get small => 'Små';
 
   @override
-  String get medium => 'Mellan';
+  String get medium => 'Medium';
 
   @override
   String get large => 'Stor';
@@ -492,7 +491,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Genrer';
+    return '$name — Genres';
   }
 
   @override
@@ -505,7 +504,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get albumArtists => 'Albumartister';
 
   @override
-  String get artists => 'Artister';
+  String get artists => 'Konstnärer';
 
   @override
   String get bookmarks => 'Bokmärken';
@@ -530,17 +529,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count min sedan';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count tim sedan';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count d sedan';
+    return '${count}d ago';
   }
 
   @override
@@ -551,7 +550,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Välj vilka ämnesflöden som ska visas i Discover.';
 
   @override
-  String get apply => 'Tillämpa';
+  String get apply => 'Tillämpas';
 
   @override
   String get openLink => 'Öppna länken';
@@ -574,7 +573,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count titlar';
+    return '$count titles';
   }
 
   @override
@@ -600,7 +599,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get listen => 'Lyssna';
 
   @override
-  String get resume => 'Återuppta';
+  String get resume => 'Ateruppta';
 
   @override
   String get failedToLoadLibrary => 'Det gick inte att läsa in biblioteket';
@@ -661,17 +660,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count författare';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count genrer';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% klart';
+    return '$percent% completed';
   }
 
   @override
@@ -688,7 +687,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titlar ordnade för läsvänlig bläddring.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -725,7 +724,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Inga $label hittades';
+    return 'No $label found';
   }
 
   @override
@@ -744,13 +743,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get readStatus => 'Läsa';
 
   @override
-  String get watched => 'Sedda';
+  String get watched => 'Tittade';
 
   @override
   String get unread => 'Oläst';
 
   @override
-  String get unwatched => 'Osedda';
+  String get unwatched => 'Obevakad';
 
   @override
   String get seriesStatus => 'Seriestatus';
@@ -762,43 +761,43 @@ class AppLocalizationsSv extends AppLocalizations {
   String get books => 'Böcker';
 
   @override
-  String get latestBooks => 'Senaste böckerna';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Senaste ljudböckerna';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count böcker',
-      one: '1 bok',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Bok';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Ljudbok';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% läst';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time kvar';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Läs';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Lyssna';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Författare';
@@ -836,12 +835,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count delar';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Först utgiven $year';
+    return 'First published $year';
   }
 
   @override
@@ -856,7 +855,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count böcker';
+    return '$count books';
   }
 
   @override
@@ -868,7 +867,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count författare';
+    return '$count Authors';
   }
 
   @override
@@ -876,8 +875,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ljudböcker',
-      one: '1 ljudbok',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -901,7 +900,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get moreLikeThis => 'Mer sånt här';
 
   @override
-  String get castAndCrew => 'Skådespelare & team';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
   String get collection => 'Samling';
@@ -913,7 +912,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get nextUp => 'Nästa upp';
 
   @override
-  String get seasons => 'Säsonger';
+  String get seasons => 'Årstider';
 
   @override
   String get chapters => 'Kapitel';
@@ -925,7 +924,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get movies => 'Filmer';
 
   @override
-  String get musicVideos => 'Musikvideor';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Andra';
@@ -944,7 +943,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Skiva $number';
+    return 'Disc $number';
   }
 
   @override
@@ -970,7 +969,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Utgiven $year';
+    return 'Published $year';
   }
 
   @override
@@ -981,52 +980,52 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count säsonger',
-      one: '1 säsong',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Slutar $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Objekt';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Extramaterial';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Bakom kulisserna';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Borttagna scener';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
   String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Intervjuer';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Scener';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Kortfilmer';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time kvar';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Slutar om $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1040,11 +1039,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Återuppta från $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Spela upp';
+  String get play => 'Spela';
 
   @override
   String get startOver => 'Börja om från början';
@@ -1059,7 +1058,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get playOffline => 'Spela offline';
 
   @override
-  String get audio => 'Ljud';
+  String get audio => 'Audio';
 
   @override
   String get subtitles => 'Undertexter';
@@ -1068,7 +1067,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get version => 'Version';
 
   @override
-  String get cast => 'Casta';
+  String get cast => 'Kasta';
 
   @override
   String get trailer => 'Trailer';
@@ -1139,7 +1138,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Ta bort nedladdade spår för \"$title\"?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1154,17 +1153,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Inga $itemLabel har lästs in';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Laddar ner $title ($count objekt)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Är du säker på att du vill ta bort \"$name\" från servern? Åtgärden kan inte ångras.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1175,7 +1174,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Bokformatet stöds inte: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1202,7 +1201,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Undertext nedladdad och vald: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1211,7 +1210,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Inga fjärrundertexter hittades för $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1239,7 +1238,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Laddar ner $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Ta bort lokala filer för $typeLabel?\n\nDet frigör lagringsutrymme. Du kan ladda ner dem igen senare.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1263,25 +1262,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get director => 'DIREKTÖR';
 
   @override
-  String get directors => 'REGISSÖRER';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'MANUSFÖRFATTARE';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'MANUSFÖRFATTARE';
+  String get writers => 'FÖRfattare';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count till';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count avsnitt';
+    return '$count Episodes';
   }
 
   @override
@@ -1291,12 +1290,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Avsnitt $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Kapitel $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1304,8 +1303,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count spår',
-      one: '1 spår',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1315,25 +1314,25 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count kapitel',
-      one: '1 kapitel',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Född $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Död $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Ålder $age';
+    return 'Age $age';
   }
 
   @override
@@ -1346,17 +1345,17 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shuffle => 'Blanda';
 
   @override
-  String get shuffleAllMusic => 'Blanda all musik';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Logga in på Moonfin i din telefon';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Kan inte nå din server';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count nedladdningar';
+    return '$count downloads';
   }
 
   @override
@@ -1364,7 +1363,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kanaler';
+    return '${count}ch';
   }
 
   @override
@@ -1375,32 +1374,32 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Fjärrundertext $action kräver Jellyfin-behörigheten för undertexthantering för den här användaren.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Objektet kunde inte hittas på servern för fjärrundertext $action.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Fjärrundertext $action misslyckades: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Fjärrundertext $action misslyckades (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Kunde inte $action fjärrundertexter.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'alla nedladdade avsnitt för \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1432,17 +1431,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label-åtgärden misslyckades: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Kunde inte ställa in volymen för cast: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label-kontroller';
+    return '$label Controls';
   }
 
   @override
@@ -1459,7 +1458,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Stoppa $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1467,7 +1466,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Spår $number';
+    return 'Track $number';
   }
 
   @override
@@ -1484,7 +1483,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds sekunder';
+    return '$seconds seconds';
   }
 
   @override
@@ -1526,7 +1525,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get subtitleDelay => 'Undertextfördröjning';
 
   @override
-  String get reset => 'Återställ';
+  String get reset => 'Återställa';
 
   @override
   String get unknown => 'Okänd';
@@ -1577,7 +1576,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoBitrate => 'Video bithastighet';
 
   @override
-  String get track => 'Spår';
+  String get track => 'Spåra';
 
   @override
   String get channels => 'Kanaler';
@@ -1599,12 +1598,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol-sessionsfel';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Kunde inte läsa in bokinformation: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1613,7 +1612,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Det här formatet (.$extension) kan inte visas i appen än.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1626,17 +1625,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Kunde inte öppna läsaren i appen: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Bokmärket är redan sparat vid $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Bokmärke tillagt: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1649,7 +1648,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Sida $number';
+    return 'Page $number';
   }
 
   @override
@@ -1665,7 +1664,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String percentRead(String percent) {
-    return '$percent% läst';
+    return '$percent% read';
   }
 
   @override
@@ -1688,7 +1687,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Återställ zoom (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1711,7 +1710,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Kunde inte uppdatera lässtatus: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1743,7 +1742,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Den här plattformen kan inte köra den inbyggda dokumentmotorn för $extension-filer.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1782,7 +1781,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Kunde inte läsa in tablån: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1793,22 +1792,22 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Nästa: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes min kvar';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours tim kvar';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours tim $minutes min kvar';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1831,29 +1830,29 @@ class AppLocalizationsSv extends AppLocalizations {
   String get favoriteChannel => 'Favoritkanal';
 
   @override
-  String get record => 'Spela in';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Avbryt inspelning';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Programmet är inställt för inspelning';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Inspelningen avbröts';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Kunde inte skapa inspelning';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Titta';
 
   @override
-  String get close => 'Stäng';
+  String get close => 'Nära';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Kunde inte spela upp $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1880,11 +1879,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Avbryta schemalagd inspelning av \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Nej';
+  String get no => 'Inga';
 
   @override
   String get yesCancel => 'Ja, avbryt';
@@ -1909,7 +1908,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Sluta spela in \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1924,12 +1923,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Inga resultat för \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Sökningen misslyckades: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1970,12 +1969,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Ta bort \"$name\" och dess filer?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count spår';
+    return '$count tracks';
   }
 
   @override
@@ -1986,12 +1985,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Kunde inte läsa in albumet: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Inga nedladdade spår hittades för $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2008,7 +2007,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Ta bort \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2023,7 +2022,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'Avsnitt $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2037,7 +2036,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Säsong $number';
+    return 'Season $number';
   }
 
   @override
@@ -2053,7 +2052,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Ta bort alla nedladdade avsnitt i $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2061,8 +2060,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count avsnitt',
-      one: '1 avsnitt',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2097,7 +2096,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Ta bort $count nedladdade objekt?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2111,7 +2110,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'av gränsen $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2196,7 +2195,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count alternativ';
+    return '$count options';
   }
 
   @override
@@ -2221,7 +2220,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get never => 'Aldrig';
 
   @override
-  String get focusExpansionAnimation => 'Animering vid fokusexpansion';
+  String get focusExpansionAnimation => 'Focus Expansion Animation';
 
   @override
   String get desktopUiScale => 'Desktop UI-skala';
@@ -2288,7 +2287,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get themeMusicVolume => 'Tema musikvolym';
 
   @override
-  String get themeMusicSettingsSubtitle => 'Detaljsidor, hemrader och volym';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2303,11 +2303,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Spela när du surfar på startskärmen';
 
   @override
-  String get loopThemeMusic => 'Loopa temamusik';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Upprepa spåret i stället för att spela det en gång';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detaljer Bakgrundsskärpa';
@@ -2330,23 +2330,23 @@ class AppLocalizationsSv extends AppLocalizations {
   String get playerZoomMode => 'Spelarens zoomläge';
 
   @override
-  String get settingsScrollWheelAction => 'Mushjul';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Välj vad som händer när du rullar med mushjulet över videon under uppspelning.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Av';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Spola (framåt/bakåt)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Volym';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Volym';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Färdig';
@@ -2400,37 +2400,37 @@ class AppLocalizationsSv extends AppLocalizations {
   String get defaultAudioLanguage => 'Standardljudspråk';
 
   @override
-  String get fallbackAudioLanguage => 'Reservspråk för ljud';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Föredra standardljudspår';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Föredra originalljudspåret framför lokaliserad dubbning.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Föredra syntolkningsspår';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Föredra syntolkningsspår framför vanliga spår.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Omkodning (ljud)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Direktström (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Omkodning (bithastighet eller upplösning)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Omkodning (video och ljud)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Omkodning (video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Auto (serverstandard)';
@@ -2507,28 +2507,27 @@ class AppLocalizationsSv extends AppLocalizations {
       'Aktivera TrueHD-ljud (fungerar kanske inte på alla plattformar)';
 
   @override
-  String get settingsAudioOutputMode => 'Ljudutgångsläge';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Välj hur ljudet avkodas. AVR Passthrough skickar råa Dolby-/DTS-strömmar till din receiver; Auto eller Nedmixning avkodar lokalt.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Reservcodec för ljud';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Välj målformatet för omkodning av flerkanaligt ljud när källströmmen inte kan direktspelas eller skickas vidare.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Identifiera automatiskt\n(Rekommenderas)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Standard)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2537,27 +2536,26 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Förlustfritt)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Endast stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Effektiv)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Förlustfritt)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max antal ljudkanaler';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Ställ in det maximala antalet kanaler för din ljudanläggning. Flerkanalsströmmar som överskrider gränsen nedmixas eller omkodas.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Identifiera automatiskt\n(Hårdvarustandard)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2569,7 +2567,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadrofoni';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2584,68 +2582,67 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (avancerat)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Codec-passthrough';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Aktivera endast format som din AVR eller HDMI-mottagare stöder.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3-passthrough';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos)-passthrough';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core-passthrough';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA-passthrough';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD-passthrough';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos-passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Skicka Dolby Digital Plus (EAC3) som bitström till extern avkodare.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Skicka Dolby Atmos över EAC3 (JOC) som bitström till extern avkodare.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Skicka DTS-HD MA (inklusive DTS core) som bitström till extern avkodare.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Skicka Dolby TrueHD med Atmos-metadata som bitström till extern avkodare.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Identifierade ljudfunktioner';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Ingen ögonblicksbild av körtidsfunktioner finns än.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Ljudväg';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Avkodning';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD-ljudväg';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2660,48 +2657,50 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Högtalare';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Hörlurar';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kanaler PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostik';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Videonivå';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Videoomfång';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Undertextcodec';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => 'Tillåtna ljudcodec';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS-ljudcodec';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs => 'HLS fMP4-ljudcodec';
+  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktiv ljudväg';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'HD-ljudstöd för ljudvägen';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Nattläge';
@@ -2746,7 +2745,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get minimal => 'Minimal';
 
   @override
-  String get nextUpTimeout => 'Tidsgräns för Näst på tur';
+  String get nextUpTimeout => 'Next Up Timeout';
 
   @override
   String secondsValue(int value) {
@@ -2764,7 +2763,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Efter $episodes avsnitt / $hours tim';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2840,45 +2839,45 @@ class AppLocalizationsSv extends AppLocalizations {
       'Anpassa undertexternas utseende';
 
   @override
-  String get subtitleMode => 'Undertextläge';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Flaggade';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Alltid';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Främmande språk';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Tvingade';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Spelar spår som internt är flaggade som \"default\" eller \"forced\" i mediefilens metadata.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Läser automatiskt in och visar undertexter varje gång en video startar.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Slår automatiskt på undertexter om standardljudspåret är på ett främmande språk.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Läser bara in undertexter som uttryckligen är märkta med flaggan forced.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Inaktiverar automatisk inläsning av undertexter helt.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Reservspråk för undertexter';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Undertextström';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2937,17 +2936,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Inställningar för profilen $profile har lästs in.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Kunde inte läsa in inställningar för profilen $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Lokala inställningar har synkats till profilen $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3065,7 +3064,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get navigationStyle => 'Navigationsstil';
 
   @override
-  String get topBar => 'Övre fält';
+  String get topBar => 'Top Bar';
 
   @override
   String get leftSidebar => 'Vänster sidofält';
@@ -3083,11 +3082,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showLibrariesInToolbar => 'Visa bibliotek i verktygsfältet';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Visa alltid etiketter i navigeringsfältet';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Visa Seerr-knapp';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Navbar Opacitet';
@@ -3162,18 +3160,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showFolderBrowsingOption => 'Visa mappsökningsalternativ';
 
   @override
-  String get groupItemsIntoCollections => 'Gruppera objekt i samlingar';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Dölj biblioteksobjekt som hör till en samling när du bläddrar i bibliotek';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'Om biblioteksgruppering';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'För att kunna använda den här inställningen måste biblioteksinställningarna \"Group movies into collections\" och/eller \"Group shows into collections\" vara aktiverade under bibliotekets visningsinställningar på din Jellyfin- eller Emby-server.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Bibliotekets synlighet';
@@ -3202,11 +3200,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count valda';
+    return '$count selected';
   }
 
   @override
-  String get mediaBar => 'Mediefält';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Mediekällor';
@@ -3285,10 +3283,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Spela upp trailers automatiskt i mediafältet efter 3 sekunder';
 
   @override
-  String get trailerAudio => 'Trailerljud';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Aktivera ljud för trailers i mediefältet';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Förhandsvisning av avsnitt';
@@ -3366,11 +3364,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kombinera båda raderna till en enda hemsektion';
 
   @override
-  String get fullScreenRows => 'Expanderade hemrader';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Begränsa hemrader till 1 rad per skärm';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Bildtyp per rad';
@@ -3385,7 +3382,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get lastUser => 'Senaste användare';
 
   @override
-  String get currentUser => 'Nuvarande användare';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentisera alltid';
@@ -3456,7 +3453,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get clock => 'Klocka';
 
   @override
-  String get timeout => 'Tidsgräns';
+  String get timeout => 'Timeout';
 
   @override
   String minutesShort(int minutes) {
@@ -3491,10 +3488,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Visa klockan under skärmsläckare';
 
   @override
-  String get clockModeStatic => 'Statisk';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Studsande';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Kritiker)';
@@ -3564,7 +3561,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Aktivera och ändra ordning på betygskällorna som visas i appen';
 
   @override
-  String get pluginLabel => 'Moonbase-plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin upptäckt';
@@ -3589,7 +3586,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get availableServices => 'Tillgängliga tjänster';
 
   @override
-  String get serverPluginSync => 'Synkning av serverplugin';
+  String get serverPluginSync => 'Server Plugin Sync';
 
   @override
   String get syncSettingsWithPlugin =>
@@ -3621,7 +3618,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get upcomingMovies => 'Kommande filmer';
 
   @override
-  String get studios => 'Studior';
+  String get studios => 'Studios';
 
   @override
   String get popularSeries => 'Populär serie';
@@ -3636,7 +3633,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get networks => 'Nätverk';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr-upptäcktsrader';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Återställ rader till standardvärden';
@@ -3659,43 +3656,44 @@ class AppLocalizationsSv extends AppLocalizations {
   String get hideAdultContent => 'Dölj barnförbjudet innehåll i resultaten';
 
   @override
-  String get seerrNotificationsSection => 'Aviseringar';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Aviseringar om nya förfrågningar';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Meddela mig när någon skickar en förfrågan';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Uppdateringar om förfrågningar';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Godkända, nekade och tillagda i ditt bibliotek';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Uppdateringar om problem';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Nya problem, svar och lösningar';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Inloggad som: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr-upptäcktssida';
+  String get discoverRows => 'Upptäck rader';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Aktivera raderna du vill se på Seerrs startsida. Dra för att ändra ordning. Den anpassade ordningen synkroniseras med Moonbase.';
+      'Dra för att ändra ordning. Aktivera eller inaktivera rader. Aktiverad radordning synkroniseras med plugin-programmet Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Aktivera raderna du vill se på Seerrs startsida. Dra för att ändra ordning. Den anpassade ordningen synkroniseras med Moonbase.';
+      'Dra för att ändra ordning. Aktivera eller inaktivera rader.';
 
   @override
   String get enabled => 'Aktiverad';
@@ -3757,7 +3755,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Uppdatering tillgänglig: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3769,7 +3767,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version finns tillgänglig';
+    return 'v$version Available';
   }
 
   @override
@@ -3847,15 +3845,15 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Laddar ner · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Importerar';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count objekt';
+    return '$count Items';
   }
 
   @override
@@ -3875,7 +3873,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Efterfrågad av $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3892,12 +3890,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Avbryta förfrågan om \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Avbryta $count förfrågningar om \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3917,7 +3915,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String revenueAmount(String amount) {
-    return 'Intäkter: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3927,7 +3925,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Efterfråga $type';
+    return 'Request $type';
   }
 
   @override
@@ -3956,14 +3954,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showMore => 'Visa mer';
 
   @override
-  String get appearances => 'Medverkan';
+  String get appearances => 'Framträdanden';
 
   @override
   String get crewSection => 'Besättning';
 
   @override
   String ageValue(int age) {
-    return 'ålder $age';
+    return 'age $age';
   }
 
   @override
@@ -3994,148 +3992,148 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deletedStatus => 'Raderad';
 
   @override
-  String get failedStatus => 'Misslyckades';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Bearbetas';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Ändrad av $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Slutförd';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Titeln har redan efterfrågats';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Gränsen för förfrågningar har nåtts';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Titeln är blockerad';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Inga säsonger kvar att efterfråga';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Du har inte behörighet att göra den här förfrågan';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Förfrågningar';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Problem';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Nyast';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Senast ändrad';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Inga problem';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining av $limit filmförfrågningar kvar';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining av $limit säsongsförfrågningar kvar';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Del av $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Visa samling';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Efterfråga samling';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total filmer · $available tillgängliga';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Efterfråga $count filmer';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Efterfrågar $current av $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Efterfrågade $count filmer';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Efterfrågade $ok av $total filmer';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Alla filmer är redan tillgängliga eller efterfrågade';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Rapportera problem';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Ljud';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Vad är fel?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Alla avsnitt';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Avsnitt';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Öppen';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Löst';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Lös';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Öppna igen';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Rapporterat av $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count kommentarer';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Lägg till en kommentar';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Ta bort det här problemet?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Skicka rapport';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB-poäng';
@@ -4159,7 +4157,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get originalLanguageLabel => 'Originalspråk';
 
   @override
-  String get seasonsLabel => 'Säsonger';
+  String get seasonsLabel => 'Årstider';
 
   @override
   String get episodesLabel => 'Avsnitt';
@@ -4168,13 +4166,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get access => 'Tillträde';
 
   @override
-  String get add => 'Lägg till';
+  String get add => 'Tillägga';
 
   @override
   String get address => 'Adress';
 
   @override
-  String get analytics => 'Analys';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'Katalog';
@@ -4192,7 +4190,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get disable => 'Inaktivera';
 
   @override
-  String get done => 'Klar';
+  String get done => 'Gjort';
 
   @override
   String get edit => 'Redigera';
@@ -4204,10 +4202,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get error => 'Fel';
 
   @override
-  String get forward => 'Framåt';
+  String get forward => 'Fram';
 
   @override
-  String get general => 'Allmänt';
+  String get general => 'Allmän';
 
   @override
   String get go => 'Gå';
@@ -4252,7 +4250,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get refresh => 'Uppdatera';
 
   @override
-  String get remote => 'Fjärrkontroll';
+  String get remote => 'Avlägsen';
 
   @override
   String get rename => 'Döpa om';
@@ -4270,7 +4268,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get run => 'Sikt';
 
   @override
-  String get search => 'Sök';
+  String get search => 'Sok';
 
   @override
   String get select => 'Välja';
@@ -4288,7 +4286,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get status => 'Status';
 
   @override
-  String get stop => 'Stoppa';
+  String get stop => 'Stopp';
 
   @override
   String get streaming => 'Streaming';
@@ -4297,7 +4295,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get time => 'Tid';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Trickspel';
 
   @override
   String get uninstall => 'Avinstallera';
@@ -4315,22 +4313,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get unmute => 'Slå på ljudet';
 
   @override
-  String get mute => 'Ljud av';
+  String get mute => 'Stum';
 
   @override
-  String get branding => 'Varumärke';
+  String get branding => 'Branding';
 
   @override
   String get adminDrawerDashboard => 'Instrumentpanel';
 
   @override
-  String get adminDrawerAnalytics => 'Analys';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'Inställningar';
 
   @override
-  String get adminDrawerBranding => 'Varumärke';
+  String get adminDrawerBranding => 'Branding';
 
   @override
   String get adminDrawerUsers => 'Användare';
@@ -4339,25 +4337,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminDrawerLibraries => 'Bibliotek';
 
   @override
-  String get adminDrawerDisplay => 'Visning';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO-inställningar';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Omkodning';
 
   @override
-  String get adminDrawerResume => 'Återuppta';
+  String get adminDrawerResume => 'Resume';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Trickspel';
 
   @override
   String get adminDrawerDevices => 'Enheter';
@@ -4409,29 +4407,29 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Pluginuppdateringar tillgängliga: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Plugins som kräver omstart: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Misslyckade schemalagda uppgifter: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Senaste varnings-/felposter: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
   String get analyticsMediaDistribution => 'Mediedistribution';
 
   @override
-  String get analyticsVideoCodecs => 'Videocodec';
+  String get analyticsVideoCodecs => 'Video Codecs';
 
   @override
   String get analyticsAudioCodecs => 'Ljudkodekar';
@@ -4449,7 +4447,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get analyticsContentRatings => 'Innehållsklassificeringar';
 
   @override
-  String get analyticsRuntimeBuckets => 'Speltidsintervall';
+  String get analyticsRuntimeBuckets => 'Runtime Buckets';
 
   @override
   String get analyticsFileFormats => 'Filformat';
@@ -4483,7 +4481,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Fel: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4510,7 +4508,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Kommandot misslyckades: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4529,7 +4527,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get sessionRewind => 'Spola tillbaka';
 
   @override
-  String get sessionForward => 'Framåt';
+  String get sessionForward => 'Fram';
 
   @override
   String get sessionNext => 'Nästa';
@@ -4553,13 +4551,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get actions => 'Åtgärder';
 
   @override
-  String get videoCodec => 'Videocodec';
+  String get videoCodec => 'Video Codec';
 
   @override
-  String get audioCodec => 'Ljudcodec';
+  String get audioCodec => 'Audio Codec';
 
   @override
-  String get hwAccel => 'HW-accel';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Komplettering';
@@ -4574,14 +4572,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminClearDates => 'Klara datum';
 
   @override
-  String get adminActivitySeverityAll => 'Alla allvarlighetsgrader';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Datumintervall';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Kunde inte läsa in aktivitetsloggen: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4598,7 +4596,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Kunde inte uppdatera enheten: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4609,28 +4607,28 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Kunde inte ta bort enheten: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Ta bort enheten \'$name\'? Användaren måste logga in igen på den här enheten.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Ta bort alla enheter';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Ta bort $count enheter? Berörda användare måste logga in igen. Din nuvarande enhet påverkas inte.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Enheterna har tagits bort';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Vissa enheter togs bort; $count kunde inte tas bort.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4659,7 +4657,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Kunde inte starta genomsökningen: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4670,12 +4668,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Biblioteket har bytt namn till \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Kunde inte byta namn: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4683,17 +4681,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Biblioteket \"$name\" har tagits bort';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Kunde inte ta bort biblioteket: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Kunde inte lägga till sökvägen: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4701,12 +4699,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Ta bort \"$path\" från det här biblioteket?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Kunde inte ta bort sökvägen: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4714,7 +4712,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Kunde inte spara alternativen: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4745,258 +4743,251 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminMetadataCountryHint => 'till exempel USA, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Sökvägar';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Alternativ';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Nedladdare';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Metadatasparare';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Undertextnedladdare';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Låttextnedladdare';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Metadatanedladdare: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Bildhämtare: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Servern erbjuder inga nedladdare för den här bibliotekstypen.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Allmänt';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Inbäddad information';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Undertexter';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Bilder';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serier';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musik';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filmer';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Aktivera realtidsövervakning';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Upptäck filändringar och behandla dem automatiskt.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Behandla arkiv som mediefiler';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Visa foton';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Spara omslagsbilder i mediemapparna';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Automatisk uppdatering av metadata';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Aldrig';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Standard';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Visning';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Biblioteksvisning';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
-  String get adminLibFolderView => 'Visa en mappvy för vanliga mediemappar';
+  String get adminLibFolderView =>
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Visa specialavsnitt i den säsong de sändes';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Gruppera filmer i samlingar';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Gruppera serier i samlingar';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Visa externt innehåll bland förslagen';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Beteende för tillagt datum';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Hämta tillagt datum från';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Datum då filen skannades in i biblioteket';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Datum då filen skapades';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata och bilder';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Föredraget metadataspråk';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Kapitel';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Längd på genererade kapitel (sekunder)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Längden på kapitel som genereras för media som saknar kapitel. Ange 0 för att inaktivera.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Upplösning för kapitelbilder';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO-inställningar';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO-metadata är kompatibel med Kodi och liknande klienter. Inställningarna gäller alla bibliotek som sparar NFO-metadata.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Användare vars visningsdata sparas i NFO-filer';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Spara bildsökvägar i NFO-filer';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Aktivera sökvägsersättning för bildsökvägar i NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopiera extrafanart-bilder till en extrathumbs-mapp';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Ingen';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days dagar';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Använd inbäddade titlar';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Använd inbäddade titlar för extramaterial';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Använd inbäddad avsnittsinformation';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Tillåt inbäddade undertexter';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Tillåt alla';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Endast text';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Endast bild';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Ingen';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Hoppa över nedladdning om inbäddade undertexter finns';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Hoppa över nedladdning om ljudspåret matchar nedladdningsspråket';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Kräv en perfekt undertextmatchning';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Spara undertexter i mediemapparna';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Extrahera kapitelbilder';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Extrahera kapitelbilder under biblioteksgenomsökningen';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Aktivera extrahering av trickplay-bilder';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Extrahera trickplay-bilder under biblioteksgenomsökningen';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Spara trickplay-bilder i mediemapparna';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Slå automatiskt ihop serier som är utspridda över flera mappar';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Visningsnamn för säsong noll';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Aktivera LUFS-genomsökning för ljudnormalisering';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Föredra icke-standardtaggen för artister';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Lägg automatiskt till filmer i samlingar';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Bibliotekets namn krävs';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Kunde inte skapa biblioteket: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5023,27 +5014,27 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Inaktivera $name? Användaren kommer inte att kunna logga in.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Aktivera $name? Användaren kommer att kunna logga in igen.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Användaren \"$name\" har inaktiverats';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Användaren \"$name\" har aktiverats';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Kunde inte uppdatera användarpolicyn: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5060,7 +5051,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Kunde inte skapa användaren: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5080,7 +5071,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Kunde inte spara: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5091,7 +5082,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Misslyckades: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5224,146 +5215,143 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminEnableAllChannels => 'Aktivera åtkomst till alla kanaler';
 
   @override
-  String get adminParentalControl => 'Föräldrakontroll';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Högsta tillåtna åldersgräns';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Innehåll med en högre åldersgräns döljs för den här användaren.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Ingen';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Blockera objekt utan eller med okänd åldersgräns';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Böcker';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kanaler';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Live-TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filmer';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musik';
+  String get adminUnratedMusic => 'Music';
 
   @override
   String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Serier';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Åtkomstscheman';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Tillåt åtkomst endast under de schemalagda tiderna nedan. Åtkomst tillåts hela dygnet när inget schema är angett.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Lägg till schema';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Dag';
+  String get adminScheduleDay => 'Day';
 
   @override
   String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Slut';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Varje dag';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Vardag';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Helg';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Söndag';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Måndag';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Tisdag';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Onsdag';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Torsdag';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Fredag';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Lördag';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Tillåtna taggar';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Endast innehåll med dessa taggar visas. Lämna tomt för att tillåta allt.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Blockerade taggar';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Innehåll med dessa taggar döljs för den här användaren.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Lägg till tagg';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Aktiverade enheter';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Aktiverade kanaler';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Autentiseringsleverantör';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Leverantör för lösenordsåterställning';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Högsta antal misslyckade inloggningsförsök före utelåsning';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Ange 0 för standardvärdet, eller -1 för att inaktivera utelåsning.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay-åtkomst';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Tillåt att skapa och gå med i grupper';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Tillåt att gå med i grupper';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Ingen åtkomst';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Tillåt borttagning av innehåll från';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5371,22 +5359,22 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Servern svarade med HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Är du säker på att du vill ta bort $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Användaren \"$name\" har tagits bort';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Kunde inte ta bort användaren: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5407,7 +5395,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Kunde inte skapa nyckeln: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5418,7 +5406,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Återkalla nyckeln för $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5426,7 +5414,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Kunde inte återkalla nyckeln: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5446,29 +5434,29 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nSkapad: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Skapa säkerhetskopia';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Välj vad som ska ingå i säkerhetskopian.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Databas';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Ingår alltid';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Undertexter';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay-bilder';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Skapar säkerhetskopia...';
@@ -5478,7 +5466,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Kunde inte skapa säkerhetskopian: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5492,7 +5480,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Kunde inte läsa in manifestet: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5503,7 +5491,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Kunde inte återställa säkerhetskopian: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5536,17 +5524,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Sparad till $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Kunde inte spara filen: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Kunde inte läsa in $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5557,7 +5545,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Kunde inte läsa in uppgifterna: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5569,17 +5557,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Kunde inte starta uppgiften: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Kunde inte stoppa uppgiften: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Kunde inte läsa in uppgiften: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5587,12 +5575,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Kunde inte ta bort utlösaren: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Kunde inte lägga till utlösaren: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5618,7 +5606,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours timme/timmar';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5629,7 +5617,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Kunde inte växla pluginet: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5637,27 +5625,27 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Är du säker på att du vill avinstallera \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Kunde inte avinstallera pluginet: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Kunde inte installera paketet: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Kunde inte installera uppdateringen: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Kunde inte läsa in plugins: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5668,12 +5656,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Installera uppdatering (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Kunde inte läsa in katalogen: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5694,17 +5682,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" tas bort efter att servern startats om';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Kunde inte avinstallera: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Uppdaterar \"$name\" till v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5713,7 +5701,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Kunde inte läsa in pluginet: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5741,24 +5729,24 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Är du säker på att du vill ta bort \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Kunde inte spara arkiven: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Kunde inte läsa in arkiven: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
   String get adminRepositoryNameHint => 'till exempel Jellyfin Stabil';
 
   @override
-  String get adminRepositoryUrl => 'Arkivets URL';
+  String get adminRepositoryUrl => 'Repository URL';
 
   @override
   String get adminAddEntry => 'Lägg till post';
@@ -5768,12 +5756,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Kunde inte läsa in plugininställningarna: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Kunde inte öppna $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -6054,12 +6042,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Kunde inte läsa in metadata: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Kunde inte spara metadata: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6079,7 +6067,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Kunde inte uppdatera metadata: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6093,7 +6081,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Fjärrsökningen misslyckades: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6107,7 +6095,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Kunde inte uppdatera innehållstypen: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6122,12 +6110,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType-bilden har uppdaterats';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Kunde inte ladda ner bilden: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6138,27 +6126,27 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType-bilden har laddats upp';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Kunde inte ladda upp bilden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Ta bort $imageType-bilden';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType-bilden har tagits bort';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Kunde inte ta bort bilden: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6169,68 +6157,67 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Sökningen efter tuners misslyckades: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Lägg till tuner';
 
   @override
-  String get adminEditTuner => 'Redigera tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U-tuner';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Fil eller URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Tunerns IP-adress';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Visningsnamn';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Gräns för samtidiga anslutningar';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Det största antal strömmar som tunern tillåter samtidigt. Ange 0 för obegränsat.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Reservgräns för strömmens bithastighet';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Importera endast favoritkanaler';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Tillåt hårdvaruomkodning';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Tillåt fMP4 som omkodningscontainer';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Tillåt delning av strömmar';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Aktivera loopning av strömmar';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ignorera DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Läs indata med ursprunglig bildfrekvens';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Redigera leverantör';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6239,50 +6226,50 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Fil eller URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Filmprefix';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Filmkategorier';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Separera flera kategorier med ett lodstreck.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Barnkategorier';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Nyhetskategorier';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Sportkategorier';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Användarnamn';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Lösenord';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Land';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Välj ett land';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Postnummer';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Hämta tablåer';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Tablåer';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Aktivera alla tuners';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Tuner typ';
@@ -6292,7 +6279,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Kunde inte lägga till tunern: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6306,12 +6293,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Kunde inte lägga till leverantören: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Kunde inte ta bort tunern: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6319,16 +6306,16 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Kunde inte återställa tunern: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Den här tunertypen stöder inte återställning.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Kunde inte ta bort leverantören: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6347,44 +6334,43 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Serieinspelningsväg';
 
   @override
-  String get adminMovieRecordingPath => 'Sökväg för filminspelningar';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Antal dagar med tablådata';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Automatiskt';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days dagar';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Sökväg till efterbehandlingsprogram';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Argument för efterbehandling';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Spara NFO-metadata för inspelningar';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Spara bilder för inspelningar';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Tidsinställning';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Inspelningssökvägar';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Efterbehandling';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Tablådata: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6392,7 +6378,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Kunde inte spara inställningarna: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6409,7 +6395,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Kunde inte uppdatera mappningarna: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6426,14 +6412,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminGuideProviders => 'Guide leverantörer';
 
   @override
-  String get adminRefreshGuideData => 'Uppdatera tablådata';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'Uppdatering av tablådata har startat';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Uppgiften för tablåuppdatering är inte tillgänglig på den här servern.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Lägg till leverantör';
@@ -6444,26 +6430,26 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Inspelningssökväg: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Seriesökväg: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Marginal före: $minutes min';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Marginal efter: $minutes min';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'Sök efter tuners';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
   String get adminChannelMappings => 'Kanalmappningar';
@@ -6492,7 +6478,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Återställa säkerhetskopian $name nu?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6516,13 +6502,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminLiveTvTitle => 'Direktsänd TV-administration';
 
   @override
-  String get adminApply => 'Tillämpa';
+  String get adminApply => 'Tillämpas';
 
   @override
   String get adminNotSet => 'Inte inställt';
 
   @override
-  String get adminReset => 'Återställ';
+  String get adminReset => 'Återställa';
 
   @override
   String get adminLogsTitle => 'Serverloggar';
@@ -6538,27 +6524,27 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes min sedan';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours tim sedan';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days d sedan';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Kunde inte läsa in $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count träffar';
+    return '$count matches';
   }
 
   @override
@@ -6568,7 +6554,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadataredigerare';
 
   @override
-  String get adminMetadataIdentify => 'Identifiera';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Typ';
@@ -6610,7 +6596,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminMetadataFieldCriticRating => 'Kritikerbetyg';
 
   @override
-  String get adminMetadataFieldTagline => 'Slogan';
+  String get adminMetadataFieldTagline => 'Tagline';
 
   @override
   String get adminMetadataFieldOverview => 'Översikt';
@@ -6622,7 +6608,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminMetadataTags => 'Taggar';
 
   @override
-  String get adminMetadataStudios => 'Studior';
+  String get adminMetadataStudios => 'Studios';
 
   @override
   String get adminMetadataPeople => 'Personer';
@@ -6668,22 +6654,22 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType-bilden har uppdaterats';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType-bilden har laddats upp';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType-bilden har tagits bort';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Kunde inte ladda ner bilden: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6692,12 +6678,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Kunde inte ladda upp bilden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Ta bort $imageType-bilden';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6706,12 +6692,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Kunde inte ta bort bilden: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Välj $imageType-bild';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6743,7 +6729,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Uppdatering tillgänglig: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6767,7 +6753,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Installera uppdatering (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6779,7 +6765,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" installeras...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6799,7 +6785,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Inställningar för $name';
+    return '$name Settings';
   }
 
   @override
@@ -6839,7 +6825,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Kunde inte läsa in arkiven: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6847,7 +6833,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Är du säker på att du vill ta bort \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6855,7 +6841,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Kunde inte spara arkiven: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6875,7 +6861,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminReposAddTitle => 'Lägg till arkiv';
 
   @override
-  String get adminReposUrl => 'Arkivets URL';
+  String get adminReposUrl => 'Repository URL';
 
   @override
   String get adminReposNameHint => 'till exempel Jellyfin Stabil';
@@ -6962,7 +6948,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminNetworkingAddEntry => 'Lägg till post';
 
   @override
-  String get adminBrandingTitle => 'Varumärke';
+  String get adminBrandingTitle => 'Branding';
 
   @override
   String get adminBrandingLoginDisclaimer =>
@@ -6983,20 +6969,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Aktivera startskärm';
 
   @override
-  String get adminBrandingSplashUpload => 'Ladda upp bild';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Startskärmen har uppdaterats';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Kunde inte ladda upp startskärmen';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Startskärmen har tagits bort';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Ingen anpassad startskärm';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Hårdvaruacceleration';
@@ -7011,122 +6996,118 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Aktivera hårdvaruavkodning för:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV-enhet';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Aktivera förbättrad NVDEC-avkodare';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Föredra systemets inbyggda hårdvaruavkodare';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Färgdjup vid hårdvaruavkodning';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bitars HEVC-avkodning';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bitars VP9-avkodning';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-bitars avkodning';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12-bitars avkodning';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Hårdvarukodning';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Tillåt HEVC-kodning';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Tillåt AV1-kodning';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Aktivera Intels lågeffekts-H.264-kodare';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Aktivera Intels lågeffekts-HEVC-kodare';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Tonmappning';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Aktivera tonmappning';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Aktivera VPP-tonmappning';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Aktivera VideoToolbox-tonmappning';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algoritm för tonmappning';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Läge för tonmappning';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Omfång för tonmappning';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Avmättnad vid tonmappning';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Topp för tonmappning';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter för tonmappning';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Ljusstyrka för VPP-tonmappning';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Kontrast för VPP-tonmappning';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Förinställningar och kvalitet';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Förinställning för kodare';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF för H.264-kodning';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF för H.265 (HEVC)-kodning';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Avflätningsmetod';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Fördubbla bildfrekvensen vid avflätning';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Ljud';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Aktivera VBR-kodning för ljud';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Förstärkning vid nedmixning av ljud';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm =>
-      'Algoritm för nedmixning till stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Max storlek på muxningskön';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7249,10 +7230,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminTaskNeverRun => 'Spring aldrig';
 
   @override
-  String get adminTaskStop => 'Stoppa';
+  String get adminTaskStop => 'Stopp';
 
   @override
-  String get adminRunningTasks => 'Pågående uppgifter';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Sikt';
@@ -7274,17 +7255,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Dagligen kl. $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Varje $day kl. $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Var $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7322,8 +7303,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count timmar',
-      one: '1 timme',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7351,17 +7332,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days d sedan';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours tim sedan';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes min sedan';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7369,22 +7350,22 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes min';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours tim';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days d';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
@@ -7404,43 +7385,43 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Publik HTTP-port';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Kräv HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Omdirigera alla fjärranslutningar till HTTPS. Har ingen effekt om servern saknar ett giltigt certifikat.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Certifikatlösenord';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP-inställningar';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Aktivera IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Aktivera IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'Aktivera automatisk portmappning';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN-nätverk';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Komma- eller radseparerad lista med IP-adresser eller CIDR-subnät som räknas som lokalt nätverk.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Publicerade server-URI:er';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Mappa ett subnät eller en adress till en publicerad URL, t.ex. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Certifikatsökväg';
@@ -7470,12 +7451,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Gasspjällsbuffring';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Fördröjning för strypning (sekunder)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Tillåt extrahering av undertexter i realtid';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minsta CV procentsats';
@@ -7525,7 +7505,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Kunde inte uppdatera innehållstypen: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7533,11 +7513,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Tröskel för långsamt svar (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Aktivera varningar om långsamma svar';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Aktivera Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7546,10 +7525,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Sökvägar';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Prestanda';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Cache-väg';
@@ -7561,7 +7540,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminGeneralServerName => 'Servernamn';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Föredraget visningsspråk';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed =>
@@ -7572,12 +7551,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Kunde inte uppdatera mappningarna: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Tidsgräns: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7614,8 +7593,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# deltagare',
-      one: '# deltagare',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7658,7 +7637,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Objekt $index';
+    return 'Item $index';
   }
 
   @override
@@ -7706,12 +7685,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName gick med i SyncPlay-gruppen';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName lämnade SyncPlay-gruppen';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7723,7 +7702,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Synkar uppspelningen till $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7761,8 +7740,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rader hittade',
-      one: '# rad hittad',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7803,20 +7782,20 @@ class AppLocalizationsSv extends AppLocalizations {
   String get offlineSavedMedia => 'Sparade media';
 
   @override
-  String get offlineBannerTitle => 'Du är offline';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Visar dina nedladdningar';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Nedladdningar';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Kan inte nå din server';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Spelar från nedladdningar tills den är tillbaka';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7832,12 +7811,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Cast-kontrollen misslyckades: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind-kontroller';
+    return '$kind Controls';
   }
 
   @override
@@ -7848,11 +7827,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Stoppa $kind';
+    return 'Stop $kind';
   }
 
   @override
-  String get audioLabel => 'Ljud';
+  String get audioLabel => 'Audio';
 
   @override
   String get subtitlesLabel => 'Undertexter';
@@ -7871,12 +7850,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Ange en $length-siffrig PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Ange din $length-siffriga PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7899,7 +7878,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect-koden är ogiltig eller har löpt ut.';
+      'Snabbanslutningskoden är ogiltig eller har löpt ut.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7919,11 +7898,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect-koden hittades inte. Prova en ny kod.';
+      'Snabbanslutningskoden hittades inte. Prova en ny kod.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect misslyckades: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7934,7 +7913,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Kommandot misslyckades: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7964,7 +7943,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Kunde inte starta cast: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8009,7 +7988,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Laddar ner $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8090,14 +8069,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Uppspelningen har pausats. Tittar du fortfarande?';
 
   @override
-  String get stillWatchingStop => 'Stoppa';
+  String get stillWatchingStop => 'Stopp';
 
   @override
   String get stillWatchingContinue => 'Fortsätta';
 
   @override
   String skipSegment(String segment) {
-    return 'Hoppa över $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8108,12 +8087,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Laddar ner $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Laddar ner $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8150,7 +8129,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Tillåt rotation';
 
   @override
-  String get playerTooltipPrevious => 'Föregående';
+  String get playerTooltipPrevious => 'Tidigare';
 
   @override
   String get playerTooltipSeekBack => 'Sök tillbaka';
@@ -8174,13 +8153,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get contextMenuGoToSeries => 'Gå till serien';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Dölj från Fortsätt titta';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Dölj från Näst på tur';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Lägg till i samling';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8235,14 +8215,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsAlphabetical => 'Alfabetisk';
 
   @override
-  String get settingsConnectionSection => 'ANSLUTNING';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Tillåt självsignerade certifikat';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Lita på servrar som använder självsignerade TLS-certifikat eller certifikat från en privat CA. Aktivera bara för servrar du själv styr. Det här inaktiverar certifikatvalidering för alla anslutningar.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'SEKRETESS OCH SÄKERHET';
@@ -8258,11 +8238,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Temaaccenter, bakgrunder, bevakade indikatorer och temamusik';
 
   @override
-  String get settingsDetailsScreen => 'Detaljsida';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Stil, bakgrundsoskärpa och flikbeteende';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Hemsida';
@@ -8300,11 +8280,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Visa Seerr-knappen i navigeringsfältet';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Visa alltid textetiketter i det övre navigeringsfältet';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8351,7 +8331,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Maximalt antal objekt att ladda ner på en gång.';
 
   @override
-  String get settingsAppInfo => 'APPINFO';
+  String get settingsAppInfo => 'APP INFO';
 
   @override
   String get settingsReportAnIssue => 'Rapportera ett problem';
@@ -8372,7 +8352,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsSupportMoonfin => 'Stöd Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Bjud utvecklaren på en kaffe';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'RÄTTSLIG';
@@ -8405,8 +8386,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# licensmeddelanden',
-      one: '# licensmeddelande',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8456,16 +8437,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hoppa över Intros och Outros?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Nedräkning för mediesegment';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Förloppsindikator';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Ingen';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Fråga användare';
@@ -8489,8 +8470,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Hur video ska skalas för att passa skärmen.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv =>
-      'Uppspelningsmotor (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8501,13 +8481,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Media3 (rekommenderas)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (äldre)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
-  String get settingsPlaybackEngineMpvLegacy => 'mpv (äldre)';
+  String get settingsPlaybackEngineMpvLegacy => 'mpv (legacy)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (rekommenderas)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Reserv';
@@ -8698,753 +8678,749 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Nyligen släppt i $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Spela nästa avsnitt automatiskt';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Spela automatiskt nästa avsnitt när det finns tillgängligt.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Hoppa över tystnad';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Hoppa automatiskt över tysta ljudavsnitt när strömmen stöder det.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Tillåt externa ljudeffekter';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Låt equalizer- och effektappar (t.ex. Wavelet) koppla in sig på Media3-uppspelningssessioner.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Inaktivera tunneling';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Framtvinga uppspelning utan tunneling. Användbart på enheter med ljud-/videoavbrott vid tunneling.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Aktivera tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Avancerat. Skickar ljud och video via en kopplad hårdvaruväg. Avstängt som standard eftersom det orsakar ljud-/videobortfall på vissa enheter.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Mappa Dolby Vision-profil 7 till HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Spela upp strömmar med Dolby Vision-profil 7 som HDR10-kompatibel HEVC på enheter utan DV-stöd.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Använd inbäddade undertextstilar';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Använd färger, teckensnitt och positionering som är inbäddade i undertextspåret. Inaktivera för att använda dina egna stilinställningar i stället.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Använd inbäddade teckenstorlekar för undertexter';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Använd de teckenstorlekar som är inbäddade i undertextspåret. Inaktivera för att använda undertextstorleken från dina stilinställningar.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Visa mediedetaljer';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Visa detaljer om det valda objektet högst upp på bibliotekssidorna.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Dölj bakgrundsbilder när du bläddrar?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Använd detaljerade underrubriker';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Visa en detaljerad eller minimal underrad på bibliotekssidorna.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Ta bort sparat tema?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Ta bort \"$themeName\" från den här enhetens cache?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Temabutik';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Bläddra bland och spara teman från communityn';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Spara ett tema för att använda det som dina andra sparade teman.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Inga teman är tillgängliga just nu.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Kunde inte läsa in Temabutiken. Kontrollera anslutningen och försök igen.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Spara';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Spara och använd';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Sparat';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Det här temat kunde inte läsas in.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" har sparats.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" har tagits bort från den här enheten.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Kunde inte ta bort \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Sparade teman';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Det här är teman som laddats ner från Moonfin-pluginet för den aktuella servern. Borttagning tar endast bort den lokala kopian.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Inga sparade teman hittades för den här servern.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Används nu';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Ta bort sparat tema';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Hantera nedladdade plugin-teman på den här enheten';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Temaredigerare';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Öppna Moonfins temaredigerare i webbläsaren';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Hemskärm';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Nedre fält';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klassisk';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Hemrader';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Visning av hemrader';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sektioner för hemrader';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Reglage för hemrader';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Aktivera eller inaktivera bibliotekbaserade kategorier på hemraderna';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Aktivera reglagen nedan för att visa raderna i hemsektionerna.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klassisk behåller bildtyp per rad och infoöverlägg. Modern använder rader som går från stående format till bakgrundsbild.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Visa favoritrader';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Visa favoritfilmer, favoritserier och andra favoritrader i hemsektionerna.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Sortering av favoritrader';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sortera favoritrader efter tillagt datum, releasedatum, alfabetiskt och mer.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Visa samlingsrader';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Visa samlingsrader i hemsektionerna.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Sortering av samlingsrader';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sortera samlingsrader efter tillagt datum, releasedatum, alfabetiskt och mer.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Visa genrerader';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => 'Visa genrerader i hemsektionerna.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Sortering av genrerader';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Sortera genrerader efter tillagt datum, releasedatum, alfabetiskt och mer.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Objekt på genrerader';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Visa filmer, serier eller båda på genrerader.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Visa spellisterader';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Visa spellisterader i hemsektionerna.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sortering av spellisterader';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sortera spellisterader efter tillagt datum, releasedatum, alfabetiskt och mer.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Visa ljudrader';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'Visa ljudrader i hemsektionerna.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sortering av ljudrader';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sortera ljudrader efter tillagt datum, releasedatum, alfabetiskt och mer.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Ljudspellistor';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Utseende';
+  String get appearance => 'Appearance';
 
   @override
   String get layout => 'Layout';
 
   @override
-  String get theme => 'Tema';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Tangentbord';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Knappar';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV-konfiguration';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Extern spelarapp';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Ange en extern spelare för att aktivera uppspelning vid långtryck';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Visa appväljaren när uppspelningen startar.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Läser in installerade spelare...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Anslutning';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Målformat för ljudomkodning';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Stöds på den här enheten';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Stöds inte på den här enheten';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD)-passthrough';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Skicka DTS:X (DTS UHD) som bitström till extern avkodare.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD med Atmos (JOC)-passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Mediespelarens beteende';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Uppspelningsförbättringar';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Alltid på.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Ersätt Hoppa över outro med Näst på tur';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Visa överlägget Näst på tur i stället för knappen Hoppa över outro.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Spelardirigering';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Föredra mjukvaruavkodare';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Använd FFmpeg (ljud) och libgav1 (AV1) före hårdvaruavkodare. Inaktivera om HDMI-ljudpassthrough slutar fungera.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Öppna videouppspelning i din valda externa app på Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Automatisk kö';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Föredra SDH-undertexter';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Prioritera SDH-/CC-undertextspår vid automatiskt val.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Webbdiagnostik';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin webbdiagnostik';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Använd den här sidan för att felsöka anslutningsproblem i webbläsaren (CORS, blandat innehåll och identifieringsinställningar).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Fel med blandat innehåll upptäckt';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS-/preflight-fel upptäckt';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin upptäckte att en HTTPS-sida försöker anropa en server-URL över HTTP. Webbläsare blockerar sådana anrop innan de når din server.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin upptäckte ett anropsfel på webbläsarnivå som vanligtvis beror på att CORS- eller preflight-huvuden saknas på mediaservern.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Mål-URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detaljer: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'Aktuell körtidskontext';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Ursprung';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Schema';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Pluginläge';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC-genomsökning';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Framtvingad server-URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Standard-URL för server';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL till identifieringsproxy';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'inte konfigurerad';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Blandat innehåll';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Den här sidan läses in över HTTPS, men en eller flera konfigurerade URL:er använder HTTP. Webbläsare blockerar HTTPS-sidor från att anropa HTTP-API:er.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Åtgärd: publicera din mediaserver eller proxyslutpunkt via HTTPS, eller läs in Moonfin över HTTP endast på betrodda lokala nätverk.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Ingen uppenbar konfiguration med blandat innehåll upptäcktes utifrån de aktuella körtidsinställningarna.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS-checklista';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Tillåt webbläsarens ursprung i Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Inkludera Authorization, X-Emby-Authorization och X-Emby-Token i Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Exponera Content-Range och Accept-Ranges för streaming och spolning.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Svara med 204 på OPTIONS-preflight-förfrågningar.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Exempel på headerkod (nginx-stil)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Obs';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Den här diagnostiksidan är avsedd för webbversioner. Om du ser den på en annan plattform kanske kontrollerna inte är relevanta.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Tillbaka till serverval';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Logga ut alla användare';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Behörighet till mikrofonen är permanent nekad. Aktivera den i systeminställningarna.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Behörighet till mikrofonen krävs för röstsökning.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Uppfattade inte det. Försök igen.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Inget tal upptäcktes.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Mikrofonfel.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Röstsökning kräver internet.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => 'Rösttjänsten är upptagen. Försök igen.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Behörighet till mikrofonen är permanent nekad.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Behörighet till mikrofonen är nekad.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Taligenkänning är inte tillgänglig på den här enheten.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Öppna iOS-utgångsväljaren';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay-utgångsväljaren är inte tillgänglig på den här enheten.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videor';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Program';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Låtar';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Fotoalbum';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Foton';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Personer';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Nyligen släppta avsnitt';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Se igen';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Gästframträdanden';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Framträdanden (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Bidrag från teamet (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Titta med grupp';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Fel';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Varningar';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Öppna i webbläsaren';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Den inbyggda webbläsaren är inte tillgänglig på den här plattformen.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Är du säker på att du vill starta om servern?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Är du säker på att du vill stänga av servern? Du måste starta den manuellt igen.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Intern';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Inaktiv';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Inga användare hittades';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'Inga användare matchar din sökning';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Inga enheter hittades';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Inga enheter matchar de aktuella filtren';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Lösenord angett';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Inget lösenord konfigurerat';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Fjärråtkomst';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Endast lokalt';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Kunde inte läsa in mediaanalysen';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Sammanslagen analys för alla mediebibliotek.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Toppartister';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Toppförfattare';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Främsta bidragsgivare';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bibliotek',
-      one: '1 bibliotek',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Inga indexerade mediesummor är tillgängliga för det här valet än.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Biblioteksdetaljer';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Fördelning per bibliotek';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Inga bibliotek är tillgängliga.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Serveradministration';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
   String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Bildcache';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Loggar';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Omkodning';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => 'Servern returnerade inga sökvägar.';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% använt';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Användaraktivitet';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Systemhändelser';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Kräver åtgärd';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Uppspelning';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Enheter';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Avancerat';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
   String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Live-TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Hemvideor';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Blandat innehåll';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Hemvideor och foton';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Blandade filmer och serier';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9456,299 +9432,299 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Inga inspelningar hittades';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Inga bildsidor hittades i .$extension-arkivet.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Den inbyggda renderaren misslyckades ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB-renderaren misslyckades ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Lokal fil saknas för läsaren: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status när bokdata skulle öppnas från $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Ingen läsbar bokslutpunkt tillgänglig';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Serietidningsarkivet stöds inte: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Pluginet för CBR-extrahering är inte tillgängligt på den här plattformen.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => 'Kunde inte extrahera .cbr-arkivet.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7-extrahering är inte tillgänglig på den här plattformen.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Pluginet för CB7-extrahering är inte tillgängligt på den här plattformen.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Stäng genrepanelen';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Läser in blandning...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'BIBLIOTEKSBLANDNING';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'SLUMPMÄSSIG BLANDNING';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'GENREBLANDNING';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Automatisk HDR-växling';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Aktivera HDR automatiskt vid uppspelning av HDR-video och återställ visningsläget när du avslutar.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'I helskärm';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Byt omslagsbild';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Saknas';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Omkodningsgränser';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Rensa alla omslagsbilder?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Är du säker på att du vill rensa alla nedladdade omslagsbilder?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Bekräfta rensning';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Är du säker på att du vill rensa $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Ladda upp?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Upplösning: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Visa endast omslagsbilder på gränssnittsspråket';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Bekräfta rensa alla';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Bilden har laddats upp!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Kunde inte ladda upp bilden: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Kunde inte ange bilden: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Kunde inte ta bort bilden: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Kunde inte rensa alla omslagsbilder: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ja';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Affisch';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Bakgrundsbilder';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Logotyp';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniatyrbild';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Grafik';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Skivgrafik';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Skärmbild';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Omslag';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Baksidesomslag';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menygrafik';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'affischen';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'bakgrundsbilden';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'bannern';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'logotypen';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniatyrbilden';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'grafiken';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'skivgrafiken';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'skärmbilden';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'omslaget';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'baksidesomslaget';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menygrafiken';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Alla';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Hög (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Mellan (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Låg (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Källor';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Kapitel';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Bokmärken';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Anteckningar';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Kö';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Tidslinje';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Tidslinjen är tom';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Hela boken';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Fokuserad tidslinje';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Exportera bokmärken';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Exportera anteckningar';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Exportera allt';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Exporterat till $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Exporten misslyckades: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Låttexter';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Lägg till bokmärke';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Lägg till anteckning';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Redigera anteckning';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Skriv en anteckning för det här stället';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Insomningstimer';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Av';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Slutet av kapitlet';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Anpassad';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining kvar';
+    return '$remaining left';
   }
 
   @override
@@ -9763,51 +9739,51 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Uppspelningshastighet';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Återstår';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Förfluten tid';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Bakåt ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Framåt ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Föregående kapitel';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Nästa kapitel';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kapitel $current av $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Inga kapitel';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Inga bokmärken än';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Inga anteckningar än';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Bokmärke tillagt vid $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Återställ till 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9815,249 +9791,249 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Spara';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Avbryt';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Radera';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Undertextinställningar';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Ändra undertextlägen, standardspråk, utseende och renderingsalternativ.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Undertextrendering';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Visningsalternativ';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Releasedatum (stigande)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Releasedatum (fallande)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Gruppera bidrag';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Gruppera flera roller';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Varning om skrivåtkomst till biblioteket';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Så här åtgärdar du det:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Ge Jellyfins tjänsteanvändare (t.ex. jellyfin eller Docker PUID/PGID) skrivbehörighet till ditt mediebiblioteks mappar på servern.\n\n2. Eller gå till Jellyfins kontrollpanel -> Bibliotek, redigera det här biblioteket och inaktivera \'Save artwork into media folders\' för att i stället lagra omslagsbilder i Jellyfins interna databas.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Stäng';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Ditt bibliotek \'$libraryName\' är konfigurerat att spara omslagsbilder direkt i mediemapparna (\'Save artwork into media folders\' är aktiverat). Jellyfin har dock testat skrivåtkomsten och saknar behörighet att skriva filer till den här katalogen:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Det verkar som att Jellyfin inte kunde uppdatera omslagsbilden. Ditt bibliotek är konfigurerat att spara omslagsbilder direkt i mediemapparna (\'Save artwork into media folders\' är aktiverat). Felet uppstår vanligtvis när Jellyfins serverprocess saknar behörighet att skriva filer till dina mediekataloger.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Externa listor';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Spela upp igen';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Filinformation';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Storlek: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Visa alla ($count) ljudspår';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Visa alla ($count) undertextspår';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Kontrollerar stöd för direktuppspelning...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Stöd för direktuppspelning: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Tvingad';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Containerformatet stöds inte av spelaren.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Videocodec stöds inte.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Ljudcodec stöds inte.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Undertextformatet stöds inte (kräver inbränning).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'Ljudprofilen stöds inte.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'Videoprofilen stöds inte.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'Videonivån stöds inte.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Videoupplösningen stöds inte av den här enheten.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Videons bitdjup stöds inte.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Videons bildfrekvens stöds inte.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Filens bithastighet överskrider spelarens streaminggräns.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Videons bithastighet överskrider streaminggränsen.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Ljudets bithastighet överskrider streaminggränsen.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Antalet ljudkanaler stöds inte.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alfabetisk';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Releaseordning (stigande)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Releaseordning (fallande)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Anpassad (dra och släpp)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Sorteringsalternativ för spellistor';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Återställ sortering';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Se om S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Se om spellistan';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Inga undertexter hittades.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Administratörskontroller';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Renderingsmotor (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller är Flutters moderna GPU-renderare som ger mjukare animationer och mindre hackande. På vissa TV-boxar och äldre GPU:er kan den orsaka grafikfel eller svart video – stäng av den om du ser sådant. Automatiskt väljer det bästa standardvärdet för din enhet. Starta om Moonfin för att tillämpa ändringen.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Automatiskt';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'På';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Av';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Omstart krävs';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin måste startas om för att byta renderingsmotor. Stäng appen nu och öppna den igen för att tillämpa ändringen.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Stäng appen nu';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Uppdatera bibliotek';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Uppdatera alla bibliotek';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Tillagt datum (äldsta först)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Tillagt datum (nyaste först)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alfabetisk (A till Ö)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alfabetisk (Ö till A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Läser in serveranalys... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Matcha källan';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Topp 250 filmer';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Topp 250 TV-serier';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Populäraste filmerna';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Populäraste TV-serierna';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Lägst betygsatta filmer';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb Högst betygsatta engelskspråkiga filmer';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -12,27 +12,27 @@ class AppLocalizationsSw extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'MAPENDELEO YA AKAUNTI';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Lugha ya Kiolesura';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Chaguo-msingi la Mfumo';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Ingia';
 
   @override
-  String get empty => 'Tupu';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Inaunganisha kwenye $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Unganisha Haraka';
 
   @override
   String get password => 'Nenosiri';
@@ -61,12 +61,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect haipatikani: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect haipatikani ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin toleo $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Ondoa \"$serverName\" kutoka kwa seva zako?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsAppearanceTheme => 'Mandhari ya Programu';
 
   @override
-  String get detailScreenStyle => 'Mtindo wa skrini ya maelezo';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasiki ni mpangilio asili wa Moonfin ulio katikati. Kisasa ni mpangilio wa kisinema unaojirekebisha.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasiki';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Kisasa';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Vichupo Vilivyopanuliwa';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Onyesha maudhui ya kichupo kiotomatiki unapovinjari vichupo. Zima ili kufungua na kufunga kila kichupo mwenyewe.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Onyesha Maelezo ya Kiufundi?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Onyesha maelezo ya kodeki, mwonekano, na mtiririko katika muhtasari wa bango';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Mfumo wa Mapendekezo';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Tumia algoriti ya maktaba ya ndani ya Moonfin Recommends au Vipimo vya Ufanano vya TMDb mtandaoni. Kumbuka: Mapendekezo ya mtandaoni yanahitaji muunganisho wa Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Ufanano wa TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Tumia Kikomo cha Ukadiriaji wa Wazazi?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Punguza mapendekezo ya Moonfin Recommends kulingana na ukadiriaji wa wazazi wa maudhui lengwa';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Mtindo wa Kiolesura';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Kiotomatiki hulingana na kifaa chako. Chagua Apple au Material ili kulazimisha muonekano.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Kiotomatiki';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,38 +205,38 @@ class AppLocalizationsSw extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Ubora wa Glass';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Otomatiki huchagua athari bora ya glass kwa kifaa hiki. Kamili hulazimisha ukungu halisi; Iliyopunguzwa hutumia glass nyepesi inayookoa nguvu ya GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Otomatiki';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Kamili';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Iliyopunguzwa';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Badili kati ya Moonfin na Neon Pulse bila kuanzisha upya programu';
 
   @override
-  String get customThemeTitle => 'Mandhari Maalum';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Mandhari maalum hubadilisha vipengele vya kuonekana katika Moonfin nzima. Chagua mojawapo ya chaguo hizi ili kuendana na mtindo wako.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Pendelea kibodi ya mfumo';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Tumia mbinu ya kuingiza maandishi ya kifaa chako kama chaguo-msingi';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -257,14 +257,14 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Mtindo wa glasi-tiririka wenye mandharinyuma ya rangi inayosogea, nyuso zenye ukungu, na rangi ya samawati ya Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Mtindo wa sanaa ya pikseli wa zamani wenye rangi nzito, mipaka ya vitalu, vivuli vikali, na fonti ya pikseli';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -315,7 +315,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Imeshindwa kuunganisha kwenye $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -328,36 +328,35 @@ class AppLocalizationsSw extends AppLocalizations {
   String get exit => 'Utgång';
 
   @override
-  String get gameMenu => 'Menyu';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Imesitishwa';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Hifadhi hali';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Michezo';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Pakia hali';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Sogeza mbele haraka';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Mipangilio ya emulator';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Kiini hiki hakina chaguo zinazoweza kurekebishwa.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Shikilia ili kufungua menyu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Kucheza michezo hakutumiki kwenye kifaa hiki bado.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded =>
@@ -380,13 +379,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get schedule => 'Ratiba';
 
   @override
-  String get series => 'Mifululizo';
+  String get series => 'Mfululizo';
 
   @override
   String get noItemsFound => 'Hakuna vipengee vilivyopatikana';
 
   @override
-  String get home => 'Mwanzo';
+  String get home => 'Nyumbani';
 
   @override
   String get browseAll => 'Vinjari Vyote';
@@ -432,7 +431,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Imeshindwa kupakia folda: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -440,7 +439,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return 'vipengee $count';
+    return '$count items';
   }
 
   @override
@@ -457,7 +456,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return 'Vipengee $count';
+    return '$count Items';
   }
 
   @override
@@ -498,7 +497,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Aina';
+    return '$name — Genres';
   }
 
   @override
@@ -537,17 +536,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'dk $count zilizopita';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'saa $count zilizopita';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return 'siku $count zilizopita';
+    return '${count}d ago';
   }
 
   @override
@@ -558,7 +557,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Chagua milisho ya mada ya kuonyesha katika Dokezo.';
 
   @override
-  String get apply => 'Tumia';
+  String get apply => 'Omba';
 
   @override
   String get openLink => 'Fungua Kiungo';
@@ -582,7 +581,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return 'vichwa $count';
+    return '$count titles';
   }
 
   @override
@@ -670,17 +669,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return 'waandishi $count';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return 'aina $count';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% imekamilika';
+    return '$percent% completed';
   }
 
   @override
@@ -697,11 +696,11 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'Vichwa $count vimepangwa kwa uvinjari unaotanguliza usomaji.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => 'Vichwa';
+  String get titles => 'Majina';
 
   @override
   String get allTitles => 'Majina Yote';
@@ -734,7 +733,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Hakuna $label';
+    return 'No $label found';
   }
 
   @override
@@ -753,13 +752,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get readStatus => 'Soma';
 
   @override
-  String get watched => 'Zilizotazamwa';
+  String get watched => 'Imetazamwa';
 
   @override
   String get unread => 'Haijasomwa';
 
   @override
-  String get unwatched => 'Zisizotazamwa';
+  String get unwatched => 'Isiyotazamwa';
 
   @override
   String get seriesStatus => 'Hali ya Mfululizo';
@@ -771,43 +770,43 @@ class AppLocalizationsSw extends AppLocalizations {
   String get books => 'Vitabu';
 
   @override
-  String get latestBooks => 'Vitabu vya Hivi Punde';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Vitabu vya Sauti vya Hivi Punde';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'vitabu $count',
-      one: 'kitabu 1',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Kitabu';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Kitabu cha Sauti';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% kimesomwa';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time zimesalia';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Soma';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Sikiliza';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Mwandishi';
@@ -845,12 +844,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return 'sehemu $count';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Ilichapishwa kwa mara ya kwanza $year';
+    return 'First published $year';
   }
 
   @override
@@ -865,7 +864,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return 'vitabu $count';
+    return '$count books';
   }
 
   @override
@@ -876,7 +875,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return 'Waandishi $count';
+    return '$count Authors';
   }
 
   @override
@@ -884,8 +883,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'vitabu $count vya sauti',
-      one: 'kitabu 1 cha sauti',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -933,7 +932,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get movies => 'Filamu';
 
   @override
-  String get musicVideos => 'Video za Muziki';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'Nyingine';
@@ -952,7 +951,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Diski $number';
+    return 'Disc $number';
   }
 
   @override
@@ -978,7 +977,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Ilichapishwa $year';
+    return 'Published $year';
   }
 
   @override
@@ -989,52 +988,52 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Misimu $count',
-      one: 'Msimu 1',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Inaisha $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Vipengee';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Nyongeza';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Nyuma ya Pazia';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Matukio Yaliyofutwa';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Vipengele Vifupi';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Mahojiano';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Matukio';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Filamu Fupi';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trela';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time zimesalia';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Inaisha baada ya $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1048,7 +1047,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Endelea kutoka $position';
+    return 'Resume from $position';
   }
 
   @override
@@ -1148,7 +1147,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Futa nyimbo zilizopakuliwa za \"$title\"?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1163,17 +1162,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Hakuna $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Inapakua $title (vipengee $count)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Una uhakika unataka kufuta \"$name\" kutoka kwa seva? Kitendo hiki hakiwezi kutenduliwa.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1185,7 +1184,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Muundo wa kitabu hauhimiliwi: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1212,7 +1211,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Manukuu yamepakuliwa na kuchaguliwa: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1221,7 +1220,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Hakuna manukuu ya mbali yaliyopatikana kwa $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1229,7 +1228,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Toleo $number';
+    return 'Version $number';
   }
 
   @override
@@ -1249,7 +1248,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Inapakua $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1257,7 +1256,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Futa faili za ndani za $typeLabel?\n\nHii itaachilia nafasi ya hifadhi. Unaweza kupakua tena baadaye.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1273,10 +1272,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get director => 'MKURUGENZI';
 
   @override
-  String get directors => 'WAKURUGENZI';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'MWANDISHI';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'WAANDISHI';
@@ -1286,12 +1285,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    return '+$count zaidi';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return 'Vipindi $count';
+    return '$count Episodes';
   }
 
   @override
@@ -1301,12 +1300,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Kipindi $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Sura $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1314,8 +1313,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'nyimbo $count',
-      one: 'wimbo 1',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1325,25 +1324,25 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'sura $count',
-      one: 'sura 1',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Alizaliwa $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Alifariki $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Umri $age';
+    return 'Age $age';
   }
 
   @override
@@ -1356,17 +1355,17 @@ class AppLocalizationsSw extends AppLocalizations {
   String get shuffle => 'Changanya';
 
   @override
-  String get shuffleAllMusic => 'Changanya muziki wote';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Ingia kwenye Moonfin kwenye simu yako';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Haiwezi kufikia seva yako';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return 'vipakuliwa $count';
+    return '$count downloads';
   }
 
   @override
@@ -1385,32 +1384,32 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '$action ya manukuu ya mbali inahitaji ruhusa ya usimamizi wa manukuu ya Jellyfin kwa mtumiaji huyu.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Kipengee hiki hakikupatikana kwenye seva kwa $action ya manukuu ya mbali.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '$action ya manukuu ya mbali imeshindwa: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '$action ya manukuu ya mbali imeshindwa (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Imeshindwa kufanya $action ya manukuu ya mbali.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'vipindi vyote vilivyopakuliwa vya \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1441,17 +1440,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Kitendo cha $label kimeshindwa: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Imeshindwa kuweka sauti ya utumaji: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Vidhibiti vya $label';
+    return '$label Controls';
   }
 
   @override
@@ -1468,7 +1467,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Simamisha $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1476,7 +1475,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Wimbo $number';
+    return 'Track $number';
   }
 
   @override
@@ -1493,7 +1492,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return 'sekunde $seconds';
+    return '$seconds seconds';
   }
 
   @override
@@ -1562,13 +1561,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get transcodeReasons => 'Sababu za Transcode';
 
   @override
-  String get player => 'Kichezaji';
+  String get player => 'Mchezaji';
 
   @override
   String get container => 'Chombo';
 
   @override
-  String get bitrate => 'Kasi ya biti';
+  String get bitrate => 'Bitrate';
 
   @override
   String get video => 'Video';
@@ -1608,12 +1607,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Hitilafu ya kipindi cha $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Imeshindwa kupakia maelezo ya kitabu: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1622,7 +1621,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Muundo huu (.$extension) hauwezi kuonyeshwa ndani ya programu bado.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1635,17 +1634,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Imeshindwa kufungua kisomaji cha ndani ya programu: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Alamisho tayari limehifadhiwa kwenye $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Alamisho limeongezwa: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1658,7 +1657,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Ukurasa $number';
+    return 'Page $number';
   }
 
   @override
@@ -1669,12 +1668,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Muundo: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% kimesomwa';
+    return '$percent% read';
   }
 
   @override
@@ -1697,7 +1696,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Weka Upya Ukuzaji (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1720,7 +1719,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Imeshindwa kusasisha hali ya kusoma: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1753,7 +1752,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Jukwaa hili haliwezi kuendesha injini ya hati iliyopachikwa kwa faili za $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1792,33 +1791,33 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Imeshindwa kupakia mwongozo: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
   String get noChannelsFound => 'Hakuna vituo vilivyopatikana';
 
   @override
-  String get liveBadge => 'MUBASHARA';
+  String get liveBadge => 'LIVE';
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Inayofuata: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'dk $minutes zimesalia';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'saa $hours zimesalia';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'saa $hours dk $minutes zimesalia';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1842,19 +1841,19 @@ class AppLocalizationsSw extends AppLocalizations {
   String get favoriteChannel => 'Idhaa Unayoipenda';
 
   @override
-  String get record => 'Rekodi';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Ghairi Kurekodi';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Kipindi kimewekwa kurekodiwa';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Kurekodi kumeghairiwa';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Imeshindwa kuunda rekodi';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Tazama';
@@ -1864,7 +1863,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Imeshindwa kucheza $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1890,7 +1889,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Ghairi kurekodi kulikopangwa kwa \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1918,7 +1917,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Simamisha kurekodi \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1933,19 +1932,19 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Hakuna matokeo ya \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Utafutaji umeshindwa: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Aina ya Akaunti ya Seerr';
+  String get seerrAccountType => 'Aina ya Akaunti ya Mtazamaji';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1979,12 +1978,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Ondoa \"$name\" na faili zake?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return 'nyimbo $count';
+    return '$count tracks';
   }
 
   @override
@@ -1995,12 +1994,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Imeshindwa kupakia albamu: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Hakuna nyimbo zilizopakuliwa zilizopatikana za $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2017,22 +2016,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Ondoa \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return 'dk $minutes';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'M$season K$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Kipindi $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2046,12 +2045,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Msimu $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'M$number';
+    return 'S$number';
   }
 
   @override
@@ -2062,7 +2061,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Futa vipindi vyote vilivyopakuliwa katika $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2070,8 +2069,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'vipindi $count',
-      one: 'kipindi 1',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2106,7 +2105,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Futa vipengee $count vilivyopakuliwa?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2120,7 +2119,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'kati ya kikomo cha $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2204,7 +2203,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return 'chaguo $count';
+    return '$count options';
   }
 
   @override
@@ -2280,7 +2279,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get fireworks => 'Fataki';
 
   @override
-  String get confetti => 'Konfeti';
+  String get confetti => 'Confetti';
 
   @override
   String get fallingLeaves => 'Kuanguka Majani';
@@ -2297,7 +2296,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Kurasa za maelezo, safu za nyumbani, na sauti';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2313,11 +2312,11 @@ class AppLocalizationsSw extends AppLocalizations {
       'Cheza unapovinjari skrini ya nyumbani';
 
   @override
-  String get loopThemeMusic => 'Rudia Muziki wa Mandhari';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Rudia wimbo badala ya kuucheza mara moja';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Ukungu wa Mandharinyuma ya Maelezo';
@@ -2340,23 +2339,23 @@ class AppLocalizationsSw extends AppLocalizations {
   String get playerZoomMode => 'Modi ya Kukuza Mchezaji';
 
   @override
-  String get settingsScrollWheelAction => 'Gurudumu la kusogeza la kipanya';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Chagua kitendo cha kusogeza gurudumu la kipanya juu ya video wakati wa uchezaji.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Imezimwa';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Sogeza (mbele / nyuma)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Sauti';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Sauti';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Inafaa';
@@ -2410,38 +2409,37 @@ class AppLocalizationsSw extends AppLocalizations {
   String get defaultAudioLanguage => 'Lugha Chaguomsingi ya Sauti';
 
   @override
-  String get fallbackAudioLanguage => 'Lugha Mbadala ya Sauti';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Pendelea Mkondo Chaguo-msingi wa Sauti';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Pendelea mkondo asili wa sauti kuliko udubu uliotafsiriwa.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Pendelea Mikondo ya Maelezo ya Sauti';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Pendelea mikondo ya maelezo ya sauti kuliko mikondo ya kawaida.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Kubadilisha Msimbo (Sauti)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Mtiririko wa Moja kwa Moja (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Kubadilisha Msimbo (Kasi ya Biti au Mwonekano)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Kubadilisha Msimbo (Video na Sauti)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Kubadilisha Msimbo (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Otomatiki (Chaguomsingi ya Seva)';
@@ -2518,28 +2516,27 @@ class AppLocalizationsSw extends AppLocalizations {
       'Washa sauti ya TrueHD (huenda isifanye kazi kwenye mifumo yote)';
 
   @override
-  String get settingsAudioOutputMode => 'Modi ya Utoaji wa Sauti';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Chagua jinsi sauti inavyosimbuliwa. AVR Passthrough hutuma mikondo ghafi ya Dolby/DTS kwa risiva yako; Otomatiki au Downmix husimbua ndani ya kifaa.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Kodeki Mbadala ya Sauti';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Chagua muundo lengwa wa kubadilisha msimbo wa sauti ya chaneli nyingi wakati mkondo asili hauwezi kuchezwa moja kwa moja au kupitishwa.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Tambua Kiotomatiki\n(Inapendekezwa)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Chaguo-msingi)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2548,27 +2545,26 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Bila Hasara)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Pekee)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Yenye Ufanisi)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Bila Hasara)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Chaneli za Juu za Sauti';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Sanidi idadi ya juu ya chaneli za mfumo wako wa sauti. Mikondo ya chaneli nyingi inayozidi kikomo hiki itapunguzwa au kubadilishwa msimbo.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Tambua Kiotomatiki\n(Chaguo-msingi la Maunzi)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2595,14 +2591,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (Ya Kina)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough ya Kodeki';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Washa miundo ambayo AVR au kifaa chako cha HDMI kinaunga mkono pekee.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
   String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
@@ -2624,39 +2620,38 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Tuma mtiririko wa biti wa Dolby Digital Plus (EAC3) kwa kisimbuzi cha nje.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Tuma mtiririko wa biti wa Dolby Atmos kupitia EAC3 (JOC) kwa kisimbuzi cha nje.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Tuma mtiririko wa biti wa DTS-HD MA (pamoja na DTS core) kwa kisimbuzi cha nje.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Tuma mtiririko wa biti wa Dolby TrueHD wenye metadata ya Atmos kwa kisimbuzi cha nje.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'Uwezo wa Sauti Uliotambuliwa';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Hakuna muhtasari wa uwezo wa wakati wa utekelezaji unaopatikana bado.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Njia';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Usimbuaji';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
   String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Njia ya sauti ya HD';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2671,10 +2666,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Spika';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Vipokea sauti';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2682,40 +2677,39 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Uchunguzi';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Kiwango cha Video';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Masafa ya Video';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Kodeki ya Manukuu';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Kodeki za Sauti Zinazoruhusiwa';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Kodeki za Sauti za HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Kodeki za Sauti za HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
       'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Njia ya Sauti Inayotumika';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Uwezo wa Njia Kutumia Sauti ya HD';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Hali ya Usiku';
@@ -2778,7 +2772,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Baada ya vipindi $episodes / saa $hours';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2854,45 +2848,45 @@ class AppLocalizationsSw extends AppLocalizations {
       'Badilisha mwonekano wa manukuu kukufaa';
 
   @override
-  String get subtitleMode => 'Modi ya Manukuu';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Yaliyoalamishwa';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Kila Wakati';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Lugha ya Kigeni';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Yaliyolazimishwa';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Hucheza mikondo iliyoalamishwa katika metadata ya faili la maudhui kama \"default\" au \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Hupakia na kuonyesha manukuu kiotomatiki kila video inapoanza.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Huwasha manukuu kiotomatiki ikiwa mkondo chaguo-msingi wa sauti uko katika lugha ya kigeni.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Hupakia manukuu yaliyowekwa alama ya \"forced\" pekee.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Huzima kabisa upakiaji wa manukuu wa kiotomatiki.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Lugha Mbadala ya Manukuu';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Mkondo wa Manukuu';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2927,7 +2921,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get green => 'Kijani';
 
   @override
-  String get cyan => 'Samawati';
+  String get cyan => 'Cyan';
 
   @override
   String get red => 'Nyekundu';
@@ -2952,17 +2946,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Mipangilio ya wasifu wa $profile imepakiwa.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Imeshindwa kupakia mipangilio ya wasifu wa $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Mipangilio ya ndani imesawazishwa na wasifu wa $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3098,11 +3092,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get showLibrariesInToolbar => 'Onyesha Maktaba kwenye Upauzana';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Panua Lebo za Upau wa Urambazaji Kila Wakati';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Onyesha Kitufe cha Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Uwazi wa Upau wa Urambazaji';
@@ -3120,16 +3113,16 @@ class AppLocalizationsSw extends AppLocalizations {
   String get purple => 'Zambarau';
 
   @override
-  String get teal => 'Kijani-buluu';
+  String get teal => 'Teal';
 
   @override
-  String get navy => 'Buluu Nyeusi';
+  String get navy => 'Navy';
 
   @override
   String get charcoal => 'Mkaa';
 
   @override
-  String get brown => 'Kahawia';
+  String get brown => 'Brown';
 
   @override
   String get darkRed => 'Nyekundu Iliyokolea';
@@ -3138,7 +3131,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get darkGreen => 'Kijani Kijani';
 
   @override
-  String get slate => 'Kijivu-buluu';
+  String get slate => 'Slate';
 
   @override
   String get indigo => 'Kihindi';
@@ -3178,18 +3171,18 @@ class AppLocalizationsSw extends AppLocalizations {
       'Onyesha chaguo la kuvinjari kwenye folda';
 
   @override
-  String get groupItemsIntoCollections => 'Panga Vipengee katika Makusanyo';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ficha vipengee vya maktaba vinavyohusiana na Mkusanyo unapovinjari maktaba';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'Ilani ya Kupanga Maktaba';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Ili kutumia mpangilio huu, tafadhali hakikisha mipangilio ya maktaba ya \"Panga filamu katika makusanyo\" na/au \"Panga vipindi katika makusanyo\" imewashwa chini ya mipangilio ya Onyesho ya maktaba yako kwenye seva yako ya Jellyfin au Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Mwonekano wa Maktaba';
@@ -3218,7 +3211,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count vimechaguliwa';
+    return '$count selected';
   }
 
   @override
@@ -3302,11 +3295,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Cheza trela kiotomatiki kwenye upau wa midia baada ya sekunde 3';
 
   @override
-  String get trailerAudio => 'Sauti ya Trela';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Washa sauti ya trela kwenye upau wa maudhui';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Muhtasari wa Kipindi';
@@ -3385,11 +3377,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Changanya safu zote mbili kwenye sehemu moja ya nyumbani';
 
   @override
-  String get fullScreenRows => 'Safu za Nyumbani Zilizopanuliwa';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Punguza safu za nyumbani hadi safu 1 kwa kila skrini';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Aina ya Picha kwa Safu Mlalo';
@@ -3404,7 +3395,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get lastUser => 'Mtumiaji wa Mwisho';
 
   @override
-  String get currentUser => 'Mtumiaji wa Sasa';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Thibitisha kila wakati';
@@ -3464,7 +3455,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Washa kihifadhi skrini kilichojengewa ndani';
 
   @override
-  String get mode => 'Modi';
+  String get mode => 'Hali';
 
   @override
   String get libraryArt => 'Sanaa ya Maktaba';
@@ -3480,7 +3471,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return 'dk $minutes';
+    return '$minutes min';
   }
 
   @override
@@ -3510,10 +3501,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get displayClockDuringScreensaver => 'Onyesha saa wakati wa skrini';
 
   @override
-  String get clockModeStatic => 'Tuli';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Inayoruka';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Nyanya zilizooza (Wakosoaji)';
@@ -3556,7 +3547,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get showMdbListAndTmdbRatings =>
-      'Onyesha ukadiriaji wa MDBList na TMDB';
+      'Onyesha ukadiriaji wa MDBLlist na TMDB';
 
   @override
   String get ratingLabels => 'Lebo za Ukadiriaji';
@@ -3587,7 +3578,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Washa na upange upya vyanzo vya ukadiriaji vinavyoonyeshwa kwenye programu nzima';
 
   @override
-  String get pluginLabel => 'Programu-jalizi ya Moonbase';
+  String get pluginLabel => 'Programu-jalizi';
 
   @override
   String get pluginDetected => 'Programu-jalizi Imegunduliwa';
@@ -3605,7 +3596,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nToleo: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3644,7 +3635,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get upcomingMovies => 'Filamu Zinazokuja';
 
   @override
-  String get studios => 'Studio';
+  String get studios => 'Studios';
 
   @override
   String get popularSeries => 'Mfululizo Maarufu';
@@ -3659,13 +3650,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get networks => 'Mitandao';
 
   @override
-  String get seerrDiscoveryRows => 'Safu za Ugunduzi za Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Weka upya safu mlalo ziwe chaguomsingi';
 
   @override
-  String get enableSeerr => 'Washa Seerr';
+  String get enableSeerr => 'Washa Kionaji';
 
   @override
   String get showSeerrInNavigation =>
@@ -3682,44 +3673,44 @@ class AppLocalizationsSw extends AppLocalizations {
   String get hideAdultContent => 'Ficha maudhui ya watu wazima katika matokeo';
 
   @override
-  String get seerrNotificationsSection => 'Arifa';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Arifa za maombi mapya';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Nijulishe mtu anapowasilisha ombi';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Masasisho ya maombi';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Yaliyoidhinishwa, yaliyokataliwa, na yaliyoongezwa kwenye maktaba yako';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Masasisho ya matatizo';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Matatizo mapya, majibu, na masuluhisho';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Umeingia kama: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Ukurasa wa Ugunduzi wa Seerr';
+  String get discoverRows => 'Gundua Safu';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Washa safu za kuonyesha kwenye ukurasa mkuu wa Seerr. Buruta ili kupanga upya. Mpangilio maalum husawazishwa na Moonbase.';
+      'Buruta ili kupanga upya. Washa au uzime safu mlalo. Usawazishaji wa mpangilio wa safu mlalo uliowezeshwa na programu-jalizi ya Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Washa safu za kuonyesha kwenye ukurasa mkuu wa Seerr. Buruta ili kupanga upya. Mpangilio maalum husawazishwa na Moonbase.';
+      'Buruta ili kupanga upya. Washa au uzime safu mlalo.';
 
   @override
   String get enabled => 'Imewashwa';
@@ -3732,7 +3723,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Toleo $version';
+    return 'Version $version';
   }
 
   @override
@@ -3782,7 +3773,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Sasisho linapatikana: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3794,7 +3785,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version Inapatikana';
+    return 'v$version Available';
   }
 
   @override
@@ -3837,7 +3828,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get mdbListTmdbRatingSources =>
-      'MDBList, TMDB, na vyanzo vya ukadiriaji';
+      'MDBLlist, TMDB, na vyanzo vya ukadiriaji';
 
   @override
   String gbValue(String value) {
@@ -3859,7 +3850,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get imageCacheCleared => 'Akiba ya picha imefutwa';
 
   @override
-  String get clear => 'Futa';
+  String get clear => 'Wazi';
 
   @override
   String get browse => 'Vinjari';
@@ -3875,19 +3866,19 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Inapakua · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Inaingiza';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return 'Vipengee $count';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Mipangilio ya Seerr';
+  String get seerrSettings => 'Mipangilio ya Mtazamaji';
 
   @override
   String get requestMore => 'Omba Zaidi';
@@ -3903,7 +3894,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Imeombwa na $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3920,12 +3911,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Ghairi ombi la \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Ghairi maombi $count ya \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3940,22 +3931,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Bajeti: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Mapato: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
   String seasonsCount(int count, String label) {
-    return '$label $count';
+    return '$count $label';
   }
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Omba $type';
+    return 'Request $type';
   }
 
   @override
@@ -3984,14 +3975,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get showMore => 'Onyesha Zaidi';
 
   @override
-  String get appearances => 'Mionekano';
+  String get appearances => 'Mwonekano';
 
   @override
   String get crewSection => 'Wafanyakazi';
 
   @override
   String ageValue(int age) {
-    return 'umri $age';
+    return 'age $age';
   }
 
   @override
@@ -4022,147 +4013,148 @@ class AppLocalizationsSw extends AppLocalizations {
   String get deletedStatus => 'Imefutwa';
 
   @override
-  String get failedStatus => 'Imeshindwa';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Inachakatwa';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Imebadilishwa na $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Imekamilika';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Kichwa hiki tayari kimeombwa';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Umefikia kikomo cha maombi';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Kichwa hiki kimezuiwa';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Hakuna misimu iliyosalia ya kuomba';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Huna ruhusa ya kufanya ombi hili';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Maombi';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Matatizo';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Mapya Zaidi';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Yaliyobadilishwa Mwisho';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Hakuna matatizo';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Maombi $remaining kati ya $limit ya filamu yamesalia';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Maombi $remaining kati ya $limit ya misimu yamesalia';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Sehemu ya $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Angalia Mkusanyo';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Omba Mkusanyo';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'Filamu $total · $available zinapatikana';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Omba filamu $count';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Inaomba $current kati ya $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Filamu $count zimeombwa';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Filamu $ok kati ya $total zimeombwa';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Filamu zote tayari zinapatikana au zimeombwa';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Ripoti Tatizo';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Sauti';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Kuna tatizo gani?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Vipindi Vyote';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Kipindi';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Imefunguliwa';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Limetatuliwa';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Tatua';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Fungua Tena';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Imeripotiwa na $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return 'maoni $count';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Ongeza maoni';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Futa tatizo hili?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Wasilisha Ripoti';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Alama ya TMDB';
@@ -4234,7 +4226,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get forward => 'Mbele';
 
   @override
-  String get general => 'Jumla';
+  String get general => 'Mkuu';
 
   @override
   String get go => 'Nenda';
@@ -4279,7 +4271,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get refresh => 'Onyesha upya';
 
   @override
-  String get remote => 'Rimoti';
+  String get remote => 'Mbali';
 
   @override
   String get rename => 'Badilisha jina';
@@ -4315,7 +4307,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get status => 'Hali';
 
   @override
-  String get stop => 'Simamisha';
+  String get stop => 'Acha';
 
   @override
   String get streaming => 'Kutiririsha';
@@ -4324,7 +4316,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get time => 'Muda';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Mchezo wa hila';
 
   @override
   String get uninstall => 'Sanidua';
@@ -4342,7 +4334,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get unmute => 'Rejesha sauti';
 
   @override
-  String get mute => 'Zima sauti';
+  String get mute => 'Nyamazisha';
 
   @override
   String get branding => 'Kuweka chapa';
@@ -4366,13 +4358,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminDrawerLibraries => 'Maktaba';
 
   @override
-  String get adminDrawerDisplay => 'Onyesho';
+  String get adminDrawerDisplay => 'Display';
 
   @override
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Mipangilio ya NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Kubadilisha msimbo';
@@ -4384,7 +4376,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminDrawerStreaming => 'Kutiririsha';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Mchezo wa hila';
 
   @override
   String get adminDrawerDevices => 'Vifaa';
@@ -4435,22 +4427,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Masasisho ya programu-jalizi yanayopatikana: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Programu-jalizi zinazohitaji kuanzishwa upya: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Kazi zilizoratibiwa zilizoshindwa: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Maingizo ya hivi karibuni ya onyo/hitilafu: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4509,7 +4501,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Hitilafu: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4536,7 +4528,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Amri imeshindwa: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4573,7 +4565,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get nowPlaying => 'Sasa Inacheza';
 
   @override
-  String get volume => 'Sauti';
+  String get volume => 'Kiasi';
 
   @override
   String get actions => 'Vitendo';
@@ -4585,7 +4577,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audioCodec => 'Kodeki ya Sauti';
 
   @override
-  String get hwAccel => 'Kasi ya Maunzi';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Kukamilika';
@@ -4600,14 +4592,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminClearDates => 'Tarehe wazi';
 
   @override
-  String get adminActivitySeverityAll => 'Viwango vyote vya ukali';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Kipindi cha tarehe';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Imeshindwa kupakia kumbukumbu ya shughuli: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4624,7 +4616,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Imeshindwa kusasisha kifaa: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4635,28 +4627,28 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Imeshindwa kufuta kifaa: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Ondoa kifaa \'$name\'? Mtumiaji atahitaji kuingia tena kwenye kifaa hiki.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Futa vifaa vyote';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Ondoa vifaa $count? Watumiaji walioathirika watahitaji kuingia tena. Kifaa chako cha sasa hakiathiriwi.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Vifaa vimeondolewa';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Baadhi ya vifaa vimeondolewa; $count havikuweza kuondolewa.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4685,7 +4677,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Imeshindwa kuanza kuchanganua: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4696,12 +4688,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Maktaba imepewa jina jipya \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Imeshindwa kubadilisha jina: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4709,17 +4701,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Maktaba \"$name\" imefutwa';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Imeshindwa kufuta maktaba: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Imeshindwa kuongeza njia: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4727,12 +4719,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Ondoa \"$path\" kutoka kwa maktaba hii?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Imeshindwa kuondoa njia: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4740,7 +4732,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi chaguo: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4772,261 +4764,251 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminMetadataCountryHint => 'k.m. Marekani, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Njia';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Chaguo';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Vipakuzi';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Vihifadhi vya metadata';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Vipakuzi vya manukuu';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Vipakuzi vya maneno ya nyimbo';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Vipakuzi vya metadata: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Vichukuzi vya picha: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Seva hii haitoi vipakuzi vyovyote kwa aina hii ya maktaba.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Jumla';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Maelezo Yaliyopachikwa';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Manukuu';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Picha';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Mifululizo';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Muziki';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Filamu';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Washa ufuatiliaji wa wakati halisi';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Tambua mabadiliko ya faili na uyachakate kiotomatiki.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Chukulia kumbukumbu kama faili za maudhui';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Onyesha picha';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'Hifadhi sanaa katika folda za maudhui';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Kuonyesha upya metadata kiotomatiki';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Kamwe';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Chaguo-msingi';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Onyesho';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Onyesho la maktaba';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Onyesha mwonekano wa folda ili kuonyesha folda za maudhui za kawaida';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Onyesha vipindi maalum ndani ya misimu vilivyorushwa';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Panga filamu katika makusanyo';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Panga vipindi katika makusanyo';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Onyesha maudhui ya nje katika mapendekezo';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Tabia ya tarehe ya kuongezwa';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Tumia tarehe ya kuongezwa kutoka';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport =>
-      'Tarehe iliyochanganuliwa kwenye maktaba';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Tarehe faili lilipoundwa';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata na Picha';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Lugha inayopendelewa ya metadata';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Sura';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Muda wa sura bandia (sekunde)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Urefu wa sura zinazotengenezwa kwa maudhui yasiyo na sura. Weka 0 ili kuzima.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Mwonekano wa picha za sura';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Mipangilio ya NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Metadata ya NFO inaoana na Kodi na programu-mteja zinazofanana. Mipangilio hutumika kwa maktaba zote zinazohifadhi metadata ya NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Mtumiaji wa kuhifadhia data ya utazamaji katika faili za NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Hifadhi njia za picha ndani ya faili za NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Washa ubadilishaji wa njia kwa njia za picha za NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Nakili picha za extrafanart kwenye folda ya extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Hakuna';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return 'siku $days';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Tumia vichwa vilivyopachikwa';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Tumia vichwa vilivyopachikwa kwa nyongeza';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Tumia maelezo ya kipindi yaliyopachikwa';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Ruhusu manukuu yaliyopachikwa';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Ruhusu yote';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Maandishi pekee';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Picha pekee';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Hakuna';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Ruka upakuaji ikiwa manukuu yaliyopachikwa yapo';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Ruka upakuaji ikiwa mkondo wa sauti unalingana na lugha ya upakuaji';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Hitaji ulinganifu kamili wa manukuu';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Hifadhi manukuu katika folda za maudhui';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Toa picha za sura';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Toa picha za sura wakati wa kuchanganua maktaba';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Washa utoaji wa picha za Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Toa picha za Trickplay wakati wa kuchanganua maktaba';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Hifadhi picha za Trickplay katika folda za maudhui';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Unganisha kiotomatiki mifululizo iliyosambaa katika folda nyingi';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Jina la kuonyesha la msimu sifuri';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Washa uchanganuzi wa LUFS kwa usawazishaji wa sauti';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Pendelea lebo isiyo ya kawaida ya wasanii';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Ongeza filamu kwenye makusanyo kiotomatiki';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Jina la maktaba linahitajika';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Imeshindwa kuunda maktaba: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5053,27 +5035,27 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Zima $name? Hataweza kuingia.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Washa $name? Ataweza kuingia tena.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Mtumiaji \"$name\" amezimwa';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Mtumiaji \"$name\" amewashwa';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Imeshindwa kusasisha sera ya mtumiaji: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5090,7 +5072,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Imeshindwa kuunda mtumiaji: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5111,7 +5093,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5122,7 +5104,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Imeshindwa: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5258,146 +5240,143 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminEnableAllChannels => 'Washa ufikiaji wa vituo vyote';
 
   @override
-  String get adminParentalControl => 'Udhibiti wa Wazazi';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Ukadiriaji wa juu wa wazazi unaoruhusiwa';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Maudhui yenye ukadiriaji wa juu zaidi yatafichwa kwa mtumiaji huyu.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Hakuna';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Zuia vipengee visivyo na maelezo ya ukadiriaji au visivyotambulika';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Vitabu';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Chaneli';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV ya moja kwa moja';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Filamu';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Muziki';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trela';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Vipindi';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Ratiba za Ufikiaji';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Ruhusu ufikiaji wakati wa nyakati zilizoratibiwa hapa chini pekee. Ufikiaji unaruhusiwa siku nzima wakati hakuna ratiba iliyowekwa.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Ongeza Ratiba';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Siku';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Mwanzo';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Mwisho';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Kila siku';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Siku ya kazi';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Wikendi';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Jumapili';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Jumatatu';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Jumanne';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Jumatano';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Alhamisi';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Ijumaa';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Jumamosi';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Lebo zinazoruhusiwa';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Maudhui yenye lebo hizi pekee ndiyo yanaonyeshwa. Acha wazi ili kuruhusu yote.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Lebo zilizozuiwa';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Maudhui yenye lebo hizi yamefichwa kwa mtumiaji huyu.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Ongeza lebo';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Vifaa vilivyowashwa';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Chaneli zilizowashwa';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Mtoa huduma wa uthibitishaji';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider =>
-      'Mtoa huduma wa kuweka upya nenosiri';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Idadi ya juu ya majaribio ya kuingia yaliyoshindwa kabla ya kufungiwa';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Weka 0 kwa chaguo-msingi, au -1 ili kuzima kufungiwa.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Ufikiaji wa SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Ruhusu kuunda na kujiunga na vikundi';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Ruhusu kujiunga na vikundi';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Hakuna ufikiaji';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Ruhusu kufuta maudhui kutoka';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5405,22 +5384,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Seva imerudisha HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Una uhakika unataka kufuta $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Mtumiaji \"$name\" amefutwa';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Imeshindwa kufuta mtumiaji: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5441,7 +5420,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Imeshindwa kuunda ufunguo: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5452,7 +5431,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Batilisha ufunguo wa $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5460,7 +5439,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Imeshindwa kubatilisha ufunguo: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5480,30 +5459,29 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Tokeni: $token\\nImeundwa: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Unda Nakala Rudufu';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'Chagua cha kujumuisha katika nakala rudufu.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Hifadhidata';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Hujumuishwa kila wakati';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Manukuu';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Picha za Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Inaunda nakala rudufu...';
@@ -5513,7 +5491,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Imeshindwa kuunda nakala rudufu: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5522,12 +5500,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Manifesti: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Imeshindwa kupakia manifesti: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5538,7 +5516,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Imeshindwa kurejesha nakala rudufu: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5570,17 +5548,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Imehifadhiwa kwenye $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi faili: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Imeshindwa kupakia $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5591,7 +5569,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Imeshindwa kupakia kazi: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5603,17 +5581,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Imeshindwa kuanzisha kazi: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Imeshindwa kusimamisha kazi: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Imeshindwa kupakia kazi: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5621,12 +5599,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Imeshindwa kuondoa kichochezi: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Imeshindwa kuongeza kichochezi: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5652,7 +5630,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return 'saa $hours';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5663,7 +5641,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Imeshindwa kubadilisha programu-jalizi: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5671,27 +5649,27 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Una uhakika unataka kuondoa \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Imeshindwa kuondoa programu-jalizi: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Imeshindwa kusakinisha kifurushi: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Imeshindwa kusakinisha sasisho: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Imeshindwa kupakia programu-jalizi: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5704,12 +5682,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Sakinisha sasisho (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Imeshindwa kupakia katalogi: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5731,17 +5709,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" itaondolewa baada ya seva kuanzishwa upya';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Imeshindwa kuondoa: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Inasasisha \"$name\" hadi v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5750,7 +5728,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Imeshindwa kupakia programu-jalizi: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5758,7 +5736,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Toleo $version';
+    return 'Version $version';
   }
 
   @override
@@ -5779,17 +5757,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Una uhakika unataka kuondoa \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi hazina: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Imeshindwa kupakia hazina: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5806,12 +5784,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Imeshindwa kupakia mipangilio ya programu-jalizi: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Imeshindwa kufungua $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5934,11 +5912,11 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminThrottleBuffering => 'Kuakibisha kaba';
 
   @override
-  String get adminTrickplaySaved => 'Mipangilio ya Trickplay imehifadhiwa';
+  String get adminTrickplaySaved => 'Mipangilio ya mchezo wa hila imehifadhiwa';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Imeshindwa kupakia mipangilio ya Trickplay';
+      'Imeshindwa kupakia mipangilio ya mchezo wa hila';
 
   @override
   String get adminEnableHardwareAcceleration => 'Washa kuongeza kasi ya maunzi';
@@ -6092,12 +6070,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Imeshindwa kupakia metadata: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi metadata: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6117,7 +6095,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Imeshindwa kuonyesha upya metadata: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6132,7 +6110,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Utafutaji wa mbali umeshindwa: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6146,7 +6124,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Imeshindwa kusasisha aina ya maudhui: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6162,12 +6140,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Picha ya $imageType imesasishwa';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Imeshindwa kupakua picha: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6178,27 +6156,27 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Picha ya $imageType imepakiwa';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Imeshindwa kupakia picha: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Futa picha ya $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Picha ya $imageType imefutwa';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Imeshindwa kufuta picha: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6209,70 +6187,67 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Ugunduzi wa Tuner umeshindwa: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Ongeza Tuner';
 
   @override
-  String get adminEditTuner => 'Hariri Tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Tuner ya M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Faili au URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Anwani ya IP ya Tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Jina rafiki';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'Wakala wa mtumiaji';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Kikomo cha miunganisho ya wakati mmoja';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Idadi ya juu ya mitiririko ambayo Tuner huruhusu kwa wakati mmoja. Weka 0 kwa isiyo na kikomo.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Kasi ya juu mbadala ya biti ya utiririshaji';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Ingiza chaneli vipendwa pekee';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Ruhusu kubadilisha msimbo kwa maunzi';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'Ruhusu kontena la kubadilisha msimbo la fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Ruhusu kushiriki mtiririko';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Washa kurudia mtiririko';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Puuza DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Soma ingizo kwa kasi asili ya fremu';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Hariri Mtoa Huduma';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6281,50 +6256,50 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Faili au URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Kiambishi awali cha filamu';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Kategoria za filamu';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Tenganisha kategoria nyingi kwa mstari wima.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Kategoria za watoto';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Kategoria za habari';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Kategoria za michezo';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Jina la mtumiaji';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Nenosiri';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Nchi';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Chagua nchi';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Msimbo wa posta';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Pata orodha';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Orodha';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Washa Tuner zote';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Aina ya Kitafuta njia';
@@ -6334,7 +6309,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Imeshindwa kuongeza Tuner: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6348,12 +6323,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Imeshindwa kuongeza mtoa huduma: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Imeshindwa kuondoa Tuner: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6361,16 +6336,16 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Imeshindwa kuweka upya Tuner: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Aina hii ya Tuner haitumii kuweka upya.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Imeshindwa kuondoa mtoa huduma: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6389,44 +6364,43 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Njia ya kurekodi mfululizo';
 
   @override
-  String get adminMovieRecordingPath => 'Njia ya kurekodi filamu';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Siku za data ya mwongozo';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Kiotomatiki';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return 'siku $days';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Njia ya programu ya uchakataji-baadaye';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Hoja za kichakataji-baadaye';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Hifadhi metadata ya NFO ya rekodi';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Hifadhi picha za rekodi';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Muda';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Njia za kurekodi';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Uchakataji-baadaye';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Data ya mwongozo: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6435,7 +6409,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi mipangilio: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6452,7 +6426,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Imeshindwa kusasisha ulinganishaji: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6470,15 +6444,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminGuideProviders => 'Watoa Mwongozo';
 
   @override
-  String get adminRefreshGuideData => 'Onyesha Upya Data ya Mwongozo';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Kuonyesha upya data ya mwongozo kumeanza';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Kazi ya kuonyesha upya mwongozo haipatikani kwenye seva hii.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Ongeza Mtoa Huduma';
@@ -6489,22 +6462,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Njia ya kurekodi: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Njia ya mfululizo: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Muda wa ziada kabla: dk $minutes';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Muda wa ziada baada: dk $minutes';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6537,7 +6510,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Rejesha nakala rudufu $name sasa?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6561,7 +6534,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminLiveTvTitle => 'Utawala wa TV ya moja kwa moja';
 
   @override
-  String get adminApply => 'Tumia';
+  String get adminApply => 'Omba';
 
   @override
   String get adminNotSet => 'Haijawekwa';
@@ -6583,27 +6556,27 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return 'dk $minutes zilizopita';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return 'saa $hours zilizopita';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return 'siku $days zilizopita';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Imeshindwa kupakia $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return 'matokeo $count';
+    return '$count matches';
   }
 
   @override
@@ -6613,7 +6586,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Mhariri wa Metadata';
 
   @override
-  String get adminMetadataIdentify => 'Tambua';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Aina';
@@ -6668,7 +6641,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminMetadataTags => 'Lebo';
 
   @override
-  String get adminMetadataStudios => 'Studio';
+  String get adminMetadataStudios => 'Studios';
 
   @override
   String get adminMetadataPeople => 'Watu';
@@ -6714,22 +6687,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Picha ya $imageType imesasishwa';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Picha ya $imageType imepakiwa';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Picha ya $imageType imefutwa';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Imeshindwa kupakua picha: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6738,12 +6711,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Imeshindwa kupakia picha: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Futa picha ya $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6752,12 +6725,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Imeshindwa kufuta picha: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Chagua picha ya $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6791,7 +6764,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Sasisho linapatikana: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6816,7 +6789,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Sakinisha sasisho (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6828,7 +6801,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" inasakinishwa...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6848,7 +6821,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Mipangilio ya $name';
+    return '$name Settings';
   }
 
   @override
@@ -6888,7 +6861,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Imeshindwa kupakia hazina: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6896,7 +6869,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Una uhakika unataka kuondoa \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6904,7 +6877,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Imeshindwa kuhifadhi hazina: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7032,20 +7005,19 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Washa skrini ya Splash';
 
   @override
-  String get adminBrandingSplashUpload => 'Pakia picha';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Skrini ya utangulizi imesasishwa';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Imeshindwa kupakia skrini ya utangulizi';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Skrini ya utangulizi imeondolewa';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Hakuna skrini maalum ya utangulizi';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Kuongeza kasi ya vifaa';
@@ -7060,132 +7032,121 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Washa usimbaji maunzi kwa:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Kifaa cha QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'Washa kisimbuzi cha NVDEC kilichoboreshwa';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Pendelea kisimbuzi asili cha maunzi cha mfumo';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Kina cha rangi cha usimbuaji wa maunzi';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Usimbuaji wa HEVC wa biti 10';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Usimbuaji wa VP9 wa biti 10';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'Usimbuaji wa HEVC RExt wa biti 8/10';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'Usimbuaji wa HEVC RExt wa biti 12';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Usimbaji wa maunzi';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Ruhusu usimbaji wa HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Ruhusu usimbaji wa AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Washa kisimbaji cha Intel cha nguvu ndogo cha H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Washa kisimbaji cha Intel cha nguvu ndogo cha HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Uchoraji wa Toni';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Washa uchoraji wa toni';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Washa uchoraji wa toni wa VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Washa uchoraji wa toni wa VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Algoriti ya uchoraji wa toni';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Modi ya uchoraji wa toni';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Masafa ya uchoraji wa toni';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Upunguzaji wa ukolezi wa uchoraji wa toni';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Kilele cha uchoraji wa toni';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Kigezo cha uchoraji wa toni';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Mwangaza wa uchoraji wa toni wa VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Utofautishaji wa uchoraji wa toni wa VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality =>
-      'Mipangilio Iliyowekwa Awali na Ubora';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Mpangilio wa awali wa kisimbaji';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF ya usimbaji wa H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF ya usimbaji wa H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Mbinu ya kuondoa mwingiliano';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Maradufu kasi ya fremu wakati wa kuondoa mwingiliano';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Sauti';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Washa usimbaji wa VBR wa sauti';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost =>
-      'Nyongeza ya upunguzaji wa chaneli za sauti';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm =>
-      'Algoriti ya upunguzaji hadi stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Ukubwa wa juu wa foleni ya muxing';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Otomatiki';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Usimbaji';
@@ -7304,10 +7265,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminTaskNeverRun => 'Usiwahi kukimbia';
 
   @override
-  String get adminTaskStop => 'Simamisha';
+  String get adminTaskStop => 'Acha';
 
   @override
-  String get adminRunningTasks => 'Kazi Zinazoendelea';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Kimbia';
@@ -7329,17 +7290,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Kila siku saa $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Kila $day saa $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Kila $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7377,8 +7338,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'saa $count',
-      one: 'saa 1',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7406,17 +7367,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return 'siku $days zilizopita';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return 'saa $hours zilizopita';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return 'dk $minutes zilizopita';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7424,27 +7385,27 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return 'dk $minutes';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return 'saa $hours';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return 'siku $days';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Sanidi utengenezaji wa picha za Trickplay kwa vijipicha vya onyesho la kutafuta.';
+      'Sanidi utengenezaji wa taswira ya hila kwa vijipicha vya onyesho la kukagua.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Mlango wa HTTPS wa umma';
@@ -7459,44 +7420,43 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Mlango wa umma wa HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Hitaji HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Elekeza maombi yote ya mbali kwa HTTPS. Haina athari ikiwa seva haina cheti halali.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Nenosiri la cheti';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Mipangilio ya IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Washa IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Washa IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Washa uchoraji wa milango wa kiotomatiki';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Mitandao ya LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Orodha ya anwani za IP au subneti za CIDR zilizotenganishwa kwa koma au mstari, zinazochukuliwa kuwa kwenye mtandao wa ndani.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI za seva zilizochapishwa';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Unganisha subneti au anwani na URL iliyochapishwa, k.m. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Njia ya cheti';
@@ -7527,12 +7487,11 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Kuakibisha kaba';
 
   @override
-  String get adminPlaybackThrottleDelay =>
-      'Ucheleweshaji wa kupunguza kasi (sekunde)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Ruhusu utoaji wa manukuu papo hapo';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Asilimia ya chini ya wasifu';
@@ -7581,7 +7540,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Imeshindwa kusasisha aina ya maudhui: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7589,23 +7548,22 @@ class AppLocalizationsSw extends AppLocalizations {
       'Kiwango cha chini cha majibu (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Washa maonyo ya majibu ya polepole';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Washa Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Seva';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Njia';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Utendaji';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Njia ya akiba';
@@ -7617,7 +7575,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminGeneralServerName => 'Jina la seva';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Lugha inayopendelewa ya kuonyesha';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Imeshindwa kupakia mipangilio';
@@ -7627,12 +7585,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Imeshindwa kusasisha ulinganishaji: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Kikomo cha muda: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7669,8 +7627,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'washiriki #',
-      one: 'mshiriki #',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7713,7 +7671,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'Kipengee $index';
+    return 'Item $index';
   }
 
   @override
@@ -7762,12 +7720,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName amejiunga na kikundi cha SyncPlay';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName ameondoka kwenye kikundi cha SyncPlay';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7779,7 +7737,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Inasawazisha uchezaji na $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7817,8 +7775,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'safu # zimegunduliwa',
-      one: 'safu # imegunduliwa',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7859,20 +7817,20 @@ class AppLocalizationsSw extends AppLocalizations {
   String get offlineSavedMedia => 'Media Iliyohifadhiwa';
 
   @override
-  String get offlineBannerTitle => 'Uko nje ya mtandao';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Inaonyesha vipakuliwa vyako';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Vipakuliwa';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Haiwezi kufikia seva yako';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Inacheza kutoka kwa vipakuliwa hadi itakaporejea';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7888,12 +7846,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Udhibiti wa utumaji umeshindwa: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Vidhibiti vya $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7904,7 +7862,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Simamisha $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7927,12 +7885,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Weka PIN ya tarakimu $length';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Weka PIN yako ya tarakimu $length';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7945,13 +7903,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get pinForgot => 'Je, umesahau PIN?';
 
   @override
-  String get pinClear => 'Futa';
+  String get pinClear => 'Wazi';
 
   @override
-  String get pinBackspace => 'Futa nyuma';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Ombi la Quick Connect limeidhinishwa.';
+  String get quickConnectAuthorized =>
+      'Ombi la Kuunganisha Haraka limeidhinishwa.';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -7978,7 +7937,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect imeshindwa: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7989,7 +7948,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Amri imeshindwa: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8018,7 +7977,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Imeshindwa kuanza kutuma: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8064,7 +8023,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Inapakua $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8147,14 +8106,14 @@ class AppLocalizationsSw extends AppLocalizations {
       'Uchezaji umesitishwa. Je, bado unatazama?';
 
   @override
-  String get stillWatchingStop => 'Simamisha';
+  String get stillWatchingStop => 'Acha';
 
   @override
   String get stillWatchingContinue => 'Endelea';
 
   @override
   String skipSegment(String segment) {
-    return 'Ruka $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8165,12 +8124,12 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Inapakua $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Inapakua $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8186,7 +8145,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get playerTooltipCastControls => 'Vidhibiti vya kutuma';
 
   @override
-  String get playerTooltipPlaybackQuality => 'Kasi ya biti';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'Ingiza skrini nzima';
@@ -8232,13 +8191,13 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Ficha kutoka Endelea Kutazama';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ficha kutoka Inayofuata';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Ongeza kwenye Mkusanyo';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8293,14 +8252,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsAlphabetical => 'Kialfabeti';
 
   @override
-  String get settingsConnectionSection => 'MUUNGANISHO';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Ruhusu vyeti vilivyojitia saini';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Amini seva zinazotumia vyeti vya TLS vilivyojitia saini au vya CA binafsi. Washa kwa seva unazodhibiti pekee. Hii huzima uthibitishaji wa vyeti kwa miunganisho yote.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'FARAGHA NA USALAMA';
@@ -8316,11 +8275,11 @@ class AppLocalizationsSw extends AppLocalizations {
       'Lafudhi za mandhari, mandhari, viashirio vilivyotazamwa na muziki wa mandhari';
 
   @override
-  String get settingsDetailsScreen => 'Skrini ya Maelezo';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Mtindo, ukungu wa mandharinyuma, na tabia ya vichupo';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Ukurasa wa Nyumbani';
@@ -8358,11 +8317,11 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Onyesha kitufe cha Seerr kwenye upau wa urambazaji';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Onyesha lebo za maandishi kwenye upau wa juu wa urambazaji kila wakati';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8431,7 +8390,8 @@ class AppLocalizationsSw extends AppLocalizations {
   String get settingsSupportMoonfin => 'Msaada Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Mchangie msanidi kahawa';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'KISHERIA';
@@ -8465,8 +8425,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'ilani # za leseni',
-      one: 'ilani # ya leseni',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8517,17 +8477,16 @@ class AppLocalizationsSw extends AppLocalizations {
       'Ungependa Kuruka Utambulisho na Outros?';
 
   @override
-  String get settingsMediaSegmentCountdown =>
-      'Hesabu ya Kurudi Nyuma ya Sehemu ya Maudhui';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Upau wa Maendeleo';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Kipima Muda';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Hakuna';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Mtumiaji wa haraka';
@@ -8551,8 +8510,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Jinsi video inapaswa kuongezwa ili kutoshea skrini.';
 
   @override
-  String get settingsPlaybackEngineAndroidTv =>
-      'Injini ya Uchezaji (Android TV)';
+  String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
 
   @override
   String get settingsPlaybackEngineAndroidTvDescription =>
@@ -8563,13 +8521,13 @@ class AppLocalizationsSw extends AppLocalizations {
       'Media3 (inapendekezwa)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (ya zamani)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (urithi)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (inapendekezwa)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Njia mbadala';
@@ -8760,758 +8718,749 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Zilizotolewa Hivi Karibuni katika $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Cheza Kipindi Kinachofuata Kiotomatiki';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Cheza kipindi kinachofuata kiotomatiki kinapopatikana.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Ruka ukimya';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Ruka kiotomatiki sehemu za sauti zenye ukimya inapotumika na mtiririko.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Ruhusu athari za sauti za nje';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Ruhusu programu za kisawazishi na athari (k.m. Wavelet) zijiunganishe na vipindi vya uchezaji vya Media3.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Zima tunneling';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Lazimisha uchezaji usio wa tunneling. Ni muhimu kwenye vifaa vyenye mikatizo ya sauti/video ya tunneling.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Washa tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Ya kina. Huelekeza sauti na video kupitia njia ya maunzi iliyounganishwa. Imezimwa kwa chaguo-msingi kwa sababu husababisha mikatizo ya sauti/video kwenye baadhi ya vifaa.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Unganisha Dolby Vision wasifu 7 na HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Cheza mitiririko ya Dolby Vision wasifu 7 kama HEVC inayooana na HDR10 kwenye vifaa visivyo vya DV.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Tumia mitindo ya manukuu iliyopachikwa';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Tumia rangi, fonti, na uwekaji vilivyopachikwa katika mkondo wa manukuu. Zima ili kutumia mapendeleo yako ya mtindo wa manukuu badala yake.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Tumia saizi za fonti za manukuu zilizopachikwa';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Tumia vidokezo vya saizi ya fonti vilivyopachikwa katika mkondo wa manukuu. Zima ili kutumia saizi ya manukuu kutoka kwa mapendeleo yako ya mtindo.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Onyesha Maelezo ya Maudhui';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Onyesha maelezo ya kipengee kilichochaguliwa juu ya kurasa za Maktaba.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Ficha Mandharinyuma Unapovinjari?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'Tumia Vichwa Vidogo vya Kina';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Onyesha safu ndogo ya kina au ya kawaida kwenye kurasa za Maktaba.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Futa mandhari iliyohifadhiwa?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Ondoa \"$themeName\" kutoka kwa akiba ya kifaa hiki?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'Duka la Mandhari';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Vinjari na uhifadhi mandhari za jamii';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Hifadhi mandhari ili kuitumia kama mandhari zako nyingine zilizohifadhiwa.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Hakuna mandhari zinazopatikana kwa sasa.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Imeshindwa kupakia Duka la Mandhari. Angalia muunganisho wako na ujaribu tena.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Hifadhi';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Hifadhi na utumie';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Imehifadhiwa';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Mandhari hii haikuweza kupakiwa.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" imehifadhiwa.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" imefutwa kutoka kwa kifaa hiki.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Imeshindwa kufuta \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Mandhari zilizohifadhiwa';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Hizi ni mandhari zilizopakuliwa kutoka kwa programu-jalizi ya Moonfin kwa seva ya sasa. Kufuta huondoa nakala hii ya ndani pekee.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Hakuna mandhari zilizohifadhiwa zilizopatikana kwa seva hii.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Inatumika sasa';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Futa mandhari iliyohifadhiwa';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Dhibiti mandhari za programu-jalizi zilizopakuliwa kwenye kifaa hiki';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'Kihariri cha Mandhari';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Fungua Kihariri cha Mandhari cha Moonfin kwenye kivinjari chako';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Skrini ya Nyumbani';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Upau wa Chini';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasiki';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'Kisasa';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Safu za Nyumbani';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Onyesho la Safu za Nyumbani';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sehemu za Safu za Nyumbani';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Vibadilishi vya Safu za Nyumbani';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Washa au zima kategoria za safu za nyumbani zinazotegemea maktaba';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Washa vibadilishi vifuatavyo ili kuonyesha safu katika Sehemu za Nyumbani.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasiki huhifadhi aina ya picha ya kila safu na kifuniko cha maelezo. Kisasa hutumia safu za wima hadi mandharinyuma.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Onyesha Safu za Vipendwa';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Onyesha Filamu Vipendwa, Mifululizo, na safu nyingine za vipendwa katika Sehemu za Nyumbani.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Upangaji wa Safu za Vipendwa';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Panga safu za Vipendwa kwa tarehe ya kuongezwa, tarehe ya kutolewa, kialfabeti, na zaidi.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Onyesha Safu za Makusanyo';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Onyesha safu za Makusanyo katika Sehemu za Nyumbani.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Upangaji wa Safu za Makusanyo';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Panga safu za Makusanyo kwa tarehe ya kuongezwa, tarehe ya kutolewa, kialfabeti, na zaidi.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Onyesha Safu za Aina';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Onyesha safu za Aina katika Sehemu za Nyumbani.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Upangaji wa Safu za Aina';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Panga safu za Aina kwa tarehe ya kuongezwa, tarehe ya kutolewa, kialfabeti, na zaidi.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Vipengee vya Safu za Aina';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Onyesha Filamu, Mifululizo, au vyote viwili katika safu za Aina.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Onyesha Safu za Orodha za Kucheza';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Onyesha safu za Orodha za Kucheza katika Sehemu za Nyumbani.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Upangaji wa Safu za Orodha za Kucheza';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Panga safu za Orodha za Kucheza kwa tarehe ya kuongezwa, tarehe ya kutolewa, kialfabeti, na zaidi.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Onyesha Safu za Sauti';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Onyesha safu za Sauti katika Sehemu za Nyumbani.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Upangaji wa Safu za Sauti';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Panga safu za Sauti kwa tarehe ya kuongezwa, tarehe ya kutolewa, kialfabeti, na zaidi.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Orodha za Kucheza za Sauti';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Mwonekano';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'Mpangilio';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Mandhari';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Kibodi';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Vitufe';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Uonyeshaji';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Usanidi wa MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Programu ya kicheza cha nje';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Weka kicheza cha nje ili kuwezesha chaguo la kucheza kwa kubonyeza kwa muda mrefu';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Onyesha kichagua programu uchezaji unapoanza.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Inapakia vicheza vilivyosakinishwa...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Muunganisho';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Lengo la Kubadilisha Msimbo wa Sauti';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Inatumika kwenye kifaa hiki';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Haitumiki kwenye kifaa hiki';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Tuma mtiririko wa biti wa DTS:X (DTS UHD) kwa kisimbuzi cha nje.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD yenye Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Tabia ya Kicheza Maudhui';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Maboresho ya Uchezaji';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Imewashwa kila wakati.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Badilisha Ruka Hitimisho na Onyesho la Inayofuata';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Onyesha kifuniko cha Inayofuata badala ya kitufe cha Ruka Hitimisho.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Uelekezaji wa Kicheza';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Pendelea visimbuzi vya programu';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Tumia FFmpeg (sauti) na libgav1 (AV1) kabla ya visimbuzi vya maunzi. Zima ikiwa passthrough ya sauti ya HDMI inaharibika.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Fungua uchezaji wa video katika programu ya nje uliyochagua kwenye Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Upangaji Foleni wa Kiotomatiki';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Pendelea manukuu ya SDH';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Tanguliza mikondo ya manukuu ya SDH/CC wakati wa kuchagua kiotomatiki.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Uchunguzi wa wavuti';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Uchunguzi wa Wavuti wa Moonfin';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Tumia ukurasa huu kuchunguza matatizo ya muunganisho wa kivinjari (CORS, maudhui mchanganyiko, na mipangilio ya ugunduzi).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Hitilafu ya Maudhui Mchanganyiko Imetambuliwa';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Hitilafu ya CORS/Preflight Imetambuliwa';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin imetambua ukurasa wa HTTPS unaojaribu kupiga simu kwa URL ya seva ya HTTP. Vivinjari huzuia ombi hili kabla halijafika kwenye seva yako.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin imetambua hitilafu ya ombi katika kiwango cha kivinjari ambayo mara nyingi husababishwa na vichwa vya CORS au preflight vinavyokosekana kwenye seva ya maudhui.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'URL lengwa: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Maelezo: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Muktadha wa Sasa wa Utekelezaji';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Asili';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Skimu';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Modi ya Programu-jalizi';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'Uchanganuzi wa WebRTC';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'URL ya Seva Iliyolazimishwa';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'URL Chaguo-msingi ya Seva';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'URL ya Proksi ya Ugunduzi';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'haijasanidiwa';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Maudhui Mchanganyiko';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Ukurasa huu umepakiwa kupitia HTTPS, lakini URL moja au zaidi zilizosanidiwa ni za HTTP. Vivinjari huzuia kurasa za HTTPS kupiga simu kwa API za HTTP.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Suluhisho: toa seva yako ya maudhui au ncha ya proksi kupitia HTTPS, au pakia Moonfin kupitia HTTP kwenye mitandao ya ndani inayoaminika pekee.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Hakuna usanidi dhahiri wa maudhui mchanganyiko uliotambuliwa kutoka kwa mipangilio ya sasa ya utekelezaji.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'Orodha ya Kukagua ya CORS';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Ruhusu asili ya kivinjari katika Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Jumuisha Authorization, X-Emby-Authorization, na X-Emby-Token katika Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Fichua Content-Range na Accept-Ranges kwa utiririshaji na tabia ya kutafuta.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Rudisha 204 kwa maombi ya preflight ya OPTIONS.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Mfano wa Kijisehemu cha Kichwa (mtindo wa nginx)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Kumbuka';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Njia hii ya uchunguzi imekusudiwa kwa ujenzi wa wavuti. Ikiwa unaiona kwenye jukwaa lingine, ukaguzi huu huenda usitumike.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Rudi kwa Uteuzi wa Seva';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Toa Watumiaji Wote';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Ruhusa ya maikrofoni imekataliwa kabisa. Iwashe katika mipangilio ya mfumo.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Ruhusa ya maikrofoni inahitajika kwa utafutaji wa sauti.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Sikuelewa. Jaribu tena.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Hakuna usemi uliotambuliwa.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Hitilafu ya maikrofoni.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Utafutaji wa sauti unahitaji intaneti.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Huduma ya sauti ina shughuli nyingi. Jaribu tena.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Ruhusa ya maikrofoni imekataliwa kabisa.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Ruhusa ya maikrofoni imekataliwa.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Utambuzi wa usemi haupatikani kwenye kifaa hiki.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Fungua kichagua njia cha iOS';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Kichagua njia cha AirPlay hakipatikani kwenye kifaa hiki.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Video';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Vipindi';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Nyimbo';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Albamu za Picha';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Picha';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Watu';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Vipindi Vilivyotolewa Hivi Karibuni';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Tazama Tena';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Kujitokeza kwa Wageni';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Kujitokeza (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Michango ya Wafanyakazi (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Tazama na kikundi';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Hitilafu';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Maonyo';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'Diski';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Fungua kwenye Kivinjari';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Kivinjari kilichopachikwa hakipatikani kwenye jukwaa hili.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Una uhakika unataka kuanzisha upya seva?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Una uhakika unataka kuzima seva? Utahitaji kuianzisha upya mwenyewe.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Ya ndani';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Haifanyi kazi';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Hakuna watumiaji waliopatikana';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Hakuna watumiaji wanaolingana na utafutaji wako';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Hakuna vifaa vilivyopatikana';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Hakuna vifaa vinavyolingana na vichujio vya sasa';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Nenosiri limewekwa';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Hakuna nenosiri lililosanidiwa';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Ufikiaji wa Mbali';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Ya Ndani Pekee';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Imeshindwa kupakia takwimu za maudhui';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Takwimu zilizounganishwa katika maktaba zote za maudhui.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Wasanii Bora';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Waandishi Bora';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Wachangiaji Bora';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Maktaba $count',
-      one: 'Maktaba 1',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Hakuna jumla za maudhui yaliyoorodheshwa zinazopatikana kwa uteuzi huu bado.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Maelezo ya Maktaba';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Mchanganuo wa Maktaba';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Hakuna maktaba zinazopatikana.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Usimamizi wa Seva';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
   String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Akiba ya Picha';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Akiba';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Kumbukumbu';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Kubadilisha Msimbo';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Hakuna njia za seva zilizorudishwa na seva hii.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% imetumika';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Shughuli za Mtumiaji';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Matukio ya Mfumo';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Inahitaji Uangalizi';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Seva';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Uchezaji';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Vifaa';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Ya Kina';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Programu-jalizi';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'TV ya moja kwa moja';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Video za Nyumbani';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Maudhui Mchanganyiko';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Video na Picha za Nyumbani';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Filamu na Vipindi Mchanganyiko';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9523,300 +9472,299 @@ class AppLocalizationsSw extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Hakuna rekodi zilizopatikana';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Hakuna kurasa za picha zilizopatikana ndani ya kumbukumbu ya .$extension.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Kionyeshi kilichopachikwa kimeshindwa ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Kionyeshi cha EPUB kimeshindwa ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Faili la ndani la kisomaji halipo: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status wakati wa kufungua data ya kitabu kutoka $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Hakuna ncha ya kitabu inayoweza kusomwa inayopatikana';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Muundo wa kumbukumbu ya katuni hauhimiliwi: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Programu-jalizi ya kutoa CBR haipatikani kwenye jukwaa hili.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Imeshindwa kutoa kumbukumbu ya .cbr.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Utoaji wa CB7 haupatikani kwenye jukwaa hili.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Programu-jalizi ya kutoa CB7 haipatikani kwenye jukwaa hili.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Funga paneli ya aina';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Inapakia mchanganyiko...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'MCHANGANYIKO WA MAKTABA';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'MCHANGANYIKO NASIBU';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'MCHANGANYIKO WA AINA';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Kubadilisha HDR Kiotomatiki';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Washa HDR kiotomatiki kwa uchezaji wa video ya HDR na urejeshe modi ya onyesho unapotoka.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Wakati wa skrini nzima';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Badilisha Sanaa';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Haipo';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Vikomo vya Kubadilisha Msimbo';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Futa sanaa yote?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Una uhakika unataka kufuta sanaa yote iliyopakuliwa?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Thibitisha Kufuta';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Una uhakika ungependa kufuta $itemType?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Pakia?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Mwonekano: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Onyesha sanaa katika lugha ya kiolesura pekee';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Thibitisha Kufuta Yote';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Picha imepakiwa kwa mafanikio!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Imeshindwa kupakia picha: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Imeshindwa kuweka picha: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Imeshindwa kufuta picha: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Imeshindwa kufuta sanaa yote: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Ndiyo';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Bango';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Mandharinyuma';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Utepe';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Nembo';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Kijipicha';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Sanaa';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Sanaa ya Diski';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Picha ya Skrini';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Jalada la Kisanduku';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Jalada la Nyuma la Kisanduku';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Sanaa ya Menyu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'bango';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'mandharinyuma';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'utepe';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'nembo';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'kijipicha';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'sanaa';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'sanaa ya diski';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'picha ya skrini';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'jalada la kisanduku';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'jalada la nyuma la kisanduku';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'sanaa ya menyu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Zote';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Juu (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Wastani (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Chini (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Vyanzo';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Sura';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Alamisho';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Vidokezo';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Foleni';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Ratiba ya Muda';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Ratiba ya muda ni tupu';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Kitabu Kizima';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Ratiba ya Muda Iliyolengwa';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Hamisha Alamisho';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Hamisha Vidokezo';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Hamisha Yote';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Imehamishiwa $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Kuhamisha kumeshindwa: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Maneno ya Wimbo';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Ongeza alamisho';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Ongeza kidokezo';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Hariri kidokezo';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Andika kidokezo cha wakati huu';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Kipima muda cha kulala';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Imezimwa';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Mwisho wa sura';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Maalum';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining zimesalia';
+    return '$remaining left';
   }
 
   @override
@@ -9824,58 +9772,58 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'dk $count',
-      one: 'dk 1',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Kasi ya uchezaji';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Zilizosalia';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Zilizopita';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Nyuma ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Mbele ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Sura iliyotangulia';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Sura inayofuata';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Sura $current kati ya $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Hakuna sura';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Hakuna alamisho bado';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Hakuna vidokezo bado';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Alamisho limeongezwa kwenye $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Weka upya hadi 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9883,256 +9831,249 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Hifadhi';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Ghairi';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Futa';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Mapendeleo ya Manukuu';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Badilisha modi za manukuu, lugha chaguo-msingi, muonekano, na chaguo za uonyeshaji.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Uonyeshaji wa Manukuu';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Chaguo za Onyesho';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Tarehe ya Kutolewa (Kupanda)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Tarehe ya Kutolewa (Kushuka)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Panga Michango';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Panga majukumu mengi pamoja';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Onyo la Ufikiaji wa Kuandika kwenye Maktaba';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Jinsi ya kurekebisha hili:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Mpe mtumiaji wa huduma ya Jellyfin (k.m. jellyfin au PUID/PGID ya Docker) ruhusa za kuandika kwenye folda za maktaba yako ya maudhui kwenye seva.\n\n2. Au, nenda kwenye Dashibodi yako ya Jellyfin -> Maktaba, hariri maktaba hii, na uzime \'Hifadhi sanaa katika folda za maudhui\' ili kuhifadhi sanaa katika hifadhidata ya ndani ya Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Ondoa';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Maktaba yako ya \'$libraryName\' imesanidiwa kuhifadhi sanaa moja kwa moja katika folda za maudhui (\'Hifadhi sanaa katika folda za maudhui\' imewashwa). Hata hivyo, Jellyfin imejaribu ufikiaji wa kuandika na haina ruhusa ya kuandika faili katika saraka hii:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Inaonekana Jellyfin imeshindwa kusasisha sanaa. Maktaba yako imesanidiwa kuhifadhi sanaa moja kwa moja katika folda za maudhui (\'Hifadhi sanaa katika folda za maudhui\' imewashwa). Hitilafu hii hutokea mara nyingi wakati mchakato wa seva ya Jellyfin hauna ruhusa ya kuandika faili katika saraka zako za maudhui.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Orodha za Nje';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Cheza Tena';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Maelezo ya Faili';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Ukubwa: $size  •  Muundo: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Onyesha Mikondo Yote ($count) ya Sauti';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Onyesha Mikondo Yote ($count) ya Manukuu';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Inakagua uwezo wa Uchezaji wa Moja kwa Moja...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel =>
-      'Uwezo wa Uchezaji wa Moja kwa Moja: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Yaliyolazimishwa';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Muundo wa kontena hauhimiliwi na kicheza.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Kodeki ya video haihimiliwi.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Kodeki ya sauti haihimiliwi.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Muundo wa manukuu hauhimiliwi (unahitaji kuchomwa).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Wasifu wa sauti hauhimiliwi.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Wasifu wa video hauhimiliwi.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Kiwango cha video hakihimiliwi.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Mwonekano wa video hauhimiliwi na kifaa hiki.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Kina cha biti cha video hakihimiliwi.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Kasi ya fremu ya video haihimiliwi.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Kasi ya biti ya faili inazidi kikomo cha utiririshaji cha kicheza.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Kasi ya biti ya video inazidi kikomo cha utiririshaji.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Kasi ya biti ya sauti inazidi kikomo cha utiririshaji.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Idadi ya chaneli za sauti haihimiliwi.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Kialfabeti';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Mpangilio wa Kutolewa (Kupanda)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Mpangilio wa Kutolewa (Kushuka)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Maalum (Buruta-na-Dondosha)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Chaguo za Kupanga Orodha ya Kucheza';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Weka Upya Upangaji';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Tazama Tena M$season:K$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Tazama Tena Orodha ya Kucheza';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Hakuna manukuu yaliyopatikana.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Vidhibiti vya Msimamizi';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Injini ya uonyeshaji (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller ni kionyeshi cha kisasa cha GPU cha Flutter kwa uhuishaji laini na mkwaruzo mdogo. Kwenye baadhi ya visanduku vya TV na GPU za zamani inaweza kusababisha hitilafu au video nyeusi; izime ikiwa unaona hayo. Kiotomatiki huchagua chaguo-msingi bora kwa kifaa chako. Anzisha upya Moonfin ili kutumia.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Kiotomatiki';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Imewashwa';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Imezimwa';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Kuanzisha upya kunahitajika';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin inahitaji kuanzishwa upya ili kubadilisha injini ya uonyeshaji. Funga programu sasa, kisha uifungue tena ili kutumia.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Funga programu sasa';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Onyesha Upya Maktaba';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Onyesha Upya Maktaba Zote';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest =>
-      'Tarehe ya Kuongezwa (Za Zamani Kwanza)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Tarehe ya Kuongezwa (Mpya Kwanza)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Kialfabeti (A hadi Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Kialfabeti (Z hadi A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Inapakia Takwimu za Seva... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource =>
-      'Linganisha na chanzo';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'Filamu 250 Bora za IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'Vipindi 250 Bora vya TV vya IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Filamu Maarufu Zaidi za IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'Vipindi Maarufu Zaidi vya TV vya IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'Filamu Zenye Ukadiriaji wa Chini Zaidi za IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'Filamu Bora za Kiingereza za IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -9,30 +9,30 @@ class AppLocalizationsTa extends AppLocalizations {
   AppLocalizationsTa([String locale = 'ta']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'மூன்ஃபின்';
 
   @override
-  String get accountPreferences => 'கணக்கு விருப்பங்கள்';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'இடைமுக மொழி';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'சிஸ்டம் இயல்புநிலை';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'உள்நுழையவும்';
 
   @override
-  String get empty => 'காலி';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName உடன் இணைக்கிறது';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'விரைவான இணைப்பு';
 
   @override
   String get password => 'கடவுச்சொல்';
@@ -51,7 +51,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get waitingForAuthorization => 'அங்கீகாரத்திற்காக காத்திருக்கிறது...';
 
   @override
-  String get back => 'பின்செல்';
+  String get back => 'மீண்டும்';
 
   @override
   String get serverUnavailable => 'சேவையகம் கிடைக்கவில்லை';
@@ -61,12 +61,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect கிடைக்கவில்லை: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect கிடைக்கவில்லை ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin பதிப்பு $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,7 +106,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'உங்கள் சர்வர்களிலிருந்து \"$serverName\" ஐ அகற்றவா?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
@@ -141,62 +141,62 @@ class AppLocalizationsTa extends AppLocalizations {
   String get settingsAppearanceTheme => 'பயன்பாட்டு தீம்';
 
   @override
-  String get detailScreenStyle => 'விவரத் திரை பாணி';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'கிளாசிக் என்பது Moonfin இன் அசல் மையப்படுத்தப்பட்ட அமைப்பு. மாடர்ன் என்பது திரைக்கேற்ப மாறும் சினிமா பாணி அமைப்பு.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'கிளாசிக்';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'மாடர்ன்';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'விரிவாக்கப்பட்ட தாவல்கள்';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'தாவல்களை உலாவும்போது அவற்றின் உள்ளடக்கத்தைத் தானாகக் காட்டும். ஒவ்வொரு தாவலையும் கைமுறையாகத் திறந்து மூட இதை அணைக்கவும்.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'தொழில்நுட்ப விவரங்களைக் காட்டவா?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'பேனர் சுருக்கத்தில் கோடெக், தெளிவுத்திறன் மற்றும் ஸ்ட்ரீம் தகவலைக் காட்டும்';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'பரிந்துரை அமைப்பு';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin பரிந்துரைகள் என்ற உள்ளூர் நூலக அல்காரிதத்தையோ அல்லது ஆன்லைன் TMDb இன் ஒற்றுமை அளவீடுகளையோ பயன்படுத்தும். குறிப்பு: ஆன்லைன் பரிந்துரைகளுக்கு Seerr ஒருங்கிணைப்பு தேவை.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin பரிந்துரைகள்';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb ஒற்றுமை';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'பெற்றோர் மதிப்பீட்டு வரம்பைப் பயன்படுத்தவா?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'இலக்கு மீடியாவின் பெற்றோர் மதிப்பீட்டின்படி Moonfin பரிந்துரைகளை வரம்பிடும்';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'இடைமுக பாணி';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'தானியங்கி உங்கள் சாதனத்திற்கு ஏற்ப அமையும். ஒரு தோற்றத்தைக் கட்டாயப்படுத்த Apple அல்லது Material ஐத் தேர்வுசெய்யவும்.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'தானியங்கி';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,41 +205,41 @@ class AppLocalizationsTa extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'கிளாஸ் தரம்';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'தானியங்கி இந்தச் சாதனத்திற்கு ஏற்ற சிறந்த கிளாஸ் விளைவைத் தேர்வுசெய்யும். முழுமை உண்மையான மங்கலைக் கட்டாயப்படுத்தும்; குறைவு GPU ஆற்றலைச் சேமிக்கும் இலகுவான கிளாஸைப் பயன்படுத்தும்.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'தானியங்கி';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'முழுமை';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'குறைவு';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'பயன்பாட்டை மறுதொடக்கம் செய்யாமல் Moonfin மற்றும் Neon Pulse இடையே மாறவும்';
 
   @override
-  String get customThemeTitle => 'தனிப்பயன் தீம்';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'தனிப்பயன் தீம்கள் Moonfin முழுவதும் காட்சிக் கூறுகளை மாற்றும். உங்கள் பாணிக்கு ஏற்ற ஒன்றைத் தேர்வுசெய்யவும்.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'சிஸ்டம் விசைப்பலகையை விரும்பு';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'உரை உள்ளீட்டிற்கு உங்கள் சாதனத்தின் உள்ளீட்டு முறையை இயல்பாகப் பயன்படுத்தும்';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'மூன்ஃபின்';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsTa extends AppLocalizations {
       'மெஜந்தா பளபளப்பு, சியான் உரை மற்றும் வலுவான குரோம் மாறுபாடு கொண்ட சின்த்வேவ் ஸ்டைலிங்';
 
   @override
-  String get themeGlass => 'கிளாஸ்';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'நகரும் சாய்வுப் பின்னணி, பனிபடர்ந்த மேற்பரப்புகள் மற்றும் Apple-நீல நிற தனித்துவத்துடன் கூடிய திரவ-கிளாஸ் பாணி';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-பிட் ஹீரோ';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'தடிமனான வண்ணத்தட்டு, சதுரமான ஓரங்கள், கூர்மையான நிழல்கள் மற்றும் பிக்சல் எழுத்துருவுடன் கூடிய ரெட்ரோ பிக்சல்-கலை பாணி';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +313,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target உடன் இணைக்க முடியவில்லை';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -326,36 +326,35 @@ class AppLocalizationsTa extends AppLocalizations {
   String get exit => 'வெளியேறு';
 
   @override
-  String get gameMenu => 'மெனு';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'இடைநிறுத்தப்பட்டது';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'நிலையைச் சேமி';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'விளையாட்டுகள்';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'நிலையை ஏற்று';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'வேகமாக முன்னோக்கி';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'எமுலேட்டர் அமைப்புகள்';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'இந்தக் கோரில் மாற்றக்கூடிய விருப்பங்கள் எதுவும் இல்லை.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'மெனுவைத் திறக்க அழுத்திப் பிடிக்கவும்';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'இந்தச் சாதனத்தில் விளையாட்டுகளை விளையாட இன்னும் ஆதரவு இல்லை.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'முகப்பு வரிசைகளை ஏற்ற முடியவில்லை';
@@ -377,13 +376,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get schedule => 'அட்டவணை';
 
   @override
-  String get series => 'தொடர்கள்';
+  String get series => 'தொடர்';
 
   @override
   String get noItemsFound => 'பொருட்கள் எதுவும் கிடைக்கவில்லை';
 
   @override
-  String get home => 'முகப்பு';
+  String get home => 'வீடு';
 
   @override
   String get browseAll => 'அனைத்தையும் உலாவவும்';
@@ -428,7 +427,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'கோப்புறையை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count உருப்படிகள்';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count உருப்படிகள்';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — வகைகள்';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +532,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count நிமி முன்';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count மணி முன்';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count நாள் முன்';
+    return '${count}d ago';
   }
 
   @override
@@ -554,7 +553,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'டிஸ்கவரில் காட்ட வேண்டிய சப்ஜெக்ட் ஃபீட்களைத் தேர்ந்தெடுக்கவும்.';
 
   @override
-  String get apply => 'பயன்படுத்து';
+  String get apply => 'விண்ணப்பிக்கவும்';
 
   @override
   String get openLink => 'இணைப்பைத் திற';
@@ -578,7 +577,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count தலைப்புகள்';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +602,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get listen => 'கேளுங்கள்';
 
   @override
-  String get resume => 'தொடர்க';
+  String get resume => 'ரெஸ்யூம்';
 
   @override
   String get failedToLoadLibrary => 'நூலகத்தை ஏற்றுவதில் தோல்வி';
@@ -666,17 +665,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count ஆசிரியர்கள்';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count வகைகள்';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% முடிந்தது';
+    return '$percent% completed';
   }
 
   @override
@@ -693,7 +692,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'வாசிப்பை முதன்மைப்படுத்தி உலாவ $count தலைப்புகள் வரிசைப்படுத்தப்பட்டுள்ளன.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -731,7 +730,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label எதுவும் இல்லை';
+    return 'No $label found';
   }
 
   @override
@@ -750,13 +749,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get readStatus => 'படிக்கவும்';
 
   @override
-  String get watched => 'பார்த்தவை';
+  String get watched => 'பார்த்தேன்';
 
   @override
   String get unread => 'படிக்காதது';
 
   @override
-  String get unwatched => 'பார்க்காதவை';
+  String get unwatched => 'பார்க்கப்படாதது';
 
   @override
   String get seriesStatus => 'தொடர் நிலை';
@@ -768,43 +767,43 @@ class AppLocalizationsTa extends AppLocalizations {
   String get books => 'புத்தகங்கள்';
 
   @override
-  String get latestBooks => 'சமீபத்திய புத்தகங்கள்';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'சமீபத்திய ஆடியோ புத்தகங்கள்';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count புத்தகங்கள்',
-      one: '1 புத்தகம்',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'புத்தகம்';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ஆடியோ புத்தகம்';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% படித்தது';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time மீதம்';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'படிக்க';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'கேட்க';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'ஆசிரியர்';
@@ -842,12 +841,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count பிரிவுகள்';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'முதல் வெளியீடு $year';
+    return 'First published $year';
   }
 
   @override
@@ -862,7 +861,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count புத்தகங்கள்';
+    return '$count books';
   }
 
   @override
@@ -873,7 +872,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count ஆசிரியர்கள்';
+    return '$count Authors';
   }
 
   @override
@@ -881,8 +880,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ஆடியோ புத்தகங்கள்',
-      one: '1 ஆடியோ புத்தகம்',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -900,7 +899,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get delete => 'நீக்கு';
 
   @override
-  String get save => 'சேமி';
+  String get save => 'சேமிக்கவும்';
 
   @override
   String get moreLikeThis => 'இது போன்ற மேலும்';
@@ -918,7 +917,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get nextUp => 'அடுத்தது';
 
   @override
-  String get seasons => 'சீசன்கள்';
+  String get seasons => 'பருவங்கள்';
 
   @override
   String get chapters => 'அத்தியாயங்கள்';
@@ -930,7 +929,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get movies => 'திரைப்படங்கள்';
 
   @override
-  String get musicVideos => 'இசை வீடியோக்கள்';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'மற்றவை';
@@ -949,7 +948,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'வட்டு $number';
+    return 'Disc $number';
   }
 
   @override
@@ -976,7 +975,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'வெளியீடு $year';
+    return 'Published $year';
   }
 
   @override
@@ -987,52 +986,52 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count சீசன்கள்',
-      one: '1 சீசன்',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time க்கு முடியும்';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'உருப்படிகள்';
+  String get items => 'Items';
 
   @override
-  String get extras => 'கூடுதல் அம்சங்கள்';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'திரைக்குப் பின்னால்';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'நீக்கப்பட்ட காட்சிகள்';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'சிறப்புத் தொகுப்புகள்';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'நேர்காணல்கள்';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'காட்சிகள்';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'குறும்படங்கள்';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'டிரெய்லர்கள்';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time மீதம்';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time இல் முடியும்';
+    return 'Ends in $time';
   }
 
   @override
@@ -1046,11 +1045,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position இலிருந்து தொடரவும்';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'இயக்கு';
+  String get play => 'விளையாடு';
 
   @override
   String get startOver => 'மீண்டும் தொடங்குங்கள்';
@@ -1074,7 +1073,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get version => 'பதிப்பு';
 
   @override
-  String get cast => 'அலைபரப்பு';
+  String get cast => 'நடிகர்கள்';
 
   @override
   String get trailer => 'டிரெய்லர்';
@@ -1145,7 +1144,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" க்காகப் பதிவிறக்கிய தடங்களை நீக்கவா?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1161,17 +1160,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel எதுவும் ஏற்றப்படவில்லை';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title பதிவிறக்குகிறது ($count உருப்படிகள்)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'சர்வரிலிருந்து \"$name\" ஐ நிச்சயமாக நீக்க வேண்டுமா? இந்தச் செயலைத் திரும்பப் பெற முடியாது.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1182,7 +1181,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'ஆதரிக்கப்படாத புத்தக வடிவம்: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1192,7 +1191,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get subtitleTrack => 'வசன வரி';
 
   @override
-  String get none => 'எதுவுமில்லை';
+  String get none => 'இல்லை';
 
   @override
   String get downloadSubtitlesLabel => 'வசனங்களைப் பதிவிறக்கவும்...';
@@ -1209,7 +1208,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'வசன வரிகள் பதிவிறக்கப்பட்டு தேர்ந்தெடுக்கப்பட்டன: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1218,7 +1217,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language க்கான தொலைநிலை வசன வரிகள் எதுவும் இல்லை.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1226,7 +1225,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'பதிப்பு $number';
+    return 'Version $number';
   }
 
   @override
@@ -1246,7 +1245,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name பதிவிறக்குகிறது ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1255,7 +1254,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel க்கான உள்ளூர் கோப்புகளை நீக்கவா?\n\nஇது சேமிப்பிட இடத்தைக் காலி செய்யும். பின்னர் மீண்டும் பதிவிறக்கலாம்.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1272,25 +1271,25 @@ class AppLocalizationsTa extends AppLocalizations {
   String get director => 'இயக்குனர்';
 
   @override
-  String get directors => 'இயக்குநர்கள்';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'எழுத்தாளர்';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'திரைக்கதை ஆசிரியர்கள்';
+  String get writers => 'எழுத்தாளர்கள்';
 
   @override
   String get studio => 'ஸ்டுடியோ';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count மேலும்';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count அத்தியாயங்கள்';
+    return '$count Episodes';
   }
 
   @override
@@ -1300,12 +1299,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'அத்தியாயம் $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'அத்தியாயம் $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1313,8 +1312,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count தடங்கள்',
-      one: '1 தடம்',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1324,25 +1323,25 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count அத்தியாயங்கள்',
-      one: '1 அத்தியாயம்',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'பிறப்பு $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'இறப்பு $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'வயது $age';
+    return 'Age $age';
   }
 
   @override
@@ -1352,20 +1351,20 @@ class AppLocalizationsTa extends AppLocalizations {
   String get readMore => 'மேலும் படிக்க';
 
   @override
-  String get shuffle => 'ஷஃபிள்';
+  String get shuffle => 'கலக்கு';
 
   @override
-  String get shuffleAllMusic => 'எல்லா இசையையும் கலைத்து இயக்கு';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'உங்கள் ஃபோனில் Moonfin இல் உள்நுழையவும்';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'உங்கள் சர்வரை அணுக முடியவில்லை';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count பதிவிறக்கங்கள்';
+    return '$count downloads';
   }
 
   @override
@@ -1384,32 +1383,32 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'தொலைநிலை வசன வரி $action செய்ய இந்தப் பயனருக்கு Jellyfin வசன வரி மேலாண்மை அனுமதி தேவை.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'தொலைநிலை வசன வரி $action செய்ய இந்த உருப்படி சர்வரில் கிடைக்கவில்லை.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'தொலைநிலை வசன வரி $action தோல்வியடைந்தது: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'தொலைநிலை வசன வரி $action தோல்வியடைந்தது (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'தொலைநிலை வசன வரிகளை $action செய்ய முடியவில்லை.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" க்காகப் பதிவிறக்கிய எல்லா அத்தியாயங்களும்';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1440,17 +1439,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label செயல் தோல்வியடைந்தது: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'காஸ்ட் ஒலி அளவை அமைக்க முடியவில்லை: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label கட்டுப்பாடுகள்';
+    return '$label Controls';
   }
 
   @override
@@ -1460,14 +1459,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get unavailable => 'கிடைக்கவில்லை';
 
   @override
-  String get pause => 'இடைநிறுத்து';
+  String get pause => 'இடைநிறுத்தம்';
 
   @override
   String get syncPosition => 'ஒத்திசைவு நிலை';
 
   @override
   String stopCast(String label) {
-    return '$label ஐ நிறுத்து';
+    return 'Stop $label';
   }
 
   @override
@@ -1475,7 +1474,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'தடம் $number';
+    return 'Track $number';
   }
 
   @override
@@ -1492,7 +1491,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds வினாடிகள்';
+    return '$seconds seconds';
   }
 
   @override
@@ -1561,7 +1560,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get transcodeReasons => 'டிரான்ஸ்கோட் காரணங்கள்';
 
   @override
-  String get player => 'பிளேயர்';
+  String get player => 'வீரர்';
 
   @override
   String get container => 'கொள்கலன்';
@@ -1585,7 +1584,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get videoBitrate => 'வீடியோ பிட்ரேட்';
 
   @override
-  String get track => 'ட்ராக்';
+  String get track => 'தடம்';
 
   @override
   String get channels => 'சேனல்கள்';
@@ -1607,12 +1606,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol அமர்வுப் பிழை';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'புத்தக விவரங்களை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1621,7 +1620,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'இந்த வடிவத்தை (.$extension) இன்னும் ஆப்ஸில் காட்ட முடியாது.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1634,17 +1633,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'ஆப்ஸ் ரீடரைத் திறக்க முடியவில்லை: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label இல் புக்மார்க் ஏற்கனவே சேமிக்கப்பட்டுள்ளது.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'புக்மார்க் சேர்க்கப்பட்டது: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1656,7 +1655,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'பக்கம் $number';
+    return 'Page $number';
   }
 
   @override
@@ -1667,12 +1666,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'வடிவம்: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% படித்தது';
+    return '$percent% read';
   }
 
   @override
@@ -1696,7 +1695,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'ஜூமை மீட்டமை (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1719,7 +1718,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'படித்த நிலையைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1752,7 +1751,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '$extension கோப்புகளுக்கான உள்ளமைந்த ஆவண எஞ்சினை இந்தத் தளத்தால் இயக்க முடியாது.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1791,7 +1790,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'வழிகாட்டியை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1802,22 +1801,22 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'அடுத்து: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes நிமி மீதம்';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours மணி மீதம்';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours மணி $minutes நிமி மீதம்';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1841,29 +1840,29 @@ class AppLocalizationsTa extends AppLocalizations {
   String get favoriteChannel => 'பிடித்த சேனல்';
 
   @override
-  String get record => 'பதிவு செய்';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'பதிவை ரத்துசெய்';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'நிகழ்ச்சி பதிவு செய்ய அமைக்கப்பட்டது';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'பதிவு ரத்துசெய்யப்பட்டது';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'பதிவை உருவாக்க முடியவில்லை';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'பார்';
+  String get watch => 'பார்க்கவும்';
 
   @override
   String get close => 'மூடு';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name ஐ இயக்க முடியவில்லை';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1890,7 +1889,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" இன் திட்டமிட்ட பதிவை ரத்துசெய்யவா?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1916,7 +1915,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" பதிவை நிறுத்தவா?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1931,19 +1930,19 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" க்கு முடிவுகள் எதுவும் இல்லை';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'தேடல் தோல்வியடைந்தது: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr கணக்கு வகை';
+  String get seerrAccountType => 'சீர் கணக்கு வகை';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1978,12 +1977,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\" ஐயும் அதன் கோப்புகளையும் அகற்றவா?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count தடங்கள்';
+    return '$count tracks';
   }
 
   @override
@@ -1994,16 +1993,16 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ஆல்பத்தை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name க்குப் பதிவிறக்கிய தடங்கள் எதுவும் இல்லை.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => 'சீசன்';
+  String get season => 'பருவம்';
 
   @override
   String get errorLoadingEpisodes => 'அத்தியாயங்களை ஏற்றுவதில் பிழை';
@@ -2016,12 +2015,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\" ஐ அகற்றவா?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes நிமி';
+    return '$minutes min';
   }
 
   @override
@@ -2031,7 +2030,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'அத்தியாயம் $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2045,7 +2044,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'சீசன் $number';
+    return 'Season $number';
   }
 
   @override
@@ -2061,7 +2060,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season இல் பதிவிறக்கிய எல்லா அத்தியாயங்களையும் நீக்கவா?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2069,8 +2068,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count அத்தியாயங்கள்',
-      one: '1 அத்தியாயம்',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2105,7 +2104,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'பதிவிறக்கிய $count உருப்படிகளை நீக்கவா?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2119,7 +2118,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit வரம்பில்';
+    return 'of $limit limit';
   }
 
   @override
@@ -2203,7 +2202,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count விருப்பங்கள்';
+    return '$count options';
   }
 
   @override
@@ -2298,7 +2297,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'விவரப் பக்கங்கள், முகப்பு வரிசைகள் மற்றும் ஒலி அளவு';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2313,11 +2312,11 @@ class AppLocalizationsTa extends AppLocalizations {
       'முகப்புத் திரையில் உலாவும்போது விளையாடு';
 
   @override
-  String get loopThemeMusic => 'தீம் இசையை லூப் செய்';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'தடத்தை ஒருமுறை இயக்குவதற்குப் பதிலாக மீண்டும் மீண்டும் இயக்கும்';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'விவரங்கள் பின்னணி தெளிவின்மை';
@@ -2340,23 +2339,23 @@ class AppLocalizationsTa extends AppLocalizations {
   String get playerZoomMode => 'பிளேயர் ஜூம் பயன்முறை';
 
   @override
-  String get settingsScrollWheelAction => 'மவுஸ் ஸ்க்ரோல் சக்கரம்';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'இயக்கத்தின்போது வீடியோ மீது மவுஸ் சக்கரத்தை உருட்டினால் என்ன நடக்க வேண்டும் என்பதைத் தேர்வுசெய்யவும்.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ஆஃப்';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'நகர்த்தல் (முன் / பின்)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ஒலியளவு';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ஒலியளவு';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'பொருத்தம்';
@@ -2410,37 +2409,37 @@ class AppLocalizationsTa extends AppLocalizations {
   String get defaultAudioLanguage => 'இயல்புநிலை ஆடியோ மொழி';
 
   @override
-  String get fallbackAudioLanguage => 'மாற்று ஆடியோ மொழி';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'இயல்பு ஆடியோ தடத்தை விரும்பு';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'உள்ளூர் டப்பிங்கை விட அசல் ஆடியோ தடத்தை விரும்பும்.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ஆடியோ விளக்கத் தடங்களை விரும்பு';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'சாதாரண தடங்களை விட ஆடியோ விளக்கத் தடங்களை விரும்பும்.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'டிரான்ஸ்கோடிங் (ஆடியோ)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'நேரடி ஸ்ட்ரீம் (ரீமக்ஸ்)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'டிரான்ஸ்கோடிங் (பிட்ரேட் அல்லது தெளிவுத்திறன்)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'டிரான்ஸ்கோடிங் (வீடியோ & ஆடியோ)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'டிரான்ஸ்கோடிங் (வீடியோ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'தானியங்கு (சர்வர் இயல்புநிலை)';
@@ -2517,28 +2516,27 @@ class AppLocalizationsTa extends AppLocalizations {
       'TrueHD ஆடியோவை இயக்கு (எல்லா தளங்களிலும் வேலை செய்யாமல் போகலாம்)';
 
   @override
-  String get settingsAudioOutputMode => 'ஆடியோ வெளியீட்டு முறை';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ஆடியோ எவ்வாறு டிகோட் செய்யப்படுகிறது என்பதைத் தேர்வுசெய்யவும். AVR பாஸ்த்ரூ உங்கள் ரிசீவருக்கு மூல Dolby/DTS ஸ்ட்ரீம்களை அனுப்பும்; தானியங்கி அல்லது டவுன்மிக்ஸ் உள்ளூரிலேயே டிகோட் செய்யும்.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR பாஸ்த்ரூ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'மாற்று ஆடியோ கோடெக்';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'மூல ஸ்ட்ரீமை நேரடியாக இயக்கவோ பாஸ்த்ரூ செய்யவோ முடியாதபோது, பல-சேனல் ஆடியோவை டிரான்ஸ்கோட் செய்ய வேண்டிய இலக்கு வடிவத்தைத் தேர்ந்தெடுக்கவும்.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'தானாகக் கண்டறி\n(பரிந்துரைக்கப்படுகிறது)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(இயல்பு)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2547,115 +2545,113 @@ class AppLocalizationsTa extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(இழப்பற்றது)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(ஸ்டீரியோ மட்டும்)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(திறமையானது)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(இழப்பற்றது)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'அதிகபட்ச ஆடியோ சேனல்கள்';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'உங்கள் ஆடியோ அமைப்பின் அதிகபட்ச சேனல்களை உள்ளமைக்கவும். இந்த வரம்பைத் தாண்டும் பல-சேனல் ஸ்ட்ரீம்கள் டவுன்மிக்ஸ் அல்லது டிரான்ஸ்கோட் செய்யப்படும்.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'தானாகக் கண்டறி\n(வன்பொருள் இயல்பு)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 மோனோ';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ஸ்டீரியோ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 சரவுண்ட்';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 குவாட்ரஃபோனிக்';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 சரவுண்ட்';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 சரவுண்ட்';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 சரவுண்ட்';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 சரவுண்ட்';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'பாஸ்த்ரூ (மேம்பட்டது)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'கோடெக் பாஸ்த்ரூ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'உங்கள் AVR அல்லது HDMI சாதனம் ஆதரிக்கும் வடிவங்களை மட்டும் இயக்கவும்.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 பாஸ்த்ரூ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) பாஸ்த்ரூ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core பாஸ்த்ரூ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA பாஸ்த்ரூ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD பாஸ்த்ரூ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos பாஸ்த்ரூ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) ஐ வெளிப்புற டிகோடருக்கு பிட்ஸ்ட்ரீம் செய்யும்.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) வழியாக Dolby Atmos ஐ வெளிப்புற டிகோடருக்கு பிட்ஸ்ட்ரீம் செய்யும்.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS Core உட்பட) ஐ வெளிப்புற டிகோடருக்கு பிட்ஸ்ட்ரீம் செய்யும்.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos மெட்டாடேட்டாவுடன் Dolby TrueHD ஐ வெளிப்புற டிகோடருக்கு பிட்ஸ்ட்ரீம் செய்யும்.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'கண்டறியப்பட்ட ஆடியோ திறன்கள்';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'இயக்க நேரத் திறன் தகவல் இன்னும் கிடைக்கவில்லை.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'வழி';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'டிகோட்';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'பாஸ்த்ரூ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ஆடியோ வழி';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2670,10 +2666,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'ஸ்பீக்கர்';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'ஹெட்ஃபோன்கள்';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2681,40 +2677,39 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'கண்டறிதல்கள்';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'வீடியோ லெவல்';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'வீடியோ வரம்பு';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'வசன வரி கோடெக்';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'அனுமதிக்கப்பட்ட ஆடியோ கோடெக்குகள்';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ஆடியோ கோடெக்குகள்';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ஆடியோ கோடெக்குகள்';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif பாஸ்த்ரூ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'செயலில் உள்ள ஆடியோ வழி';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'வழியின் HD ஆடியோ ஆதரவு';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'இரவு முறை';
@@ -2764,7 +2759,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$valueவி';
+    return '${value}s';
   }
 
   @override
@@ -2779,7 +2774,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes அத்தியாயங்கள் / $hours மணி நேரத்திற்குப் பிறகு';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2804,7 +2799,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get thirtySeconds => '30 வினாடிகள்';
 
   @override
-  String get skipBackLength => 'பின்னோக்கித் தாவும் நீளம்';
+  String get skipBackLength => 'Skip Back Length';
 
   @override
   String get skipForwardLength => 'முன்னோக்கி நீளத்தைத் தவிர்க்கவும்';
@@ -2855,45 +2850,45 @@ class AppLocalizationsTa extends AppLocalizations {
       'வசனத் தோற்றத்தைத் தனிப்பயனாக்கு';
 
   @override
-  String get subtitleMode => 'வசன வரி முறை';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'குறியிடப்பட்டது';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'எப்போதும்';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'வெளிமொழி';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'கட்டாயம்';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'மீடியா கோப்பின் மெட்டாடேட்டாவில் \"default\" அல்லது \"forced\" எனக் குறியிடப்பட்ட தடங்களை இயக்கும்.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'வீடியோ தொடங்கும் ஒவ்வொரு முறையும் வசன வரிகளைத் தானாக ஏற்றிக் காட்டும்.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'இயல்பு ஆடியோ தடம் வெளிமொழியில் இருந்தால் வசன வரிகளைத் தானாக இயக்கும்.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'forced மெட்டாடேட்டா குறியுடன் வெளிப்படையாகக் குறிக்கப்பட்ட வசன வரிகளை மட்டும் ஏற்றும்.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'தானியங்கி வசன வரி ஏற்றலை முழுவதுமாக முடக்கும்.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'மாற்று வசன வரி மொழி';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'வசன வரி ஸ்ட்ரீம்';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2952,17 +2947,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile சுயவிவர அமைப்புகள் ஏற்றப்பட்டன.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile சுயவிவர அமைப்புகளை ஏற்ற முடியவில்லை.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'உள்ளூர் அமைப்புகள் $profile சுயவிவரத்துடன் ஒத்திசைக்கப்பட்டன.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3099,10 +3094,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showLibrariesInToolbar => 'கருவிப்பட்டியில் நூலகங்களைக் காட்டு';
 
   @override
-  String get navbarAlwaysExpanded => 'நேவ்பார் லேபிள்களை எப்போதும் விரிவாக்கு';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr பட்டனைக் காட்டு';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'நவ்பார் ஒளிபுகா';
@@ -3177,20 +3172,18 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showFolderBrowsingOption => 'கோப்புறை உலாவல் விருப்பத்தைக் காட்டு';
 
   @override
-  String get groupItemsIntoCollections =>
-      'உருப்படிகளைத் தொகுப்புகளாகக் குழுவாக்கு';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'நூலகங்களை உலாவும்போது தொகுப்புடன் தொடர்புடைய நூலக உருப்படிகளை மறை';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'நூலகக் குழுவாக்கல் அறிவிப்பு';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'இந்த அமைப்பைப் பயன்படுத்த, உங்கள் Jellyfin அல்லது Emby சர்வரில் உங்கள் நூலகத்தின் Display அமைப்புகளின் கீழ் \"Group movies into collections\" மற்றும்/அல்லது \"Group shows into collections\" நூலக அமைப்புகள் இயக்கப்பட்டுள்ளதா என்பதை உறுதிசெய்யவும்.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'நூலகத் தெரிவுநிலை';
@@ -3219,7 +3212,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count தேர்ந்தெடுக்கப்பட்டது';
+    return '$count selected';
   }
 
   @override
@@ -3249,7 +3242,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'Moonfin, MakD ஆகியவற்றிற்கு இடையே தேர்வு செய்யவும் அல்லது மீடியா பட்டியை அணைக்கவும்';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'மூன்ஃபின்';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3302,11 +3295,10 @@ class AppLocalizationsTa extends AppLocalizations {
       '3 வினாடிகளுக்குப் பிறகு மீடியா பட்டியில் டிரெய்லர்களைத் தானாக இயக்கவும்';
 
   @override
-  String get trailerAudio => 'டிரெய்லர் ஆடியோ';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'மீடியா பட்டியில் டிரெய்லர்களுக்கு ஆடியோவை இயக்கும்';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'எபிசோட் முன்னோட்டம்';
@@ -3384,11 +3376,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'இரண்டு வரிசைகளையும் ஒரு முகப்புப் பிரிவில் இணைக்கவும்';
 
   @override
-  String get fullScreenRows => 'விரிவாக்கப்பட்ட முகப்பு வரிசைகள்';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'ஒரு திரைக்கு 1 முகப்பு வரிசை என வரம்பிடும்';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ஒவ்வொரு வரிசை பட வகை';
@@ -3403,7 +3394,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get lastUser => 'கடைசி பயனர்';
 
   @override
-  String get currentUser => 'தற்போதைய பயனர்';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'எப்போதும் அங்கீகரிக்கவும்';
@@ -3480,7 +3471,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes நிமி';
+    return '$minutes min';
   }
 
   @override
@@ -3512,10 +3503,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஸ்கிரீன்சேவரின் போது காட்சி கடிகாரம்';
 
   @override
-  String get clockModeStatic => 'நிலையானது';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'துள்ளுவது';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'அழுகிய தக்காளி (விமர்சகர்கள்)';
@@ -3527,7 +3518,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get imdb => 'IMDb';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'டிஎம்டிபி';
 
   @override
   String get metacritic => 'மெட்டாக்ரிடிக்';
@@ -3536,7 +3527,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get metacriticUser => 'மெட்டாக்ரிடிக் (பயனர்)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'டிராக்ட்';
 
   @override
   String get letterboxd => 'கடிதப்பெட்டி';
@@ -3589,7 +3580,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஆப்ஸ் முழுவதும் காட்டப்படும் மதிப்பீட்டு ஆதாரங்களை இயக்கி மறுவரிசைப்படுத்தவும்';
 
   @override
-  String get pluginLabel => 'Moonbase செருகுநிரல்';
+  String get pluginLabel => 'செருகுநிரல்';
 
   @override
   String get pluginDetected => 'செருகுநிரல் கண்டறியப்பட்டது';
@@ -3607,7 +3598,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nபதிப்பு: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3661,7 +3652,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get networks => 'நெட்வொர்க்குகள்';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr கண்டுபிடிப்பு வரிசைகள்';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'வரிசைகளை இயல்புநிலைக்கு மீட்டமைக்கவும்';
@@ -3685,44 +3676,44 @@ class AppLocalizationsTa extends AppLocalizations {
       'முடிவுகளில் வயது வந்தோருக்கான உள்ளடக்கத்தை மறை';
 
   @override
-  String get seerrNotificationsSection => 'அறிவிப்புகள்';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'புதிய கோரிக்கை அறிவிப்புகள்';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'யாராவது கோரிக்கை சமர்ப்பிக்கும்போது எனக்கு அறிவிக்கவும்';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'கோரிக்கை புதுப்பிப்புகள்';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'அங்கீகரிக்கப்பட்டது, நிராகரிக்கப்பட்டது மற்றும் உங்கள் நூலகத்தில் சேர்க்கப்பட்டது';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'சிக்கல் புதுப்பிப்புகள்';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'புதிய சிக்கல்கள், பதில்கள் மற்றும் தீர்வுகள்';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'உள்நுழைந்துள்ளவர்: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr கண்டுபிடிப்புப் பக்கம்';
+  String get discoverRows => 'வரிசைகளைக் கண்டறியவும்';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr முகப்புப் பக்கத்தில் காண வேண்டிய வரிசைகளை இயக்கவும். வரிசையை மாற்ற இழுக்கவும். தனிப்பயன் வரிசை Moonbase உடன் ஒத்திசைக்கப்படும்.';
+      'மறுவரிசைப்படுத்த இழுக்கவும். வரிசைகளை இயக்கவும் அல்லது முடக்கவும். இயக்கப்பட்ட வரிசை ஒழுங்கு Moonfin செருகுநிரலுடன் ஒத்திசைக்கப்படுகிறது.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr முகப்புப் பக்கத்தில் காண வேண்டிய வரிசைகளை இயக்கவும். வரிசையை மாற்ற இழுக்கவும். தனிப்பயன் வரிசை Moonbase உடன் ஒத்திசைக்கப்படும்.';
+      'மறுவரிசைப்படுத்த இழுக்கவும். வரிசைகளை இயக்கவும் அல்லது முடக்கவும்.';
 
   @override
   String get enabled => 'இயக்கப்பட்டது';
@@ -3735,7 +3726,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'பதிப்பு $version';
+    return 'Version $version';
   }
 
   @override
@@ -3786,7 +3777,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'புதுப்பிப்பு கிடைக்கிறது: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3798,7 +3789,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version கிடைக்கிறது';
+    return 'v$version Available';
   }
 
   @override
@@ -3864,7 +3855,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get imageCacheCleared => 'படக் கேச் அழிக்கப்பட்டது';
 
   @override
-  String get clear => 'அழி';
+  String get clear => 'தெளிவு';
 
   @override
   String get browse => 'உலாவவும்';
@@ -3880,19 +3871,19 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'பதிவிறக்குகிறது · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'இறக்குமதி செய்கிறது';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count உருப்படிகள்';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr அமைப்புகள்';
+  String get seerrSettings => 'சீர் அமைப்புகள்';
 
   @override
   String get requestMore => 'மேலும் கோரிக்கை';
@@ -3908,7 +3899,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name கோரியுள்ளார்';
+    return 'Requested by $name';
   }
 
   @override
@@ -3925,12 +3916,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" க்கான கோரிக்கையை ரத்துசெய்யவா?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" க்கான $count கோரிக்கைகளை ரத்துசெய்யவா?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3945,12 +3936,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'பட்ஜெட்: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'வருவாய்: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3960,7 +3951,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type கோரவும்';
+    return 'Request $type';
   }
 
   @override
@@ -3996,7 +3987,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'வயது $age';
+    return 'age $age';
   }
 
   @override
@@ -4027,149 +4018,148 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deletedStatus => 'நீக்கப்பட்டது';
 
   @override
-  String get failedStatus => 'தோல்வி';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'செயலாக்கத்தில்';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name மாற்றியுள்ளார்';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'முடிந்தது';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'இந்தத் தலைப்பு ஏற்கனவே கோரப்பட்டுள்ளது';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'கோரிக்கை வரம்பை எட்டிவிட்டது';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted =>
-      'இந்தத் தலைப்பு தடுப்புப்பட்டியலில் உள்ளது';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'கோர எந்த சீசனும் மீதமில்லை';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'இந்தக் கோரிக்கையை வைக்க உங்களுக்கு அனுமதி இல்லை';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'கோரிக்கைகள்';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'சிக்கல்கள்';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'புதியவை முதலில்';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'கடைசியாக மாற்றியவை';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'சிக்கல்கள் எதுவும் இல்லை';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit திரைப்படக் கோரிக்கைகளில் $remaining மீதம்';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit சீசன் கோரிக்கைகளில் $remaining மீதம்';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name இன் ஒரு பகுதி';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'தொகுப்பைப் பார்';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'தொகுப்பைக் கோரவும்';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total திரைப்படங்கள் · $available கிடைக்கின்றன';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count திரைப்படங்களைக் கோரவும்';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total இல் $current கோரப்படுகிறது...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count திரைப்படங்கள் கோரப்பட்டன';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total திரைப்படங்களில் $ok கோரப்பட்டன';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'எல்லாத் திரைப்படங்களும் ஏற்கனவே கிடைக்கின்றன அல்லது கோரப்பட்டுள்ளன';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'சிக்கலைப் புகாரளி';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'வீடியோ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ஆடியோ';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'என்ன பிரச்சினை?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'எல்லா அத்தியாயங்களும்';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'அத்தியாயம்';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'திறந்துள்ளது';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'தீர்க்கப்பட்டது';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'தீர்';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'மீண்டும் திற';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name புகாரளித்துள்ளார்';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count கருத்துகள்';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'கருத்தைச் சேர்க்கவும்';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'இந்தச் சிக்கலை நீக்கவா?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'புகாரைச் சமர்ப்பி';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB மதிப்பெண்';
@@ -4193,7 +4183,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get originalLanguageLabel => 'அசல் மொழி';
 
   @override
-  String get seasonsLabel => 'சீசன்கள்';
+  String get seasonsLabel => 'பருவங்கள்';
 
   @override
   String get episodesLabel => 'அத்தியாயங்கள்';
@@ -4229,7 +4219,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get done => 'முடிந்தது';
 
   @override
-  String get edit => 'திருத்து';
+  String get edit => 'திருத்தவும்';
 
   @override
   String get encoding => 'குறியாக்கம்';
@@ -4331,7 +4321,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get time => 'நேரம்';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'தந்திரம்';
 
   @override
   String get uninstall => 'நிறுவல் நீக்கவும்';
@@ -4349,7 +4339,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get unmute => 'ஒலியடக்கவும்';
 
   @override
-  String get mute => 'ஒலியடக்கு';
+  String get mute => 'முடக்கு';
 
   @override
   String get branding => 'பிராண்டிங்';
@@ -4373,25 +4363,25 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminDrawerLibraries => 'நூலகங்கள்';
 
   @override
-  String get adminDrawerDisplay => 'காட்சி';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'மெட்டாடேட்டா';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO அமைப்புகள்';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'டிரான்ஸ்கோடிங்';
 
   @override
-  String get adminDrawerResume => 'தொடர்க';
+  String get adminDrawerResume => 'ரெஸ்யூம்';
 
   @override
   String get adminDrawerStreaming => 'ஸ்ட்ரீமிங்';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'தந்திரம்';
 
   @override
   String get adminDrawerDevices => 'சாதனங்கள்';
@@ -4442,22 +4432,22 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'செருகுநிரல் புதுப்பிப்புகள் கிடைக்கின்றன: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'மறுதொடக்கம் தேவைப்படும் செருகுநிரல்கள்: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'தோல்வியடைந்த திட்டமிட்ட பணிகள்: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'சமீபத்திய எச்சரிக்கை/பிழை பதிவுகள்: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4516,7 +4506,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'பிழை: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4543,7 +4533,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'கட்டளை தோல்வியடைந்தது: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4580,7 +4570,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get nowPlaying => 'இப்போது விளையாடுகிறது';
 
   @override
-  String get volume => 'ஒலியளவு';
+  String get volume => 'தொகுதி';
 
   @override
   String get actions => 'செயல்கள்';
@@ -4592,7 +4582,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audioCodec => 'ஆடியோ கோடெக்';
 
   @override
-  String get hwAccel => 'HW முடுக்கம்';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'நிறைவு';
@@ -4607,14 +4597,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminClearDates => 'தெளிவான தேதிகள்';
 
   @override
-  String get adminActivitySeverityAll => 'எல்லா தீவிரநிலைகளும்';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'தேதி வரம்பு';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'செயல்பாட்டுப் பதிவை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4631,7 +4621,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'சாதனத்தைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4642,28 +4632,28 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'சாதனத்தை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' சாதனத்தை அகற்றவா? இந்தச் சாதனத்தில் பயனர் மீண்டும் உள்நுழைய வேண்டியிருக்கும்.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'எல்லா சாதனங்களையும் நீக்கு';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count சாதனங்களை அகற்றவா? பாதிக்கப்படும் பயனர்கள் மீண்டும் உள்நுழைய வேண்டியிருக்கும். உங்கள் தற்போதைய சாதனம் பாதிக்கப்படாது.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'சாதனங்கள் அகற்றப்பட்டன';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'சில சாதனங்கள் அகற்றப்பட்டன; $count அகற்ற முடியவில்லை.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4692,7 +4682,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'ஸ்கேனைத் தொடங்க முடியவில்லை: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4703,12 +4693,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'நூலகம் \"$name\" எனப் பெயர்மாற்றப்பட்டது';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'பெயர்மாற்ற முடியவில்லை: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4716,17 +4706,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" நூலகம் நீக்கப்பட்டது';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'நூலகத்தை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'பாதையைச் சேர்க்க முடியவில்லை: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4734,12 +4724,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'இந்த நூலகத்திலிருந்து \"$path\" ஐ அகற்றவா?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'பாதையை அகற்ற முடியவில்லை: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4747,7 +4737,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'விருப்பங்களைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4778,262 +4768,251 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminMetadataCountryHint => 'எ.கா. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'பாதைகள்';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'விருப்பங்கள்';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'பதிவிறக்கிகள்';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'மெட்டாடேட்டா சேமிப்பான்கள்';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'வசன வரி பதிவிறக்கிகள்';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'பாடல் வரி பதிவிறக்கிகள்';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'மெட்டாடேட்டா பதிவிறக்கிகள்: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'படம் பெறுவான்கள்: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'இந்த நூலக வகைக்கு இந்த சர்வர் எந்தப் பதிவிறக்கியையும் வழங்கவில்லை.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'பொது';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'மெட்டாடேட்டா';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'உள்ளமைந்த தகவல்';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'வசன வரிகள்';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'படங்கள்';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'தொடர்கள்';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'இசை';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'திரைப்படங்கள்';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'நிகழ்நேரக் கண்காணிப்பை இயக்கு';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'கோப்பு மாற்றங்களைக் கண்டறிந்து தானாகச் செயலாக்கும்.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'காப்பகங்களை மீடியா கோப்புகளாகக் கருது';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'புகைப்படங்களைக் காட்டு';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'கலைப்படைப்புகளை மீடியா கோப்புறைகளில் சேமி';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'தானியங்கி மெட்டாடேட்டா புதுப்பிப்பு';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ஒருபோதும் இல்லை';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'இயல்பு';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'காட்சி';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'நூலகக் காட்சி';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'எளிய மீடியா கோப்புறைகளைக் காட்ட கோப்புறைக் காட்சியைக் காட்டு';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'சிறப்பு அத்தியாயங்களை அவை ஒளிபரப்பான சீசன்களுக்குள் காட்டு';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'திரைப்படங்களைத் தொகுப்புகளாகக் குழுவாக்கு';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'நிகழ்ச்சிகளைத் தொகுப்புகளாகக் குழுவாக்கு';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'பரிந்துரைகளில் வெளிப்புற உள்ளடக்கத்தைக் காட்டு';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'சேர்க்கப்பட்ட தேதி நடத்தை';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel =>
-      'சேர்க்கப்பட்ட தேதியை இதிலிருந்து பயன்படுத்து';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'நூலகத்தில் ஸ்கேன் செய்யப்பட்ட தேதி';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'கோப்பு உருவாக்கப்பட்ட தேதி';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'மெட்டாடேட்டா மற்றும் படங்கள்';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'விருப்பமான மெட்டாடேட்டா மொழி';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'அத்தியாயங்கள்';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'போலி அத்தியாய கால அளவு (வினாடிகள்)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'அத்தியாயங்கள் இல்லாத மீடியாவுக்கு உருவாக்கப்படும் அத்தியாயங்களின் நீளம். முடக்க 0 என அமைக்கவும்.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'அத்தியாயப் படத் தெளிவுத்திறன்';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO அமைப்புகள்';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO மெட்டாடேட்டா Kodi மற்றும் அது போன்ற கிளையண்டுகளுடன் இணக்கமானது. NFO மெட்டாடேட்டாவைச் சேமிக்கும் எல்லா நூலகங்களுக்கும் இந்த அமைப்புகள் பொருந்தும்.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO கோப்புகளில் பார்த்த தரவைச் சேமிக்க வேண்டிய பயனர்';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'NFO கோப்புகளுக்குள் படப் பாதைகளைச் சேமி';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO படப் பாதைகளுக்கு பாதை மாற்றீட்டை இயக்கு';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart படங்களை extrathumbs கோப்புறைக்கு நகலெடு';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'எதுவுமில்லை';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days நாட்கள்';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'உள்ளமைந்த தலைப்புகளைப் பயன்படுத்து';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'கூடுதல் அம்சங்களுக்கு உள்ளமைந்த தலைப்புகளைப் பயன்படுத்து';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'உள்ளமைந்த அத்தியாயத் தகவலைப் பயன்படுத்து';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'உள்ளமைந்த வசன வரிகளை அனுமதி';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'அனைத்தையும் அனுமதி';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'உரை மட்டும்';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'படம் மட்டும்';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'எதுவுமில்லை';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'உள்ளமைந்த வசன வரிகள் இருந்தால் பதிவிறக்கத்தைத் தவிர்';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ஆடியோ தடம் பதிவிறக்க மொழியுடன் பொருந்தினால் பதிவிறக்கத்தைத் தவிர்';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'வசன வரி முழுமையாகப் பொருந்த வேண்டும்';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'வசன வரிகளை மீடியா கோப்புறைகளில் சேமி';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'அத்தியாயப் படங்களைப் பிரித்தெடு';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'நூலக ஸ்கேனின்போது அத்தியாயப் படங்களைப் பிரித்தெடு';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay படப் பிரித்தெடுத்தலை இயக்கு';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'நூலக ஸ்கேனின்போது Trickplay படங்களைப் பிரித்தெடு';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay படங்களை மீடியா கோப்புறைகளில் சேமி';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'பல கோப்புறைகளில் பரவியுள்ள தொடர்களைத் தானாக இணை';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'பூஜ்ஜிய சீசன் காட்சிப் பெயர்';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'ஆடியோ சீரமைப்புக்கான LUFS ஸ்கேனை இயக்கு';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'தரமற்ற கலைஞர்கள் குறிச்சொல்லை விரும்பு';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'திரைப்படங்களைத் தொகுப்புகளில் தானாகச் சேர்';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'நூலகத்தின் பெயர் தேவை';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'நூலகத்தை உருவாக்க முடியவில்லை: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5060,27 +5039,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name ஐ முடக்கவா? அவரால் உள்நுழைய முடியாது.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name ஐ இயக்கவா? அவர் மீண்டும் உள்நுழைய முடியும்.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" பயனர் முடக்கப்பட்டார்';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" பயனர் இயக்கப்பட்டார்';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'பயனர் கொள்கையைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5097,7 +5076,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'பயனரை உருவாக்க முடியவில்லை: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5117,7 +5096,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5128,7 +5107,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'தோல்வி: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5269,146 +5248,143 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminEnableAllChannels => 'எல்லா சேனல்களுக்கும் அணுகலை இயக்கவும்';
 
   @override
-  String get adminParentalControl => 'பெற்றோர் கட்டுப்பாடு';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'அனுமதிக்கப்பட்ட அதிகபட்ச பெற்றோர் மதிப்பீடு';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'அதிக மதிப்பீடு கொண்ட உள்ளடக்கம் இந்தப் பயனரிடமிருந்து மறைக்கப்படும்.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'எதுவுமில்லை';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'மதிப்பீட்டுத் தகவல் இல்லாத அல்லது அடையாளம் காணப்படாத உருப்படிகளைத் தடு';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'புத்தகங்கள்';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'சேனல்கள்';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'நேரலை டிவி';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'திரைப்படங்கள்';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'இசை';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'டிரெய்லர்கள்';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'நிகழ்ச்சிகள்';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'அணுகல் அட்டவணைகள்';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'கீழே உள்ள திட்டமிட்ட நேரங்களில் மட்டும் அணுகலை அனுமதிக்கும். அட்டவணை எதுவும் அமைக்கப்படாதபோது நாள் முழுவதும் அணுகல் அனுமதிக்கப்படும்.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'அட்டவணையைச் சேர்';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'நாள்';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'தொடக்கம்';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'முடிவு';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'தினமும்';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'வார நாள்';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'வார இறுதி';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ஞாயிறு';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'திங்கள்';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'செவ்வாய்';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'புதன்';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'வியாழன்';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'வெள்ளி';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'சனி';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'அனுமதிக்கப்பட்ட குறிச்சொற்கள்';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'இந்தக் குறிச்சொற்கள் கொண்ட உள்ளடக்கம் மட்டுமே காட்டப்படும். அனைத்தையும் அனுமதிக்க காலியாக விடவும்.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'தடுக்கப்பட்ட குறிச்சொற்கள்';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'இந்தக் குறிச்சொற்கள் கொண்ட உள்ளடக்கம் இந்தப் பயனரிடமிருந்து மறைக்கப்படும்.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'குறிச்சொல்லைச் சேர்';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'இயக்கப்பட்ட சாதனங்கள்';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'இயக்கப்பட்ட சேனல்கள்';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'அங்கீகார வழங்குநர்';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'கடவுச்சொல் மீட்டமைப்பு வழங்குநர்';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'பூட்டுவதற்கு முன் அதிகபட்ச தோல்வியுற்ற உள்நுழைவு முயற்சிகள்';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'இயல்புநிலைக்கு 0 எனவும், பூட்டுதலை முடக்க -1 எனவும் அமைக்கவும்.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay அணுகல்';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'குழுக்களை உருவாக்கவும் சேரவும் அனுமதி';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'குழுக்களில் சேர அனுமதி';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'அணுகல் இல்லை';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'இதிலிருந்து உள்ளடக்க நீக்கத்தை அனுமதி';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5416,22 +5392,22 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'சர்வர் HTTP $status ஐத் திருப்பியது';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name ஐ நிச்சயமாக நீக்க வேண்டுமா?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" பயனர் நீக்கப்பட்டார்';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'பயனரை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5452,7 +5428,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'விசையை உருவாக்க முடியவில்லை: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5463,7 +5439,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name க்கான விசையைத் திரும்பப் பெறவா?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5471,7 +5447,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'விசையைத் திரும்பப் பெற முடியவில்லை: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5491,30 +5467,29 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'டோக்கன்: $token\\nஉருவாக்கப்பட்டது: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'காப்புப்பிரதி உருவாக்கு';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'காப்புப்பிரதியில் எதைச் சேர்க்க வேண்டும் என்பதைத் தேர்வுசெய்யவும்.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'தரவுத்தளம்';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'எப்போதும் சேர்க்கப்படும்';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'மெட்டாடேட்டா';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'வசன வரிகள்';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay படங்கள்';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'காப்புப்பிரதியை உருவாக்குகிறது...';
@@ -5524,7 +5499,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'காப்புப்பிரதியை உருவாக்க முடியவில்லை: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5532,12 +5507,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'மேனிஃபெஸ்ட்: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'மேனிஃபெஸ்டை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5548,7 +5523,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'காப்புப்பிரதியை மீட்டெடுக்க முடியவில்லை: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5580,17 +5555,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path இல் சேமிக்கப்பட்டது';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'கோப்பைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName ஐ ஏற்ற முடியவில்லை';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5601,7 +5576,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'பணிகளை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5613,17 +5588,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'பணியைத் தொடங்க முடியவில்லை: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'பணியை நிறுத்த முடியவில்லை: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'பணியை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5631,12 +5606,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'தூண்டியை அகற்ற முடியவில்லை: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'தூண்டியைச் சேர்க்க முடியவில்லை: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5662,7 +5637,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours மணி நேரம்';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5673,7 +5648,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'செருகுநிரலை மாற்ற முடியவில்லை: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5681,27 +5656,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '\"$name\" ஐ நிச்சயமாக நிறுவல் நீக்க வேண்டுமா?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'செருகுநிரலை நிறுவல் நீக்க முடியவில்லை: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'தொகுப்பை நிறுவ முடியவில்லை: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'புதுப்பிப்பை நிறுவ முடியவில்லை: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'செருகுநிரல்களை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5714,12 +5689,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'புதுப்பிப்பை நிறுவு (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'பட்டியலை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5741,17 +5716,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'சர்வர் மறுதொடக்கத்திற்குப் பிறகு \"$name\" அகற்றப்படும்';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'நிறுவல் நீக்க முடியவில்லை: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\" ஐ v$version க்குப் புதுப்பிக்கிறது...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5760,7 +5735,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'செருகுநிரலை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5768,7 +5743,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'பதிப்பு $version';
+    return 'Version $version';
   }
 
   @override
@@ -5788,17 +5763,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '\"$name\" ஐ நிச்சயமாக அகற்ற வேண்டுமா?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'களஞ்சியங்களைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'களஞ்சியங்களை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5815,12 +5790,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'செருகுநிரல் அமைப்புகளை ஏற்ற முடியவில்லை: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri ஐத் திறக்க முடியவில்லை';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5942,11 +5917,11 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminThrottleBuffering => 'த்ரோட்டில் பஃபரிங்';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay அமைப்புகள் சேமிக்கப்பட்டன';
+  String get adminTrickplaySaved => 'ட்ரிக்ப்ளே அமைப்புகள் சேமிக்கப்பட்டன';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Trickplay அமைப்புகளை ஏற்ற முடியவில்லை';
+      'ட்ரிக்ப்ளே அமைப்புகளை ஏற்றுவதில் தோல்வி';
 
   @override
   String get adminEnableHardwareAcceleration => 'வன்பொருள் முடுக்கத்தை இயக்கு';
@@ -6059,7 +6034,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminBaseUrl => 'அடிப்படை URL';
 
   @override
-  String get adminBaseUrlHint => 'எ.கா. /jellyfin';
+  String get adminBaseUrlHint => 'எ.கா. /ஜெல்லிஃபின்';
 
   @override
   String get https => 'HTTPS';
@@ -6099,12 +6074,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'மெட்டாடேட்டாவை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'மெட்டாடேட்டாவைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6125,7 +6100,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'மெட்டாடேட்டாவைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6140,7 +6115,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'தொலைநிலைத் தேடல் தோல்வியடைந்தது: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6154,7 +6129,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'உள்ளடக்க வகையைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6169,12 +6144,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType படம் புதுப்பிக்கப்பட்டது';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'படத்தைப் பதிவிறக்க முடியவில்லை: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6186,27 +6161,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType படம் பதிவேற்றப்பட்டது';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'படத்தைப் பதிவேற்ற முடியவில்லை: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType படத்தை நீக்கு';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType படம் நீக்கப்பட்டது';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'படத்தை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6217,69 +6192,67 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'டியூனர் கண்டுபிடிப்பு தோல்வியடைந்தது: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'ட்யூனரைச் சேர்க்கவும்';
 
   @override
-  String get adminEditTuner => 'டியூனரைத் திருத்து';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U டியூனர்';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'கோப்பு அல்லது URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'டியூனர் IP முகவரி';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'எளிய பெயர்';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'பயனர் ஏஜென்ட்';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ஒரே நேரத்தில் இணைப்பு வரம்பு';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'டியூனர் ஒரே நேரத்தில் அனுமதிக்கும் அதிகபட்ச ஸ்ட்ரீம்களின் எண்ணிக்கை. வரம்பின்றி இருக்க 0 என அமைக்கவும்.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'மாற்று அதிகபட்ச ஸ்ட்ரீமிங் பிட்ரேட்';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'பிடித்த சேனல்களை மட்டும் இறக்குமதி செய்';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'வன்பொருள் டிரான்ஸ்கோடிங்கை அனுமதி';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 டிரான்ஸ்கோடிங் கண்டெய்னரை அனுமதி';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ஸ்ட்ரீம் பகிர்வை அனுமதி';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ஸ்ட்ரீம் லூப்பிங்கை இயக்கு';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS ஐப் புறக்கணி';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'உள்ளீட்டை நேட்டிவ் ஃபிரேம் ரேட்டில் படி';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'வழங்குநரைத் திருத்து';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6288,50 +6261,50 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'கோப்பு அல்லது URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'திரைப்பட முன்னொட்டு';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'திரைப்பட வகைகள்';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'பல வகைகளைச் செங்குத்துக் கோட்டால் பிரிக்கவும்.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'குழந்தைகள் வகைகள்';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'செய்தி வகைகள்';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'விளையாட்டு வகைகள்';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'பயனர் பெயர்';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'கடவுச்சொல்';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'நாடு';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'ஒரு நாட்டைத் தேர்ந்தெடுக்கவும்';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'அஞ்சல் குறியீடு';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'பட்டியல்களைப் பெறு';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'பட்டியல்கள்';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'எல்லா டியூனர்களையும் இயக்கு';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ட்யூனர் வகை';
@@ -6341,7 +6314,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'டியூனரைச் சேர்க்க முடியவில்லை: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6355,12 +6328,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'வழங்குநரைச் சேர்க்க முடியவில்லை: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'டியூனரை அகற்ற முடியவில்லை: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6368,16 +6341,16 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'டியூனரை மீட்டமைக்க முடியவில்லை: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'இந்த டியூனர் வகை மீட்டமைப்பை ஆதரிக்கவில்லை.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'வழங்குநரை அகற்ற முடியவில்லை: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6396,44 +6369,43 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminSeriesRecordingPath => 'தொடர் பதிவு பாதை';
 
   @override
-  String get adminMovieRecordingPath => 'திரைப்படப் பதிவுப் பாதை';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'வழிகாட்டி தரவு நாட்கள்';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'தானியங்கி';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days நாட்கள்';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'பிந்தைய செயலாக்கப் பயன்பாட்டுப் பாதை';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'பிந்தைய செயலாக்கி அளபுருக்கள்';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'பதிவின் NFO மெட்டாடேட்டாவைச் சேமி';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'பதிவின் படங்களைச் சேமி';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'நேரம்';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'பதிவுப் பாதைகள்';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'பிந்தைய செயலாக்கம்';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'வழிகாட்டி தரவு: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6441,7 +6413,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'அமைப்புகளைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6459,7 +6431,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'மேப்பிங்குகளைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6477,15 +6449,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminGuideProviders => 'வழிகாட்டி வழங்குநர்கள்';
 
   @override
-  String get adminRefreshGuideData => 'வழிகாட்டி தரவைப் புதுப்பி';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'வழிகாட்டி தரவுப் புதுப்பிப்பு தொடங்கியது';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'இந்த சர்வரில் வழிகாட்டி புதுப்பிப்புப் பணி கிடைக்கவில்லை.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'வழங்குநரைச் சேர்க்கவும்';
@@ -6496,22 +6467,22 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'பதிவுப் பாதை: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'தொடர்ப் பாதை: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'முன் இடைவெளி: $minutes நிமி';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'பின் இடைவெளி: $minutes நிமி';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6545,7 +6516,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name காப்புப்பிரதியை இப்போது மீட்டெடுக்கவா?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6569,7 +6540,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminLiveTvTitle => 'நேரடி தொலைக்காட்சி நிர்வாகம்';
 
   @override
-  String get adminApply => 'பயன்படுத்து';
+  String get adminApply => 'விண்ணப்பிக்கவும்';
 
   @override
   String get adminNotSet => 'அமைக்கப்படவில்லை';
@@ -6591,27 +6562,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes நிமி முன்';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours மணி முன்';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days நாள் முன்';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName ஐ ஏற்ற முடியவில்லை';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count பொருத்தங்கள்';
+    return '$count matches';
   }
 
   @override
@@ -6621,7 +6592,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminMetadataEditorTitle => 'மெட்டாடேட்டா எடிட்டர்';
 
   @override
-  String get adminMetadataIdentify => 'அடையாளம் காண்';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'வகை';
@@ -6721,22 +6692,22 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType படம் புதுப்பிக்கப்பட்டது';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType படம் பதிவேற்றப்பட்டது';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType படம் நீக்கப்பட்டது';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'படத்தைப் பதிவிறக்க முடியவில்லை: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6745,12 +6716,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'படத்தைப் பதிவேற்ற முடியவில்லை: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType படத்தை நீக்கு';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6759,12 +6730,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'படத்தை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType படத்தைத் தேர்வுசெய்';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6798,7 +6769,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'புதுப்பிப்பு கிடைக்கிறது: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6823,7 +6794,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'புதுப்பிப்பை நிறுவு (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6835,7 +6806,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" நிறுவப்படுகிறது...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6855,7 +6826,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name அமைப்புகள்';
+    return '$name Settings';
   }
 
   @override
@@ -6895,7 +6866,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'களஞ்சியங்களை ஏற்ற முடியவில்லை: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6903,7 +6874,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '\"$name\" ஐ நிச்சயமாக அகற்ற வேண்டுமா?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6911,7 +6882,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'களஞ்சியங்களைச் சேமிக்க முடியவில்லை: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7036,20 +7007,19 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminBrandingEnableSplash => 'ஸ்பிளாஸ் திரையை இயக்கவும்';
 
   @override
-  String get adminBrandingSplashUpload => 'படத்தைப் பதிவேற்று';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'ஸ்பிளாஸ் திரை புதுப்பிக்கப்பட்டது';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'ஸ்பிளாஸ் திரையைப் பதிவேற்ற முடியவில்லை';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'ஸ்பிளாஸ் திரை அகற்றப்பட்டது';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'தனிப்பயன் ஸ்பிளாஸ் திரை இல்லை';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'வன்பொருள் முடுக்கம்';
@@ -7064,124 +7034,121 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'வன்பொருள் டிகோடிங்கை இயக்கு:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV சாதனம்';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'மேம்படுத்தப்பட்ட NVDEC டிகோடரை இயக்கு';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'சிஸ்டத்தின் நேட்டிவ் வன்பொருள் டிகோடரை விரும்பு';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'வன்பொருள் டிகோடிங் வண்ண ஆழம்';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-பிட் HEVC டிகோடிங்';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-பிட் VP9 டிகோடிங்';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-பிட் டிகோடிங்';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-பிட் டிகோடிங்';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'வன்பொருள் என்கோடிங்';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC என்கோடிங்கை அனுமதி';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 என்கோடிங்கை அனுமதி';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel குறைந்த-ஆற்றல் H.264 என்கோடரை இயக்கு';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel குறைந்த-ஆற்றல் HEVC என்கோடரை இயக்கு';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'டோன் மேப்பிங்';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'டோன் மேப்பிங்கை இயக்கு';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'VPP டோன் மேப்பிங்கை இயக்கு';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox டோன் மேப்பிங்கை இயக்கு';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'டோன் மேப்பிங் அல்காரிதம்';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'டோன் மேப்பிங் முறை';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'டோன் மேப்பிங் வரம்பு';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'டோன் மேப்பிங் நிறமிழப்பு';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'டோன் மேப்பிங் உச்சம்';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'டோன் மேப்பிங் அளபுரு';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP டோன் மேப்பிங் பிரகாசம்';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP டோன் மேப்பிங் மாறுபாடு';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'முன்னமைவுகள் & தரம்';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'என்கோடர் முன்னமைவு';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 என்கோடிங் CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) என்கோடிங் CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'டீஇன்டர்லேஸ் முறை';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'டீஇன்டர்லேஸ் செய்யும்போது ஃபிரேம் ரேட்டை இரட்டிப்பாக்கு';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ஆடியோ';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'ஆடியோ VBR என்கோடிங்கை இயக்கு';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ஆடியோ டவுன்மிக்ஸ் அதிகரிப்பு';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ஸ்டீரியோ டவுன்மிக்ஸ் அல்காரிதம்';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'அதிகபட்ச மக்ஸிங் வரிசை அளவு';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'தானியங்கி';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'குறியாக்கம்';
@@ -7305,7 +7272,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminTaskStop => 'நிறுத்து';
 
   @override
-  String get adminRunningTasks => 'இயங்கும் பணிகள்';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'ஓடவும்';
@@ -7327,17 +7294,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'தினமும் $time க்கு';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'ஒவ்வொரு $day அன்று $time க்கு';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'ஒவ்வொரு $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7375,8 +7342,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count மணி நேரம்',
-      one: '1 மணி நேரம்',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7404,17 +7371,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days நாள் முன்';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours மணி முன்';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes நிமி முன்';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7422,27 +7389,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesநி';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursம';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysநா';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'தேடல் முன்னோட்டச் சிறுபடங்களுக்கான Trickplay படம் உருவாக்கத்தை உள்ளமைக்கவும்.';
+      'முன்னோட்ட சிறுபடங்களை தேடுவதற்கு ட்ரிக்பிளே பட உருவாக்கத்தை உள்ளமைக்கவும்.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'பொது HTTPS போர்ட்';
@@ -7451,50 +7418,49 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'அடிப்படை URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'எ.கா. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'எ.கா. /ஜெல்லிஃபின்';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'பொது HTTP போர்ட்';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS தேவை';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'எல்லா தொலைநிலைக் கோரிக்கைகளையும் HTTPS க்குத் திருப்பிவிடும். சர்வரில் செல்லுபடியாகும் சான்றிதழ் இல்லாவிட்டால் இதற்கு விளைவு இல்லை.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'சான்றிதழ் கடவுச்சொல்';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP அமைப்புகள்';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 ஐ இயக்கு';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 ஐ இயக்கு';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'தானியங்கி போர்ட் மேப்பிங்கை இயக்கு';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN நெட்வொர்க்குகள்';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'உள்ளூர் நெட்வொர்க்கில் உள்ளதாகக் கருதப்படும் IP முகவரிகள் அல்லது CIDR சப்நெட்களின் பட்டியல், காற்புள்ளி அல்லது வரிவாரியாகப் பிரிக்கப்பட்டது.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'வெளியிடப்பட்ட சர்வர் URI கள்';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'ஒரு சப்நெட் அல்லது முகவரியை வெளியிடப்பட்ட URL உடன் மேப் செய்யவும், எ.கா. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'சான்றிதழ் பாதை';
@@ -7524,11 +7490,11 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'த்ரோட்டில் பஃபரிங்';
 
   @override
-  String get adminPlaybackThrottleDelay => 'த்ராட்டில் தாமதம் (வினாடிகள்)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'உடனுக்குடன் வசன வரி பிரித்தெடுத்தலை அனுமதி';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'குறைந்தபட்ச விண்ணப்பம் சதவீதம்';
@@ -7578,7 +7544,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'உள்ளடக்க வகையைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7586,23 +7552,22 @@ class AppLocalizationsTa extends AppLocalizations {
       'மெதுவான மறுமொழி வரம்பு (மிவி)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'மெதுவான பதில் எச்சரிக்கைகளை இயக்கு';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect ஐ இயக்கு';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'சர்வர்';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'மெட்டாடேட்டா';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'பாதைகள்';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'செயல்திறன்';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'கேச் பாதை';
@@ -7614,7 +7579,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminGeneralServerName => 'சர்வர் பெயர்';
 
   @override
-  String get adminGeneralDisplayLanguage => 'விருப்பமான காட்சி மொழி';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'அமைப்புகளை ஏற்றுவதில் தோல்வி';
@@ -7624,12 +7589,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'மேப்பிங்குகளைப் புதுப்பிக்க முடியவில்லை: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'நேர வரம்பு: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -7666,8 +7631,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# பங்கேற்பாளர்கள்',
-      one: '# பங்கேற்பாளர்',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7711,7 +7676,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'உருப்படி $index';
+    return 'Item $index';
   }
 
   @override
@@ -7759,12 +7724,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay குழுவில் சேர்ந்தார்';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay குழுவிலிருந்து வெளியேறினார்';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7776,7 +7741,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupName உடன் இயக்கத்தை ஒத்திசைக்கிறது';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7814,8 +7779,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# வரிசைகள் கண்டறியப்பட்டன',
-      one: '# வரிசை கண்டறியப்பட்டது',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7856,20 +7821,20 @@ class AppLocalizationsTa extends AppLocalizations {
   String get offlineSavedMedia => 'சேமிக்கப்பட்ட மீடியா';
 
   @override
-  String get offlineBannerTitle => 'நீங்கள் ஆஃப்லைனில் உள்ளீர்கள்';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'உங்கள் பதிவிறக்கங்களைக் காட்டுகிறது';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'பதிவிறக்கங்கள்';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'உங்கள் சர்வரை அணுக முடியவில்லை';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'அது திரும்பும் வரை பதிவிறக்கங்களிலிருந்து இயக்குகிறது';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7885,12 +7850,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'காஸ்ட் கட்டுப்பாடு தோல்வியடைந்தது: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind கட்டுப்பாடுகள்';
+    return '$kind Controls';
   }
 
   @override
@@ -7901,7 +7866,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kind ஐ நிறுத்து';
+    return 'Stop $kind';
   }
 
   @override
@@ -7925,12 +7890,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length-இலக்க PIN ஐ உள்ளிடவும்';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'உங்கள் $length-இலக்க PIN ஐ உள்ளிடவும்';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7943,18 +7908,18 @@ class AppLocalizationsTa extends AppLocalizations {
   String get pinForgot => 'பின்னை மறந்துவிட்டீர்களா?';
 
   @override
-  String get pinClear => 'அழி';
+  String get pinClear => 'தெளிவு';
 
   @override
   String get pinBackspace => 'பேக்ஸ்பேஸ்';
 
   @override
   String get quickConnectAuthorized =>
-      'Quick Connect கோரிக்கை அங்கீகரிக்கப்பட்டது.';
+      'விரைவு இணைப்பு கோரிக்கை அங்கீகரிக்கப்பட்டது.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect குறியீடு தவறானது அல்லது காலாவதியானது.';
+      'விரைவு இணைப்பு குறியீடு தவறானது அல்லது காலாவதியானது.';
 
   @override
   String get quickConnectNotSupported =>
@@ -7962,7 +7927,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect குறியீட்டை அங்கீகரிக்க முடியவில்லை.';
+      'விரைவு இணைப்புக் குறியீட்டை அங்கீகரிக்க முடியவில்லை.';
 
   @override
   String get quickConnectDisabled =>
@@ -7970,15 +7935,15 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get quickConnectForbidden =>
-      'உங்கள் கணக்கால் இந்த Quick Connect கோரிக்கையை அங்கீகரிக்க முடியாது.';
+      'இந்த விரைவு இணைப்பு கோரிக்கையை உங்கள் கணக்கால் அங்கீகரிக்க முடியாது.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect குறியீடு கிடைக்கவில்லை. புதிய குறியீட்டை முயற்சிக்கவும்.';
+      'விரைவு இணைப்புக் குறியீடு கிடைக்கவில்லை. புதிய குறியீட்டை முயற்சிக்கவும்.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect தோல்வியடைந்தது: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7989,7 +7954,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'கட்டளை தோல்வியடைந்தது: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8019,7 +7984,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'காஸ்ட்டிங்கைத் தொடங்க முடியவில்லை: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8064,7 +8029,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name பதிவிறக்குகிறது...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8154,7 +8119,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return '$segment ஐத் தவிர்';
+    return 'Skip $segment';
   }
 
   @override
@@ -8165,12 +8130,12 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$current/$total பதிவிறக்குகிறது — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName பதிவிறக்குகிறது';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8207,7 +8172,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'சுழற்சியை அனுமதிக்கவும்';
 
   @override
-  String get playerTooltipPrevious => 'முந்தையது';
+  String get playerTooltipPrevious => 'முந்தைய';
 
   @override
   String get playerTooltipSeekBack => 'திரும்பி தேடுங்கள்';
@@ -8232,13 +8197,13 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'தொடர்ந்து பார்க்கவும் பிரிவிலிருந்து மறை';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'அடுத்தது பிரிவிலிருந்து மறை';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'தொகுப்பில் சேர்';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'சேவையக நிர்வாக குழுவை அணுகவும்';
@@ -8273,7 +8238,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'செருகுநிரல் ஒத்திசைவு, Seerr, மதிப்பீடுகள் மற்றும் பல';
+      'செருகுநிரல் ஒத்திசைவு, சீர், மதிப்பீடுகள் மற்றும் பல';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8292,15 +8257,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get settingsAlphabetical => 'அகரவரிசைப்படி';
 
   @override
-  String get settingsConnectionSection => 'இணைப்பு';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'சுய-கையொப்பமிட்ட சான்றிதழ்களை அனுமதி';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'சுய-கையொப்பமிட்ட அல்லது தனிப்பட்ட-CA TLS சான்றிதழ்களைப் பயன்படுத்தும் சர்வர்களை நம்பும். நீங்கள் கட்டுப்படுத்தும் சர்வர்களுக்கு மட்டும் இயக்கவும். இது எல்லா இணைப்புகளுக்கும் சான்றிதழ் சரிபார்ப்பை முடக்கும்.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'தனியுரிமை & பாதுகாப்பு';
@@ -8316,11 +8280,11 @@ class AppLocalizationsTa extends AppLocalizations {
       'தீம் உச்சரிப்புகள், பின்னணிகள், பார்த்த குறிகாட்டிகள் மற்றும் தீம் இசை';
 
   @override
-  String get settingsDetailsScreen => 'விவரத் திரை';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'பாணி, பின்னணி மங்கல் மற்றும் தாவல் நடத்தை';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'முகப்பு பக்கம்';
@@ -8358,11 +8322,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'வழிசெலுத்தல் பட்டியில் Seerr பட்டனைக் காட்டு';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'மேல் வழிசெலுத்தல் பட்டியில் உரை லேபிள்களை எப்போதும் காட்டு';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8383,7 +8347,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'கூடுதல் மதிப்பீட்டு ஆதாரங்கள், Seerr கோரிக்கைகள் மற்றும் ஒத்திசைக்கப்பட்ட விருப்பங்கள் உட்பட சர்வர்-பக்க ஒருங்கிணைப்புகளை Moonbase இயக்குகிறது.';
+      'Moonbase கூடுதல் மதிப்பீட்டு ஆதாரங்கள், சீர் கோரிக்கைகள் மற்றும் ஒத்திசைக்கப்பட்ட விருப்பத்தேர்வுகள் உட்பட சர்வர் பக்க ஒருங்கிணைப்புகளை வழங்குகிறது.';
 
   @override
   String get settingsOfflineDownloads => 'ஆஃப்லைன் பதிவிறக்கங்கள்';
@@ -8432,7 +8396,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'டெவலப்பருக்கு ஒரு காபி வழங்குங்கள்';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'சட்டபூர்வமானது';
@@ -8465,8 +8429,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# உரிம அறிவிப்புகள்',
-      one: '# உரிம அறிவிப்பு',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8517,16 +8481,16 @@ class AppLocalizationsTa extends AppLocalizations {
       'அறிமுகங்கள் மற்றும் அவுட்ரோக்களை தவிர்க்கவா?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'மீடியா பிரிவு கவுண்ட்டவுன்';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'முன்னேற்றப் பட்டி';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'டைமர்';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'எதுவுமில்லை';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'உடனடி பயனர்';
@@ -8562,14 +8526,13 @@ class AppLocalizationsTa extends AppLocalizations {
       'Media3 (பரிந்துரைக்கப்பட்டது)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (பழையது)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (மரபு)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended =>
-      'mpv (பரிந்துரைக்கப்படுகிறது)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision ஃபால்பேக்';
@@ -8757,763 +8720,749 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'சமீபத்தில் வெளியான $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'அடுத்த அத்தியாயத்தைத் தானாக இயக்கு';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'கிடைக்கும்போது அடுத்த அத்தியாயத்தைத் தானாக இயக்கும்.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'அமைதியைத் தவிர்';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'ஸ்ட்ரீம் ஆதரிக்கும்போது அமைதியான ஆடியோ பிரிவுகளைத் தானாகத் தவிர்க்கும்.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'வெளிப்புற ஆடியோ விளைவுகளை அனுமதி';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'ஈக்வலைசர் மற்றும் விளைவு ஆப்ஸ் (எ.கா. Wavelet) Media3 இயக்க அமர்வுகளுடன் இணைய அனுமதிக்கும்.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'டன்னலிங்கை முடக்கு';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'டன்னல் இல்லாத இயக்கத்தைக் கட்டாயப்படுத்தும். டன்னலிங் ஆடியோ/வீடியோ தடைகள் உள்ள சாதனங்களில் பயனுள்ளது.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'டன்னலிங்கை இயக்கு';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'மேம்பட்டது. ஆடியோ மற்றும் வீடியோவை இணைந்த வன்பொருள் பாதை வழியாக அனுப்பும். சில சாதனங்களில் ஆடியோ/வீடியோ தடைகளை ஏற்படுத்துவதால் இயல்பாக அணைக்கப்பட்டுள்ளது.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision சுயவிவரம் 7 ஐ HEVC உடன் மேப் செய்';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'DV அல்லாத சாதனங்களில் Dolby Vision சுயவிவரம் 7 ஸ்ட்ரீம்களை HDR10-இணக்கமான HEVC ஆக இயக்கும்.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'உள்ளமைந்த வசன வரி பாணிகளைப் பயன்படுத்து';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'வசன வரி தடத்தில் உள்ளமைந்த வண்ணங்கள், எழுத்துருக்கள் மற்றும் இருப்பிடத்தைப் பயன்படுத்தும். உங்கள் வசன வரி பாணி விருப்பங்களைப் பயன்படுத்த இதை முடக்கவும்.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'உள்ளமைந்த வசன வரி எழுத்துரு அளவுகளைப் பயன்படுத்து';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'வசன வரி தடத்தில் உள்ளமைந்த எழுத்துரு-அளவு குறிப்புகளைப் பயன்படுத்தும். உங்கள் பாணி விருப்பங்களில் உள்ள வசன வரி அளவைப் பயன்படுத்த இதை முடக்கவும்.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'மீடியா விவரங்களைக் காட்டு';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'நூலகப் பக்கங்களின் மேலே தேர்ந்தெடுக்கப்பட்ட உருப்படியின் விவரங்களைக் காட்டும்.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'உலாவும்போது பின்னணிப் படங்களை மறைக்கவா?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings =>
-      'விரிவான துணைத் தலைப்புகளைப் பயன்படுத்து';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'நூலகப் பக்கங்களில் விரிவான அல்லது எளிய துணை வரிசையைக் காட்டும்.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'சேமித்த தீமை நீக்கவா?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'இந்தச் சாதனத்தின் கேசிலிருந்து \"$themeName\" ஐ அகற்றவா?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'தீம் ஸ்டோர்';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'சமூகத் தீம்களை உலாவிச் சேமிக்கவும்';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'மற்ற சேமித்த தீம்களைப் போலப் பயன்படுத்த ஒரு தீமைச் சேமிக்கவும்.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'இப்போது தீம்கள் எதுவும் கிடைக்கவில்லை.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'தீம் ஸ்டோரை ஏற்ற முடியவில்லை. உங்கள் இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'சேமி';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'சேமித்துப் பயன்படுத்து';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'சேமிக்கப்பட்டது';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'இந்தத் தீமை ஏற்ற முடியவில்லை.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" சேமிக்கப்பட்டது.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'இந்தச் சாதனத்திலிருந்து \"$themeName\" நீக்கப்பட்டது.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" ஐ நீக்க முடியவில்லை.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'சேமித்த தீம்கள்';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'இவை தற்போதைய சர்வருக்காக Moonfin செருகுநிரலிலிருந்து பதிவிறக்கப்பட்ட தீம்கள். நீக்குவது இந்த உள்ளூர் நகலை மட்டுமே அகற்றும்.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'இந்த சர்வருக்கான சேமித்த தீம்கள் எதுவும் கிடைக்கவில்லை.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • தற்போது செயலில்';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'சேமித்த தீமை நீக்கு';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'இந்தச் சாதனத்தில் பதிவிறக்கிய செருகுநிரல் தீம்களை நிர்வகிக்கவும்';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'தீம் எடிட்டர்';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'உங்கள் உலாவியில் Moonfin தீம் எடிட்டரைத் திறக்கும்';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'முகப்புத் திரை';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'கீழ்ப் பட்டி';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'கிளாசிக்';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'மாடர்ன்';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'முகப்பு வரிசைகள்';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'முகப்பு வரிசைக் காட்சி';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'முகப்பு வரிசைப் பிரிவுகள்';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'முகப்பு வரிசை நிலைமாற்றிகள்';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'நூலகம் சார்ந்த முகப்பு வரிசை வகைகளை இயக்கவும் அல்லது முடக்கவும்';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'முகப்புப் பிரிவுகளில் வரிசைகளைக் காட்ட பின்வரும் நிலைமாற்றிகளை இயக்கவும்.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'கிளாசிக் ஒவ்வொரு வரிசைக்கும் படவகை மற்றும் தகவல் மேலடுக்கைத் தக்கவைக்கும். மாடர்ன் போர்ட்ரெய்ட்-டு-பேக்டிராப் வரிசைகளைப் பயன்படுத்தும்.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'பிடித்தவை வரிசைகளைக் காட்டு';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'முகப்புப் பிரிவுகளில் பிடித்த திரைப்படங்கள், தொடர்கள் மற்றும் பிற பிடித்தவை வரிசைகளைக் காட்டும்.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'பிடித்தவை வரிசை வரிசையாக்கம்';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'பிடித்தவை வரிசைகளைச் சேர்த்த தேதி, வெளியீட்டுத் தேதி, அகர வரிசை மற்றும் பலவற்றின்படி வரிசைப்படுத்தும்.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'தொகுப்பு வரிசைகளைக் காட்டு';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'முகப்புப் பிரிவுகளில் தொகுப்பு வரிசைகளைக் காட்டும்.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'தொகுப்பு வரிசை வரிசையாக்கம்';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'தொகுப்பு வரிசைகளைச் சேர்த்த தேதி, வெளியீட்டுத் தேதி, அகர வரிசை மற்றும் பலவற்றின்படி வரிசைப்படுத்தும்.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'வகை வரிசைகளைக் காட்டு';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'முகப்புப் பிரிவுகளில் வகை வரிசைகளைக் காட்டும்.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'வகை வரிசை வரிசையாக்கம்';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'வகை வரிசைகளைச் சேர்த்த தேதி, வெளியீட்டுத் தேதி, அகர வரிசை மற்றும் பலவற்றின்படி வரிசைப்படுத்தும்.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'வகை வரிசை உருப்படிகள்';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'வகை வரிசைகளில் திரைப்படங்கள், தொடர்கள் அல்லது இரண்டையும் காட்டும்.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'பிளேலிஸ்ட் வரிசைகளைக் காட்டு';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'முகப்புப் பிரிவுகளில் பிளேலிஸ்ட் வரிசைகளைக் காட்டும்.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'பிளேலிஸ்ட் வரிசை வரிசையாக்கம்';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'பிளேலிஸ்ட் வரிசைகளைச் சேர்த்த தேதி, வெளியீட்டுத் தேதி, அகர வரிசை மற்றும் பலவற்றின்படி வரிசைப்படுத்தும்.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ஆடியோ வரிசைகளைக் காட்டு';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'முகப்புப் பிரிவுகளில் ஆடியோ வரிசைகளைக் காட்டும்.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ஆடியோ வரிசைகள் வரிசையாக்கம்';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ஆடியோ வரிசைகளைச் சேர்த்த தேதி, வெளியீட்டுத் தேதி, அகர வரிசை மற்றும் பலவற்றின்படி வரிசைப்படுத்தும்.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ஆடியோ பிளேலிஸ்ட்கள்';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'தோற்றம்';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'அமைப்பு';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'தீம்';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'விசைப்பலகை';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'பட்டன்கள்';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'ரெண்டரிங்';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV உள்ளமைவு';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'வெளிப்புற பிளேயர் ஆப்';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'நீண்ட-அழுத்த இயக்க விருப்பத்தை இயக்க வெளிப்புற பிளேயரை அமைக்கவும்';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'இயக்கம் தொடங்கும்போது ஆப் தேர்வியைக் காட்டும்.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'நிறுவப்பட்ட பிளேயர்கள் ஏற்றப்படுகின்றன...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'இணைப்பு';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ஆடியோ டிரான்ஸ்கோட் இலக்கு';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'பாஸ்த்ரூ';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'இந்தச் சாதனத்தில் ஆதரிக்கப்படுகிறது';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'இந்தச் சாதனத்தில் ஆதரிக்கப்படவில்லை';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) பாஸ்த்ரூ';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) ஐ வெளிப்புற டிகோடருக்கு பிட்ஸ்ட்ரீம் செய்யும்.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) உடன் TrueHD பாஸ்த்ரூ';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'மீடியா பிளேயர் நடத்தை';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'இயக்க மேம்பாடுகள்';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'எப்போதும் இயக்கத்தில்.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'தவிர் அவுட்ரோவை அடுத்தது காட்சியால் மாற்று';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'தவிர் அவுட்ரோ பட்டனுக்குப் பதிலாக அடுத்தது மேலடுக்கைக் காட்டும்.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'பிளேயர் ரூட்டிங்';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'மென்பொருள் டிகோடர்களை விரும்பு';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'வன்பொருள் டிகோடர்களுக்கு முன் FFmpeg (ஆடியோ) மற்றும் libgav1 (AV1) ஐப் பயன்படுத்தும். HDMI ஆடியோ பாஸ்த்ரூ செயலிழந்தால் முடக்கவும்.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV இல் தேர்ந்தெடுத்த வெளிப்புற ஆப்பில் வீடியோ இயக்கத்தைத் திறக்கும்.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'தானியங்கி வரிசைப்படுத்தல்';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH வசன வரிகளை விரும்பு';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'தானாகத் தேர்ந்தெடுக்கும்போது SDH/CC வசன வரி தடங்களுக்கு முன்னுரிமை அளிக்கும்.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'வலை கண்டறிதல்கள்';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin வலை கண்டறிதல்கள்';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'உலாவி இணைப்புச் சிக்கல்களை (CORS, கலப்பு உள்ளடக்கம் மற்றும் கண்டுபிடிப்பு அமைப்புகள்) கண்டறிய இந்தப் பக்கத்தைப் பயன்படுத்தவும்.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'கலப்பு-உள்ளடக்கத் தோல்வி கண்டறியப்பட்டது';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight தோல்வி கண்டறியப்பட்டது';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'ஒரு HTTPS பக்கம் HTTP சர்வர் URL ஐ அழைக்க முயல்வதை Moonfin கண்டறிந்தது. உங்கள் சர்வரை அடையும் முன்பே உலாவிகள் இந்தக் கோரிக்கையைத் தடுக்கின்றன.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'மீடியா சர்வரில் CORS அல்லது preflight தலைப்புகள் இல்லாததால் பொதுவாக ஏற்படும் உலாவி-நிலைக் கோரிக்கைத் தோல்வியை Moonfin கண்டறிந்தது.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'இலக்கு URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'விவரம்: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'தற்போதைய இயக்க நேரச் சூழல்';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'மூலம்';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'திட்டம்';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'செருகுநிரல் முறை';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC ஸ்கேன்';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'கட்டாய சர்வர் URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'இயல்பு சர்வர் URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'கண்டுபிடிப்பு ப்ராக்ஸி URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'உள்ளமைக்கப்படவில்லை';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'கலப்பு உள்ளடக்கம்';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'இந்தப் பக்கம் HTTPS வழியாக ஏற்றப்படுகிறது, ஆனால் உள்ளமைக்கப்பட்ட ஒன்று அல்லது அதற்கு மேற்பட்ட URL கள் HTTP ஆக உள்ளன. HTTPS பக்கங்கள் HTTP API களை அழைப்பதை உலாவிகள் தடுக்கின்றன.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'தீர்வு: உங்கள் மீடியா சர்வர் அல்லது ப்ராக்ஸி எண்ட்பாயின்ட்டை HTTPS வழியாக வழங்கவும், அல்லது நம்பகமான உள்ளூர் நெட்வொர்க்குகளில் மட்டும் Moonfin ஐ HTTP வழியாக ஏற்றவும்.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'தற்போதைய இயக்க நேர அமைப்புகளிலிருந்து வெளிப்படையான கலப்பு-உள்ளடக்க உள்ளமைவு எதுவும் கண்டறியப்படவில்லை.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS சரிபார்ப்புப் பட்டியல்';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin இல் உலாவி மூலத்தை அனுமதிக்கவும்.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers இல் Authorization, X-Emby-Authorization மற்றும் X-Emby-Token ஐச் சேர்க்கவும்.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ஸ்ட்ரீமிங் மற்றும் தேடல் நடத்தைக்காக Content-Range மற்றும் Accept-Ranges ஐ வெளிப்படுத்தவும்.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight கோரிக்கைகளுக்கு 204 ஐத் திருப்பவும்.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'எடுத்துக்காட்டு தலைப்புத் துணுக்கு (nginx-பாணி)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'குறிப்பு';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'இந்தக் கண்டறிதல் வழி வலை பதிப்புகளுக்காக உருவாக்கப்பட்டது. வேறு தளத்தில் இதைப் பார்த்தால், இந்தச் சரிபார்ப்புகள் பொருந்தாமல் போகலாம்.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'சர்வர் தேர்வுக்குத் திரும்பு';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'எல்லா பயனர்களையும் வெளியேற்று';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'மைக்ரோஃபோன் அனுமதி நிரந்தரமாக மறுக்கப்பட்டது. சிஸ்டம் அமைப்புகளில் அதை இயக்கவும்.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'குரல் தேடலுக்கு மைக்ரோஃபோன் அனுமதி தேவை.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'அது புரியவில்லை. மீண்டும் முயற்சிக்கவும்.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'பேச்சு எதுவும் கண்டறியப்படவில்லை.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'மைக்ரோஃபோன் பிழை.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'குரல் தேடலுக்கு இணையம் தேவை.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'குரல் சேவை பயன்பாட்டில் உள்ளது. மீண்டும் முயற்சிக்கவும்.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'மைக்ரோஃபோன் அனுமதி நிரந்தரமாக மறுக்கப்பட்டது.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'மைக்ரோஃபோன் அனுமதி மறுக்கப்பட்டது.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'இந்தச் சாதனத்தில் பேச்சு அறிதல் கிடைக்கவில்லை.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS வழி தேர்வியைத் திற';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'இந்தச் சாதனத்தில் AirPlay வழி தேர்வி கிடைக்கவில்லை.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'வீடியோக்கள்';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'நிகழ்ச்சிகள்';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'பாடல்கள்';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'புகைப்பட ஆல்பங்கள்';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'புகைப்படங்கள்';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'நபர்கள்';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'சமீபத்தில் வெளியான அத்தியாயங்கள்';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'மீண்டும் பார்';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'விருந்தினர் தோற்றங்கள்';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'தோற்றங்கள் (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'குழுப் பங்களிப்புகள் (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'குழுவுடன் பார்';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'பிழைகள்';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'எச்சரிக்கைகள்';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'வட்டு';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'உலாவியில் திற';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'இந்தத் தளத்தில் உள்ளமைந்த உலாவி கிடைக்கவில்லை.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'சர்வரை நிச்சயமாக மறுதொடக்கம் செய்ய வேண்டுமா?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'சர்வரை நிச்சயமாக அணைக்க வேண்டுமா? அதை நீங்கள் கைமுறையாக மறுதொடக்கம் செய்ய வேண்டியிருக்கும்.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'உள்ளகம்';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'செயலற்று';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'பயனர்கள் எவரும் இல்லை';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'உங்கள் தேடலுக்குப் பொருந்தும் பயனர்கள் இல்லை';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'சாதனங்கள் எதுவும் இல்லை';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'தற்போதைய வடிகட்டிகளுக்குப் பொருந்தும் சாதனங்கள் இல்லை';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'கடவுச்சொல் அமைக்கப்பட்டது';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'கடவுச்சொல் உள்ளமைக்கப்படவில்லை';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'தொலைநிலை அணுகல்';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'உள்ளூர் மட்டும்';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'மீடியா அனலிட்டிக்ஸை ஏற்ற முடியவில்லை';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'எல்லா மீடியா நூலகங்களிலும் இணைந்த அனலிட்டிக்ஸ்.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'சிறந்த கலைஞர்கள்';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'சிறந்த ஆசிரியர்கள்';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'சிறந்த பங்களிப்பாளர்கள்';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count நூலகங்கள்',
-      one: '1 நூலகம்',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'இந்தத் தேர்வுக்கான அட்டவணைப்படுத்தப்பட்ட மீடியா மொத்தங்கள் இன்னும் கிடைக்கவில்லை.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'நூலக விவரங்கள்';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'நூலக விவரப்பகுப்பு';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable =>
-      'நூலகங்கள் எதுவும் கிடைக்கவில்லை.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'சர்வர் நிர்வாகம்';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'தரவு';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'படக் கேச்';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'கேச்';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'பதிவுகள்';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'மெட்டாடேட்டா';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'டிரான்ஸ்கோட்';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'இந்த சர்வர் எந்த சர்வர் பாதைகளையும் திருப்பவில்லை.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% பயன்படுத்தப்பட்டது';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'பயனர் செயல்பாடு';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'சிஸ்டம் நிகழ்வுகள்';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'கவனம் தேவை';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'சர்வர்';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'இயக்கம்';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'சாதனங்கள்';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'மேம்பட்டது';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'செருகுநிரல்கள்';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'நேரலை டிவி';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'வீட்டு வீடியோக்கள்';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'கலப்பு உள்ளடக்கம்';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'வீட்டு வீடியோக்கள் & புகைப்படங்கள்';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'கலப்பு திரைப்படங்கள் & நிகழ்ச்சிகள்';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9525,300 +9474,299 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'பதிவுகள் எதுவும் இல்லை';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension காப்பகத்தில் படப் பக்கங்கள் எதுவும் இல்லை.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'உள்ளமைந்த ரெண்டரர் தோல்வியடைந்தது ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB ரெண்டரர் தோல்வியடைந்தது ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'ரீடருக்கான உள்ளூர் கோப்பு காணவில்லை: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri இலிருந்து புத்தகத் தரவைத் திறக்கும்போது HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'படிக்கக்கூடிய புத்தக எண்ட்பாயின்ட் எதுவும் கிடைக்கவில்லை';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'ஆதரிக்கப்படாத காமிக் காப்பக வடிவம்: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'இந்தத் தளத்தில் CBR பிரித்தெடுத்தல் செருகுநிரல் கிடைக்கவில்லை.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr காப்பகத்தைப் பிரித்தெடுக்க முடியவில்லை.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'இந்தத் தளத்தில் CB7 பிரித்தெடுத்தல் கிடைக்கவில்லை.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'இந்தத் தளத்தில் CB7 பிரித்தெடுத்தல் செருகுநிரல் கிடைக்கவில்லை.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'வகைப் பலகத்தை மூடு';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'கலைத்தல் ஏற்றப்படுகிறது...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'நூலக கலைத்தல்';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'சீரற்ற கலைத்தல்';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'வகைகள் கலைத்தல்';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'தானியங்கி HDR மாற்றம்';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR வீடியோ இயக்கத்திற்கு HDR ஐத் தானாக இயக்கி, வெளியேறும்போது காட்சி முறையை மீட்டமைக்கும்.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'முழுத்திரையில் இருக்கும்போது';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'கலைப்படைப்பை மாற்று';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'காணவில்லை';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'டிரான்ஸ்கோடிங் வரம்புகள்';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'எல்லா கலைப்படைப்புகளையும் அழிக்கவா?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'பதிவிறக்கிய எல்லா கலைப்படைப்புகளையும் நிச்சயமாக அழிக்க வேண்டுமா?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'அழித்தலை உறுதிசெய்';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'இந்த $itemType ஐ நிச்சயமாக அழிக்க வேண்டுமா?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'பதிவேற்றவா?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'தெளிவுத்திறன்: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'இடைமுக மொழியில் மட்டும் கலைப்படைப்பைக் காட்டு';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'அனைத்தையும் அழித்தலை உறுதிசெய்';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'படம் வெற்றிகரமாகப் பதிவேற்றப்பட்டது!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'படத்தைப் பதிவேற்ற முடியவில்லை: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'படத்தை அமைக்க முடியவில்லை: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'படத்தை நீக்க முடியவில்லை: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'எல்லா கலைப்படைப்புகளையும் அழிக்க முடியவில்லை: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ஆம்';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'போஸ்டர்';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'பின்னணிப் படங்கள்';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'பேனர்';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'லோகோ';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'சிறுபடம்';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'கலை';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'வட்டுக் கலை';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'ஸ்கிரீன்ஷாட்';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'பெட்டி அட்டை';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'பெட்டி பின் அட்டை';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'மெனு கலை';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'போஸ்டர்';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'பின்னணிப் படம்';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'பேனர்';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'லோகோ';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'சிறுபடம்';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'கலை';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'வட்டுக் கலை';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ஸ்கிரீன்ஷாட்';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'பெட்டி அட்டை';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'பெட்டி பின் அட்டை';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'மெனு கலை';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'அனைத்தும்';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'உயர் (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'நடுத்தரம் (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'குறைவு (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'ஆதாரங்கள்';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'அத்தியாயங்கள்';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'புக்மார்க்குகள்';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'குறிப்புகள்';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'வரிசை';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'காலவரிசை';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'காலவரிசை காலியாக உள்ளது';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'முழுப் புத்தகம்';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'மையப்படுத்திய காலவரிசை';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'புக்மார்க்குகளை ஏற்றுமதி செய்';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'குறிப்புகளை ஏற்றுமதி செய்';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'அனைத்தையும் ஏற்றுமதி செய்';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path இற்கு ஏற்றுமதி செய்யப்பட்டது';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'ஏற்றுமதி தோல்வியடைந்தது: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'பாடல் வரிகள்';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'புக்மார்க்கைச் சேர்';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'குறிப்பைச் சேர்';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'குறிப்பைத் திருத்து';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'இந்தத் தருணத்திற்கு ஒரு குறிப்பை எழுதவும்';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'தூக்க டைமர்';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ஆஃப்';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'அத்தியாயத்தின் முடிவில்';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'தனிப்பயன்';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining மீதம்';
+    return '$remaining left';
   }
 
   @override
@@ -9826,58 +9774,58 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count நிமி',
-      one: '1 நிமி',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'இயக்க வேகம்';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'மீதம்';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'கடந்தது';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'பின் $secondsவி';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'முன் $secondsவி';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'முந்தைய அத்தியாயம்';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'அடுத்த அத்தியாயம்';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'அத்தியாயம் $current / $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'அத்தியாயங்கள் இல்லை';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'இன்னும் புக்மார்க்குகள் இல்லை';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'இன்னும் குறிப்புகள் இல்லை';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position இல் புக்மார்க் சேர்க்கப்பட்டது';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x க்கு மீட்டமை';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9885,255 +9833,249 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'சேமி';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'ரத்துசெய்';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'நீக்கு';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'வசன வரி விருப்பங்கள்';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'வசன வரி முறைகள், இயல்பு மொழிகள், தோற்றம் மற்றும் ரெண்டரிங் விருப்பங்களை மாற்றவும்.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'வசன வரி ரெண்டரிங்';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'காட்சி விருப்பங்கள்';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'வெளியீட்டுத் தேதி (ஏறுவரிசை)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'வெளியீட்டுத் தேதி (இறங்குவரிசை)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'பங்களிப்புகளைக் குழுவாக்கு';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'பல பங்குகளைக் குழுவாக்கு';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'நூலக எழுத்து அணுகல் எச்சரிக்கை';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'இதை எப்படிச் சரிசெய்வது:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. சர்வரில் உங்கள் மீடியா நூலகக் கோப்புறைகளுக்கு Jellyfin சேவை பயனருக்கு (எ.கா. jellyfin அல்லது Docker PUID/PGID) எழுது அனுமதிகளை வழங்கவும்.\n\n2. அல்லது, உங்கள் Jellyfin டாஷ்போர்டு -> Libraries க்குச் சென்று, இந்த நூலகத்தைத் திருத்தி, கலைப்படைப்பை Jellyfin இன் உள்ளக தரவுத்தளத்தில் சேமிக்க \'Save artwork into media folders\' ஐ முடக்கவும்.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'நிராகரி';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'உங்கள் \'$libraryName\' நூலகம் கலைப்படைப்பை நேரடியாக மீடியா கோப்புறைகளில் சேமிக்க உள்ளமைக்கப்பட்டுள்ளது (\'Save artwork into media folders\' இயக்கப்பட்டுள்ளது). இருப்பினும், Jellyfin எழுது அணுகலைச் சோதித்தபோது இந்த அடைவில் கோப்புகளை எழுத அனுமதி இல்லை:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'கலைப்படைப்பைப் புதுப்பிக்க Jellyfin தோல்வியடைந்தது போல் தெரிகிறது. உங்கள் நூலகம் கலைப்படைப்பை நேரடியாக மீடியா கோப்புறைகளில் சேமிக்க உள்ளமைக்கப்பட்டுள்ளது (\'Save artwork into media folders\' இயக்கப்பட்டுள்ளது). உங்கள் மீடியா அடைவுகளில் கோப்புகளை எழுத Jellyfin சர்வர் செயலுக்கு அனுமதி இல்லாதபோது இந்தப் பிழை பொதுவாக ஏற்படுகிறது.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'வெளிப்புறப் பட்டியல்கள்';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'மீண்டும் இயக்கு';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'கோப்புத் தகவல்';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'அளவு: $size  •  வடிவம்: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'எல்லா ($count) ஆடியோ தடங்களையும் காட்டு';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'எல்லா ($count) வசன வரி தடங்களையும் காட்டு';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'நேரடி இயக்கத் திறனைச் சரிபார்க்கிறது...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'நேரடி இயக்கத் திறன்: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'கட்டாயம்';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'கண்டெய்னர் வடிவத்தை பிளேயர் ஆதரிக்கவில்லை.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'வீடியோ கோடெக் ஆதரிக்கப்படவில்லை.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'ஆடியோ கோடெக் ஆதரிக்கப்படவில்லை.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'வசன வரி வடிவம் ஆதரிக்கப்படவில்லை (பதிவு தேவை).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ஆடியோ சுயவிவரம் ஆதரிக்கப்படவில்லை.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'வீடியோ சுயவிவரம் ஆதரிக்கப்படவில்லை.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'வீடியோ லெவல் ஆதரிக்கப்படவில்லை.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'இந்தச் சாதனத்தில் வீடியோ தெளிவுத்திறன் ஆதரிக்கப்படவில்லை.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'வீடியோ பிட் ஆழம் ஆதரிக்கப்படவில்லை.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'வீடியோ ஃபிரேம் ரேட் ஆதரிக்கப்படவில்லை.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'கோப்பு பிட்ரேட் பிளேயர் ஸ்ட்ரீமிங் வரம்பை மீறுகிறது.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'வீடியோ பிட்ரேட் ஸ்ட்ரீமிங் வரம்பை மீறுகிறது.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ஆடியோ பிட்ரேட் ஸ்ட்ரீமிங் வரம்பை மீறுகிறது.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ஆடியோ சேனல்களின் எண்ணிக்கை ஆதரிக்கப்படவில்லை.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'அகர வரிசை';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'வெளியீட்டு வரிசை (ஏறுவரிசை)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'வெளியீட்டு வரிசை (இறங்குவரிசை)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'தனிப்பயன் (இழுத்து விடு)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'பிளேலிஸ்ட் வரிசை விருப்பங்கள்';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'வரிசையை மீட்டமை';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode ஐ மீண்டும் பார்';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'பிளேலிஸ்ட்டை மீண்டும் பார்';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'வசன வரிகள் எதுவும் இல்லை.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'நிர்வாகக் கட்டுப்பாடுகள்';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'ரெண்டரிங் எஞ்சின் (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller என்பது மென்மையான அனிமேஷன்கள் மற்றும் குறைவான தடங்கலுக்கான Flutter இன் நவீன GPU ரெண்டரர். சில TV பாக்ஸ்கள் மற்றும் பழைய GPU களில் இது கோளாறுகள் அல்லது கருப்பு வீடியோவை ஏற்படுத்தலாம்; அவற்றைக் கண்டால் இதை அணைக்கவும். தானியங்கி உங்கள் சாதனத்திற்கு ஏற்ற சிறந்த இயல்பைத் தேர்வுசெய்யும். பயன்படுத்த Moonfin ஐ மறுதொடக்கம் செய்யவும்.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'தானியங்கி';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ஆன்';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ஆஃப்';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'மறுதொடக்கம் தேவை';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'ரெண்டரிங் எஞ்சினை மாற்ற Moonfin மறுதொடக்கம் செய்ய வேண்டும். இப்போது ஆப்பை மூடி, பயன்படுத்த மீண்டும் திறக்கவும்.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'இப்போது ஆப்பை மூடு';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'நூலகத்தைப் புதுப்பி';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'எல்லா நூலகங்களையும் புதுப்பி';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'சேர்த்த தேதி (பழையது முதலில்)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'சேர்த்த தேதி (புதியது முதலில்)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'அகர வரிசை (A முதல் Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'அகர வரிசை (Z முதல் A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'சர்வர் அனலிட்டிக்ஸ் ஏற்றப்படுகிறது... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'மூலத்துடன் பொருந்து';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb சிறந்த 250 திரைப்படங்கள்';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb சிறந்த 250 டிவி நிகழ்ச்சிகள்';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb மிகவும் பிரபலமான திரைப்படங்கள்';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows =>
-      'IMDb மிகவும் பிரபலமான டிவி நிகழ்ச்சிகள்';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'IMDb குறைந்த மதிப்பிடப்பட்ட திரைப்படங்கள்';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb சிறந்த மதிப்பிடப்பட்ட ஆங்கிலத் திரைப்படங்கள்';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -9,30 +9,30 @@ class AppLocalizationsTe extends AppLocalizations {
   AppLocalizationsTe([String locale = 'te']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'మూన్‌ఫిన్';
 
   @override
-  String get accountPreferences => 'ఖాతా ప్రాధాన్యతలు';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ఇంటర్‌ఫేస్ భాష';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'సిస్టమ్ డిఫాల్ట్';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'సైన్ ఇన్ చేయండి';
 
   @override
-  String get empty => 'ఖాళీ';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverNameకి కనెక్ట్ అవుతోంది';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'త్వరిత కనెక్ట్';
 
   @override
   String get password => 'పాస్వర్డ్';
@@ -61,12 +61,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect అందుబాటులో లేదు: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect అందుబాటులో లేదు ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin వెర్షన్ $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'మీ సర్వర్‌ల నుండి \"$serverName\"ని తీసివేయాలా?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'రద్దు చేయి';
 
   @override
-  String get remove => 'తీసివేయండి';
+  String get remove => 'తొలగించు';
 
   @override
   String get connectToServer => 'సర్వర్‌కి కనెక్ట్ చేయండి';
@@ -141,62 +141,62 @@ class AppLocalizationsTe extends AppLocalizations {
   String get settingsAppearanceTheme => 'యాప్ థీమ్';
 
   @override
-  String get detailScreenStyle => 'వివరాల స్క్రీన్ శైలి';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'క్లాసిక్ అనేది Moonfin అసలైన మధ్యస్థ లేఅవుట్. మోడర్న్ అనేది స్క్రీన్‌కు అనుగుణంగా మారే సినిమాటిక్ లేఅవుట్.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'క్లాసిక్';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'మోడర్న్';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'విస్తరించిన ట్యాబ్‌లు';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'ట్యాబ్‌లను బ్రౌజ్ చేస్తున్నప్పుడు వాటి కంటెంట్‌ను స్వయంచాలకంగా చూపుతుంది. ప్రతి ట్యాబ్‌ను మాన్యువల్‌గా తెరవడానికి, మూసివేయడానికి దీన్ని ఆఫ్ చేయండి.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'సాంకేతిక వివరాలను చూపించాలా?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'బ్యానర్ సారాంశంలో కోడెక్, రిజల్యూషన్, స్ట్రీమ్ సమాచారాన్ని చూపుతుంది';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'సిఫార్సు వ్యవస్థ';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin సిఫార్సులు అనే స్థానిక-లైబ్రరీ అల్గారిథమ్‌ను లేదా ఆన్‌లైన్ TMDb సారూప్య కొలమానాలను ఉపయోగించండి. గమనిక: ఆన్‌లైన్ సిఫార్సులకు Seerr ఇంటిగ్రేషన్ అవసరం.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin సిఫార్సులు';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb సారూప్యత';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'పేరెంటల్ రేటింగ్ పరిమితిని వర్తింపజేయాలా?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'లక్ష్య మీడియా పేరెంటల్ రేటింగ్ ఆధారంగా Moonfin సిఫార్సులను పరిమితం చేస్తుంది';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'ఇంటర్‌ఫేస్ శైలి';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ఆటోమేటిక్ మీ పరికరానికి సరిపోతుంది. ఒక రూపాన్ని బలవంతంగా అమలు చేయడానికి Apple లేదా Materialను ఎంచుకోండి.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ఆటోమేటిక్';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,42 +205,41 @@ class AppLocalizationsTe extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'గ్లాస్ నాణ్యత';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ఆటో ఈ పరికరానికి ఉత్తమ గ్లాస్ ప్రభావాన్ని ఎంచుకుంటుంది. ఫుల్ నిజమైన బ్లర్‌ను బలవంతంగా అమలు చేస్తుంది; రిడ్యూస్డ్ GPU శక్తిని ఆదా చేసే తేలికపాటి గ్లాస్‌ను ఉపయోగిస్తుంది.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ఆటో';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'ఫుల్';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'రిడ్యూస్డ్';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'యాప్‌ని పునఃప్రారంభించకుండానే Moonfin మరియు Neon Pulse మధ్య మారండి';
 
   @override
-  String get customThemeTitle => 'అనుకూల థీమ్';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'అనుకూల థీమ్‌లు Moonfin అంతటా దృశ్య అంశాలను మారుస్తాయి. మీ శైలికి సరిపోయేలా వీటిలో ఒకదాన్ని ఎంచుకోండి.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme =>
-      'సిస్టమ్ కీబోర్డ్‌కు ప్రాధాన్యం ఇవ్వండి';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'టెక్స్ట్ ఎంట్రీ కోసం డిఫాల్ట్‌గా మీ పరికర ఇన్‌పుట్ పద్ధతిని ఉపయోగించండి';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'మూన్‌ఫిన్';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -254,18 +253,18 @@ class AppLocalizationsTe extends AppLocalizations {
       'మెజెంటా గ్లో, సియాన్ టెక్స్ట్ మరియు బలమైన క్రోమ్ కాంట్రాస్ట్‌తో సింథ్‌వేవ్ స్టైలింగ్';
 
   @override
-  String get themeGlass => 'గ్లాస్';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'కదిలే గ్రేడియంట్ నేపథ్యం, మంచు లాంటి ఉపరితలాలు, Apple-నీలం యాక్సెంట్‌తో లిక్విడ్-గ్లాస్ శైలి';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-బిట్ హీరో';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'దట్టమైన రంగుల ప్యాలెట్, చతురస్రాకార అంచులు, గట్టి నీడలు, పిక్సెల్ ఫాంట్‌తో రెట్రో పిక్సెల్-ఆర్ట్ శైలి';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +313,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$targetకి కనెక్ట్ చేయడం సాధ్యపడలేదు';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -328,35 +327,35 @@ class AppLocalizationsTe extends AppLocalizations {
   String get exit => 'నిష్క్రమించు';
 
   @override
-  String get gameMenu => 'మెను';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'పాజ్ చేయబడింది';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'స్థితిని సేవ్ చేయండి';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'గేమ్‌లు';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'స్థితిని లోడ్ చేయండి';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'ఫాస్ట్-ఫార్వర్డ్';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'ఎమ్యులేటర్ సెట్టింగ్‌లు';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'ఈ కోర్‌కు సర్దుబాటు చేయగల ఎంపికలు లేవు.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'మెనును తెరవడానికి నొక్కి పట్టుకోండి';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'ఈ పరికరంలో గేమ్‌లను ఆడటం ఇంకా మద్దతు లేదు.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'హోమ్ వరుసలు ఏవీ లోడ్ చేయబడలేదు';
@@ -428,7 +427,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'ఫోల్డర్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count అంశాలు';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count అంశాలు';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — శైలులు';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +532,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$countని క్రితం';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$countగం క్రితం';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$countరో క్రితం';
+    return '${count}d ago';
   }
 
   @override
@@ -554,7 +553,7 @@ class AppLocalizationsTe extends AppLocalizations {
       'Discoverలో ఏ సబ్జెక్ట్ ఫీడ్‌లను చూపించాలో ఎంచుకోండి.';
 
   @override
-  String get apply => 'వర్తింపజేయండి';
+  String get apply => 'దరఖాస్తు చేసుకోండి';
 
   @override
   String get openLink => 'లింక్ తెరవండి';
@@ -578,7 +577,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count శీర్షికలు';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +602,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get listen => 'వినండి';
 
   @override
-  String get resume => 'కొనసాగించండి';
+  String get resume => 'పునఃప్రారంభించండి';
 
   @override
   String get failedToLoadLibrary => 'లైబ్రరీని లోడ్ చేయడంలో విఫలమైంది';
@@ -666,17 +665,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count రచయితలు';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count శైలులు';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% పూర్తయింది';
+    return '$percent% completed';
   }
 
   @override
@@ -693,7 +692,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'చదవడానికి-ప్రాధాన్యత ఇచ్చే బ్రౌజింగ్ కోసం $count శీర్షికలు అమర్చబడ్డాయి.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -730,7 +729,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label ఏదీ కనుగొనబడలేదు';
+    return 'No $label found';
   }
 
   @override
@@ -749,13 +748,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get readStatus => 'చదవండి';
 
   @override
-  String get watched => 'వీక్షించినవి';
+  String get watched => 'వీక్షించారు';
 
   @override
   String get unread => 'చదవలేదు';
 
   @override
-  String get unwatched => 'వీక్షించనివి';
+  String get unwatched => 'చూడలేదు';
 
   @override
   String get seriesStatus => 'సిరీస్ స్థితి';
@@ -767,43 +766,43 @@ class AppLocalizationsTe extends AppLocalizations {
   String get books => 'పుస్తకాలు';
 
   @override
-  String get latestBooks => 'సరికొత్త పుస్తకాలు';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'సరికొత్త ఆడియోబుక్‌లు';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count పుస్తకాలు',
-      one: '1 పుస్తకం',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'పుస్తకం';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ఆడియోబుక్';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% చదివారు';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time మిగిలి ఉంది';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'చదవండి';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'వినండి';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'రచయిత';
@@ -841,12 +840,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count విభాగాలు';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'మొదట ప్రచురించబడింది $year';
+    return 'First published $year';
   }
 
   @override
@@ -861,7 +860,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count పుస్తకాలు';
+    return '$count books';
   }
 
   @override
@@ -873,7 +872,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count రచయితలు';
+    return '$count Authors';
   }
 
   @override
@@ -881,8 +880,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ఆడియోబుక్‌లు',
-      one: '1 ఆడియోబుక్',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -897,7 +896,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get failedToLoad => 'లోడ్ చేయడంలో విఫలమైంది';
 
   @override
-  String get delete => 'తొలగించండి';
+  String get delete => 'తొలగించు';
 
   @override
   String get save => 'సేవ్ చేయండి';
@@ -918,7 +917,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get nextUp => 'తదుపరి';
 
   @override
-  String get seasons => 'సీజన్‌లు';
+  String get seasons => 'సీజన్లు';
 
   @override
   String get chapters => 'అధ్యాయాలు';
@@ -930,7 +929,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get movies => 'సినిమాలు';
 
   @override
-  String get musicVideos => 'మ్యూజిక్ వీడియోలు';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'ఇతర';
@@ -949,7 +948,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'డిస్క్ $number';
+    return 'Disc $number';
   }
 
   @override
@@ -974,7 +973,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'ప్రచురించబడింది $year';
+    return 'Published $year';
   }
 
   @override
@@ -985,52 +984,52 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count సీజన్‌లు',
-      one: '1 సీజన్',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$timeకి ముగుస్తుంది';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'అంశాలు';
+  String get items => 'Items';
 
   @override
-  String get extras => 'అదనపు అంశాలు';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'తెర వెనుక';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'తొలగించిన సన్నివేశాలు';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'ఫీచరెట్‌లు';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'ఇంటర్వ్యూలు';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'సన్నివేశాలు';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'షార్ట్స్';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ట్రైలర్‌లు';
+  String get trailers => 'ట్రైలర్స్';
 
   @override
   String timeRemaining(String time) {
-    return '$time మిగిలి ఉంది';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$timeలో ముగుస్తుంది';
+    return 'Ends in $time';
   }
 
   @override
@@ -1044,11 +1043,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position నుండి కొనసాగించండి';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'ప్లే చేయండి';
+  String get play => 'ఆడండి';
 
   @override
   String get startOver => 'ప్రారంభించండి';
@@ -1072,7 +1071,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get version => 'వెర్షన్';
 
   @override
-  String get cast => 'కాస్ట్ చేయండి';
+  String get cast => 'తారాగణం';
 
   @override
   String get trailer => 'ట్రైలర్';
@@ -1142,7 +1141,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '\"$title\" కోసం డౌన్‌లోడ్ చేసిన ట్రాక్‌లను తొలగించాలా?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1158,17 +1157,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel ఏదీ లోడ్ కాలేదు';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title డౌన్‌లోడ్ అవుతోంది ($count అంశాలు)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'సర్వర్ నుండి \"$name\"ని ఖచ్చితంగా తొలగించాలా? ఈ చర్యను రద్దు చేయలేరు.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1179,7 +1178,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'మద్దతు లేని పుస్తక ఫార్మాట్: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1206,7 +1205,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'సబ్‌టైటిల్ డౌన్‌లోడ్ చేయబడి ఎంపిక చేయబడింది: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1215,7 +1214,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language కోసం రిమోట్ సబ్‌టైటిల్‌లు ఏవీ కనుగొనబడలేదు.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1223,7 +1222,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'వెర్షన్ $number';
+    return 'Version $number';
   }
 
   @override
@@ -1243,7 +1242,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name డౌన్‌లోడ్ అవుతోంది ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1251,7 +1250,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel కోసం స్థానిక ఫైల్‌లను తొలగించాలా?\n\nఇది నిల్వ స్థలాన్ని ఖాళీ చేస్తుంది. మీరు తర్వాత మళ్లీ డౌన్‌లోడ్ చేసుకోవచ్చు.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1267,10 +1266,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get director => 'దర్శకుడు';
 
   @override
-  String get directors => 'దర్శకులు';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'రచయిత';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'రచయితలు';
@@ -1280,12 +1279,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    return '+$count మరిన్ని';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count ఎపిసోడ్‌లు';
+    return '$count Episodes';
   }
 
   @override
@@ -1295,12 +1294,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'ఎపిసోడ్ $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'అధ్యాయం $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1308,8 +1307,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ట్రాక్‌లు',
-      one: '1 ట్రాక్',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1319,25 +1318,25 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count అధ్యాయాలు',
-      one: '1 అధ్యాయం',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'జననం $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'మరణం $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'వయస్సు $age';
+    return 'Age $age';
   }
 
   @override
@@ -1350,17 +1349,17 @@ class AppLocalizationsTe extends AppLocalizations {
   String get shuffle => 'షఫుల్ చేయండి';
 
   @override
-  String get shuffleAllMusic => 'మొత్తం సంగీతాన్ని షఫుల్ చేయండి';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'మీ ఫోన్‌లో Moonfinకి సైన్ ఇన్ చేయండి';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'మీ సర్వర్‌ను చేరుకోలేకపోతోంది';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count డౌన్‌లోడ్‌లు';
+    return '$count downloads';
   }
 
   @override
@@ -1379,32 +1378,32 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'రిమోట్ సబ్‌టైటిల్ $action కోసం ఈ వినియోగదారుకు Jellyfin సబ్‌టైటిల్ నిర్వహణ అనుమతి అవసరం.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'రిమోట్ సబ్‌టైటిల్ $action కోసం ఈ అంశం సర్వర్‌లో కనుగొనబడలేదు.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'రిమోట్ సబ్‌టైటిల్ $action విఫలమైంది: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'రిమోట్ సబ్‌టైటిల్ $action విఫలమైంది (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'రిమోట్ సబ్‌టైటిల్‌లను $action చేయడం విఫలమైంది.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '\"$name\" కోసం డౌన్‌లోడ్ చేసిన అన్ని ఎపిసోడ్‌లు';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1435,17 +1434,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label చర్య విఫలమైంది: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'కాస్ట్ వాల్యూమ్‌ను సెట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label నియంత్రణలు';
+    return '$label Controls';
   }
 
   @override
@@ -1462,7 +1461,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '$labelని ఆపండి';
+    return 'Stop $label';
   }
 
   @override
@@ -1470,7 +1469,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'ట్రాక్ $number';
+    return 'Track $number';
   }
 
   @override
@@ -1487,7 +1486,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds సెకన్లు';
+    return '$seconds seconds';
   }
 
   @override
@@ -1556,7 +1555,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get transcodeReasons => 'ట్రాన్స్‌కోడ్ కారణాలు';
 
   @override
-  String get player => 'ప్లేయర్';
+  String get player => 'ఆటగాడు';
 
   @override
   String get container => 'కంటైనర్';
@@ -1580,7 +1579,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get videoBitrate => 'వీడియో బిట్రేట్';
 
   @override
-  String get track => 'ట్రాక్';
+  String get track => 'ట్రాక్ చేయండి';
 
   @override
   String get channels => 'ఛానెల్‌లు';
@@ -1602,12 +1601,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol సెషన్ లోపం';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'పుస్తక వివరాలను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1616,7 +1615,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'ఈ ఫార్మాట్ (.$extension)ను యాప్‌లో ఇంకా రెండర్ చేయలేరు.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1629,17 +1628,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'యాప్ రీడర్‌ను తెరవడం విఫలమైంది: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label వద్ద బుక్‌మార్క్ ఇప్పటికే సేవ్ చేయబడింది.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'బుక్‌మార్క్ జోడించబడింది: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1651,7 +1650,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'పేజీ $number';
+    return 'Page $number';
   }
 
   @override
@@ -1662,12 +1661,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'ఫార్మాట్: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% చదివారు';
+    return '$percent% read';
   }
 
   @override
@@ -1691,7 +1690,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'జూమ్‌ను రీసెట్ చేయండి (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1714,7 +1713,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'చదివిన స్థితిని అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1747,7 +1746,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '$extension ఫైల్‌ల కోసం ఎంబెడెడ్ డాక్యుమెంట్ ఇంజిన్‌ను ఈ ప్లాట్‌ఫారమ్ హోస్ట్ చేయలేదు.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1786,7 +1785,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'గైడ్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1797,22 +1796,22 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'తదుపరి: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutesని మిగిలి ఉంది';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hoursగం మిగిలి ఉంది';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hoursగం $minutesని మిగిలి ఉంది';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1836,30 +1835,29 @@ class AppLocalizationsTe extends AppLocalizations {
   String get favoriteChannel => 'ఇష్టమైన ఛానెల్';
 
   @override
-  String get record => 'రికార్డ్ చేయండి';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'రికార్డింగ్‌ను రద్దు చేయండి';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord =>
-      'ప్రోగ్రామ్ రికార్డ్ చేయడానికి సెట్ చేయబడింది';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'రికార్డింగ్ రద్దు చేయబడింది';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'రికార్డింగ్‌ను సృష్టించడం సాధ్యపడలేదు';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'చూడండి';
 
   @override
-  String get close => 'మూసివేయండి';
+  String get close => 'మూసివేయి';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$nameను ప్లే చేయడం విఫలమైంది';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1885,11 +1883,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '\"$name\" షెడ్యూల్ చేసిన రికార్డింగ్‌ను రద్దు చేయాలా?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'కాదు';
+  String get no => 'సంఖ్య';
 
   @override
   String get yesCancel => 'అవును, రద్దు చేయి';
@@ -1914,7 +1912,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '\"$name\" రికార్డింగ్‌ను ఆపాలా?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1929,19 +1927,19 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '\"$query\" కోసం ఫలితాలు లేవు';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'శోధన విఫలమైంది: $error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr ఖాతా రకం';
+  String get seerrAccountType => 'సీర్ ఖాతా రకం';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1975,12 +1973,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '\"$name\"ని, దాని ఫైల్‌లను తీసివేయాలా?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ట్రాక్‌లు';
+    return '$count tracks';
   }
 
   @override
@@ -1991,12 +1989,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ఆల్బమ్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name కోసం డౌన్‌లోడ్ చేసిన ట్రాక్‌లు ఏవీ లేవు.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2013,12 +2011,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '\"$name\"ని తీసివేయాలా?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes ని';
+    return '$minutes min';
   }
 
   @override
@@ -2028,7 +2026,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return 'ఎపిసోడ్ $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2042,7 +2040,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'సీజన్ $number';
+    return 'Season $number';
   }
 
   @override
@@ -2058,7 +2056,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$seasonలో డౌన్‌లోడ్ చేసిన అన్ని ఎపిసోడ్‌లను తొలగించాలా?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2066,8 +2064,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ఎపిసోడ్‌లు',
-      one: '1 ఎపిసోడ్',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2102,7 +2100,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'డౌన్‌లోడ్ చేసిన $count అంశాలను తొలగించాలా?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2116,7 +2114,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit పరిమితిలో';
+    return 'of $limit limit';
   }
 
   @override
@@ -2199,7 +2197,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count ఎంపికలు';
+    return '$count options';
   }
 
   @override
@@ -2294,7 +2292,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'వివరాల పేజీలు, హోమ్ వరుసలు, వాల్యూమ్';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2309,11 +2307,11 @@ class AppLocalizationsTe extends AppLocalizations {
       'హోమ్ స్క్రీన్‌ని బ్రౌజ్ చేస్తున్నప్పుడు ప్లే చేయండి';
 
   @override
-  String get loopThemeMusic => 'థీమ్ మ్యూజిక్‌ను లూప్ చేయండి';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'ట్రాక్‌ను ఒకసారి ప్లే చేయడానికి బదులుగా పునరావృతం చేయండి';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'వివరాలు బ్యాక్‌గ్రౌండ్ బ్లర్';
@@ -2336,23 +2334,23 @@ class AppLocalizationsTe extends AppLocalizations {
   String get playerZoomMode => 'ప్లేయర్ జూమ్ మోడ్';
 
   @override
-  String get settingsScrollWheelAction => 'మౌస్ స్క్రోల్ వీల్';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'ప్లేబ్యాక్ సమయంలో వీడియోపై మౌస్ వీల్‌ను స్క్రోల్ చేస్తే ఏమి జరగాలో ఎంచుకోండి.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ఆఫ్';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'సీక్ (ముందుకు / వెనుకకు)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'వాల్యూమ్';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'వాల్యూమ్';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'ఫిట్';
@@ -2367,7 +2365,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get refreshRateSwitching => 'రిఫ్రెష్ రేట్ స్విచింగ్';
 
   @override
-  String get disabled => 'నిలిపివేయబడింది';
+  String get disabled => 'వికలాంగుడు';
 
   @override
   String get scaleOnTv => 'టీవీలో స్కేల్';
@@ -2406,39 +2404,37 @@ class AppLocalizationsTe extends AppLocalizations {
   String get defaultAudioLanguage => 'డిఫాల్ట్ ఆడియో భాష';
 
   @override
-  String get fallbackAudioLanguage => 'ప్రత్యామ్నాయ ఆడియో భాష';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'డిఫాల్ట్ ఆడియో ట్రాక్‌కు ప్రాధాన్యం ఇవ్వండి';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'స్థానికీకరించిన డబ్ కంటే అసలైన ఆడియో ట్రాక్‌కు ప్రాధాన్యం ఇవ్వండి.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'ఆడియో వివరణ ట్రాక్‌లకు ప్రాధాన్యం ఇవ్వండి';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'సాధారణ ట్రాక్‌ల కంటే ఆడియో వివరణ ట్రాక్‌లకు ప్రాధాన్యం ఇవ్వండి.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'ట్రాన్స్‌కోడింగ్ (ఆడియో)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'డైరెక్ట్ స్ట్రీమ్ (రీమక్స్)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'ట్రాన్స్‌కోడింగ్ (బిట్‌రేట్ లేదా రిజల్యూషన్)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'ట్రాన్స్‌కోడింగ్ (వీడియో & ఆడియో)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'ట్రాన్స్‌కోడింగ్ (వీడియో)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ఆటో (సర్వర్ డిఫాల్ట్)';
@@ -2515,28 +2511,27 @@ class AppLocalizationsTe extends AppLocalizations {
       'TrueHD ఆడియోను ప్రారంభించండి (అన్ని ప్లాట్‌ఫారమ్‌లలో పని చేయకపోవచ్చు)';
 
   @override
-  String get settingsAudioOutputMode => 'ఆడియో అవుట్‌పుట్ మోడ్';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ఆడియో ఎలా డీకోడ్ చేయబడాలో ఎంచుకోండి. AVR పాస్‌త్రూ ముడి Dolby/DTS స్ట్రీమ్‌లను మీ రిసీవర్‌కు పంపుతుంది; ఆటో లేదా డౌన్‌మిక్స్ స్థానికంగా డీకోడ్ చేస్తుంది.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR పాస్‌త్రూ';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'ఆడియో ప్రత్యామ్నాయ కోడెక్';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'మూల స్ట్రీమ్‌ను నేరుగా ప్లే చేయలేని లేదా పాస్‌త్రూ చేయలేని సందర్భంలో మల్టీ-ఛానల్ ఆడియోను ట్రాన్స్‌కోడ్ చేయడానికి లక్ష్య ఫార్మాట్‌ను ఎంచుకోండి.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'ఆటో డిటెక్ట్\n(సిఫార్సు చేయబడింది)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(డిఫాల్ట్)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2545,115 +2540,113 @@ class AppLocalizationsTe extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(నష్టం లేని)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(స్టీరియో మాత్రమే)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(సమర్థవంతమైన)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(నష్టం లేని)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'గరిష్ఠ ఆడియో ఛానెల్‌లు';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'మీ ఆడియో సెటప్ గరిష్ఠ ఛానెల్‌లను కాన్ఫిగర్ చేయండి. ఈ పరిమితిని మించిన మల్టీఛానల్ స్ట్రీమ్‌లు డౌన్‌మిక్స్ లేదా ట్రాన్స్‌కోడ్ అవుతాయి.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ఆటో డిటెక్ట్\n(హార్డ్‌వేర్ డిఫాల్ట్)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 మోనో';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 స్టీరియో';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 సరౌండ్';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 క్వాడ్రాఫోనిక్';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 సరౌండ్';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 సరౌండ్';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 సరౌండ్';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 సరౌండ్';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'పాస్‌త్రూ (అధునాతన)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'కోడెక్ పాస్‌త్రూ';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'మీ AVR లేదా HDMI సింక్ మద్దతిచ్చే ఫార్మాట్‌లను మాత్రమే ప్రారంభించండి.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 పాస్‌త్రూ';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) పాస్‌త్రూ';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core పాస్‌త్రూ';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA పాస్‌త్రూ';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD పాస్‌త్రూ';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos పాస్‌త్రూ';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3)ను బాహ్య డీకోడర్‌కు బిట్‌స్ట్రీమ్ చేస్తుంది.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) ద్వారా Dolby Atmosను బాహ్య డీకోడర్‌కు బిట్‌స్ట్రీమ్ చేస్తుంది.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS core కలిపి)ను బాహ్య డీకోడర్‌కు బిట్‌స్ట్రీమ్ చేస్తుంది.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos మెటాడేటాతో Dolby TrueHDను బాహ్య డీకోడర్‌కు బిట్‌స్ట్రీమ్ చేస్తుంది.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities =>
-      'గుర్తించిన ఆడియో సామర్థ్యాలు';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'రన్‌టైమ్ సామర్థ్య స్నాప్‌షాట్ ఇంకా అందుబాటులో లేదు.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'మార్గం';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'డీకోడ్';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'పాస్‌త్రూ';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ఆడియో మార్గం';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2668,10 +2661,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'స్పీకర్';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'హెడ్‌ఫోన్‌లు';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2679,39 +2672,39 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get settingsAudioDiagnostics => 'డయాగ్నోస్టిక్స్';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'వీడియో లెవల్';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'వీడియో పరిధి';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'సబ్‌టైటిల్ కోడెక్';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'అనుమతించిన ఆడియో కోడెక్‌లు';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ఆడియో కోడెక్‌లు';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ఆడియో కోడెక్‌లు';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif పాస్‌త్రూ';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'సక్రియ ఆడియో మార్గం';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'మార్గం HD ఆడియో మద్దతు';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'రాత్రి మోడ్';
@@ -2774,7 +2767,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes ఎపిసోడ్‌లు / $hoursగం తర్వాత';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2850,45 +2843,45 @@ class AppLocalizationsTe extends AppLocalizations {
       'ఉపశీర్షిక రూపాన్ని అనుకూలీకరించండి';
 
   @override
-  String get subtitleMode => 'సబ్‌టైటిల్ మోడ్';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ఫ్లాగ్ చేయబడింది';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'ఎల్లప్పుడూ';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'విదేశీ';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'బలవంతం';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'మీడియా ఫైల్ మెటాడేటాలో అంతర్గతంగా \"default\" లేదా \"forced\"గా ఫ్లాగ్ చేయబడిన ట్రాక్‌లను ప్లే చేస్తుంది.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'వీడియో ప్రారంభమయ్యే ప్రతిసారీ సబ్‌టైటిల్‌లను స్వయంచాలకంగా లోడ్ చేసి ప్రదర్శిస్తుంది.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'డిఫాల్ట్ ఆడియో ట్రాక్ విదేశీ భాషలో ఉంటే సబ్‌టైటిల్‌లను స్వయంచాలకంగా ఆన్ చేస్తుంది.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'forced మెటాడేటా ఫ్లాగ్‌తో స్పష్టంగా ట్యాగ్ చేయబడిన సబ్‌టైటిల్‌లను మాత్రమే లోడ్ చేస్తుంది.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'స్వయంచాలక సబ్‌టైటిల్ లోడింగ్‌ను పూర్తిగా నిలిపివేస్తుంది.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ప్రత్యామ్నాయ సబ్‌టైటిల్ భాష';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'సబ్‌టైటిల్ స్ట్రీమ్';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2948,17 +2941,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile ప్రొఫైల్ సెట్టింగ్‌లు లోడ్ చేయబడ్డాయి.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile ప్రొఫైల్ సెట్టింగ్‌లను లోడ్ చేయడం విఫలమైంది.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'స్థానిక సెట్టింగ్‌లు $profile ప్రొఫైల్‌కు సింక్ చేయబడ్డాయి.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3095,11 +3088,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showLibrariesInToolbar => 'టూల్‌బార్‌లో లైబ్రరీలను చూపండి';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'నావ్‌బార్ లేబుల్‌లను ఎల్లప్పుడూ విస్తరించండి';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr బటన్‌ను చూపించండి';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'నవబార్ అస్పష్టత';
@@ -3174,18 +3166,18 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showFolderBrowsingOption => 'ఫోల్డర్ బ్రౌజింగ్ ఎంపికను చూపు';
 
   @override
-  String get groupItemsIntoCollections => 'అంశాలను సేకరణలుగా సమూహపరచండి';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'లైబ్రరీలను బ్రౌజ్ చేస్తున్నప్పుడు సేకరణతో అనుబంధించిన లైబ్రరీ అంశాలను దాచండి';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'లైబ్రరీ సమూహపరిచే గమనిక';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'ఈ సెట్టింగ్‌ను ఉపయోగించడానికి, మీ Jellyfin లేదా Emby సర్వర్‌లో మీ లైబ్రరీ Display సెట్టింగ్‌ల కింద \"Group movies into collections\" మరియు/లేదా \"Group shows into collections\" లైబ్రరీ సెట్టింగ్‌లు ప్రారంభించబడ్డాయని నిర్ధారించుకోండి.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'లైబ్రరీ దృశ్యమానత';
@@ -3214,7 +3206,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count ఎంపిక చేయబడ్డాయి';
+    return '$count selected';
   }
 
   @override
@@ -3244,7 +3236,7 @@ class AppLocalizationsTe extends AppLocalizations {
       'Moonfin, MakD మధ్య ఎంచుకోండి లేదా మీడియా బార్‌ను ఆఫ్ చేయండి';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'మూన్‌ఫిన్';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3297,11 +3289,10 @@ class AppLocalizationsTe extends AppLocalizations {
       '3 సెకన్ల తర్వాత మీడియా బార్‌లో ట్రైలర్‌లను ఆటో-ప్లే చేయండి';
 
   @override
-  String get trailerAudio => 'ట్రైలర్ ఆడియో';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'మీడియా బార్‌లో ట్రైలర్‌ల కోసం ఆడియోను ప్రారంభించండి';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'ఎపిసోడ్ ప్రివ్యూ';
@@ -3378,11 +3369,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get combineBothRows => 'రెండు అడ్డు వరుసలను ఒకే హోమ్ విభాగంలో కలపండి';
 
   @override
-  String get fullScreenRows => 'విస్తరించిన హోమ్ వరుసలు';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'హోమ్ వరుసలను స్క్రీన్‌కు 1 వరుసకు పరిమితం చేయండి';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ప్రతి వరుస చిత్రం రకం';
@@ -3397,7 +3387,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get lastUser => 'చివరి వినియోగదారు';
 
   @override
-  String get currentUser => 'ప్రస్తుత వినియోగదారు';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ఎల్లప్పుడూ ప్రమాణీకరించండి';
@@ -3474,7 +3464,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes ని';
+    return '$minutes min';
   }
 
   @override
@@ -3505,10 +3495,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'స్క్రీన్‌సేవర్ సమయంలో గడియారాన్ని ప్రదర్శించండి';
 
   @override
-  String get clockModeStatic => 'స్థిరం';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'బౌన్సింగ్';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'రాటెన్ టొమాటోస్ (విమర్శకులు)';
@@ -3529,7 +3519,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get metacriticUser => 'మెటాక్రిటిక్ (వినియోగదారు)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'ట్రాక్ట్';
 
   @override
   String get letterboxd => 'లెటర్‌బాక్స్డ్';
@@ -3581,7 +3571,7 @@ class AppLocalizationsTe extends AppLocalizations {
       'యాప్ అంతటా చూపబడిన రేటింగ్ మూలాలను ప్రారంభించండి మరియు క్రమాన్ని మార్చండి';
 
   @override
-  String get pluginLabel => 'Moonbase ప్లగిన్';
+  String get pluginLabel => 'ప్లగిన్';
 
   @override
   String get pluginDetected => 'ప్లగిన్ కనుగొనబడింది';
@@ -3599,7 +3589,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nవెర్షన్: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3653,7 +3643,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get networks => 'నెట్‌వర్క్‌లు';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr డిస్కవరీ వరుసలు';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'అడ్డు వరుసలను డిఫాల్ట్‌లకు రీసెట్ చేయండి';
@@ -3663,11 +3653,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get showSeerrInNavigation =>
-      'నావిగేషన్‌లో Seerrను చూపించండి (సర్వర్ ప్లగిన్ అవసరం)';
+      'నావిగేషన్‌లో సీర్‌ని చూపించు (సర్వర్ ప్లగ్ఇన్ అవసరం)';
 
   @override
   String get seerrUnavailable =>
-      'సర్వర్ ప్లగిన్ Seerr మద్దతు నిలిపివేయబడినందున అందుబాటులో లేదు.';
+      'సర్వర్ ప్లగ్ఇన్ సీర్ మద్దతు నిలిపివేయబడినందున అందుబాటులో లేదు.';
 
   @override
   String get nsfwFilter => 'NSFW ఫిల్టర్';
@@ -3676,44 +3666,44 @@ class AppLocalizationsTe extends AppLocalizations {
   String get hideAdultContent => 'ఫలితాల్లో పెద్దల కంటెంట్‌ను దాచండి';
 
   @override
-  String get seerrNotificationsSection => 'నోటిఫికేషన్‌లు';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'కొత్త అభ్యర్థన నోటిఫికేషన్‌లు';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'ఎవరైనా అభ్యర్థన సమర్పించినప్పుడు నాకు తెలియజేయండి';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'అభ్యర్థన అప్‌డేట్‌లు';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'ఆమోదించబడింది, తిరస్కరించబడింది, మీ లైబ్రరీకి జోడించబడింది';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'సమస్య అప్‌డేట్‌లు';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'కొత్త సమస్యలు, ప్రత్యుత్తరాలు, పరిష్కారాలు';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'లాగిన్ అయినవారు: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr డిస్కవరీ పేజీ';
+  String get discoverRows => 'అడ్డు వరుసలను కనుగొనండి';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr మెయిన్‌పేజీలో చూడటానికి వరుసలను ప్రారంభించండి. క్రమాన్ని మార్చడానికి లాగండి. అనుకూల క్రమం Moonbaseతో సింక్ అవుతుంది.';
+      'క్రమాన్ని మార్చడానికి లాగండి. అడ్డు వరుసలను ప్రారంభించండి లేదా నిలిపివేయండి. Moonfin ప్లగిన్‌తో ప్రారంభించబడిన అడ్డు వరుస ఆర్డర్ సమకాలీకరణ.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr మెయిన్‌పేజీలో చూడటానికి వరుసలను ప్రారంభించండి. క్రమాన్ని మార్చడానికి లాగండి. అనుకూల క్రమం Moonbaseతో సింక్ అవుతుంది.';
+      'క్రమాన్ని మార్చడానికి లాగండి. అడ్డు వరుసలను ప్రారంభించండి లేదా నిలిపివేయండి.';
 
   @override
   String get enabled => 'ప్రారంభించబడింది';
@@ -3726,7 +3716,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'వెర్షన్ $version';
+    return 'Version $version';
   }
 
   @override
@@ -3776,7 +3766,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'అప్‌డేట్ అందుబాటులో ఉంది: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3788,7 +3778,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version అందుబాటులో ఉంది';
+    return 'v$version Available';
   }
 
   @override
@@ -3853,7 +3843,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get imageCacheCleared => 'ఇమేజ్ కాష్ క్లియర్ చేయబడింది';
 
   @override
-  String get clear => 'క్లియర్ చేయండి';
+  String get clear => 'క్లియర్';
 
   @override
   String get browse => 'బ్రౌజ్ చేయండి';
@@ -3869,19 +3859,19 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'డౌన్‌లోడ్ అవుతోంది · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'దిగుమతి అవుతోంది';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count అంశాలు';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr సెట్టింగ్‌లు';
+  String get seerrSettings => 'సీర్ సెట్టింగ్‌లు';
 
   @override
   String get requestMore => 'మరింత అభ్యర్థించండి';
@@ -3897,7 +3887,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name అభ్యర్థించారు';
+    return 'Requested by $name';
   }
 
   @override
@@ -3914,12 +3904,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" కోసం అభ్యర్థనను రద్దు చేయాలా?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" కోసం $count అభ్యర్థనలను రద్దు చేయాలా?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3933,12 +3923,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'బడ్జెట్: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'ఆదాయం: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3948,7 +3938,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$typeని అభ్యర్థించండి';
+    return 'Request $type';
   }
 
   @override
@@ -3977,14 +3967,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showMore => 'మరిన్ని చూపించు';
 
   @override
-  String get appearances => 'నటించినవి';
+  String get appearances => 'ప్రదర్శనలు';
 
   @override
   String get crewSection => 'సిబ్బంది';
 
   @override
   String ageValue(int age) {
-    return 'వయస్సు $age';
+    return 'age $age';
   }
 
   @override
@@ -4015,147 +4005,148 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deletedStatus => 'తొలగించబడింది';
 
   @override
-  String get failedStatus => 'విఫలమైంది';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'ప్రాసెస్ అవుతోంది';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name మార్చారు';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'పూర్తయింది';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'ఈ శీర్షిక ఇప్పటికే అభ్యర్థించబడింది';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'అభ్యర్థన పరిమితి చేరుకుంది';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'ఈ శీర్షిక బ్లాక్‌లిస్ట్ చేయబడింది';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'అభ్యర్థించడానికి సీజన్‌లు ఏవీ మిగలలేదు';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'ఈ అభ్యర్థన చేయడానికి మీకు అనుమతి లేదు';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'అభ్యర్థనలు';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'సమస్యలు';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'సరికొత్తవి';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'చివరిగా మార్చినవి';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'సమస్యలు లేవు';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit సినిమా అభ్యర్థనలలో $remaining మిగిలి ఉన్నాయి';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit సీజన్ అభ్యర్థనలలో $remaining మిగిలి ఉన్నాయి';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$nameలో భాగం';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'సేకరణను చూడండి';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'సేకరణను అభ్యర్థించండి';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total సినిమాలు · $available అందుబాటులో ఉన్నాయి';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count సినిమాలను అభ్యర్థించండి';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$totalలో $current అభ్యర్థిస్తోంది...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count సినిమాలు అభ్యర్థించబడ్డాయి';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total సినిమాలలో $ok అభ్యర్థించబడ్డాయి';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'అన్ని సినిమాలు ఇప్పటికే అందుబాటులో ఉన్నాయి లేదా అభ్యర్థించబడ్డాయి';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'సమస్యను నివేదించండి';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'వీడియో';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ఆడియో';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'ఏమి తప్పు?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'అన్ని ఎపిసోడ్‌లు';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'ఎపిసోడ్';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'తెరిచి ఉంది';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'పరిష్కరించబడింది';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'పరిష్కరించండి';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'మళ్లీ తెరవండి';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name నివేదించారు';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count వ్యాఖ్యలు';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'వ్యాఖ్యను జోడించండి';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'ఈ సమస్యను తొలగించాలా?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'నివేదికను సమర్పించండి';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB స్కోరు';
@@ -4179,7 +4170,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get originalLanguageLabel => 'అసలు భాష';
 
   @override
-  String get seasonsLabel => 'సీజన్‌లు';
+  String get seasonsLabel => 'సీజన్లు';
 
   @override
   String get episodesLabel => 'ఎపిసోడ్‌లు';
@@ -4188,7 +4179,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get access => 'యాక్సెస్';
 
   @override
-  String get add => 'జోడించండి';
+  String get add => 'జోడించు';
 
   @override
   String get address => 'చిరునామా';
@@ -4215,7 +4206,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get done => 'పూర్తయింది';
 
   @override
-  String get edit => 'సవరించండి';
+  String get edit => 'సవరించు';
 
   @override
   String get encoding => 'ఎన్కోడింగ్';
@@ -4227,7 +4218,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get forward => 'ముందుకు';
 
   @override
-  String get general => 'సాధారణం';
+  String get general => 'జనరల్';
 
   @override
   String get go => 'వెళ్ళు';
@@ -4248,7 +4239,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get networking => 'నెట్వర్కింగ్';
 
   @override
-  String get next => 'తర్వాత';
+  String get next => 'తదుపరి';
 
   @override
   String get path => 'మార్గం';
@@ -4308,7 +4299,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get status => 'స్థితి';
 
   @override
-  String get stop => 'ఆపండి';
+  String get stop => 'ఆపు';
 
   @override
   String get streaming => 'స్ట్రీమింగ్';
@@ -4317,7 +4308,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get time => 'సమయం';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'ట్రిక్ ప్లే';
 
   @override
   String get uninstall => 'అన్‌ఇన్‌స్టాల్ చేయండి';
@@ -4356,28 +4347,28 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminDrawerUsers => 'వినియోగదారులు';
 
   @override
-  String get adminDrawerLibraries => 'లైబ్రరీలు';
+  String get adminDrawerLibraries => 'గ్రంథాలయాలు';
 
   @override
-  String get adminDrawerDisplay => 'డిస్‌ప్లే';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'మెటాడేటా';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO సెట్టింగ్‌లు';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'ట్రాన్స్‌కోడింగ్';
 
   @override
-  String get adminDrawerResume => 'కొనసాగింపు';
+  String get adminDrawerResume => 'పునఃప్రారంభించండి';
 
   @override
   String get adminDrawerStreaming => 'స్ట్రీమింగ్';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'ట్రిక్ ప్లే';
 
   @override
   String get adminDrawerDevices => 'పరికరాలు';
@@ -4429,22 +4420,22 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'ప్లగిన్ అప్‌డేట్‌లు అందుబాటులో ఉన్నాయి: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'పునఃప్రారంభం అవసరమైన ప్లగిన్‌లు: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'విఫలమైన షెడ్యూల్డ్ టాస్క్‌లు: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'ఇటీవలి హెచ్చరిక/లోపం ఎంట్రీలు: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4503,7 +4494,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'లోపం: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4530,7 +4521,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'కమాండ్ విఫలమైంది: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4552,7 +4543,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get sessionForward => 'ముందుకు';
 
   @override
-  String get sessionNext => 'తర్వాత';
+  String get sessionNext => 'తదుపరి';
 
   @override
   String get sessionVolumeDown => 'వాల్యూమ్ -';
@@ -4579,7 +4570,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audioCodec => 'ఆడియో కోడెక్';
 
   @override
-  String get hwAccel => 'HW యాక్సెల్';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'పూర్తి';
@@ -4594,14 +4585,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminClearDates => 'తేదీలను క్లియర్ చేయండి';
 
   @override
-  String get adminActivitySeverityAll => 'అన్ని తీవ్రతలు';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'తేదీ పరిధి';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'కార్యకలాప లాగ్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4618,7 +4609,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'పరికరాన్ని అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4629,28 +4620,28 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'పరికరాన్ని తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '\'$name\' పరికరాన్ని తీసివేయాలా? ఈ పరికరంలో వినియోగదారు మళ్లీ సైన్ ఇన్ చేయాల్సి ఉంటుంది.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'అన్ని పరికరాలను తొలగించండి';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count పరికరాలను తీసివేయాలా? ప్రభావితమైన వినియోగదారులు మళ్లీ సైన్ ఇన్ చేయాల్సి ఉంటుంది. మీ ప్రస్తుత పరికరం ప్రభావితం కాదు.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'పరికరాలు తీసివేయబడ్డాయి';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'కొన్ని పరికరాలు తీసివేయబడ్డాయి; $countని తీసివేయడం సాధ్యపడలేదు.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4679,7 +4670,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'స్కాన్‌ను ప్రారంభించడం విఫలమైంది: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4690,12 +4681,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'లైబ్రరీ పేరు \"$name\"గా మార్చబడింది';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'పేరు మార్చడం విఫలమైంది: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4703,17 +4694,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" లైబ్రరీ తొలగించబడింది';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'లైబ్రరీని తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'పాత్‌ను జోడించడం విఫలమైంది: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4721,12 +4712,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'ఈ లైబ్రరీ నుండి \"$path\"ని తీసివేయాలా?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'పాత్‌ను తీసివేయడం విఫలమైంది: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4734,7 +4725,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'ఎంపికలను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4765,262 +4756,251 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminMetadataCountryHint => 'ఉదా US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'పాత్‌లు';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'ఎంపికలు';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'డౌన్‌లోడర్‌లు';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'మెటాడేటా సేవర్‌లు';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'సబ్‌టైటిల్ డౌన్‌లోడర్‌లు';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'సాహిత్య డౌన్‌లోడర్‌లు';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'మెటాడేటా డౌన్‌లోడర్‌లు: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ఇమేజ్ ఫెచర్‌లు: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'ఈ లైబ్రరీ రకం కోసం ఈ సర్వర్ ఏ డౌన్‌లోడర్‌లను అందించదు.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'సాధారణం';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'మెటాడేటా';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'ఎంబెడెడ్ సమాచారం';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'సబ్‌టైటిల్‌లు';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'ఇమేజ్‌లు';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'సిరీస్';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'సంగీతం';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'సినిమాలు';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor =>
-      'రియల్-టైమ్ మానిటరింగ్‌ను ప్రారంభించండి';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ఫైల్ మార్పులను గుర్తించి వాటిని స్వయంచాలకంగా ప్రాసెస్ చేస్తుంది.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'ఆర్కైవ్‌లను మీడియా ఫైల్‌లుగా పరిగణించండి';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'ఫోటోలను ప్రదర్శించండి';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'ఆర్ట్‌వర్క్‌ను మీడియా ఫోల్డర్‌లలో సేవ్ చేయండి';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'స్వయంచాలక మెటాడేటా రిఫ్రెష్';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ఎప్పటికీ కాదు';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'డిఫాల్ట్';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'డిస్‌ప్లే';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'లైబ్రరీ డిస్‌ప్లే';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'సాధారణ మీడియా ఫోల్డర్‌లను చూపడానికి ఫోల్డర్ వీక్షణను ప్రదర్శించండి';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'ప్రసారమైన సీజన్‌లలోనే స్పెషల్‌లను ప్రదర్శించండి';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'సినిమాలను సేకరణలుగా సమూహపరచండి';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'షోలను సేకరణలుగా సమూహపరచండి';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'సూచనలలో బాహ్య కంటెంట్‌ను చూపించండి';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'జోడించిన తేదీ ప్రవర్తన';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'జోడించిన తేదీని దీని నుండి ఉపయోగించండి';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'లైబ్రరీలోకి స్కాన్ చేసిన తేదీ';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ఫైల్ సృష్టించబడిన తేదీ';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'మెటాడేటా మరియు ఇమేజ్‌లు';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ప్రాధాన్య మెటాడేటా భాష';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'అధ్యాయాలు';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'డమ్మీ అధ్యాయ నిడివి (సెకన్లు)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'అధ్యాయాలు లేని మీడియా కోసం రూపొందించే అధ్యాయాల నిడివి. నిలిపివేయడానికి 0కి సెట్ చేయండి.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'అధ్యాయ ఇమేజ్ రిజల్యూషన్';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO సెట్టింగ్‌లు';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO మెటాడేటా Kodi మరియు సారూప్య క్లయింట్‌లతో అనుకూలంగా ఉంటుంది. NFO మెటాడేటాను సేవ్ చేసే అన్ని లైబ్రరీలకు సెట్టింగ్‌లు వర్తిస్తాయి.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ఫైల్‌లలో వీక్షణ డేటాను నిల్వ చేయవలసిన వినియోగదారు';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'NFO ఫైల్‌లలో ఇమేజ్ పాత్‌లను సేవ్ చేయండి';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO ఇమేజ్ పాత్‌ల కోసం పాత్ ప్రత్యామ్నాయాన్ని ప్రారంభించండి';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart ఇమేజ్‌లను extrathumbs ఫోల్డర్‌లోకి కాపీ చేయండి';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ఏదీ లేదు';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days రోజులు';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'ఎంబెడెడ్ శీర్షికలను ఉపయోగించండి';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'అదనపు అంశాల కోసం ఎంబెడెడ్ శీర్షికలను ఉపయోగించండి';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'ఎంబెడెడ్ ఎపిసోడ్ సమాచారాన్ని ఉపయోగించండి';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'ఎంబెడెడ్ సబ్‌టైటిల్‌లను అనుమతించండి';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'అన్నింటిని అనుమతించండి';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'టెక్స్ట్ మాత్రమే';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'ఇమేజ్ మాత్రమే';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ఏదీ లేదు';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'ఎంబెడెడ్ సబ్‌టైటిల్‌లు ఉంటే డౌన్‌లోడ్‌ను దాటవేయండి';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ఆడియో ట్రాక్ డౌన్‌లోడ్ భాషతో సరిపోతే డౌన్‌లోడ్‌ను దాటవేయండి';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'పరిపూర్ణ సబ్‌టైటిల్ సరిపోలిక అవసరం';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'సబ్‌టైటిల్‌లను మీడియా ఫోల్డర్‌లలో సేవ్ చేయండి';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'అధ్యాయ ఇమేజ్‌లను వెలికితీయండి';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'లైబ్రరీ స్కాన్ సమయంలో అధ్యాయ ఇమేజ్‌లను వెలికితీయండి';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay ఇమేజ్ వెలికితీతను ప్రారంభించండి';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'లైబ్రరీ స్కాన్ సమయంలో Trickplay ఇమేజ్‌లను వెలికితీయండి';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay ఇమేజ్‌లను మీడియా ఫోల్డర్‌లలో సేవ్ చేయండి';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'బహుళ ఫోల్డర్‌లలో విస్తరించిన సిరీస్‌ను స్వయంచాలకంగా విలీనం చేయండి';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'సీజన్ జీరో డిస్‌ప్లే పేరు';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'ఆడియో నార్మలైజేషన్ కోసం LUFS స్కాన్‌ను ప్రారంభించండి';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'నాన్-స్టాండర్డ్ ఆర్టిస్ట్‌ల ట్యాగ్‌కు ప్రాధాన్యం ఇవ్వండి';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'సినిమాలను సేకరణలకు స్వయంచాలకంగా జోడించండి';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'లైబ్రరీ పేరు అవసరం';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'లైబ్రరీని సృష్టించడం విఫలమైంది: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5047,27 +5027,27 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$nameని నిలిపివేయాలా? వారు సైన్ ఇన్ చేయలేరు.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$nameని ప్రారంభించాలా? వారు మళ్లీ సైన్ ఇన్ చేయగలరు.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" వినియోగదారు నిలిపివేయబడ్డారు';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" వినియోగదారు ప్రారంభించబడ్డారు';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'వినియోగదారు విధానాన్ని అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5084,7 +5064,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'వినియోగదారుని సృష్టించడం విఫలమైంది: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5104,7 +5084,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5115,7 +5095,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'విఫలమైంది: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5256,145 +5236,143 @@ class AppLocalizationsTe extends AppLocalizations {
       'అన్ని ఛానెల్‌లకు ప్రాప్యతను ప్రారంభించండి';
 
   @override
-  String get adminParentalControl => 'పేరెంటల్ కంట్రోల్';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'అనుమతించిన గరిష్ఠ పేరెంటల్ రేటింగ్';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'అధిక రేటింగ్ ఉన్న కంటెంట్ ఈ వినియోగదారు నుండి దాచబడుతుంది.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ఏదీ లేదు';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'రేటింగ్ సమాచారం లేని లేదా గుర్తించని అంశాలను నిరోధించండి';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'పుస్తకాలు';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ఛానెల్‌లు';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'లైవ్ TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'సినిమాలు';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'సంగీతం';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ట్రైలర్‌లు';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'షోలు';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'యాక్సెస్ షెడ్యూల్‌లు';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'దిగువన ఉన్న షెడ్యూల్ చేసిన సమయాల్లో మాత్రమే యాక్సెస్‌ను అనుమతించండి. షెడ్యూల్ సెట్ చేయనప్పుడు రోజంతా యాక్సెస్ అనుమతించబడుతుంది.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'షెడ్యూల్‌ను జోడించండి';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'రోజు';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'ప్రారంభం';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'ముగింపు';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'ప్రతిరోజూ';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'వారంలో పనిదినం';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'వారాంతం';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'ఆదివారం';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'సోమవారం';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'మంగళవారం';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'బుధవారం';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'గురువారం';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'శుక్రవారం';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'శనివారం';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'అనుమతించిన ట్యాగ్‌లు';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'ఈ ట్యాగ్‌లు ఉన్న కంటెంట్ మాత్రమే చూపబడుతుంది. అన్నింటిని అనుమతించడానికి ఖాళీగా ఉంచండి.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'నిరోధించిన ట్యాగ్‌లు';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'ఈ ట్యాగ్‌లు ఉన్న కంటెంట్ ఈ వినియోగదారు నుండి దాచబడుతుంది.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'ట్యాగ్‌ను జోడించండి';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'ప్రారంభించిన పరికరాలు';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'ప్రారంభించిన ఛానెల్‌లు';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ప్రామాణీకరణ ప్రొవైడర్';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'పాస్‌వర్డ్ రీసెట్ ప్రొవైడర్';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'లాక్‌అవుట్‌కు ముందు గరిష్ఠ విఫల లాగిన్ ప్రయత్నాలు';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'డిఫాల్ట్ కోసం 0కి, లేదా లాక్‌అవుట్‌ను నిలిపివేయడానికి -1కి సెట్ చేయండి.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay యాక్సెస్';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'గ్రూప్‌లను సృష్టించడం, చేరడం అనుమతించండి';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'గ్రూప్‌లలో చేరడం అనుమతించండి';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'యాక్సెస్ లేదు';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'దీని నుండి కంటెంట్ తొలగింపును అనుమతించండి';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5402,22 +5380,22 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'సర్వర్ HTTP $statusను తిరిగి ఇచ్చింది';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$nameని ఖచ్చితంగా తొలగించాలా?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" వినియోగదారు తొలగించబడ్డారు';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'వినియోగదారుని తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5438,7 +5416,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'కీని సృష్టించడం విఫలమైంది: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5449,7 +5427,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name కోసం కీని ఉపసంహరించాలా?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5457,7 +5435,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'కీని ఉపసంహరించడం విఫలమైంది: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5477,29 +5455,29 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'టోకెన్: $token\\nసృష్టించబడింది: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'బ్యాకప్ సృష్టించండి';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'బ్యాకప్‌లో దేనిని చేర్చాలో ఎంచుకోండి.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'డేటాబేస్';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'ఎల్లప్పుడూ చేర్చబడుతుంది';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'మెటాడేటా';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'సబ్‌టైటిల్‌లు';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay ఇమేజ్‌లు';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'బ్యాకప్ సృష్టిస్తోంది...';
@@ -5509,7 +5487,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'బ్యాకప్‌ను సృష్టించడం విఫలమైంది: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5518,12 +5496,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'మేనిఫెస్ట్: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'మేనిఫెస్ట్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5534,7 +5512,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'బ్యాకప్‌ను పునరుద్ధరించడం విఫలమైంది: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5566,17 +5544,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$pathకి సేవ్ చేయబడింది';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ఫైల్‌ను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileNameను లోడ్ చేయడం విఫలమైంది';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5587,7 +5565,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'టాస్క్‌లను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5600,17 +5578,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'టాస్క్‌ను ప్రారంభించడం విఫలమైంది: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'టాస్క్‌ను ఆపడం విఫలమైంది: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'టాస్క్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5618,12 +5596,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'ట్రిగ్గర్‌ను తీసివేయడం విఫలమైంది: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'ట్రిగ్గర్‌ను జోడించడం విఫలమైంది: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5649,7 +5627,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours గంట(లు)';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5660,7 +5638,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'ప్లగిన్‌ను టోగుల్ చేయడం విఫలమైంది: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5668,27 +5646,27 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '\"$name\"ని ఖచ్చితంగా అన్‌ఇన్‌స్టాల్ చేయాలా?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'ప్లగిన్‌ను అన్‌ఇన్‌స్టాల్ చేయడం విఫలమైంది: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'ప్యాకేజీని ఇన్‌స్టాల్ చేయడం విఫలమైంది: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'అప్‌డేట్‌ను ఇన్‌స్టాల్ చేయడం విఫలమైంది: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'ప్లగిన్‌లను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5699,12 +5677,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'అప్‌డేట్‌ను ఇన్‌స్టాల్ చేయండి (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'క్యాటలాగ్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5726,17 +5704,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'సర్వర్ పునఃప్రారంభం తర్వాత \"$name\" తీసివేయబడుతుంది';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'అన్‌ఇన్‌స్టాల్ చేయడం విఫలమైంది: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\"ని v$versionకి అప్‌డేట్ చేస్తోంది...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5745,7 +5723,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'ప్లగిన్‌ను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5753,7 +5731,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'వెర్షన్ $version';
+    return 'Version $version';
   }
 
   @override
@@ -5773,17 +5751,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '\"$name\"ని ఖచ్చితంగా తీసివేయాలా?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'రిపోజిటరీలను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'రిపోజిటరీలను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5800,12 +5778,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'ప్లగిన్ సెట్టింగ్‌లను లోడ్ చేయడం సాధ్యపడలేదు: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uriను తెరవడం సాధ్యపడలేదు';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5931,11 +5909,11 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminThrottleBuffering => 'థొరెటల్ బఫరింగ్';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay సెట్టింగ్‌లు సేవ్ చేయబడ్డాయి';
+  String get adminTrickplaySaved => 'ట్రిక్‌ప్లే సెట్టింగ్‌లు సేవ్ చేయబడ్డాయి';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Trickplay సెట్టింగ్‌లను లోడ్ చేయడం విఫలమైంది';
+      'ట్రిక్‌ప్లే సెట్టింగ్‌లను లోడ్ చేయడంలో విఫలమైంది';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6048,7 +6026,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminBaseUrl => 'బేస్ URL';
 
   @override
-  String get adminBaseUrlHint => 'ఉదా. /jellyfin';
+  String get adminBaseUrlHint => 'ఉదా / జెల్లీఫిన్';
 
   @override
   String get https => 'HTTPS';
@@ -6088,12 +6066,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'మెటాడేటాను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'మెటాడేటాను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6114,7 +6092,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'మెటాడేటాను రిఫ్రెష్ చేయడం విఫలమైంది: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6128,7 +6106,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'రిమోట్ శోధన విఫలమైంది: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6142,7 +6120,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'కంటెంట్ రకాన్ని అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6157,12 +6135,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType ఇమేజ్ అప్‌డేట్ చేయబడింది';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'ఇమేజ్‌ను డౌన్‌లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6173,27 +6151,27 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType ఇమేజ్ అప్‌లోడ్ చేయబడింది';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'ఇమేజ్‌ను అప్‌లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType ఇమేజ్‌ను తొలగించండి';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType ఇమేజ్ తొలగించబడింది';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'ఇమేజ్‌ను తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6204,72 +6182,67 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'ట్యూనర్ డిస్కవరీ విఫలమైంది: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'ట్యూనర్‌ని జోడించండి';
 
   @override
-  String get adminEditTuner => 'ట్యూనర్‌ను సవరించండి';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U ట్యూనర్';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ఫైల్ లేదా URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ట్యూనర్ IP చిరునామా';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'సులభ పేరు';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => 'యూజర్ ఏజెంట్';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ఏకకాల కనెక్షన్ పరిమితి';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'ట్యూనర్ ఒకేసారి అనుమతించే గరిష్ఠ స్ట్రీమ్‌ల సంఖ్య. అపరిమితం కోసం 0కి సెట్ చేయండి.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'ప్రత్యామ్నాయ గరిష్ఠ స్ట్రీమింగ్ బిట్‌రేట్';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'ఇష్టమైన ఛానెల్‌లను మాత్రమే దిగుమతి చేయండి';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'హార్డ్‌వేర్ ట్రాన్స్‌కోడింగ్‌ను అనుమతించండి';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'fMP4 ట్రాన్స్‌కోడింగ్ కంటైనర్‌ను అనుమతించండి';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'స్ట్రీమ్ షేరింగ్‌ను అనుమతించండి';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping =>
-      'స్ట్రీమ్ లూపింగ్‌ను ప్రారంభించండి';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTSను విస్మరించండి';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'ఇన్‌పుట్‌ను నేటివ్ ఫ్రేమ్ రేట్‌లో చదవండి';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'ప్రొవైడర్‌ను సవరించండి';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6278,50 +6251,50 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ఫైల్ లేదా URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'సినిమా ప్రిఫిక్స్';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'సినిమా వర్గాలు';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'బహుళ వర్గాలను నిలువు గీతతో వేరు చేయండి.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'పిల్లల వర్గాలు';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'వార్తల వర్గాలు';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'క్రీడల వర్గాలు';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'వినియోగదారు పేరు';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'పాస్‌వర్డ్';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'దేశం';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'ఒక దేశాన్ని ఎంచుకోండి';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'పోస్టల్ కోడ్';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'జాబితాలను పొందండి';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'జాబితాలు';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'అన్ని ట్యూనర్‌లను ప్రారంభించండి';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ట్యూనర్ రకం';
@@ -6331,7 +6304,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'ట్యూనర్‌ను జోడించడం విఫలమైంది: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6345,12 +6318,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'ప్రొవైడర్‌ను జోడించడం విఫలమైంది: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'ట్యూనర్‌ను తీసివేయడం విఫలమైంది: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6358,16 +6331,16 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'ట్యూనర్‌ను రీసెట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'ఈ ట్యూనర్ రకం రీసెట్ చేయడానికి మద్దతివ్వదు.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'ప్రొవైడర్‌ను తీసివేయడం విఫలమైంది: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6386,45 +6359,43 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminSeriesRecordingPath => 'సిరీస్ రికార్డింగ్ మార్గం';
 
   @override
-  String get adminMovieRecordingPath => 'సినిమా రికార్డింగ్ పాత్';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'గైడ్ డేటా రోజులు';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ఆటోమేటిక్';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days రోజులు';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'పోస్ట్-ప్రాసెసింగ్ అప్లికేషన్ పాత్';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'పోస్ట్-ప్రాసెసర్ ఆర్గ్యుమెంట్‌లు';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'రికార్డింగ్ NFO మెటాడేటాను సేవ్ చేయండి';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'రికార్డింగ్ ఇమేజ్‌లను సేవ్ చేయండి';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'సమయం';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'రికార్డింగ్ పాత్‌లు';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'పోస్ట్-ప్రాసెసింగ్';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'గైడ్ డేటా: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6433,7 +6404,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'సెట్టింగ్‌లను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6451,7 +6422,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'మ్యాపింగ్‌లను అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6468,14 +6439,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminGuideProviders => 'గైడ్ ప్రొవైడర్లు';
 
   @override
-  String get adminRefreshGuideData => 'గైడ్ డేటాను రిఫ్రెష్ చేయండి';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'గైడ్ డేటా రిఫ్రెష్ ప్రారంభమైంది';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'ఈ సర్వర్‌లో గైడ్ రిఫ్రెష్ టాస్క్ అందుబాటులో లేదు.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'ప్రదాతని జోడించండి';
@@ -6486,22 +6457,22 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'రికార్డింగ్ పాత్: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'సిరీస్ పాత్: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'ప్రీ-ప్యాడింగ్: $minutes ని';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'పోస్ట్-ప్యాడింగ్: $minutes ని';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6534,7 +6505,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name బ్యాకప్‌ను ఇప్పుడు పునరుద్ధరించాలా?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6558,7 +6529,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminLiveTvTitle => 'లైవ్ టీవీ అడ్మినిస్ట్రేషన్';
 
   @override
-  String get adminApply => 'వర్తింపజేయండి';
+  String get adminApply => 'దరఖాస్తు చేసుకోండి';
 
   @override
   String get adminNotSet => 'సెట్ కాలేదు';
@@ -6580,27 +6551,27 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutesని క్రితం';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hoursగం క్రితం';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$daysరో క్రితం';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileNameను లోడ్ చేయడం విఫలమైంది';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count సరిపోలికలు';
+    return '$count matches';
   }
 
   @override
@@ -6610,7 +6581,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminMetadataEditorTitle => 'మెటాడేటా ఎడిటర్';
 
   @override
-  String get adminMetadataIdentify => 'గుర్తించండి';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'టైప్ చేయండి';
@@ -6710,22 +6681,22 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType ఇమేజ్ అప్‌డేట్ చేయబడింది';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType ఇమేజ్ అప్‌లోడ్ చేయబడింది';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType ఇమేజ్ తొలగించబడింది';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'ఇమేజ్‌ను డౌన్‌లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6734,12 +6705,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'ఇమేజ్‌ను అప్‌లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType ఇమేజ్‌ను తొలగించండి';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6748,12 +6719,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'ఇమేజ్‌ను తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType ఇమేజ్‌ను ఎంచుకోండి';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6785,7 +6756,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'అప్‌డేట్ అందుబాటులో ఉంది: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6810,7 +6781,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'అప్‌డేట్‌ను ఇన్‌స్టాల్ చేయండి (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6822,7 +6793,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" ఇన్‌స్టాల్ అవుతోంది...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6842,7 +6813,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name సెట్టింగ్‌లు';
+    return '$name Settings';
   }
 
   @override
@@ -6882,7 +6853,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'రిపోజిటరీలను లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6890,15 +6861,15 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '\"$name\"ని ఖచ్చితంగా తీసివేయాలా?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'తీసివేయండి';
+  String get adminReposRemove => 'తొలగించు';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'రిపోజిటరీలను సేవ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7024,21 +6995,19 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminBrandingEnableSplash => 'స్ప్లాష్ స్క్రీన్‌ని ప్రారంభించండి';
 
   @override
-  String get adminBrandingSplashUpload => 'ఇమేజ్‌ను అప్‌లోడ్ చేయండి';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded =>
-      'స్ప్లాష్‌స్క్రీన్ అప్‌డేట్ చేయబడింది';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'స్ప్లాష్‌స్క్రీన్‌ను అప్‌లోడ్ చేయడం విఫలమైంది';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'స్ప్లాష్‌స్క్రీన్ తీసివేయబడింది';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'అనుకూల స్ప్లాష్‌స్క్రీన్ లేదు';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'హార్డ్‌వేర్ త్వరణం';
@@ -7055,128 +7024,121 @@ class AppLocalizationsTe extends AppLocalizations {
       'దీని కోసం హార్డ్‌వేర్ డీకోడింగ్‌ని ప్రారంభించండి:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV పరికరం';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'మెరుగైన NVDEC డీకోడర్‌ను ప్రారంభించండి';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'సిస్టమ్ నేటివ్ హార్డ్‌వేర్ డీకోడర్‌కు ప్రాధాన్యం ఇవ్వండి';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'హార్డ్‌వేర్ డీకోడింగ్ కలర్ డెప్త్';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-బిట్ HEVC డీకోడింగ్';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-బిట్ VP9 డీకోడింగ్';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10-బిట్ డీకోడింగ్';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-బిట్ డీకోడింగ్';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'హార్డ్‌వేర్ ఎన్‌కోడింగ్';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding =>
-      'HEVC ఎన్‌కోడింగ్‌ను అనుమతించండి';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 ఎన్‌కోడింగ్‌ను అనుమతించండి';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel లో-పవర్ H.264 ఎన్‌కోడర్‌ను ప్రారంభించండి';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel లో-పవర్ HEVC ఎన్‌కోడర్‌ను ప్రారంభించండి';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'టోన్ మ్యాపింగ్';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'టోన్ మ్యాపింగ్‌ను ప్రారంభించండి';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP టోన్ మ్యాపింగ్‌ను ప్రారంభించండి';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox టోన్ మ్యాపింగ్‌ను ప్రారంభించండి';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'టోన్ మ్యాపింగ్ అల్గారిథమ్';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'టోన్ మ్యాపింగ్ మోడ్';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'టోన్ మ్యాపింగ్ పరిధి';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'టోన్ మ్యాపింగ్ డీశాచురేషన్';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'టోన్ మ్యాపింగ్ పీక్';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'టోన్ మ్యాపింగ్ పరామితి';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP టోన్ మ్యాపింగ్ ప్రకాశం';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP టోన్ మ్యాపింగ్ కాంట్రాస్ట్';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'ప్రీసెట్‌లు & నాణ్యత';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'ఎన్‌కోడర్ ప్రీసెట్';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 ఎన్‌కోడింగ్ CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) ఎన్‌కోడింగ్ CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'డీఇంటర్‌లేస్ పద్ధతి';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'డీఇంటర్‌లేస్ చేసేటప్పుడు ఫ్రేమ్ రేట్‌ను రెట్టింపు చేయండి';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ఆడియో';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'ఆడియో VBR ఎన్‌కోడింగ్‌ను ప్రారంభించండి';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ఆడియో డౌన్‌మిక్స్ బూస్ట్';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'స్టీరియో డౌన్‌మిక్స్ అల్గారిథమ్';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'గరిష్ఠ మక్సింగ్ క్యూ పరిమాణం';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ఆటో';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'ఎన్కోడింగ్';
@@ -7296,10 +7258,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminTaskNeverRun => 'ఎప్పుడూ పరుగెత్తకండి';
 
   @override
-  String get adminTaskStop => 'ఆపండి';
+  String get adminTaskStop => 'ఆపు';
 
   @override
-  String get adminRunningTasks => 'నడుస్తున్న టాస్క్‌లు';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'పరుగు';
@@ -7321,17 +7283,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'ప్రతిరోజూ $timeకి';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'ప్రతి $day $timeకి';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'ప్రతి $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7369,8 +7331,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count గంటలు',
-      one: '1 గంట',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7398,17 +7360,17 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$daysరో క్రితం';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hoursగం క్రితం';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutesని క్రితం';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7416,27 +7378,27 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutesని';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hoursగం';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$daysరో';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'సీక్ ప్రివ్యూ థంబ్‌నెయిల్‌ల కోసం Trickplay ఇమేజ్ ఉత్పత్తిని కాన్ఫిగర్ చేయండి.';
+      'సీక్ ప్రివ్యూ థంబ్‌నెయిల్‌ల కోసం ట్రిక్‌ప్లే ఇమేజ్ జనరేషన్‌ను కాన్ఫిగర్ చేయండి.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'పబ్లిక్ HTTPS పోర్ట్';
@@ -7445,50 +7407,49 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'బేస్ URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ఉదా. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ఉదా / జెల్లీఫిన్';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'పబ్లిక్ HTTP పోర్ట్';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS అవసరం';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'అన్ని రిమోట్ అభ్యర్థనలను HTTPSకి రీడైరెక్ట్ చేస్తుంది. సర్వర్‌కు చెల్లుబాటు అయ్యే సర్టిఫికేట్ లేకపోతే ప్రభావం ఉండదు.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'సర్టిఫికేట్ పాస్‌వర్డ్';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP సెట్టింగ్‌లు';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4ను ప్రారంభించండి';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6ను ప్రారంభించండి';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'స్వయంచాలక పోర్ట్ మ్యాపింగ్‌ను ప్రారంభించండి';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN నెట్‌వర్క్‌లు';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'స్థానిక నెట్‌వర్క్‌లో ఉన్నట్లుగా పరిగణించే IP చిరునామాలు లేదా CIDR సబ్‌నెట్‌ల జాబితా, కామా లేదా లైన్ ద్వారా వేరు చేయబడింది.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'ప్రచురించిన సర్వర్ URIలు';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'సబ్‌నెట్ లేదా చిరునామాను ప్రచురించిన URLకి మ్యాప్ చేయండి, ఉదా. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'సర్టిఫికేట్ మార్గం';
@@ -7518,11 +7479,11 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'థొరెటల్ బఫరింగ్';
 
   @override
-  String get adminPlaybackThrottleDelay => 'థ్రొటిల్ ఆలస్యం (సెకన్లు)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'వెంటనే సబ్‌టైటిల్ వెలికితీతను అనుమతించండి';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'కనిష్ట రెజ్యూమ్ శాతం';
@@ -7571,7 +7532,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'కంటెంట్ రకాన్ని అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7579,23 +7540,22 @@ class AppLocalizationsTe extends AppLocalizations {
       'స్లో రెస్పాన్స్ థ్రెషోల్డ్ (మిసె)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'నెమ్మది ప్రతిస్పందన హెచ్చరికలను ప్రారంభించండి';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connectను ప్రారంభించండి';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'సర్వర్';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'మెటాడేటా';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'పాత్‌లు';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'పనితీరు';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'కాష్ మార్గం';
@@ -7607,7 +7567,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminGeneralServerName => 'సర్వర్ పేరు';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ప్రాధాన్య డిస్‌ప్లే భాష';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'సెట్టింగ్‌లను లోడ్ చేయడంలో విఫలమైంది';
@@ -7617,19 +7577,19 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'మ్యాపింగ్‌లను అప్‌డేట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'సమయ పరిమితి: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'ఫోల్డర్లు';
 
   @override
-  String get libraries => 'లైబ్రరీలు';
+  String get libraries => 'గ్రంథాలయాలు';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7659,8 +7619,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# పాల్గొనేవారు',
-      one: '# పాల్గొనేవారు',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7704,7 +7664,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'అంశం $index';
+    return 'Item $index';
   }
 
   @override
@@ -7752,12 +7712,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay గ్రూప్‌లో చేరారు';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay గ్రూప్ నుండి నిష్క్రమించారు';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7769,7 +7729,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '$groupNameకి ప్లేబ్యాక్‌ను సింక్ చేస్తోంది';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7807,8 +7767,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# వరుసలు కనుగొనబడ్డాయి',
-      one: '# వరుస కనుగొనబడింది',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7849,20 +7809,20 @@ class AppLocalizationsTe extends AppLocalizations {
   String get offlineSavedMedia => 'సేవ్ చేయబడిన మీడియా';
 
   @override
-  String get offlineBannerTitle => 'మీరు ఆఫ్‌లైన్‌లో ఉన్నారు';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'మీ డౌన్‌లోడ్‌లను చూపుతోంది';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'డౌన్‌లోడ్‌లు';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'మీ సర్వర్‌ను చేరుకోలేకపోతోంది';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'అది తిరిగి వచ్చే వరకు డౌన్‌లోడ్‌ల నుండి ప్లే చేస్తోంది';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7878,12 +7838,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'కాస్ట్ నియంత్రణ విఫలమైంది: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind నియంత్రణలు';
+    return '$kind Controls';
   }
 
   @override
@@ -7894,7 +7854,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '$kindని ఆపండి';
+    return 'Stop $kind';
   }
 
   @override
@@ -7918,12 +7878,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length-అంకెల PINను నమోదు చేయండి';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'మీ $length-అంకెల PINను నమోదు చేయండి';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7936,42 +7896,41 @@ class AppLocalizationsTe extends AppLocalizations {
   String get pinForgot => 'పిన్ మర్చిపోయారా?';
 
   @override
-  String get pinClear => 'క్లియర్ చేయండి';
+  String get pinClear => 'క్లియర్';
 
   @override
   String get pinBackspace => 'బ్యాక్‌స్పేస్';
 
   @override
-  String get quickConnectAuthorized =>
-      'Quick Connect అభ్యర్థన అధీకృతం చేయబడింది.';
+  String get quickConnectAuthorized => 'త్వరిత కనెక్ట్ అభ్యర్థన అధికారం.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect కోడ్ చెల్లదు లేదా గడువు ముగిసింది.';
+      'త్వరిత కనెక్ట్ కోడ్ చెల్లదు లేదా గడువు ముగిసింది.';
 
   @override
   String get quickConnectNotSupported =>
-      'ఈ సర్వర్‌లో Quick Connectకు మద్దతు లేదు.';
+      'ఈ సర్వర్‌లో త్వరిత అనుసంధానానికి మద్దతు లేదు.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect కోడ్‌ను అధీకృతం చేయడం విఫలమైంది.';
+      'త్వరిత కనెక్ట్ కోడ్‌ని ప్రామాణీకరించడంలో విఫలమైంది.';
 
   @override
   String get quickConnectDisabled =>
-      'ఈ సర్వర్‌లో Quick Connect నిలిపివేయబడింది.';
+      'ఈ సర్వర్‌లో త్వరిత అనుసంధానం నిలిపివేయబడింది.';
 
   @override
   String get quickConnectForbidden =>
-      'మీ ఖాతా ఈ Quick Connect అభ్యర్థనను అధీకృతం చేయలేదు.';
+      'మీ ఖాతా ఈ త్వరిత అనుసంధాన అభ్యర్థనను ప్రామాణీకరించలేదు.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect కోడ్ కనుగొనబడలేదు. కొత్త కోడ్‌ను ప్రయత్నించండి.';
+      'త్వరిత కనెక్ట్ కోడ్ కనుగొనబడలేదు. కొత్త కోడ్‌ని ప్రయత్నించండి.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect విఫలమైంది: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7982,7 +7941,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'కమాండ్ విఫలమైంది: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8011,7 +7970,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'కాస్టింగ్‌ను ప్రారంభించడం విఫలమైంది: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8056,7 +8015,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name డౌన్‌లోడ్ అవుతోంది...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8137,14 +8096,14 @@ class AppLocalizationsTe extends AppLocalizations {
       'ప్లేబ్యాక్ పాజ్ చేయబడింది. మీరు ఇంకా చూస్తున్నారా?';
 
   @override
-  String get stillWatchingStop => 'ఆపండి';
+  String get stillWatchingStop => 'ఆపు';
 
   @override
   String get stillWatchingContinue => 'కొనసాగించు';
 
   @override
   String skipSegment(String segment) {
-    return '$segmentను దాటవేయండి';
+    return 'Skip $segment';
   }
 
   @override
@@ -8155,12 +8114,12 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '$current/$total డౌన్‌లోడ్ అవుతోంది — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName డౌన్‌లోడ్ అవుతోంది';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8224,13 +8183,13 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'చూడటం కొనసాగించండి నుండి దాచండి';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'తదుపరి నుండి దాచండి';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'సేకరణకు జోడించండి';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8266,7 +8225,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get settingsIntegrationsSubtitle =>
-      'ప్లగిన్ సింక్, Seerr, రేటింగ్‌లు మరియు మరిన్ని';
+      'ప్లగిన్ సమకాలీకరణ, సీర్, రేటింగ్‌లు మరియు మరిన్ని';
 
   @override
   String get settingsAboutSubtitle =>
@@ -8285,15 +8244,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get settingsAlphabetical => 'అక్షరక్రమం';
 
   @override
-  String get settingsConnectionSection => 'కనెక్షన్';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'సెల్ఫ్-సైన్డ్ సర్టిఫికేట్‌లను అనుమతించండి';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'సెల్ఫ్-సైన్డ్ లేదా ప్రైవేట్-CA TLS సర్టిఫికేట్‌లను ఉపయోగించే సర్వర్‌లను విశ్వసించండి. మీరు నియంత్రించే సర్వర్‌లకు మాత్రమే ప్రారంభించండి. ఇది అన్ని కనెక్షన్‌లకు సర్టిఫికేట్ ధ్రువీకరణను నిలిపివేస్తుంది.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'గోప్యత & భద్రత';
@@ -8309,11 +8267,11 @@ class AppLocalizationsTe extends AppLocalizations {
       'థీమ్ స్వరాలు, బ్యాక్‌డ్రాప్‌లు, వీక్షించిన సూచికలు మరియు థీమ్ సంగీతం';
 
   @override
-  String get settingsDetailsScreen => 'వివరాల స్క్రీన్';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'శైలి, నేపథ్య బ్లర్, ట్యాబ్ ప్రవర్తన';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'హోమ్ పేజీ';
@@ -8351,11 +8309,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'నావిగేషన్ బార్‌లో Seerr బటన్‌ను చూపించండి';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'టాప్ నావిగేషన్ బార్‌లో టెక్స్ట్ లేబుల్‌లను ఎల్లప్పుడూ చూపించండి';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8376,7 +8334,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get settingsPluginScreenDescription =>
-      'అదనపు రేటింగ్ మూలాలు, Seerr అభ్యర్థనలు, సింక్ చేసిన ప్రాధాన్యతలతో సహా సర్వర్-వైపు ఇంటిగ్రేషన్‌లను Moonbase శక్తివంతం చేస్తుంది.';
+      'Moonbase అదనపు రేటింగ్ మూలాధారాలు, సీర్ అభ్యర్థనలు మరియు సమకాలీకరించబడిన ప్రాధాన్యతలతో సహా సర్వర్-సైడ్ ఇంటిగ్రేషన్‌లకు శక్తినిస్తుంది.';
 
   @override
   String get settingsOfflineDownloads => 'ఆఫ్‌లైన్ డౌన్‌లోడ్‌లు';
@@ -8425,7 +8383,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'డెవలపర్‌కు ఒక కాఫీని దానం చేయండి';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'చట్టపరమైన';
@@ -8459,8 +8417,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# లైసెన్స్ నోటీసులు',
-      one: '# లైసెన్స్ నోటీసు',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8510,16 +8468,16 @@ class AppLocalizationsTe extends AppLocalizations {
       'పరిచయాలు మరియు అవుట్‌రోలను దాటవేయాలా?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'మీడియా సెగ్మెంట్ కౌంట్‌డౌన్';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'ప్రోగ్రెస్ బార్';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'టైమర్';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ఏదీ లేదు';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ప్రాంప్ట్ యూజర్';
@@ -8555,13 +8513,13 @@ class AppLocalizationsTe extends AppLocalizations {
       'Media3 (సిఫార్సు చేయబడింది)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (లెగసీ)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (లెగసీ)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (సిఫార్సు చేయబడింది)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision ఫాల్‌బ్యాక్';
@@ -8751,7 +8709,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'ఇటీవల విడుదలైన $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8784,11 +8742,11 @@ class AppLocalizationsTe extends AppLocalizations {
       'ఫోర్స్ నాన్-టన్నల్ ప్లేబ్యాక్. టన్నెలింగ్ ఆడియో/వీడియో నిలిపివేతలు ఉన్న పరికరాలలో ఉపయోగకరంగా ఉంటుంది.';
 
   @override
-  String get enableTunnelingTitle => 'టన్నెలింగ్‌ను ప్రారంభించండి';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'అధునాతన. ఆడియో మరియు వీడియోను కపుల్డ్ హార్డ్‌వేర్ పాత్ ద్వారా పంపుతుంది. కొన్ని పరికరాల్లో ఆడియో/వీడియో డ్రాప్‌అవుట్‌లను కలిగిస్తుంది కాబట్టి డిఫాల్ట్‌గా ఆఫ్‌లో ఉంటుంది.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title =>
@@ -8815,15 +8773,14 @@ class AppLocalizationsTe extends AppLocalizations {
       'ఉపశీర్షిక ట్రాక్‌లో పొందుపరిచిన ఫాంట్-పరిమాణ సూచనలను వర్తింపజేయండి. మీ శైలి ప్రాధాన్యతల నుండి ఉపశీర్షిక పరిమాణాన్ని ఉపయోగించడాన్ని నిలిపివేయండి.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'మీడియా వివరాలను చూపించండి';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'లైబ్రరీ పేజీల ఎగువన ఎంచుకున్న అంశం వివరాలను చూపుతుంది.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'బ్రౌజ్ చేస్తున్నప్పుడు బ్యాక్‌డ్రాప్‌లను దాచాలా?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'వివరణాత్మక ఉపశీర్షికలను ఉపయోగించండి';
@@ -8841,37 +8798,37 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'థీమ్ స్టోర్';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'కమ్యూనిటీ థీమ్‌లను బ్రౌజ్ చేసి సేవ్ చేయండి';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'మీ ఇతర సేవ్ చేసిన థీమ్‌ల వలె దాన్ని ఉపయోగించడానికి ఒక థీమ్‌ను సేవ్ చేయండి.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ప్రస్తుతం థీమ్‌లు ఏవీ అందుబాటులో లేవు.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'థీమ్ స్టోర్‌ను లోడ్ చేయడం సాధ్యపడలేదు. మీ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'సేవ్ చేయండి';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'సేవ్ చేసి వర్తింపజేయండి';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'సేవ్ చేయబడింది';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'ఈ థీమ్‌ను లోడ్ చేయడం సాధ్యపడలేదు.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '\"$themeName\" సేవ్ చేయబడింది.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8930,21 +8887,21 @@ class AppLocalizationsTe extends AppLocalizations {
   String get homeRowsSection => 'హోమ్ వరుసలు';
 
   @override
-  String get homeRowDisplay => 'హోమ్ వరుస డిస్‌ప్లే';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'హోమ్ వరుస విభాగాలు';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'హోమ్ వరుస టోగుల్‌లు';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'లైబ్రరీ-ఆధారిత హోమ్ వరుస వర్గాలను ప్రారంభించండి లేదా నిలిపివేయండి';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'హోమ్ విభాగాలలో వరుసలను ప్రదర్శించడానికి కింది టోగుల్‌లను ప్రారంభించండి.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'అడ్డు వరుసల రకం';
@@ -9003,56 +8960,55 @@ class AppLocalizationsTe extends AppLocalizations {
       'చలన చిత్రాలను, సిరీస్‌లను లేదా రెండింటినీ జెనర్‌ల వరుసలలో చూపండి.';
 
   @override
-  String get displayPlaylistsRows => 'ప్లేజాబితా వరుసలను చూపించండి';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'హోమ్ విభాగాలలో ప్లేజాబితా వరుసలను చూపుతుంది.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'ప్లేజాబితా వరుస క్రమబద్ధీకరణ';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'ప్లేజాబితా వరుసలను జోడించిన తేదీ, విడుదల తేదీ, అక్షర క్రమం మరియు మరిన్నింటి ప్రకారం క్రమబద్ధీకరించండి.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ఆడియో వరుసలను చూపించండి';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'హోమ్ విభాగాలలో ఆడియో వరుసలను చూపుతుంది.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ఆడియో వరుసల క్రమబద్ధీకరణ';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ఆడియో వరుసలను జోడించిన తేదీ, విడుదల తేదీ, అక్షర క్రమం మరియు మరిన్నింటి ప్రకారం క్రమబద్ధీకరించండి.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ఆడియో ప్లేజాబితాలు';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'స్వరూపం';
 
   @override
-  String get layout => 'లేఅవుట్';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'థీమ్';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'కీబోర్డ్';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'బటన్‌లు';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'రెండరింగ్';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV కాన్ఫిగరేషన్';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'కార్డ్ పరిమాణం';
@@ -9062,7 +9018,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'లాంగ్-ప్రెస్ ప్లే ఎంపికను ప్రారంభించడానికి బాహ్య ప్లేయర్‌ను సెట్ చేయండి';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9326,10 +9282,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get guestAppearances => 'అతిథి ప్రదర్శనలు';
 
   @override
-  String get appearancesSeerr => 'కనిపించినవి (Seerr)';
+  String get appearancesSeerr => 'ప్రదర్శనలు (సీర్)';
 
   @override
-  String get crewContributionsSeerr => 'సిబ్బంది సహకారాలు (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'సమూహంతో చూడండి';
@@ -9415,8 +9371,8 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count లైబ్రరీలు',
-      one: '1 లైబ్రరీ',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9507,7 +9463,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get mixedMoviesAndShows => 'మిశ్రమ చలనచిత్రాలు & ప్రదర్శనలు';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'ఇంటెల్ త్వరిత సమకాలీకరణ';
 
   @override
   String get rockchipMpp => 'రాక్‌చిప్ MPP';
@@ -9575,13 +9531,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get loadingShuffle => 'షఫుల్ లోడ్ అవుతోంది...';
 
   @override
-  String get libraryShuffleLabel => 'లైబ్రరీ షఫుల్';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'యాదృచ్ఛిక షఫుల్';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'శైలుల షఫుల్';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'ఆటో HDR స్విచింగ్';
@@ -9594,222 +9550,222 @@ class AppLocalizationsTe extends AppLocalizations {
   String get whenFullscreen => 'పూర్తి స్క్రీన్‌లో ఉన్నప్పుడు';
 
   @override
-  String get changeArtwork => 'ఆర్ట్‌వర్క్‌ను మార్చండి';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'తప్పిపోయింది';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'ట్రాన్స్‌కోడింగ్ పరిమితులు';
 
   @override
-  String get clearAllArtworkButton => 'మొత్తం ఆర్ట్‌వర్క్‌ను క్లియర్ చేయాలా?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'డౌన్‌లోడ్ చేసిన మొత్తం ఆర్ట్‌వర్క్‌ను ఖచ్చితంగా క్లియర్ చేయాలా?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'క్లియర్‌ను నిర్ధారించండి';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'ఈ $itemTypeను ఖచ్చితంగా క్లియర్ చేయాలా?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'అప్‌లోడ్ చేయాలా?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'రిజల్యూషన్: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'ఇంటర్‌ఫేస్ భాషలో మాత్రమే ఆర్ట్‌వర్క్‌ను చూపించండి';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'అన్నింటిని క్లియర్ చేయడాన్ని నిర్ధారించండి';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'ఇమేజ్ విజయవంతంగా అప్‌లోడ్ చేయబడింది!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'ఇమేజ్‌ను అప్‌లోడ్ చేయడం విఫలమైంది: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ఇమేజ్‌ను సెట్ చేయడం విఫలమైంది: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ఇమేజ్‌ను తొలగించడం విఫలమైంది: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'మొత్తం ఆర్ట్‌వర్క్‌ను క్లియర్ చేయడం విఫలమైంది: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'అవును';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'పోస్టర్';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'బ్యాక్‌డ్రాప్‌లు';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'బ్యానర్';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'లోగో';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'థంబ్‌నెయిల్';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'ఆర్ట్';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'డిస్క్ ఆర్ట్';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'స్క్రీన్‌షాట్';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'బాక్స్ కవర్';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'బాక్స్ వెనుక కవర్';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'మెను ఆర్ట్';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'పోస్టర్';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'బ్యాక్‌డ్రాప్';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'బ్యానర్';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'లోగో';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'థంబ్‌నెయిల్';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ఆర్ట్';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'డిస్క్ ఆర్ట్';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'స్క్రీన్‌షాట్';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'బాక్స్ కవర్';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'బాక్స్ వెనుక కవర్';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'మెను ఆర్ట్';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'అన్నీ';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'అధిక (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'మధ్యస్థ (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'తక్కువ (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'మూలాలు';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'అధ్యాయాలు';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'బుక్‌మార్క్‌లు';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'గమనికలు';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'క్యూ';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'టైమ్‌లైన్';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'టైమ్‌లైన్ ఖాళీగా ఉంది';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'మొత్తం పుస్తకం';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'కేంద్రీకృత టైమ్‌లైన్';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'బుక్‌మార్క్‌లను ఎగుమతి చేయండి';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'గమనికలను ఎగుమతి చేయండి';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'అన్నింటిని ఎగుమతి చేయండి';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$pathకి ఎగుమతి చేయబడింది';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'ఎగుమతి విఫలమైంది: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'సాహిత్యం';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'బుక్‌మార్క్‌ను జోడించండి';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'గమనికను జోడించండి';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'గమనికను సవరించండి';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'ఈ క్షణం కోసం ఒక గమనిక రాయండి';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'స్లీప్ టైమర్';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ఆఫ్';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'అధ్యాయం ముగింపు';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'అనుకూలం';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining మిగిలి ఉంది';
+    return '$remaining left';
   }
 
   @override
@@ -9817,58 +9773,58 @@ class AppLocalizationsTe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ని',
-      one: '1 ని',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'ప్లేబ్యాక్ వేగం';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'మిగిలి ఉంది';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'గడిచింది';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'వెనుకకు ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'ముందుకు ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'మునుపటి అధ్యాయం';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'తదుపరి అధ్యాయం';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'అధ్యాయం $current / $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'అధ్యాయాలు లేవు';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'ఇంకా బుక్‌మార్క్‌లు లేవు';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'ఇంకా గమనికలు లేవు';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position వద్ద బుక్‌మార్క్ జోడించబడింది';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0xకి రీసెట్ చేయండి';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9876,250 +9832,249 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'సేవ్ చేయండి';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'రద్దు చేయండి';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'తొలగించండి';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'సబ్‌టైటిల్ ప్రాధాన్యతలు';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'సబ్‌టైటిల్ మోడ్‌లు, డిఫాల్ట్ భాషలు, రూపం, రెండరింగ్ ఎంపికలను మార్చండి.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'సబ్‌టైటిల్ రెండరింగ్';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'డిస్‌ప్లే ఎంపికలు';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'విడుదల తేదీ (ఆరోహణ)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'విడుదల తేదీ (అవరోహణ)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'సహకారాలను సమూహపరచండి';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'బహుళ పాత్రలను సమూహపరచండి';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'లైబ్రరీ రైట్ యాక్సెస్ హెచ్చరిక';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'దీన్ని ఎలా సరిచేయాలి:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. సర్వర్‌లో మీ మీడియా లైబ్రరీ ఫోల్డర్‌ల కోసం Jellyfin సర్వీస్ వినియోగదారుకు (ఉదా. jellyfin లేదా Docker PUID/PGID) రైట్ అనుమతులను మంజూరు చేయండి.\n\n2. లేదా, మీ Jellyfin Dashboard -> Librariesకి వెళ్లి, ఈ లైబ్రరీని సవరించి, ఆర్ట్‌వర్క్‌ను Jellyfin అంతర్గత డేటాబేస్‌లో నిల్వ చేయడానికి \'Save artwork into media folders\'ను నిలిపివేయండి.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'కొట్టివేయండి';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'మీ \'$libraryName\' లైబ్రరీ ఆర్ట్‌వర్క్‌ను నేరుగా మీడియా ఫోల్డర్‌లలో సేవ్ చేయడానికి కాన్ఫిగర్ చేయబడింది (\'Save artwork into media folders\' ప్రారంభించబడింది). అయితే, Jellyfin రైట్ యాక్సెస్‌ను పరీక్షించింది మరియు ఈ డైరెక్టరీలో ఫైల్‌లను రాయడానికి అనుమతి లేదు:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin ఆర్ట్‌వర్క్‌ను అప్‌డేట్ చేయడంలో విఫలమైనట్లు కనిపిస్తోంది. మీ లైబ్రరీ ఆర్ట్‌వర్క్‌ను నేరుగా మీడియా ఫోల్డర్‌లలో సేవ్ చేయడానికి కాన్ఫిగర్ చేయబడింది (\'Save artwork into media folders\' ప్రారంభించబడింది). Jellyfin సర్వర్ ప్రాసెస్‌కు మీ మీడియా డైరెక్టరీలలో ఫైల్‌లను రాయడానికి అనుమతి లేనప్పుడు ఈ లోపం సాధారణంగా సంభవిస్తుంది.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'బాహ్య జాబితాలు';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'మళ్లీ ప్లే చేయండి';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ఫైల్ సమాచారం';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'పరిమాణం: $size  •  ఫార్మాట్: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'అన్ని ($count) ఆడియో ట్రాక్‌లను చూపించండి';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'అన్ని ($count) సబ్‌టైటిల్ ట్రాక్‌లను చూపించండి';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'డైరెక్ట్ ప్లే సామర్థ్యాన్ని తనిఖీ చేస్తోంది...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'డైరెక్ట్ ప్లే సామర్థ్యం: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'బలవంతం';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'కంటైనర్ ఫార్మాట్‌కు ప్లేయర్ మద్దతివ్వదు.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'వీడియో కోడెక్‌కు మద్దతు లేదు.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'ఆడియో కోడెక్‌కు మద్దతు లేదు.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'సబ్‌టైటిల్ ఫార్మాట్‌కు మద్దతు లేదు (బర్నింగ్ అవసరం).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'ఆడియో ప్రొఫైల్‌కు మద్దతు లేదు.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'వీడియో ప్రొఫైల్‌కు మద్దతు లేదు.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'వీడియో లెవల్‌కు మద్దతు లేదు.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'ఈ పరికరం వీడియో రిజల్యూషన్‌కు మద్దతివ్వదు.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'వీడియో బిట్ డెప్త్‌కు మద్దతు లేదు.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'వీడియో ఫ్రేమ్‌రేట్‌కు మద్దతు లేదు.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ఫైల్ బిట్‌రేట్ ప్లేయర్ స్ట్రీమింగ్ పరిమితిని మించింది.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'వీడియో బిట్‌రేట్ స్ట్రీమింగ్ పరిమితిని మించింది.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ఆడియో బిట్‌రేట్ స్ట్రీమింగ్ పరిమితిని మించింది.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ఆడియో ఛానెల్‌ల సంఖ్యకు మద్దతు లేదు.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'అక్షర క్రమం';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'విడుదల క్రమం (ఆరోహణ)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'విడుదల క్రమం (అవరోహణ)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'అనుకూలం (డ్రాగ్-అండ్-డ్రాప్)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'ప్లేజాబితా క్రమబద్ధీకరణ ఎంపికలు';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'క్రమబద్ధీకరణను రీసెట్ చేయండి';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episodeను మళ్లీ చూడండి';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'ప్లేజాబితాను మళ్లీ చూడండి';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'సబ్‌టైటిల్‌లు ఏవీ కనుగొనబడలేదు.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'అడ్మిన్ నియంత్రణలు';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'రెండరింగ్ ఇంజిన్ (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller అనేది సున్నితమైన యానిమేషన్‌లు మరియు తక్కువ స్టటర్ కోసం Flutter ఆధునిక GPU రెండరర్. కొన్ని TV బాక్స్‌లు మరియు పాత GPUలలో ఇది గ్లిచ్‌లు లేదా బ్లాక్ వీడియోను కలిగిస్తుంది; అవి కనిపిస్తే దీన్ని ఆఫ్ చేయండి. ఆటోమేటిక్ మీ పరికరానికి ఉత్తమ డిఫాల్ట్‌ను ఎంచుకుంటుంది. వర్తింపజేయడానికి Moonfinను పునఃప్రారంభించండి.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ఆటోమేటిక్';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ఆన్';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ఆఫ్';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'పునఃప్రారంభం అవసరం';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'రెండరింగ్ ఇంజిన్‌ను మార్చడానికి Moonfin పునఃప్రారంభం కావాలి. ఇప్పుడు యాప్‌ను మూసివేసి, వర్తింపజేయడానికి మళ్లీ తెరవండి.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ఇప్పుడు యాప్‌ను మూసివేయండి';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'లైబ్రరీని రిఫ్రెష్ చేయండి';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'అన్ని లైబ్రరీలను రిఫ్రెష్ చేయండి';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'జోడించిన తేదీ (పాతవి ముందుగా)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'జోడించిన తేదీ (కొత్తవి ముందుగా)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'అక్షర క్రమం (A నుండి Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'అక్షర క్రమం (Z నుండి A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'సర్వర్ అనలిటిక్స్ లోడ్ అవుతోంది... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'మూలంతో సరిపోల్చండి';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb టాప్ 250 సినిమాలు';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb టాప్ 250 TV షోలు';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb అత్యంత జనాదరణ పొందిన సినిమాలు';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb అత్యంత జనాదరణ పొందిన TV షోలు';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb అత్యల్ప రేటింగ్ సినిమాలు';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb టాప్ రేటెడ్ ఇంగ్లీష్ సినిమాలు';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -9,22 +9,22 @@ class AppLocalizationsTh extends AppLocalizations {
   AppLocalizationsTh([String locale = 'th']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'มูนฟิน';
 
   @override
-  String get accountPreferences => 'การตั้งค่าบัญชี';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'ภาษาของอินเทอร์เฟซ';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'ค่าเริ่มต้นของระบบ';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'เข้าสู่ระบบ';
 
   @override
-  String get empty => 'ว่างเปล่า';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'เชื่อมต่อด่วน';
 
   @override
   String get password => 'รหัสผ่าน';
@@ -51,7 +51,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get waitingForAuthorization => 'กำลังรอการอนุญาต...';
 
   @override
-  String get back => 'ย้อนกลับ';
+  String get back => 'กลับ';
 
   @override
   String get serverUnavailable => 'เซิร์ฟเวอร์ไม่พร้อมใช้งาน';
@@ -61,12 +61,12 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect ใช้งานไม่ได้: $detail';
+    return 'การเชื่อมต่อด่วนไม่พร้อมใช้งาน: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect ใช้งานไม่ได้ ($status): $detail';
+    return 'การเชื่อมต่อด่วนไม่พร้อมใช้งาน ($status): $detail';
   }
 
   @override
@@ -113,7 +113,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get cancel => 'ยกเลิก';
 
   @override
-  String get remove => 'นำออก';
+  String get remove => 'ลบ';
 
   @override
   String get connectToServer => 'เชื่อมต่อกับเซิร์ฟเวอร์';
@@ -142,62 +142,62 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsAppearanceTheme => 'ธีมแอป';
 
   @override
-  String get detailScreenStyle => 'สไตล์หน้ารายละเอียด';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'คลาสสิกคือเลย์เอาต์ Moonfin ดั้งเดิมที่จัดกึ่งกลาง โมเดิร์นคือเลย์เอาต์แนวภาพยนตร์ที่ปรับตามขนาดหน้าจอ';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'คลาสสิก';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'โมเดิร์น';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'แท็บแบบขยาย';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'แสดงเนื้อหาของแท็บโดยอัตโนมัติขณะเลื่อนดูแท็บ ปิดเพื่อเปิดและปิดแต่ละแท็บด้วยตนเอง';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'แสดงรายละเอียดทางเทคนิคหรือไม่?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'แสดงข้อมูลตัวแปลงสัญญาณ ความละเอียด และสตรีมในสรุปแบนเนอร์';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'ระบบแนะนำ';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'ใช้อัลกอริทึม Moonfin แนะนำ ที่ทำงานกับคลังสื่อในเครื่อง หรือใช้ค่าความคล้ายคลึงออนไลน์ของ TMDb หมายเหตุ: การแนะนำแบบออนไลน์ต้องเชื่อมต่อกับ Seerr';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin แนะนำ';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'ความคล้ายคลึงจาก TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'จำกัดตามเรตผู้ปกครองหรือไม่?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'จำกัดคำแนะนำของ Moonfin แนะนำ ตามเรตผู้ปกครองของสื่อเป้าหมาย';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'สไตล์อินเทอร์เฟซ';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'อัตโนมัติจะปรับตามอุปกรณ์ของคุณ เลือก Apple หรือ Material เพื่อกำหนดรูปลักษณ์เอง';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'อัตโนมัติ';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,31 +206,31 @@ class AppLocalizationsTh extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'คุณภาพกระจก';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'อัตโนมัติจะเลือกเอฟเฟกต์กระจกที่ดีที่สุดสำหรับอุปกรณ์นี้ เต็มรูปแบบจะบังคับใช้การเบลอจริง ส่วนลดทอนจะใช้กระจกแบบเบาที่ช่วยประหยัดพลังงาน GPU';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'อัตโนมัติ';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'เต็มรูปแบบ';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'ลดทอน';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'สลับระหว่าง Moonfin และ Neon Pulse โดยไม่ต้องรีสตาร์ทแอป';
 
   @override
-  String get customThemeTitle => 'ธีมกำหนดเอง';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ธีมกำหนดเองจะเปลี่ยนองค์ประกอบภาพทั่วทั้ง Moonfin เลือกหนึ่งตัวเลือกให้เข้ากับสไตล์ของคุณ';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'ต้องการแป้นพิมพ์ระบบ';
@@ -240,7 +240,7 @@ class AppLocalizationsTh extends AppLocalizations {
       'ใช้วิธีการป้อนข้อมูลจากอุปกรณ์ของคุณเป็นค่าเริ่มต้นสำหรับการป้อนข้อความ';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'มูนฟิน';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -254,18 +254,18 @@ class AppLocalizationsTh extends AppLocalizations {
       'สไตล์ซินธ์เวฟพร้อมเรืองแสงสีม่วงแดง ข้อความสีฟ้า และคอนทราสต์ของโครเมียมที่เข้มกว่า';
 
   @override
-  String get themeGlass => 'กระจก';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'สไตล์กระจกเหลว พร้อมพื้นหลังไล่เฉดที่ค่อยๆ เคลื่อน พื้นผิวฝ้า และสีเน้นฟ้าแบบ Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'ฮีโร่ 8-bit';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'สไตล์พิกเซลอาร์ตย้อนยุค พร้อมชุดสีหนา ขอบทึบเป็นบล็อก เงาตกกระทบคมชัด และฟอนต์พิกเซล';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -328,34 +328,35 @@ class AppLocalizationsTh extends AppLocalizations {
   String get exit => 'ออก';
 
   @override
-  String get gameMenu => 'เมนู';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'หยุดชั่วคราว';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'บันทึกสถานะ';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'เกม';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'โหลดสถานะ';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'เดินหน้าเร็ว';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'การตั้งค่าอีมูเลเตอร์';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'คอร์นี้ไม่มีตัวเลือกที่ปรับได้';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'กดค้างเพื่อเปิดเมนู';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
-  String get gamePlaybackUnsupported => 'อุปกรณ์นี้ยังไม่รองรับการเล่นเกม';
+  String get gamePlaybackUnsupported =>
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ไม่สามารถโหลดแถวบ้านได้';
@@ -370,19 +371,19 @@ class AppLocalizationsTh extends AppLocalizations {
   String get guide => 'แนะนำ';
 
   @override
-  String get recordings => 'รายการบันทึก';
+  String get recordings => 'การบันทึก';
 
   @override
   String get schedule => 'กำหนดการ';
 
   @override
-  String get series => 'ซีรีส์';
+  String get series => 'ชุด';
 
   @override
   String get noItemsFound => 'ไม่พบรายการ';
 
   @override
-  String get home => 'หน้าแรก';
+  String get home => 'บ้าน';
 
   @override
   String get browseAll => 'เรียกดูทั้งหมด';
@@ -413,7 +414,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get noLibrariesFound => 'ไม่พบห้องสมุด';
 
   @override
-  String get library => 'ไลบรารี';
+  String get library => 'ห้องสมุด';
 
   @override
   String get displaySettings => 'การตั้งค่าการแสดงผล';
@@ -550,7 +551,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get pickDiscoverySubjects => 'เลือกฟีดหัวเรื่องที่จะแสดงใน Discover';
 
   @override
-  String get apply => 'นำไปใช้';
+  String get apply => 'นำมาใช้';
 
   @override
   String get openLink => 'เปิดลิงก์';
@@ -598,7 +599,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get listen => 'ฟัง';
 
   @override
-  String get resume => 'อ่านต่อ';
+  String get resume => 'ประวัติย่อ';
 
   @override
   String get failedToLoadLibrary => 'โหลดไลบรารี่ไม่สำเร็จ';
@@ -663,7 +664,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String genresCount(int count) {
-    return '$count แนว';
+    return '$count genres';
   }
 
   @override
@@ -689,7 +690,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get titles => 'เรื่อง';
+  String get titles => 'ชื่อเรื่อง';
 
   @override
   String get allTitles => 'ชื่อเรื่องทั้งหมด';
@@ -747,7 +748,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get unread => 'ยังไม่ได้อ่าน';
 
   @override
-  String get unwatched => 'ยังไม่ได้ดู';
+  String get unwatched => 'ไม่ได้ดู';
 
   @override
   String get seriesStatus => 'สถานะซีรีส์';
@@ -759,43 +760,43 @@ class AppLocalizationsTh extends AppLocalizations {
   String get books => 'หนังสือ';
 
   @override
-  String get latestBooks => 'หนังสือล่าสุด';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'หนังสือเสียงล่าสุด';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count เล่ม',
-      one: '1 เล่ม',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'หนังสือ';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'หนังสือเสียง';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'อ่านแล้ว $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'เหลือ $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'อ่าน';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'ฟัง';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'ผู้เขียน';
@@ -872,8 +873,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'หนังสือเสียง $count เล่ม',
-      one: 'หนังสือเสียง 1 เล่ม',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -909,7 +910,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get nextUp => 'ถัดไปขึ้นมา';
 
   @override
-  String get seasons => 'ซีซั่น';
+  String get seasons => 'ฤดูกาล';
 
   @override
   String get chapters => 'บท';
@@ -975,8 +976,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ซีซัน',
-      one: '1 ซีซัน',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -987,40 +988,40 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get items => 'รายการ';
+  String get items => 'Items';
 
   @override
-  String get extras => 'ส่วนเสริม';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'เบื้องหลังการถ่ายทำ';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ฉากที่ถูกตัดออก';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'สารคดีสั้น';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'บทสัมภาษณ์';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'ฉาก';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'หนังสั้น';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ตัวอย่าง';
+  String get trailers => 'รถพ่วง';
 
   @override
   String timeRemaining(String time) {
-    return 'เหลืออีก $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'จบใน $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1062,7 +1063,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get version => 'เวอร์ชัน';
 
   @override
-  String get cast => 'แคสต์';
+  String get cast => 'หล่อ';
 
   @override
   String get trailer => 'ตัวอย่าง';
@@ -1255,13 +1256,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get director => 'ผู้อำนวยการ';
 
   @override
-  String get directors => 'ผู้กำกับ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'ผู้เขียนบท';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'ผู้เขียนบท';
+  String get writers => 'นักเขียน';
 
   @override
   String get studio => 'สตูดิโอ';
@@ -1296,8 +1297,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count แทร็ก',
-      one: '1 แทร็ก',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1307,8 +1308,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count บท',
-      one: '1 บท',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1335,16 +1336,16 @@ class AppLocalizationsTh extends AppLocalizations {
   String get readMore => 'อ่านเพิ่มเติม';
 
   @override
-  String get shuffle => 'สุ่มเล่น';
+  String get shuffle => 'สับเปลี่ยน';
 
   @override
-  String get shuffleAllMusic => 'สุ่มเล่นเพลงทั้งหมด';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'ลงชื่อเข้าใช้ Moonfin บนโทรศัพท์ของคุณ';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'เชื่อมต่อเซิร์ฟเวอร์ของคุณไม่ได้';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1356,7 +1357,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count ช่อง';
+    return '${count}ch';
   }
 
   @override
@@ -1542,7 +1543,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get transcodeReasons => 'เหตุผลในการแปลงรหัส';
 
   @override
-  String get player => 'ตัวเล่น';
+  String get player => 'ผู้เล่น';
 
   @override
   String get container => 'คอนเทนเนอร์';
@@ -1566,7 +1567,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get videoBitrate => 'อัตราบิตของวิดีโอ';
 
   @override
-  String get track => 'แทร็ก';
+  String get track => 'ติดตาม';
 
   @override
   String get channels => 'ช่อง';
@@ -1780,22 +1781,22 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'ถัดไป: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'เหลือ $minutes นาที';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'เหลือ $hours ชม.';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'เหลือ $hours ชม. $minutes นาที';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1817,7 +1818,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get favoriteChannel => 'ช่องโปรด';
 
   @override
-  String get record => 'บันทึกรายการ';
+  String get record => 'บันทึก';
 
   @override
   String get cancelRecordingAction => 'ยกเลิกการบันทึก';
@@ -1832,7 +1833,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get unableToCreateRecording => 'ไม่สามารถสร้างการบันทึกได้';
 
   @override
-  String get watch => 'รับชม';
+  String get watch => 'ดู';
 
   @override
   String get close => 'ปิด';
@@ -1869,7 +1870,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get no => 'ไม่';
+  String get no => 'เลขที่';
 
   @override
   String get yesCancel => 'ใช่ ยกเลิก';
@@ -1976,7 +1977,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get season => 'ซีซั่น';
+  String get season => 'ฤดูกาล';
 
   @override
   String get errorLoadingEpisodes => 'เกิดข้อผิดพลาดในการโหลดตอน';
@@ -2042,8 +2043,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ตอน',
-      one: '1 ตอน',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2266,7 +2267,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'หน้ารายละเอียด แถวหน้าแรก และระดับเสียง';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2280,10 +2281,11 @@ class AppLocalizationsTh extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'เล่นเมื่อเรียกดูหน้าจอหลัก';
 
   @override
-  String get loopThemeMusic => 'เล่นเพลงประจำเรื่องวนซ้ำ';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => 'เล่นแทร็กซ้ำแทนการเล่นเพียงครั้งเดียว';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'รายละเอียด พื้นหลังเบลอ';
@@ -2306,23 +2308,23 @@ class AppLocalizationsTh extends AppLocalizations {
   String get playerZoomMode => 'โหมดซูมผู้เล่น';
 
   @override
-  String get settingsScrollWheelAction => 'ล้อเลื่อนเมาส์';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'เลือกการทำงานเมื่อเลื่อนล้อเมาส์เหนือวิดีโอระหว่างการเล่น';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'ปิด';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'เลื่อนหา (ไปหน้า / ย้อนกลับ)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ระดับเสียง';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ระดับเสียง';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'พอดี';
@@ -2337,7 +2339,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get refreshRateSwitching => 'การสลับอัตราการรีเฟรช';
 
   @override
-  String get disabled => 'ปิดใช้งาน';
+  String get disabled => 'พิการ';
 
   @override
   String get scaleOnTv => 'สเกลบนทีวี';
@@ -2375,37 +2377,37 @@ class AppLocalizationsTh extends AppLocalizations {
   String get defaultAudioLanguage => 'ภาษาเสียงเริ่มต้น';
 
   @override
-  String get fallbackAudioLanguage => 'ภาษาเสียงสำรอง';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'ใช้แทร็กเสียงเริ่มต้นก่อน';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'ใช้แทร็กเสียงต้นฉบับแทนเสียงพากย์';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'ใช้แทร็กเสียงบรรยายภาพก่อน';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'ใช้แทร็กเสียงบรรยายภาพแทนแทร็กปกติ';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'แปลงสัญญาณ (เสียง)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'สตรีมโดยตรง (รีมักซ์)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'แปลงสัญญาณ (บิตเรตหรือความละเอียด)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'แปลงสัญญาณ (วิดีโอและเสียง)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'แปลงสัญญาณ (วิดีโอ)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'อัตโนมัติ (ค่าเริ่มต้นของเซิร์ฟเวอร์)';
@@ -2471,7 +2473,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get dtsPassthrough => 'DTS พาสทรู';
 
   @override
-  String get trueHdSupport => 'รองรับ TrueHD';
+  String get trueHdSupport => 'รองรับ True HD';
 
   @override
   String get enableDtsPassthrough =>
@@ -2486,7 +2488,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'เลือกวิธีถอดรหัสเสียง AVR Passthrough จะส่งสตรีม Dolby/DTS ดิบไปยังเครื่องรับของคุณ ส่วนอัตโนมัติหรือดาวน์มิกซ์จะถอดรหัสในเครื่อง';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR พาสทรู';
@@ -2496,13 +2498,13 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'เลือกรูปแบบปลายทางสำหรับแปลงเสียงหลายช่องสัญญาณ เมื่อสตรีมต้นทางไม่สามารถเล่นโดยตรงหรือส่งผ่านได้';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'ตรวจหาอัตโนมัติ\n(แนะนำ)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(ค่าเริ่มต้น)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2511,51 +2513,50 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(ไม่สูญเสียคุณภาพ)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(สเตอริโอเท่านั้น)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ประหยัดพื้นที่)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(ไม่สูญเสียคุณภาพ)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'ช่องสัญญาณเสียงสูงสุด';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'กำหนดจำนวนช่องสัญญาณสูงสุดของชุดเครื่องเสียงของคุณ สตรีมหลายช่องสัญญาณที่เกินขีดจำกัดนี้จะถูกดาวน์มิกซ์หรือแปลงสัญญาณ';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ตรวจหาอัตโนมัติ\n(ค่าเริ่มต้นของฮาร์ดแวร์)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 โมโน';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 สเตอริโอ';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 เซอร์ราวด์';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 ควอดราโฟนิก';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 เซอร์ราวด์';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 เซอร์ราวด์';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 เซอร์ราวด์';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 เซอร์ราวด์';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'ส่งผ่าน (ขั้นสูง)';
@@ -2637,11 +2638,11 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'วิทยากร';
 
   @override
-  String get settingsAudioRouteHeadphones => 'หูฟัง';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return 'PCM $count ช่อง';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2727,7 +2728,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value วิ';
+    return '${value}s';
   }
 
   @override
@@ -2816,45 +2817,45 @@ class AppLocalizationsTh extends AppLocalizations {
   String get subtitleCustomizationDescription => 'ปรับแต่งลักษณะคำบรรยาย';
 
   @override
-  String get subtitleMode => 'โหมดคำบรรยาย';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'ตามการกำกับ';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'เสมอ';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'ภาษาต่างประเทศ';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'บังคับ';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'เล่นแทร็กที่ถูกกำกับไว้ในข้อมูลเมตาของไฟล์สื่อว่าเป็น \"default\" หรือ \"forced\"';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'โหลดและแสดงคำบรรยายโดยอัตโนมัติทุกครั้งที่เริ่มเล่นวิดีโอ';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'เปิดคำบรรยายโดยอัตโนมัติหากแทร็กเสียงเริ่มต้นเป็นภาษาต่างประเทศ';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'โหลดเฉพาะคำบรรยายที่ถูกกำกับด้วยแฟล็ก forced เท่านั้น';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'ปิดการโหลดคำบรรยายอัตโนมัติทั้งหมด';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'ภาษาคำบรรยายสำรอง';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'สตรีมคำบรรยาย';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -3058,10 +3059,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showLibrariesInToolbar => 'แสดงไลบรารีในแถบเครื่องมือ';
 
   @override
-  String get navbarAlwaysExpanded => 'แสดงชื่อเมนูบนแถบนำทางเสมอ';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'แสดงปุ่ม Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'ความทึบของแถบนำทาง';
@@ -3134,19 +3135,18 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showFolderBrowsingOption => 'แสดงตัวเลือกการเรียกดูโฟลเดอร์';
 
   @override
-  String get groupItemsIntoCollections => 'จัดกลุ่มรายการเป็นคอลเลกชัน';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ซ่อนรายการในคลังที่อยู่ในคอลเลกชันขณะเรียกดูคลังสื่อ';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'ประกาศเกี่ยวกับการจัดกลุ่มคลังสื่อ';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'หากต้องการใช้การตั้งค่านี้ โปรดตรวจสอบว่าได้เปิดการตั้งค่าคลังสื่อ \"Group movies into collections\" และ/หรือ \"Group shows into collections\" ในการตั้งค่าการแสดงผลของคลังสื่อบนเซิร์ฟเวอร์ Jellyfin หรือ Emby ของคุณแล้ว';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'การมองเห็นห้องสมุด';
@@ -3205,7 +3205,7 @@ class AppLocalizationsTh extends AppLocalizations {
       'เลือกระหว่าง Moonfin, MakD หรือปิดแถบสื่อ';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'มูนฟิน';
 
   @override
   String get mediaBarModeMakd => 'หมากดี';
@@ -3258,10 +3258,10 @@ class AppLocalizationsTh extends AppLocalizations {
       'เล่นตัวอย่างอัตโนมัติในแถบสื่อหลังจากผ่านไป 3 วินาที';
 
   @override
-  String get trailerAudio => 'เสียงตัวอย่าง';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'เปิดเสียงสำหรับตัวอย่างในแถบสื่อ';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'ดูตัวอย่างตอน';
@@ -3337,11 +3337,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get combineBothRows => 'รวมทั้งสองแถวเป็นส่วนบ้านเดียว';
 
   @override
-  String get fullScreenRows => 'แถวหน้าแรกแบบขยาย';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'จำกัดแถวหน้าแรกให้เหลือ 1 แถวต่อหน้าจอ';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ประเภทรูปภาพต่อแถว';
@@ -3356,7 +3355,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get lastUser => 'ผู้ใช้คนสุดท้าย';
 
   @override
-  String get currentUser => 'ผู้ใช้ปัจจุบัน';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ตรวจสอบสิทธิ์เสมอ';
@@ -3460,10 +3459,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get displayClockDuringScreensaver => 'แสดงนาฬิการะหว่างสกรีนเซฟเวอร์';
 
   @override
-  String get clockModeStatic => 'อยู่กับที่';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'เคลื่อนไปมา';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'มะเขือเทศเน่า (นักวิจารณ์)';
@@ -3472,10 +3471,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get rottenTomatoesAudience => 'มะเขือเทศเน่า (ผู้ชม)';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => 'ไอเอ็มดีบี';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'ทีเอ็มดีบี';
 
   @override
   String get metacritic => 'ริติค';
@@ -3484,7 +3483,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get metacriticUser => 'ริติค (ผู้ใช้)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'แทรคท์';
 
   @override
   String get letterboxd => 'ตู้จดหมายd';
@@ -3533,7 +3532,7 @@ class AppLocalizationsTh extends AppLocalizations {
       'เปิดใช้งานและจัดลำดับแหล่งการให้คะแนนที่แสดงทั่วทั้งแอปใหม่';
 
   @override
-  String get pluginLabel => 'ปลั๊กอิน Moonbase';
+  String get pluginLabel => 'ปลั๊กอิน';
 
   @override
   String get pluginDetected => 'ตรวจพบปลั๊กอิน';
@@ -3604,7 +3603,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get networks => 'เครือข่าย';
 
   @override
-  String get seerrDiscoveryRows => 'แถวสำรวจของ Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'รีเซ็ตแถวเป็นค่าเริ่มต้น';
@@ -3627,26 +3626,28 @@ class AppLocalizationsTh extends AppLocalizations {
   String get hideAdultContent => 'ซ่อนเนื้อหาสำหรับผู้ใหญ่ในผลลัพธ์';
 
   @override
-  String get seerrNotificationsSection => 'การแจ้งเตือน';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'แจ้งเตือนคำขอใหม่';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => 'แจ้งเตือนฉันเมื่อมีคนส่งคำขอ';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'อัปเดตคำขอ';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'อนุมัติ ปฏิเสธ และเพิ่มลงคลังสื่อของคุณ';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'อัปเดตปัญหา';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'ปัญหาใหม่ การตอบกลับ และการแก้ไข';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3654,18 +3655,18 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'หน้าสำรวจของ Seerr';
+  String get discoverRows => 'ค้นพบแถว';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'เปิดแถวที่ต้องการแสดงบนหน้าหลักของ Seerr ลากเพื่อจัดลำดับ ลำดับที่กำหนดเองจะซิงค์กับ Moonbase';
+      'ลากเพื่อเรียงลำดับใหม่ เปิดหรือปิดการใช้งานแถว เปิดใช้งานการซิงค์ลำดับแถวกับปลั๊กอิน Moonfin';
 
   @override
   String get discoverRowsDescription =>
-      'เปิดแถวที่ต้องการแสดงบนหน้าหลักของ Seerr ลากเพื่อจัดลำดับ ลำดับที่กำหนดเองจะซิงค์กับ Moonbase';
+      'ลากเพื่อเรียงลำดับใหม่ เปิดหรือปิดการใช้งานแถว';
 
   @override
-  String get enabled => 'เปิดใช้งาน';
+  String get enabled => 'เปิดใช้งานแล้ว';
 
   @override
   String get hidden => 'ที่ซ่อนอยู่';
@@ -3797,7 +3798,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get imageCacheCleared => 'ล้างแคชรูปภาพแล้ว';
 
   @override
-  String get clear => 'ล้าง';
+  String get clear => 'ชัดเจน';
 
   @override
   String get browse => 'เรียกดู';
@@ -3813,11 +3814,11 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'กำลังดาวน์โหลด · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'กำลังนำเข้า';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3825,7 +3826,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'การตั้งค่า Seerr';
+  String get seerrSettings => 'การตั้งค่าเซียร์';
 
   @override
   String get requestMore => 'ขอเพิ่มเติม';
@@ -3920,7 +3921,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showMore => 'แสดงเพิ่มเติม';
 
   @override
-  String get appearances => 'ผลงานการแสดง';
+  String get appearances => 'การปรากฏตัว';
 
   @override
   String get crewSection => 'ลูกทีม';
@@ -3958,146 +3959,148 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deletedStatus => 'ลบแล้ว';
 
   @override
-  String get failedStatus => 'ล้มเหลว';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'กำลังดำเนินการ';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'แก้ไขโดย $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'เสร็จสิ้น';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'มีการขอเรื่องนี้ไปแล้ว';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'ใช้สิทธิ์การขอครบแล้ว';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'เรื่องนี้อยู่ในรายการที่ถูกบล็อก';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'ไม่มีซีซันที่ขอได้เหลืออยู่';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'คุณไม่มีสิทธิ์ส่งคำขอนี้';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'คำขอ';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'ปัญหา';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'ใหม่ที่สุด';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'แก้ไขล่าสุด';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'ไม่มีปัญหา';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'เหลือสิทธิ์ขอภาพยนตร์ $remaining จาก $limit ครั้ง';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'เหลือสิทธิ์ขอซีซัน $remaining จาก $limit ครั้ง';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'อยู่ในชุด $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'ดูคอลเลกชัน';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'ขอทั้งคอลเลกชัน';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return 'ภาพยนตร์ $total เรื่อง · พร้อมดู $available เรื่อง';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'ขอภาพยนตร์ $count เรื่อง';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'กำลังส่งคำขอ $current จาก $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'ขอภาพยนตร์แล้ว $count เรื่อง';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'ขอภาพยนตร์แล้ว $ok จาก $total เรื่อง';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'ภาพยนตร์ทั้งหมดพร้อมดูหรือถูกขอไปแล้ว';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'รายงานปัญหา';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'วิดีโอ';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'เสียง';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'เกิดปัญหาอะไรขึ้น?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'ทุกตอน';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'ตอน';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'เปิดอยู่';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'แก้ไขแล้ว';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'ปิดปัญหา';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'เปิดปัญหาใหม่';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'รายงานโดย $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count ความคิดเห็น';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'เพิ่มความคิดเห็น';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'ลบปัญหานี้หรือไม่?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'ส่งรายงาน';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'คะแนน TMDB';
@@ -4121,7 +4124,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get originalLanguageLabel => 'ภาษาต้นฉบับ';
 
   @override
-  String get seasonsLabel => 'ซีซั่น';
+  String get seasonsLabel => 'ฤดูกาล';
 
   @override
   String get episodesLabel => 'ตอน';
@@ -4154,7 +4157,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get disable => 'ปิดการใช้งาน';
 
   @override
-  String get done => 'เสร็จสิ้น';
+  String get done => 'เสร็จแล้ว';
 
   @override
   String get edit => 'แก้ไข';
@@ -4166,7 +4169,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get error => 'ข้อผิดพลาด';
 
   @override
-  String get forward => 'กรอไปข้างหน้า';
+  String get forward => 'ซึ่งไปข้างหน้า';
 
   @override
   String get general => 'ทั่วไป';
@@ -4190,7 +4193,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get networking => 'เครือข่าย';
 
   @override
-  String get next => 'ถัดไป';
+  String get next => 'ต่อไป';
 
   @override
   String get path => 'เส้นทาง';
@@ -4214,7 +4217,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get refresh => 'รีเฟรช';
 
   @override
-  String get remote => 'รีโมต';
+  String get remote => 'ระยะไกล';
 
   @override
   String get rename => 'เปลี่ยนชื่อ';
@@ -4259,7 +4262,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get time => 'เวลา';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'เล่นกล';
 
   @override
   String get uninstall => 'ถอนการติดตั้ง';
@@ -4298,28 +4301,28 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminDrawerUsers => 'ผู้ใช้';
 
   @override
-  String get adminDrawerLibraries => 'ไลบรารี';
+  String get adminDrawerLibraries => 'ห้องสมุด';
 
   @override
-  String get adminDrawerDisplay => 'การแสดงผล';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'ข้อมูลเมตา';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'การตั้งค่า NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'การแปลงรหัส';
 
   @override
-  String get adminDrawerResume => 'เล่นต่อ';
+  String get adminDrawerResume => 'ประวัติย่อ';
 
   @override
   String get adminDrawerStreaming => 'สตรีมมิ่ง';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'เล่นกล';
 
   @override
   String get adminDrawerDevices => 'อุปกรณ์';
@@ -4489,10 +4492,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get sessionRewind => 'กรอกลับ';
 
   @override
-  String get sessionForward => 'กรอไปข้างหน้า';
+  String get sessionForward => 'ซึ่งไปข้างหน้า';
 
   @override
-  String get sessionNext => 'ถัดไป';
+  String get sessionNext => 'ต่อไป';
 
   @override
   String get sessionVolumeDown => 'เล่ม –';
@@ -4507,7 +4510,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get nowPlaying => 'กำลังเล่นอยู่';
 
   @override
-  String get volume => 'ระดับเสียง';
+  String get volume => 'ปริมาณ';
 
   @override
   String get actions => 'การดำเนินการ';
@@ -4534,10 +4537,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminClearDates => 'วันที่ที่ชัดเจน';
 
   @override
-  String get adminActivitySeverityAll => 'ทุกระดับความรุนแรง';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'ช่วงวันที่';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4574,23 +4577,23 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'นำอุปกรณ์ \'$name\' ออกหรือไม่? ผู้ใช้จะต้องลงชื่อเข้าใช้บนอุปกรณ์นี้อีกครั้ง';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'ลบอุปกรณ์ทั้งหมด';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'นำอุปกรณ์ $count เครื่องออกหรือไม่? ผู้ใช้ที่ได้รับผลกระทบจะต้องลงชื่อเข้าใช้อีกครั้ง อุปกรณ์ปัจจุบันของคุณจะไม่ได้รับผลกระทบ';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'นำอุปกรณ์ออกแล้ว';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'นำอุปกรณ์ออกบางส่วนแล้ว มี $count เครื่องที่นำออกไม่ได้';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4705,243 +4708,244 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminMetadataCountryHint => 'เช่น สหรัฐอเมริกา เยอรมนี ฝรั่งเศส';
 
   @override
-  String get adminLibraryTabPaths => 'เส้นทาง';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'ตัวเลือก';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'ตัวดาวน์โหลด';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'ตัวบันทึกข้อมูลเมตา';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'ตัวดาวน์โหลดคำบรรยาย';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'ตัวดาวน์โหลดเนื้อเพลง';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'ตัวดาวน์โหลดข้อมูลเมตา: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'ตัวดึงรูปภาพ: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'เซิร์ฟเวอร์นี้ไม่มีตัวดาวน์โหลดสำหรับคลังสื่อประเภทนี้';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'ทั่วไป';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'ข้อมูลเมตา';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'ข้อมูลที่ฝังในไฟล์';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'คำบรรยาย';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'รูปภาพ';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'ซีรีส์';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'เพลง';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'ภาพยนตร์';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'เปิดการตรวจสอบแบบเรียลไทม์';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ตรวจจับการเปลี่ยนแปลงของไฟล์และประมวลผลโดยอัตโนมัติ';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'ถือว่าไฟล์บีบอัดเป็นไฟล์สื่อ';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'แสดงรูปภาพ';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'บันทึกภาพปกลงในโฟลเดอร์สื่อ';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'รีเฟรชข้อมูลเมตาอัตโนมัติ';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ไม่เลย';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'ค่าเริ่มต้น';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'การแสดงผล';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'การแสดงผลคลังสื่อ';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'แสดงมุมมองโฟลเดอร์เพื่อดูโฟลเดอร์สื่อแบบธรรมดา';
+      'Display a folder view to show plain media folders';
 
   @override
-  String get adminLibSpecialsInSeasons => 'แสดงตอนพิเศษในซีซันที่ออกอากาศ';
+  String get adminLibSpecialsInSeasons =>
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'จัดกลุ่มภาพยนตร์เป็นคอลเลกชัน';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'จัดกลุ่มรายการเป็นคอลเลกชัน';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => 'แสดงเนื้อหาภายนอกในรายการแนะนำ';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'การกำหนดวันที่เพิ่ม';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'ใช้วันที่เพิ่มจาก';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'วันที่สแกนเข้าคลังสื่อ';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'วันที่สร้างไฟล์';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'ข้อมูลเมตาและรูปภาพ';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ภาษาของข้อมูลเมตาที่ต้องการ';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'บท';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ความยาวบทจำลอง (วินาที)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'ความยาวของบทที่สร้างขึ้นสำหรับสื่อที่ไม่มีบท ตั้งเป็น 0 เพื่อปิดใช้งาน';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'ความละเอียดรูปภาพของบท';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'การตั้งค่า NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'ข้อมูลเมตา NFO ใช้ได้กับ Kodi และไคลเอ็นต์ที่คล้ายกัน การตั้งค่านี้มีผลกับทุกคลังสื่อที่บันทึกข้อมูลเมตา NFO';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => 'ผู้ใช้ที่จะบันทึกข้อมูลการรับชมลงในไฟล์ NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'บันทึกเส้นทางรูปภาพในไฟล์ NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'เปิดการแทนที่เส้นทางสำหรับเส้นทางรูปภาพใน NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'คัดลอกรูป extrafanart ไปยังโฟลเดอร์ extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'ไม่มี';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days วัน';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'ใช้ชื่อเรื่องที่ฝังในไฟล์';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'ใช้ชื่อเรื่องที่ฝังในไฟล์สำหรับส่วนเสริม';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => 'ใช้ข้อมูลตอนที่ฝังในไฟล์';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'อนุญาตคำบรรยายที่ฝังในไฟล์';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'อนุญาตทั้งหมด';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'ข้อความเท่านั้น';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'รูปภาพเท่านั้น';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'ไม่มี';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'ข้ามการดาวน์โหลดหากมีคำบรรยายฝังอยู่ในไฟล์แล้ว';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ข้ามการดาวน์โหลดหากแทร็กเสียงตรงกับภาษาที่ดาวน์โหลด';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'ต้องการคำบรรยายที่ตรงกันทุกประการ';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => 'บันทึกคำบรรยายลงในโฟลเดอร์สื่อ';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'ดึงรูปภาพของบท';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'ดึงรูปภาพของบทระหว่างการสแกนคลังสื่อ';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'เปิดการดึงรูปภาพ Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'ดึงรูปภาพ Trickplay ระหว่างการสแกนคลังสื่อ';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'บันทึกรูปภาพ Trickplay ลงในโฟลเดอร์สื่อ';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'รวมซีรีส์ที่กระจายอยู่หลายโฟลเดอร์โดยอัตโนมัติ';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'ชื่อที่แสดงของซีซัน 0';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'เปิดการสแกน LUFS เพื่อปรับระดับเสียงให้สม่ำเสมอ';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'ใช้แท็กศิลปินแบบไม่มาตรฐานก่อน';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'เพิ่มภาพยนตร์ลงคอลเลกชันโดยอัตโนมัติ';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'ต้องระบุชื่อห้องสมุด';
@@ -5179,143 +5183,143 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminEnableAllChannels => 'เปิดให้เข้าถึงทุกช่องทาง';
 
   @override
-  String get adminParentalControl => 'การควบคุมโดยผู้ปกครอง';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'เรตผู้ปกครองสูงสุดที่อนุญาต';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'เนื้อหาที่มีเรตสูงกว่านี้จะถูกซ่อนจากผู้ใช้รายนี้';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'ไม่มี';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'บล็อกรายการที่ไม่มีข้อมูลเรตหรือมีเรตที่ไม่รู้จัก';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'หนังสือ';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'ช่อง';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'ทีวีสด';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'ภาพยนตร์';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'เพลง';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ตัวอย่าง';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'รายการ';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'ตารางการเข้าถึง';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'อนุญาตให้เข้าถึงเฉพาะช่วงเวลาที่กำหนดไว้ด้านล่าง หากไม่ได้ตั้งตารางไว้จะเข้าถึงได้ตลอดทั้งวัน';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'เพิ่มตาราง';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'วัน';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'เริ่ม';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'สิ้นสุด';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'ทุกวัน';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'วันธรรมดา';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'วันหยุดสุดสัปดาห์';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'วันอาทิตย์';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'วันจันทร์';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'วันอังคาร';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'วันพุธ';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'วันพฤหัสบดี';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'วันศุกร์';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'วันเสาร์';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'แท็กที่อนุญาต';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'แสดงเฉพาะเนื้อหาที่มีแท็กเหล่านี้ เว้นว่างไว้เพื่ออนุญาตทั้งหมด';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'แท็กที่ถูกบล็อก';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'เนื้อหาที่มีแท็กเหล่านี้จะถูกซ่อนจากผู้ใช้รายนี้';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'เพิ่มแท็ก';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'อุปกรณ์ที่เปิดใช้งาน';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'ช่องที่เปิดใช้งาน';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'ผู้ให้บริการการยืนยันตัวตน';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'ผู้ให้บริการรีเซ็ตรหัสผ่าน';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'จำนวนครั้งสูงสุดที่เข้าสู่ระบบล้มเหลวก่อนถูกล็อก';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'ตั้งเป็น 0 เพื่อใช้ค่าเริ่มต้น หรือ -1 เพื่อปิดการล็อก';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'การเข้าถึง SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'อนุญาตให้สร้างและเข้าร่วมกลุ่ม';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'อนุญาตให้เข้าร่วมกลุ่ม';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'ไม่มีสิทธิ์เข้าถึง';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'อนุญาตให้ลบเนื้อหาจาก';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5403,25 +5407,25 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'สร้างข้อมูลสำรอง';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'เลือกสิ่งที่ต้องการรวมไว้ในข้อมูลสำรอง';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ฐานข้อมูล';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'รวมไว้เสมอ';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'ข้อมูลเมตา';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'คำบรรยาย';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'รูปภาพ Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'กำลังสร้างข้อมูลสำรอง...';
@@ -5849,7 +5853,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminTrickplaySaved => 'บันทึกการตั้งค่า Trickplay แล้ว';
 
   @override
-  String get adminTrickplayLoadFailed => 'โหลดการตั้งค่า Trickplay ไม่สำเร็จ';
+  String get adminTrickplayLoadFailed => 'ไม่สามารถโหลดการตั้งค่าการเล่นกล';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -5962,7 +5966,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminBaseUrl => 'URL ฐาน';
 
   @override
-  String get adminBaseUrlHint => 'เช่น /jellyfin';
+  String get adminBaseUrlHint => 'เช่น /เจลลี่ฟิน';
 
   @override
   String get https => 'HTTPS';
@@ -6105,7 +6109,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'ลบรูปภาพไม่สำเร็จ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6123,60 +6127,60 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminAddTuner => 'เพิ่มจูนเนอร์';
 
   @override
-  String get adminEditTuner => 'แก้ไขจูนเนอร์';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'จูนเนอร์ M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ไฟล์หรือ URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'ที่อยู่ IP ของจูนเนอร์';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'ชื่อที่จดจำง่าย';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'ขีดจำกัดการเชื่อมต่อพร้อมกัน';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'จำนวนสตรีมสูงสุดที่จูนเนอร์รองรับพร้อมกัน ตั้งเป็น 0 เพื่อไม่จำกัด';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'บิตเรตสตรีมมิงสูงสุดสำรอง';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'นำเข้าเฉพาะช่องรายการโปรด';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'อนุญาตการแปลงสัญญาณด้วยฮาร์ดแวร์';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'อนุญาตคอนเทนเนอร์แปลงสัญญาณ fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'อนุญาตการแชร์สตรีม';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'เปิดการวนซ้ำสตรีม';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'ละเว้น DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'อ่านอินพุตตามอัตราเฟรมดั้งเดิม';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'แก้ไขผู้ให้บริการ';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6185,50 +6189,50 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ไฟล์หรือ URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'คำนำหน้าภาพยนตร์';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'หมวดหมู่ภาพยนตร์';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'คั่นหลายหมวดหมู่ด้วยเครื่องหมายขีดตั้ง (|)';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'หมวดหมู่สำหรับเด็ก';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'หมวดหมู่ข่าว';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'หมวดหมู่กีฬา';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ชื่อผู้ใช้';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'รหัสผ่าน';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'ประเทศ';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'เลือกประเทศ';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'รหัสไปรษณีย์';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'ดึงรายการช่อง';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'รายการช่อง';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'เปิดใช้งานจูนเนอร์ทั้งหมด';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'ประเภทจูนเนอร์';
@@ -6270,7 +6274,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'จูนเนอร์ประเภทนี้ไม่รองรับการรีเซ็ต';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6293,45 +6297,43 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminSeriesRecordingPath => 'เส้นทางการบันทึกซีรีส์';
 
   @override
-  String get adminMovieRecordingPath => 'เส้นทางบันทึกภาพยนตร์';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'จำนวนวันของข้อมูลผังรายการ';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'อัตโนมัติ';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days วัน';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'เส้นทางแอปพลิเคชันประมวลผลหลังบันทึก';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'อาร์กิวเมนต์ของตัวประมวลผลหลังบันทึก';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'บันทึกข้อมูลเมตา NFO ของรายการที่บันทึก';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'บันทึกรูปภาพของรายการที่บันทึก';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'การจับเวลา';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'เส้นทางการบันทึก';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'การประมวลผลหลังบันทึก';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'ข้อมูลผังรายการ: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6372,14 +6374,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminGuideProviders => 'ผู้ให้บริการคู่มือ';
 
   @override
-  String get adminRefreshGuideData => 'รีเฟรชข้อมูลผังรายการ';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => 'เริ่มรีเฟรชข้อมูลผังรายการแล้ว';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'งานรีเฟรชผังรายการไม่พร้อมใช้งานบนเซิร์ฟเวอร์นี้';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'เพิ่มผู้ให้บริการ';
@@ -6461,7 +6463,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminLiveTvTitle => 'การบริหารรายการถ่ายทอดสดทางโทรทัศน์';
 
   @override
-  String get adminApply => 'นำไปใช้';
+  String get adminApply => 'นำมาใช้';
 
   @override
   String get adminNotSet => 'ไม่ได้ตั้งค่า';
@@ -6513,7 +6515,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminMetadataEditorTitle => 'ตัวแก้ไขข้อมูลเมตา';
 
   @override
-  String get adminMetadataIdentify => 'ระบุข้อมูล';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'พิมพ์';
@@ -6528,7 +6530,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminMetadataImages => 'รูปภาพ';
 
   @override
-  String get adminMetadataFieldTitle => 'ชื่อเรื่อง';
+  String get adminMetadataFieldTitle => 'ชื่อ';
 
   @override
   String get adminMetadataFieldSortTitle => 'เรียงลำดับชื่อเรื่อง';
@@ -6795,7 +6797,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'นำออก';
+  String get adminReposRemove => 'ลบ';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6927,20 +6929,19 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminBrandingEnableSplash => 'เปิดใช้งานหน้าจอเริ่มต้น';
 
   @override
-  String get adminBrandingSplashUpload => 'อัปโหลดรูปภาพ';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'อัปเดตหน้าจอเริ่มต้นแล้ว';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'อัปโหลดหน้าจอเริ่มต้นไม่สำเร็จ';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'นำหน้าจอเริ่มต้นออกแล้ว';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'ไม่มีหน้าจอเริ่มต้นที่กำหนดเอง';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'การเร่งความเร็วด้วยฮาร์ดแวร์';
@@ -6956,126 +6957,121 @@ class AppLocalizationsTh extends AppLocalizations {
       'เปิดใช้งานการถอดรหัสฮาร์ดแวร์สำหรับ:';
 
   @override
-  String get adminPlaybackQsvDevice => 'อุปกรณ์ QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'เปิดใช้ตัวถอดรหัส NVDEC แบบปรับปรุง';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'ใช้ตัวถอดรหัสฮาร์ดแวร์ดั้งเดิมของระบบก่อน';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'ความลึกสีของการถอดรหัสด้วยฮาร์ดแวร์';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'การถอดรหัส HEVC 10 บิต';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'การถอดรหัส VP9 10 บิต';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'การถอดรหัส HEVC RExt 8/10 บิต';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'การถอดรหัส HEVC RExt 12 บิต';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'การเข้ารหัสด้วยฮาร์ดแวร์';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'อนุญาตการเข้ารหัส HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'อนุญาตการเข้ารหัส AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'เปิดใช้ตัวเข้ารหัส H.264 แบบประหยัดพลังงานของ Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'เปิดใช้ตัวเข้ารหัส HEVC แบบประหยัดพลังงานของ Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'การแมปโทนสี';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'เปิดการแมปโทนสี';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'เปิดการแมปโทนสีแบบ VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'เปิดการแมปโทนสีแบบ VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'อัลกอริทึมการแมปโทนสี';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'โหมดการแมปโทนสี';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'ช่วงการแมปโทนสี';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'การลดความอิ่มตัวสีของการแมปโทนสี';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'ค่าสูงสุดของการแมปโทนสี';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'พารามิเตอร์การแมปโทนสี';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'ความสว่างของการแมปโทนสีแบบ VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'คอนทราสต์ของการแมปโทนสีแบบ VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'ค่าที่ตั้งไว้และคุณภาพ';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'ค่าที่ตั้งไว้ของตัวเข้ารหัส';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'ค่า CRF การเข้ารหัส H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'ค่า CRF การเข้ารหัส H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'วิธีการดีอินเทอร์เลซ';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'เพิ่มอัตราเฟรมเป็นสองเท่าเมื่อดีอินเทอร์เลซ';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'เสียง';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'เปิดการเข้ารหัสเสียงแบบ VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'การเพิ่มระดับเสียงเมื่อดาวน์มิกซ์';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm =>
-      'อัลกอริทึมดาวน์มิกซ์เป็นสเตอริโอ';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'ขนาดคิวมักซ์สูงสุด';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'อัตโนมัติ';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'การเข้ารหัส';
@@ -7195,7 +7191,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminTaskStop => 'หยุด';
 
   @override
-  String get adminRunningTasks => 'งานที่กำลังทำงาน';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'วิ่ง';
@@ -7265,8 +7261,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ชั่วโมง',
-      one: '1 ชั่วโมง',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7312,27 +7308,27 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes นาที';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours ชม.';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days วัน';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'กำหนดค่าการสร้างรูปภาพ Trickplay สำหรับภาพตัวอย่างขณะเลื่อนหา';
+      'กำหนดค่าการสร้างภาพเล่นกลเพื่อค้นหาภาพขนาดย่อตัวอย่าง';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'พอร์ต HTTPS สาธารณะ';
@@ -7341,49 +7337,49 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'URL ฐาน';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'เช่น /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'เช่น /เจลลี่ฟิน';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'พอร์ต HTTP สาธารณะ';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'บังคับใช้ HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'เปลี่ยนเส้นทางคำขอจากระยะไกลทั้งหมดไปยัง HTTPS จะไม่มีผลหากเซิร์ฟเวอร์ไม่มีใบรับรองที่ถูกต้อง';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'รหัสผ่านใบรับรอง';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'การตั้งค่า IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'เปิดใช้งาน IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'เปิดใช้งาน IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'เปิดการแมปพอร์ตอัตโนมัติ';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'เครือข่าย LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'รายการที่อยู่ IP หรือซับเน็ต CIDR ที่ถือว่าอยู่ในเครือข่ายท้องถิ่น คั่นด้วยเครื่องหมายจุลภาคหรือขึ้นบรรทัดใหม่';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI ของเซิร์ฟเวอร์ที่เผยแพร่';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'แมปซับเน็ตหรือที่อยู่ไปยัง URL ที่เผยแพร่ เช่น all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'เส้นทางใบรับรอง';
@@ -7413,11 +7409,11 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'การบัฟเฟอร์คันเร่ง';
 
   @override
-  String get adminPlaybackThrottleDelay => 'ความหน่วงของการจำกัดอัตรา (วินาที)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'อนุญาตให้ดึงคำบรรยายแบบทันที';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'เปอร์เซ็นต์เรซูเม่ขั้นต่ำ';
@@ -7474,22 +7470,22 @@ class AppLocalizationsTh extends AppLocalizations {
       'เกณฑ์การตอบสนองช้า (มิลลิวินาที)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'เปิดคำเตือนเมื่อตอบสนองช้า';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'เปิดใช้งาน Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'เซิร์ฟเวอร์';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'ข้อมูลเมตา';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'เส้นทาง';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'ประสิทธิภาพ';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'เส้นทางแคช';
@@ -7501,7 +7497,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminGeneralServerName => 'ชื่อเซิร์ฟเวอร์';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ภาษาที่ต้องการแสดงผล';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'โหลดการตั้งค่าไม่สำเร็จ';
@@ -7523,7 +7519,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get folders => 'โฟลเดอร์';
 
   @override
-  String get libraries => 'ไลบรารี';
+  String get libraries => 'ห้องสมุด';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7553,8 +7549,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'ผู้เข้าร่วม # คน',
-      one: 'ผู้เข้าร่วม # คน',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7700,8 +7696,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'พบ # แถว',
-      one: 'พบ # แถว',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7742,20 +7738,20 @@ class AppLocalizationsTh extends AppLocalizations {
   String get offlineSavedMedia => 'สื่อที่บันทึกไว้';
 
   @override
-  String get offlineBannerTitle => 'คุณออฟไลน์อยู่';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'กำลังแสดงรายการที่ดาวน์โหลดไว้';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'ดาวน์โหลด';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'เชื่อมต่อเซิร์ฟเวอร์ของคุณไม่ได้';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'กำลังเล่นจากรายการที่ดาวน์โหลดไว้จนกว่าจะกลับมา';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7828,13 +7824,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get pinForgot => 'ลืมรหัส PIN?';
 
   @override
-  String get pinClear => 'ล้าง';
+  String get pinClear => 'ชัดเจน';
 
   @override
   String get pinBackspace => 'แบ็คสเปซ';
 
   @override
-  String get quickConnectAuthorized => 'อนุมัติคำขอ Quick Connect แล้ว';
+  String get quickConnectAuthorized => 'อนุมัติคำขอเชื่อมต่อด่วนแล้ว';
 
   @override
   String get quickConnectInvalidOrExpired =>
@@ -7842,7 +7838,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get quickConnectNotSupported =>
-      'เซิร์ฟเวอร์นี้ไม่รองรับ Quick Connect';
+      'ไม่รองรับการเชื่อมต่อด่วนบนเซิร์ฟเวอร์นี้';
 
   @override
   String get quickConnectAuthorizeFailed =>
@@ -7857,11 +7853,11 @@ class AppLocalizationsTh extends AppLocalizations {
       'บัญชีของคุณไม่สามารถอนุญาตคำขอ Quick Connect นี้';
 
   @override
-  String get quickConnectNotFound => 'ไม่พบรหัส Quick Connect ลองใช้รหัสใหม่';
+  String get quickConnectNotFound => 'ไม่พบรหัสการเชื่อมต่อด่วน ลองรหัสใหม่';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect ล้มเหลว: $message';
+    return 'การเชื่อมต่อด่วนล้มเหลว: $message';
   }
 
   @override
@@ -7965,7 +7961,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get shuffleSelectGenre => 'เลือกประเภท';
 
   @override
-  String get shuffleLibrary => 'ไลบรารี';
+  String get shuffleLibrary => 'ห้องสมุด';
 
   @override
   String get shuffleGenre => 'ประเภท';
@@ -8109,13 +8105,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get contextMenuGoToSeries => 'ไปที่ซีรีส์';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'ซ่อนจากรายการดูต่อ';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'ซ่อนจากรายการถัดไป';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'เพิ่มลงคอลเลกชัน';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8168,14 +8165,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsAlphabetical => 'ตามตัวอักษร';
 
   @override
-  String get settingsConnectionSection => 'การเชื่อมต่อ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'อนุญาตใบรับรองที่ลงนามด้วยตนเอง';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'เชื่อถือเซิร์ฟเวอร์ที่ใช้ใบรับรอง TLS แบบลงนามด้วยตนเองหรือจาก CA ส่วนตัว เปิดใช้เฉพาะกับเซิร์ฟเวอร์ที่คุณควบคุมเท่านั้น การตั้งค่านี้จะปิดการตรวจสอบใบรับรองสำหรับทุกการเชื่อมต่อ';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'ความเป็นส่วนตัวและความปลอดภัย';
@@ -8191,11 +8188,11 @@ class AppLocalizationsTh extends AppLocalizations {
       'การเน้นเสียงของธีม ฉากหลัง สัญลักษณ์แสดงการดู และเพลงของธีม';
 
   @override
-  String get settingsDetailsScreen => 'หน้ารายละเอียด';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'สไตล์ การเบลอพื้นหลัง และการทำงานของแท็บ';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'หน้าแรก';
@@ -8230,11 +8227,12 @@ class AppLocalizationsTh extends AppLocalizations {
       'แสดงปุ่มไลบรารีในแถบนำทาง';
 
   @override
-  String get settingsShowSeerrButtonInNavigation => 'แสดงปุ่ม Seerr ในแถบนำทาง';
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'แสดงชื่อเมนูในแถบนำทางด้านบนเสมอ';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8301,7 +8299,8 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsSupportMoonfin => 'สนับสนุน Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'เลี้ยงกาแฟให้นักพัฒนา';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ถูกกฎหมาย';
@@ -8334,8 +8333,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'ประกาศลิขสิทธิ์ # รายการ',
-      one: 'ประกาศลิขสิทธิ์ # รายการ',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8382,16 +8381,16 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'ข้ามช่วงแนะนำและส่วนท้ายใช่ไหม';
 
   @override
-  String get settingsMediaSegmentCountdown => 'การนับถอยหลังของช่วงสื่อ';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'แถบความคืบหน้า';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ตัวจับเวลา';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'ไม่มี';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'ผู้ใช้พร้อมท์';
@@ -8615,7 +8614,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName ที่เพิ่งออกฉาย';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8647,11 +8646,11 @@ class AppLocalizationsTh extends AppLocalizations {
       'บังคับให้เล่นแบบไม่มีช่องสัญญาณ มีประโยชน์บนอุปกรณ์ที่มีความไม่ต่อเนื่องของเสียง/วิดีโอแบบทันเนล';
 
   @override
-  String get enableTunnelingTitle => 'เปิดใช้งาน Tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'ขั้นสูง ส่งเสียงและวิดีโอผ่านเส้นทางฮาร์ดแวร์ที่เชื่อมต่อกัน ปิดไว้เป็นค่าเริ่มต้นเพราะทำให้เสียงหรือภาพขาดหายบนอุปกรณ์บางรุ่น';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'แมป Dolby Vision โปรไฟล์ 7 ไปยัง HEVC';
@@ -8676,14 +8675,14 @@ class AppLocalizationsTh extends AppLocalizations {
       'ใช้คำแนะนำขนาดตัวอักษรที่ฝังอยู่ในแทร็กคำบรรยาย ปิดการใช้งานเพื่อใช้ขนาดคำบรรยายจากการตั้งค่าสไตล์ของคุณ';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'แสดงรายละเอียดสื่อ';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'แสดงรายละเอียดของรายการที่เลือกไว้ด้านบนของหน้าคลังสื่อ';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'ซ่อนภาพพื้นหลังขณะเรียกดูหรือไม่?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'ใช้หัวข้อย่อยโดยละเอียด';
@@ -8701,37 +8700,37 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'ร้านธีม';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'เรียกดูและบันทึกธีมจากชุมชน';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'บันทึกธีมเพื่อใช้งานเหมือนธีมอื่นที่คุณบันทึกไว้';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ยังไม่มีธีมให้ใช้งานในขณะนี้';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'โหลดร้านธีมไม่สำเร็จ ตรวจสอบการเชื่อมต่อแล้วลองอีกครั้ง';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'บันทึก';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'บันทึกและใช้งาน';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'บันทึกแล้ว';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'โหลดธีมนี้ไม่สำเร็จ';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'บันทึก \"$themeName\" แล้ว';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8789,21 +8788,21 @@ class AppLocalizationsTh extends AppLocalizations {
   String get homeRowsSection => 'แถวบ้าน';
 
   @override
-  String get homeRowDisplay => 'การแสดงผลแถวหน้าแรก';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'ส่วนของแถวหน้าแรก';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'สวิตช์แถวหน้าแรก';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'เปิดหรือปิดหมวดหมู่แถวหน้าแรกที่อิงตามคลังสื่อ';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'เปิดสวิตช์ต่อไปนี้เพื่อแสดงแถวในส่วนของหน้าแรก';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'ประเภทแถว';
@@ -8860,55 +8859,55 @@ class AppLocalizationsTh extends AppLocalizations {
       'แสดงภาพยนตร์ ซีรีส์ หรือทั้งสองอย่างในแถวประเภท';
 
   @override
-  String get displayPlaylistsRows => 'แสดงแถวเพลย์ลิสต์';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'แสดงแถวเพลย์ลิสต์ในส่วนของหน้าแรก';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'การเรียงลำดับแถวเพลย์ลิสต์';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'เรียงแถวเพลย์ลิสต์ตามวันที่เพิ่ม วันที่ออกฉาย ตามตัวอักษร และอื่นๆ';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'แสดงแถวเสียง';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => 'แสดงแถวเสียงในส่วนของหน้าแรก';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'การเรียงลำดับแถวเสียง';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'เรียงแถวเสียงตามวันที่เพิ่ม วันที่ออกฉาย ตามตัวอักษร และอื่นๆ';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'เพลย์ลิสต์เสียง';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'รูปลักษณ์';
+  String get appearance => 'รูปร่าง';
 
   @override
-  String get layout => 'เลย์เอาต์';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'ธีม';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'แป้นพิมพ์';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'ปุ่ม';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'การเรนเดอร์';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'การกำหนดค่า MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'ขนาดการ์ด';
@@ -8918,7 +8917,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'ตั้งค่าโปรแกรมเล่นภายนอกเพื่อเปิดใช้ตัวเลือกเล่นแบบกดค้าง';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9180,10 +9179,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get guestAppearances => 'การปรากฏตัวของแขก';
 
   @override
-  String get appearancesSeerr => 'การปรากฏตัว (Seerr)';
+  String get appearancesSeerr => 'การปรากฏตัว (เซียร์)';
 
   @override
-  String get crewContributionsSeerr => 'ผลงานทีมงาน (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'ดูกับกลุ่ม.';
@@ -9267,8 +9266,8 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count คลังสื่อ',
-      one: '1 คลังสื่อ',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9359,7 +9358,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get mixedMoviesAndShows => 'ภาพยนตร์และรายการผสม';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Intel ซิงค์ด่วน';
 
   @override
   String get rockchipMpp => 'ร็อคชิป เอ็มพีพี';
@@ -9426,13 +9425,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get loadingShuffle => 'กำลังโหลดแบบสุ่ม...';
 
   @override
-  String get libraryShuffleLabel => 'สุ่มจากคลังสื่อ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'สุ่มทั้งหมด';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'สุ่มตามแนว';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'การสลับ HDR อัตโนมัติ';
@@ -9445,222 +9444,222 @@ class AppLocalizationsTh extends AppLocalizations {
   String get whenFullscreen => 'เมื่อเปิดเต็มจอ';
 
   @override
-  String get changeArtwork => 'เปลี่ยนภาพปก';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'ไม่มี';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'ขีดจำกัดการแปลงรหัส';
 
   @override
-  String get clearAllArtworkButton => 'ล้างภาพปกทั้งหมดหรือไม่?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'คุณแน่ใจหรือไม่ว่าต้องการล้างภาพปกที่ดาวน์โหลดไว้ทั้งหมด?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'ยืนยันการล้าง';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'คุณแน่ใจหรือไม่ว่าต้องการล้าง$itemTypeนี้?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'อัปโหลดหรือไม่?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'ความละเอียด: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'แสดงเฉพาะภาพปกที่ตรงกับภาษาอินเทอร์เฟซ';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'ยืนยันการล้างทั้งหมด';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'อัปโหลดรูปภาพสำเร็จ!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'อัปโหลดรูปภาพไม่สำเร็จ: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'ตั้งค่ารูปภาพไม่สำเร็จ: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'ลบรูปภาพไม่สำเร็จ: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'ล้างภาพปกทั้งหมดไม่สำเร็จ: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ใช่';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'โปสเตอร์';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'ภาพพื้นหลัง';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'แบนเนอร์';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'โลโก้';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'ภาพขนาดย่อ';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'ภาพประกอบ';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'ภาพหน้าแผ่น';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'ภาพหน้าจอ';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'ปกกล่อง';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'ปกหลังกล่อง';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'ภาพเมนู';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'โปสเตอร์';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ภาพพื้นหลัง';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'แบนเนอร์';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'โลโก้';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'ภาพขนาดย่อ';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ภาพประกอบ';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ภาพหน้าแผ่น';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ภาพหน้าจอ';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'ปกกล่อง';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'ปกหลังกล่อง';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ภาพเมนู';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'ทั้งหมด';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'สูง (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'ปานกลาง (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'ต่ำ (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'แหล่งที่มา';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'บท';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'ที่คั่นหนังสือ';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'บันทึก';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'คิว';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ไทม์ไลน์';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ไทม์ไลน์ว่างเปล่า';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'ทั้งเล่ม';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'ไทม์ไลน์เฉพาะจุด';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'ส่งออกที่คั่นหนังสือ';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'ส่งออกบันทึก';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'ส่งออกทั้งหมด';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'ส่งออกไปยัง $path แล้ว';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'ส่งออกไม่สำเร็จ: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'เนื้อเพลง';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'เพิ่มที่คั่นหนังสือ';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'เพิ่มบันทึก';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'แก้ไขบันทึก';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'เขียนบันทึกสำหรับช่วงนี้';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'ตั้งเวลาปิด';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'ปิด';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'จบบท';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'กำหนดเอง';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'เหลือ $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9668,58 +9667,58 @@ class AppLocalizationsTh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count นาที',
-      one: '1 นาที',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'ความเร็วในการเล่น';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'เวลาที่เหลือ';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'เวลาที่ผ่านไป';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'ถอยหลัง $seconds วิ';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'เดินหน้า $seconds วิ';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'บทก่อนหน้า';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'บทถัดไป';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'บทที่ $current จาก $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'ไม่มีบท';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'ยังไม่มีที่คั่นหนังสือ';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'ยังไม่มีบันทึก';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'เพิ่มที่คั่นหนังสือที่ $position แล้ว';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'รีเซ็ตเป็น 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9727,250 +9726,249 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'บันทึก';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'ยกเลิก';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'ลบ';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'การตั้งค่าคำบรรยาย';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'เปลี่ยนโหมดคำบรรยาย ภาษาเริ่มต้น รูปลักษณ์ และตัวเลือกการเรนเดอร์';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'การเรนเดอร์คำบรรยาย';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'ตัวเลือกการแสดงผล';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'วันที่ออกฉาย (เก่าไปใหม่)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'วันที่ออกฉาย (ใหม่ไปเก่า)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'จัดกลุ่มผลงาน';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'จัดกลุ่มบทบาทหลายบทบาท';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'คำเตือนสิทธิ์การเขียนในคลังสื่อ';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'วิธีแก้ไข:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. ให้สิทธิ์การเขียนแก่ผู้ใช้ของบริการ Jellyfin (เช่น jellyfin หรือ PUID/PGID ของ Docker) สำหรับโฟลเดอร์คลังสื่อของคุณบนเซิร์ฟเวอร์\n\n2. หรือไปที่แดชบอร์ด Jellyfin -> คลังสื่อ แก้ไขคลังสื่อนี้ แล้วปิด \'Save artwork into media folders\' เพื่อจัดเก็บภาพปกไว้ในฐานข้อมูลภายในของ Jellyfin';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'ปิด';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'คลังสื่อ \'$libraryName\' ของคุณถูกตั้งค่าให้บันทึกภาพปกลงในโฟลเดอร์สื่อโดยตรง (เปิด \'Save artwork into media folders\' ไว้) แต่ Jellyfin ได้ทดสอบสิทธิ์การเขียนแล้วและไม่มีสิทธิ์เขียนไฟล์ลงในไดเรกทอรีนี้:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'ดูเหมือนว่า Jellyfin จะอัปเดตภาพปกไม่สำเร็จ คลังสื่อของคุณถูกตั้งค่าให้บันทึกภาพปกลงในโฟลเดอร์สื่อโดยตรง (เปิด \'Save artwork into media folders\' ไว้) ข้อผิดพลาดนี้มักเกิดขึ้นเมื่อโปรเซสของเซิร์ฟเวอร์ Jellyfin ไม่มีสิทธิ์เขียนไฟล์ลงในไดเรกทอรีสื่อของคุณ';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'รายการภายนอก';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'เล่นอีกครั้ง';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ข้อมูลไฟล์';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'ขนาด: $size  •  รูปแบบ: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'แสดงแทร็กเสียงทั้งหมด ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'แสดงแทร็กคำบรรยายทั้งหมด ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'กำลังตรวจสอบความสามารถในการเล่นโดยตรง...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'ความสามารถในการเล่นโดยตรง: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'บังคับ';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'โปรแกรมเล่นไม่รองรับรูปแบบคอนเทนเนอร์นี้';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'ไม่รองรับตัวแปลงสัญญาณวิดีโอนี้';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'ไม่รองรับตัวแปลงสัญญาณเสียงนี้';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'ไม่รองรับรูปแบบคำบรรยายนี้ (ต้องฝังลงในภาพ)';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'ไม่รองรับโปรไฟล์เสียงนี้';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'ไม่รองรับโปรไฟล์วิดีโอนี้';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'ไม่รองรับระดับวิดีโอนี้';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'อุปกรณ์นี้ไม่รองรับความละเอียดวิดีโอนี้';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'ไม่รองรับความลึกบิตของวิดีโอนี้';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'ไม่รองรับอัตราเฟรมของวิดีโอนี้';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'บิตเรตของไฟล์เกินขีดจำกัดการสตรีมของโปรแกรมเล่น';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'บิตเรตวิดีโอเกินขีดจำกัดการสตรีม';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'บิตเรตเสียงเกินขีดจำกัดการสตรีม';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ไม่รองรับจำนวนช่องสัญญาณเสียงนี้';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'ตามตัวอักษร';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'ลำดับการออกฉาย (เก่าไปใหม่)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'ลำดับการออกฉาย (ใหม่ไปเก่า)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'กำหนดเอง (ลากและวาง)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'ตัวเลือกการเรียงเพลย์ลิสต์';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'รีเซ็ตการเรียงลำดับ';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'ดูซ้ำ S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'เพลย์ลิสต์ดูซ้ำ';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'ไม่พบคำบรรยาย';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'การควบคุมของผู้ดูแล';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'เอนจินการเรนเดอร์ (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller คือตัวเรนเดอร์ GPU สมัยใหม่ของ Flutter ที่ให้ภาพเคลื่อนไหวลื่นไหลและกระตุกน้อยลง บนกล่องทีวีบางรุ่นและ GPU รุ่นเก่าอาจทำให้ภาพผิดเพี้ยนหรือวิดีโอเป็นสีดำ หากพบปัญหาให้ปิดไว้ อัตโนมัติจะเลือกค่าที่ดีที่สุดสำหรับอุปกรณ์ของคุณ รีสตาร์ท Moonfin เพื่อใช้งาน';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'อัตโนมัติ';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'เปิด';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'ปิด';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'ต้องรีสตาร์ท';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin ต้องรีสตาร์ทเพื่อเปลี่ยนเอนจินการเรนเดอร์ ปิดแอปตอนนี้ แล้วเปิดใหม่เพื่อใช้งาน';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ปิดแอปตอนนี้';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'รีเฟรชคลังสื่อ';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'รีเฟรชคลังสื่อทั้งหมด';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'วันที่เพิ่ม (เก่าสุดก่อน)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'วันที่เพิ่ม (ใหม่สุดก่อน)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'ตามตัวอักษร (A ถึง Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'ตามตัวอักษร (Z ถึง A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'กำลังโหลดข้อมูลวิเคราะห์เซิร์ฟเวอร์... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'ตามต้นฉบับ';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'ภาพยนตร์ 250 อันดับแรกของ IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'รายการทีวี 250 อันดับแรกของ IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'ภาพยนตร์ยอดนิยมที่สุดของ IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'รายการทีวียอดนิยมที่สุดของ IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'ภาพยนตร์คะแนนต่ำสุดของ IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'ภาพยนตร์ภาษาอังกฤษคะแนนสูงสุดของ IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -12,19 +12,19 @@ class AppLocalizationsTl extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'MGA KAGUSTUHAN SA ACCOUNT';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Wika ng Interface';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Default ng System';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Mag-sign In';
 
   @override
-  String get empty => 'Walang laman';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Mabilis na Kumonekta';
 
   @override
   String get password => 'Password';
@@ -142,11 +142,11 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Tema ng App';
 
   @override
-  String get detailScreenStyle => 'Istilo ng detail screen';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Ang Classic ay ang orihinal na nakasentrong layout ng Moonfin. Ang Modern ay isang responsive na cinematic na layout.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
   String get detailScreenStyleMoonfin => 'Classic';
@@ -155,25 +155,25 @@ class AppLocalizationsTl extends AppLocalizations {
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Mga Naka-expand na Tab';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Awtomatikong ipakita ang nilalaman ng tab habang nagba-browse ng mga tab. I-off para manu-manong buksan at isara ang bawat tab.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Ipakita ang Mga Teknikal na Detalye?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Ipakita ang impormasyon ng codec, resolution, at stream sa buod ng banner';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Sistema ng Rekomendasyon';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Gamitin ang local-library na algorithm ng Moonfin Recommends o ang online na Similarity Metrics ng TMDb. Tandaan: Kailangan ng Seerr integration para sa mga online na rekomendasyon.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
@@ -183,18 +183,18 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Ilapat ang Limitasyon sa Parental Rating?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limitahan ang mga suhestiyon ng Moonfin Recommends ayon sa parental rating ng target na media';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Istilo ng Interface';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Tumutugma ang Automatic sa iyong device. Pumili ng Apple o Material para piliting gamitin ang isang hitsura.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
   String get interfaceStyleAutomatic => 'Automatic';
@@ -206,11 +206,11 @@ class AppLocalizationsTl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Kalidad ng Glass';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Pinipili ng Auto ang pinakamahusay na glass effect para sa device na ito. Pinipilit ng Full ang tunay na blur; gumagamit ang Reduced ng magaan na glass na nakakatipid ng GPU power.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
@@ -226,11 +226,11 @@ class AppLocalizationsTl extends AppLocalizations {
       'Lumipat sa pagitan ng Moonfin at Neon Pulse nang hindi nire-restart ang app';
 
   @override
-  String get customThemeTitle => 'Custom na Theme';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Binabago ng mga custom na theme ang mga visual na elemento sa buong Moonfin. Pumili ng isa sa mga opsyong ito para tumugma sa iyong istilo.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Mas gusto ang keyboard ng system';
@@ -258,14 +258,14 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid-glass na istilo na may gumagalaw na gradient na backdrop, mga frosted na surface, at Apple-blue na accent';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro na pixel-art na istilo na may makapal na palette, blocky na mga border, matitinding drop-shadow, at pixel font';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -331,32 +331,32 @@ class AppLocalizationsTl extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Naka-pause';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'I-save ang state';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Mga Laro';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'I-load ang state';
+  String get gameLoadState => 'Load state';
 
   @override
   String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Mga setting ng emulator';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Walang naaayos na opsyon ang core na ito.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Pindutin nang matagal para buksan ang menu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Hindi pa suportado ang paglalaro sa device na ito.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Walang mga home row ang ma-load';
@@ -384,7 +384,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noItemsFound => 'Walang nakitang mga item';
 
   @override
-  String get home => 'Home';
+  String get home => 'Bahay';
 
   @override
   String get browseAll => 'I-browse Lahat';
@@ -416,7 +416,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noLibrariesFound => 'Walang nakitang mga aklatan';
 
   @override
-  String get library => 'Library';
+  String get library => 'Aklatan';
 
   @override
   String get displaySettings => 'Mga Setting ng Display';
@@ -491,7 +491,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get large => 'Malaki';
 
   @override
-  String get extraLarge => 'Napakalaki';
+  String get extraLarge => 'Extra Large';
 
   @override
   String libraryGenresTitle(String name) {
@@ -508,7 +508,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get albumArtists => 'Mga Artist ng Album';
 
   @override
-  String get artists => 'Mga artist';
+  String get artists => 'Mga artista';
 
   @override
   String get bookmarks => 'Mga bookmark';
@@ -555,7 +555,7 @@ class AppLocalizationsTl extends AppLocalizations {
       'Piliin kung aling mga feed ng paksa ang ipapakita sa Discover.';
 
   @override
-  String get apply => 'Ilapat';
+  String get apply => 'Mag-apply';
 
   @override
   String get openLink => 'Buksan ang Link';
@@ -604,7 +604,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get listen => 'Makinig ka';
 
   @override
-  String get resume => 'Ituloy';
+  String get resume => 'Ipagpatuloy';
 
   @override
   String get failedToLoadLibrary => 'Nabigong i-load ang library';
@@ -697,7 +697,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get titles => 'Mga title';
+  String get titles => 'Mga pamagat';
 
   @override
   String get allTitles => 'Lahat ng Pamagat';
@@ -749,13 +749,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get readStatus => 'Basahin';
 
   @override
-  String get watched => 'Napanood na';
+  String get watched => 'Napanood';
 
   @override
   String get unread => 'Hindi pa nababasa';
 
   @override
-  String get unwatched => 'Hindi pa napanood';
+  String get unwatched => 'Hindi napanood';
 
   @override
   String get seriesStatus => 'Katayuan ng Serye';
@@ -767,43 +767,43 @@ class AppLocalizationsTl extends AppLocalizations {
   String get books => 'Mga libro';
 
   @override
-  String get latestBooks => 'Mga Pinakabagong Aklat';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Mga Pinakabagong Audiobook';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na aklat',
-      one: '1 aklat',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Aklat';
+  String get bookFormatBook => 'Book';
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% nabasa';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time na natitira';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Basahin';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Pakinggan';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'May-akda';
@@ -880,7 +880,7 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na audiobook',
+      other: '$count audiobooks',
       one: '1 audiobook',
     );
     return '$_temp0';
@@ -896,7 +896,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get failedToLoad => 'Nabigong mag-load';
 
   @override
-  String get delete => 'I-delete';
+  String get delete => 'Tanggalin';
 
   @override
   String get save => 'I-save';
@@ -917,7 +917,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get nextUp => 'Next Up';
 
   @override
-  String get seasons => 'Mga season';
+  String get seasons => 'Mga panahon';
 
   @override
   String get chapters => 'Mga kabanata';
@@ -986,7 +986,7 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na Season',
+      other: '$count Seasons',
       one: '1 Season',
     );
     return '$_temp0';
@@ -998,40 +998,40 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get items => 'Mga Item';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Mga Extra';
+  String get extras => 'Extras';
 
   @override
   String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Mga Deleted Scene';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Mga Featurette';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Mga Panayam';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Mga Eksena';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Mga Short';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Mga trailer';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time na natitira';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Matatapos sa $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,7 +1049,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get play => 'I-play';
+  String get play => 'Maglaro';
 
   @override
   String get startOver => 'Magsimulang Muli';
@@ -1073,7 +1073,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get version => 'Bersyon';
 
   @override
-  String get cast => 'I-cast';
+  String get cast => 'Cast';
 
   @override
   String get trailer => 'Trailer';
@@ -1192,7 +1192,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get subtitleTrack => 'Subtitle na Track';
 
   @override
-  String get none => 'Wala';
+  String get none => 'wala';
 
   @override
   String get downloadSubtitlesLabel => 'Mag-download ng mga subtitle...';
@@ -1273,10 +1273,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
-  String get directors => 'MGA DIREKTOR';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'MANUNULAT';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'MGA MANUNULAT';
@@ -1314,7 +1314,7 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na track',
+      other: '$count tracks',
       one: '1 track',
     );
     return '$_temp0';
@@ -1325,8 +1325,8 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na kabanata',
-      one: '1 kabanata',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1353,16 +1353,16 @@ class AppLocalizationsTl extends AppLocalizations {
   String get readMore => 'Magbasa pa';
 
   @override
-  String get shuffle => 'I-shuffle';
+  String get shuffle => 'Balasahin';
 
   @override
-  String get shuffleAllMusic => 'I-shuffle ang lahat ng musika';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Mag-sign in sa Moonfin sa iyong telepono';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Hindi maabot ang iyong server';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1370,7 +1370,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get perfectMatch => 'Perpektong tugma';
+  String get perfectMatch => 'Perfect match';
 
   @override
   String channelsCount(int count) {
@@ -1563,7 +1563,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get transcodeReasons => 'Mga Dahilan ng Transcode';
 
   @override
-  String get player => 'Player';
+  String get player => 'Manlalaro';
 
   @override
   String get container => 'Lalagyan';
@@ -1587,7 +1587,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get videoBitrate => 'Bitrate ng Video';
 
   @override
-  String get track => 'Track';
+  String get track => 'Subaybayan';
 
   @override
   String get channels => 'Mga channel';
@@ -1805,22 +1805,22 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Susunod: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m na natitira';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h na natitira';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m na natitira';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1843,7 +1843,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get favoriteChannel => 'Paboritong Channel';
 
   @override
-  String get record => 'I-record';
+  String get record => 'Itala';
 
   @override
   String get cancelRecordingAction => 'Kanselahin ang Pagre-record';
@@ -2071,7 +2071,7 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na episode',
+      other: '$count episodes',
       one: '1 episode',
     );
     return '$_temp0';
@@ -2300,7 +2300,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Mga detail page, home row, at volume';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2315,11 +2315,11 @@ class AppLocalizationsTl extends AppLocalizations {
       'I-play kapag nagba-browse sa home screen';
 
   @override
-  String get loopThemeMusic => 'I-loop ang Theme Music';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Ulitin ang track sa halip na patugtugin ito nang isang beses';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Mga Detalye ng Background Blur';
@@ -2333,7 +2333,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get browsingBackgroundBlur => 'Pag-browse sa Background Blur';
 
   @override
-  String get maxStreamingBitrate => 'Max na Streaming Bitrate';
+  String get maxStreamingBitrate => 'Max Streaming Bitrate';
 
   @override
   String get maxResolution => 'Max na Resolusyon';
@@ -2346,13 +2346,13 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Piliin kung ano ang ginagawa ng pag-scroll ng mouse wheel sa ibabaw ng video habang nagpe-playback.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Naka-off';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Seek (pasulong / paatras)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2373,7 +2373,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get refreshRateSwitching => 'Paglipat ng Rate ng Pag-refresh';
 
   @override
-  String get disabled => 'Naka-disable';
+  String get disabled => 'Hindi pinagana';
 
   @override
   String get scaleOnTv => 'Scale sa TV';
@@ -2412,21 +2412,21 @@ class AppLocalizationsTl extends AppLocalizations {
   String get defaultAudioLanguage => 'Default na Wika ng Audio';
 
   @override
-  String get fallbackAudioLanguage => 'Fallback na Wika ng Audio';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Piliin ang Default na Audio Track';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Piliin ang orihinal na audio track kaysa sa localized na dub.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Piliin ang Mga Audio Description Track';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Piliin ang mga audio description track kaysa sa mga normal na track.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
   String get transcodingAudio => 'Transcoding (Audio)';
@@ -2436,10 +2436,10 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcoding (Bitrate o Resolution)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcoding (Video at Audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
   String get transcodingVideo => 'Transcoding (Video)';
@@ -2478,28 +2478,28 @@ class AppLocalizationsTl extends AppLocalizations {
   String get russian => 'Ruso';
 
   @override
-  String get arabic => 'Arabe';
+  String get arabic => 'Arabic';
 
   @override
   String get hindi => 'Hindi';
 
   @override
-  String get dutch => 'Olandes';
+  String get dutch => 'Dutch';
 
   @override
-  String get swedish => 'Suweko';
+  String get swedish => 'Swedish';
 
   @override
-  String get norwegian => 'Norwego';
+  String get norwegian => 'Norwegian';
 
   @override
-  String get danish => 'Danes';
+  String get danish => 'Danish';
 
   @override
-  String get finnish => 'Finlandes';
+  String get finnish => 'Finnish';
 
   @override
-  String get polish => 'Polako';
+  String get polish => 'Polish';
 
   @override
   String get ac3Passthrough => 'AC3 Passthrough';
@@ -2519,24 +2519,24 @@ class AppLocalizationsTl extends AppLocalizations {
       'Paganahin ang TrueHD audio (maaaring hindi gumana sa lahat ng platform)';
 
   @override
-  String get settingsAudioOutputMode => 'Mode ng Audio Output';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Piliin kung paano ide-decode ang audio. Ipinapadala ng AVR Passthrough ang mga raw na Dolby/DTS stream sa iyong receiver; nagde-decode nang lokal ang Auto o Downmix.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Fallback na Audio Codec';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Piliin ang target na format para i-transcode ang multi-channel na audio kapag hindi maaaring direct-play o mapasa ang source stream.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Inirerekomenda)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
   String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
@@ -2551,7 +2551,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Lang)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
   String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
@@ -2560,15 +2560,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max na Audio Channel';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'I-configure ang pinakamaraming channel ng iyong audio setup. Ang mga multichannel na stream na lumalampas sa limitasyong ito ay ida-downmix o ita-transcode.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Auto Detect\n(Default ng Hardware)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2862,36 +2861,36 @@ class AppLocalizationsTl extends AppLocalizations {
   String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Palagi';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Dayuhan';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
   String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Nagpe-play ng mga track na panloob na na-flag sa metadata ng media file bilang \"default\" o \"forced\".';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Awtomatikong nilo-load at ipinapakita ang mga subtitle sa tuwing magsisimula ang isang video.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Awtomatikong ino-on ang mga subtitle kung ang default na audio track ay nasa wikang dayuhan.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Nilo-load lang ang mga subtitle na tahasang na-tag ng forced na metadata flag.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Ganap na hindi pinapagana ang awtomatikong pag-load ng subtitle.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Fallback na Wika ng Subtitle';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
   String get subtitleStream => 'Subtitle Stream';
@@ -3001,7 +3000,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get network => 'Network';
 
   @override
-  String get wifiOnlyDownloads => 'Mga Download sa WiFi Lang';
+  String get wifiOnlyDownloads => 'WiFi-Only Downloads';
 
   @override
   String get reportDownloadsActivity => 'Ipakita ang mga download sa server';
@@ -3101,14 +3100,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Ipakita ang Mga Aklatan sa Toolbar';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'Palaging I-expand ang Mga Label ng Navbar';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Ipakita ang Seerr Button';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
-  String get navbarOpacity => 'Opacity ng Navbar';
+  String get navbarOpacity => 'Navbar Opacity';
 
   @override
   String get navbarColor => 'Kulay ng Navbar';
@@ -3181,20 +3179,18 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ipakita ang opsyon sa pagba-browse ng folder';
 
   @override
-  String get groupItemsIntoCollections =>
-      'Pagsama-samahin ang Mga Item sa Mga Collection';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Itago ang mga library item na kaugnay ng Collection kapag nagba-browse ng mga library';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Paunawa sa Paggrupo ng Library';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Para gamitin ang setting na ito, pakisiguro na naka-enable ang mga Library setting na \"Group movies into collections\" at/o \"Group shows into collections\" sa ilalim ng Display setting ng iyong library sa iyong Jellyfin o Emby server.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Visibility ng Library';
@@ -3213,7 +3209,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get sourceLibraries => 'Pinagmulan ng mga Aklatan';
 
   @override
-  String get sourceCollections => 'Mga Source Collection';
+  String get sourceCollections => 'Source Collections';
 
   @override
   String get excludedGenres => 'Mga Ibinukod na Genre';
@@ -3296,7 +3292,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get autoAdvanceSlides => 'Awtomatikong sumulong sa susunod na slide';
 
   @override
-  String get autoAdvanceInterval => 'Interval ng Auto Advance';
+  String get autoAdvanceInterval => 'Auto Advance Interval';
 
   @override
   String get trailerPreview => 'Preview ng Trailer';
@@ -3306,11 +3302,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'I-auto-play ang mga trailer sa media bar pagkatapos ng 3 segundo';
 
   @override
-  String get trailerAudio => 'Audio ng Trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'I-enable ang audio para sa mga trailer sa media bar';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Preview ng Episode';
@@ -3389,11 +3384,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Pagsamahin ang parehong mga hilera sa isang solong seksyon ng tahanan';
 
   @override
-  String get fullScreenRows => 'Mga Naka-expand na Home Row';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limitahan ang mga home row sa 1 row bawat screen';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Uri ng Larawan sa Bawat Hilera';
@@ -3408,7 +3402,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get lastUser => 'Huling Gumagamit';
 
   @override
-  String get currentUser => 'Kasalukuyang User';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Palaging Authenticate';
@@ -3463,7 +3457,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get screensaver => 'Screensaver';
 
   @override
-  String get inAppScreensaver => 'In-App na Screensaver';
+  String get inAppScreensaver => 'In-App Screensaver';
 
   @override
   String get enableBuiltInScreensaver =>
@@ -3594,7 +3588,7 @@ class AppLocalizationsTl extends AppLocalizations {
       'I-enable at muling isaayos ang mga source ng rating na ipinapakita sa buong app';
 
   @override
-  String get pluginLabel => 'Moonbase Plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Natukoy ang Plugin';
@@ -3666,7 +3660,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get networks => 'Mga network';
 
   @override
-  String get seerrDiscoveryRows => 'Mga Seerr Discovery Row';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'I-reset ang mga hilera sa mga default';
@@ -3690,29 +3684,28 @@ class AppLocalizationsTl extends AppLocalizations {
       'Itago ang nilalamang pang-adulto sa mga resulta';
 
   @override
-  String get seerrNotificationsSection => 'Mga Notification';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle =>
-      'Mga notification ng bagong request';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Abisuhan ako kapag may nagsumite ng request';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Mga update sa request';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Naaprubahan, natanggihan, at naidagdag sa iyong library';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Mga update sa issue';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Mga bagong issue, tugon, at resolusyon';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3720,18 +3713,18 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Seerr Discovery Page';
+  String get discoverRows => 'Tuklasin ang Mga Row';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'I-enable ang mga row na makikita sa mainpage ng Seerr. I-drag para baguhin ang pagkakasunod-sunod. Nagsi-sync ang custom na order sa Moonbase.';
+      'I-drag upang muling ayusin. Paganahin o huwag paganahin ang mga hilera. Ang naka-enable na row order ay nagsi-sync sa Moonfin plugin.';
 
   @override
   String get discoverRowsDescription =>
-      'I-enable ang mga row na makikita sa mainpage ng Seerr. I-drag para baguhin ang pagkakasunod-sunod. Nagsi-sync ang custom na order sa Moonbase.';
+      'I-drag upang muling ayusin. Paganahin o huwag paganahin ang mga hilera.';
 
   @override
-  String get enabled => 'Naka-enable';
+  String get enabled => 'Pinagana';
 
   @override
   String get hidden => 'Nakatago';
@@ -3792,7 +3785,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'May available na update: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3804,7 +3797,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Available na ang v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3870,7 +3863,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get imageCacheCleared => 'Na-clear ang image cache';
 
   @override
-  String get clear => 'I-clear';
+  String get clear => 'Maaliwalas';
 
   @override
   String get browse => 'Mag-browse';
@@ -3886,15 +3879,15 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Nagda-download · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Nag-i-import';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count na Item';
+    return '$count Items';
   }
 
   @override
@@ -3914,7 +3907,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Hiniling ni $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3931,12 +3924,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Kanselahin ang request para sa \"$title\"?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Kanselahin ang $count na request para sa \"$title\"?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3956,7 +3949,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String revenueAmount(String amount) {
-    return 'Kita: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3966,7 +3959,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Mag-request ng $type';
+    return 'Request $type';
   }
 
   @override
@@ -3995,14 +3988,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showMore => 'Ipakita ang Higit Pa';
 
   @override
-  String get appearances => 'Mga appearance';
+  String get appearances => 'Mga pagpapakita';
 
   @override
   String get crewSection => 'Crew';
 
   @override
   String ageValue(int age) {
-    return 'edad $age';
+    return 'age $age';
   }
 
   @override
@@ -4033,103 +4026,102 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deletedStatus => 'Tinanggal';
 
   @override
-  String get failedStatus => 'Nabigo';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Pinoproseso';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Binago ni $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Nakumpleto';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Na-request na ang title na ito';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Naabot na ang limitasyon ng request';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Naka-blocklist ang title na ito';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons =>
-      'Wala nang natitirang season na i-request';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Wala kang pahintulot na gawin ang request na ito';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Mga Request';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Mga Issue';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Pinakabago';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Huling Binago';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Walang issue';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining sa $limit na movie request ang natitira';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining sa $limit na season request ang natitira';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Bahagi ng $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Tingnan ang Collection';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'I-request ang Collection';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total na pelikula · $available available';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Mag-request ng $count na pelikula';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Nire-request ang $current sa $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Na-request ang $count na pelikula';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Na-request ang $ok sa $total na pelikula';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Available na o na-request na ang lahat ng pelikula';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Mag-ulat ng Issue';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
@@ -4138,44 +4130,44 @@ class AppLocalizationsTl extends AppLocalizations {
   String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Ano ang mali?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Lahat ng Episode';
+  String get allEpisodes => 'All Episodes';
 
   @override
   String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Bukas';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Naresolba';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Iresolba';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Buksang muli';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Iniulat ni $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count na komento';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Magdagdag ng komento';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Tanggalin ang issue na ito?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Isumite ang Ulat';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB Score';
@@ -4199,7 +4191,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get originalLanguageLabel => 'Orihinal na Wika';
 
   @override
-  String get seasonsLabel => 'Mga season';
+  String get seasonsLabel => 'Mga panahon';
 
   @override
   String get episodesLabel => 'Mga episode';
@@ -4244,10 +4236,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get error => 'Error';
 
   @override
-  String get forward => 'I-forward';
+  String get forward => 'Pasulong';
 
   @override
-  String get general => 'Pangkalahatan';
+  String get general => 'Heneral';
 
   @override
   String get go => 'Pumunta ka';
@@ -4328,7 +4320,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get status => 'Katayuan';
 
   @override
-  String get stop => 'Ihinto';
+  String get stop => 'Tumigil ka';
 
   @override
   String get streaming => 'Streaming';
@@ -4376,7 +4368,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminDrawerUsers => 'Mga gumagamit';
 
   @override
-  String get adminDrawerLibraries => 'Mga library';
+  String get adminDrawerLibraries => 'Mga aklatan';
 
   @override
   String get adminDrawerDisplay => 'Display';
@@ -4385,13 +4377,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Mga Setting ng NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Transcoding';
 
   @override
-  String get adminDrawerResume => 'Resume';
+  String get adminDrawerResume => 'Ipagpatuloy';
 
   @override
   String get adminDrawerStreaming => 'Streaming';
@@ -4448,22 +4440,22 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Mga available na update ng plugin: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Mga plugin na kailangang i-restart: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Mga nabigong scheduled task: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Mga kamakailang warning/error entry: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4550,7 +4542,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Nabigo ang command: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4569,7 +4561,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get sessionRewind => 'I-rewind';
 
   @override
-  String get sessionForward => 'I-forward';
+  String get sessionForward => 'Pasulong';
 
   @override
   String get sessionNext => 'Susunod';
@@ -4587,7 +4579,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get nowPlaying => 'Naglalaro Ngayon';
 
   @override
-  String get volume => 'Volume';
+  String get volume => 'Dami';
 
   @override
   String get actions => 'Mga aksyon';
@@ -4614,14 +4606,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminClearDates => 'I-clear ang mga petsa';
 
   @override
-  String get adminActivitySeverityAll => 'Lahat ng severity';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Saklaw ng petsa';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Nabigong i-load ang activity log: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4638,7 +4630,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Nabigong i-update ang device: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4649,28 +4641,28 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang device: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Alisin ang device na \'$name\'? Kakailanganin ng user na mag-sign in muli sa device na ito.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Tanggalin ang lahat ng device';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Alisin ang $count na device? Kakailanganin ng mga apektadong user na mag-sign in muli. Hindi apektado ang iyong kasalukuyang device.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Naalis ang mga device';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Naalis ang ilang device; $count ang hindi maalis.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4699,7 +4691,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Nabigong simulan ang scan: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4710,12 +4702,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Pinalitan ang pangalan ng library sa \"$name\"';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Nabigong palitan ang pangalan: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4723,17 +4715,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Tinanggal ang library na \"$name\"';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang library: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Nabigong magdagdag ng path: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4741,12 +4733,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Alisin ang \"$path\" mula sa library na ito?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Nabigong alisin ang path: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4754,7 +4746,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Nabigong i-save ang mga opsyon: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4785,84 +4777,82 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminMetadataCountryHint => 'hal. US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'Mga Path';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Mga Opsyon';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Mga Downloader';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Mga metadata saver';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Mga subtitle downloader';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Mga lyric downloader';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Mga metadata downloader: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Mga image fetcher: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Walang inilalantad na downloader ang server na ito para sa uri ng library na ito.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Pangkalahatan';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
   String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Embedded na Impormasyon';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Mga Subtitle';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Mga Larawan';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Serye';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Musika';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Mga Pelikula';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'I-enable ang real-time na pagsubaybay';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Tuklasin ang mga pagbabago sa file at awtomatikong iproseso ang mga ito.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'Ituring ang mga archive bilang media file';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Ipakita ang mga larawan';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'I-save ang artwork sa mga media folder';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Awtomatikong pag-refresh ng metadata';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Hindi kailanman';
+  String get adminLibRefreshNever => 'Never';
 
   @override
   String get adminLibDefault => 'Default';
@@ -4871,172 +4861,160 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Display ng library';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Magpakita ng folder view para ipakita ang mga plain na media folder';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Ipakita ang mga special sa loob ng mga season kung saan sila unang ipinalabas';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies =>
-      'Pagsama-samahin ang mga pelikula sa mga collection';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows =>
-      'Pagsama-samahin ang mga palabas sa mga collection';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Ipakita ang external na nilalaman sa mga suhestiyon';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Kilos ng petsang idinagdag';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Gamitin ang petsang idinagdag mula sa';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Petsang na-scan sa library';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Petsang ginawa ang file';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Metadata at Mga Larawan';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Gustong wika ng metadata';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Mga Kabanata';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Tagal ng dummy chapter (segundo)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Haba ng mga kabanatang binuo para sa media na walang kabanata. Itakda sa 0 para i-disable.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Resolution ng larawan ng kabanata';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Mga Setting ng NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Ang NFO metadata ay compatible sa Kodi at mga katulad na client. Nalalapat ang mga setting sa lahat ng library na nagse-save ng NFO metadata.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'User na pagta-store-an ng watch data sa mga NFO file';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'I-save ang mga image path sa loob ng mga NFO file';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'I-enable ang path substitution para sa mga NFO image path';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Kopyahin ang mga extrafanart na larawan sa isang extrathumbs folder';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Wala';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days na araw';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Gamitin ang mga embedded na title';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Gamitin ang mga embedded na title para sa mga extra';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Gamitin ang embedded na impormasyon ng episode';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'Payagan ang mga embedded na subtitle';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Payagan lahat';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Text lang';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Larawan lang';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Wala';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Laktawan ang download kung may mga embedded na subtitle';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Laktawan ang download kung tumutugma ang audio track sa wika ng download';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'Mangailangan ng perpektong tugma ng subtitle';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'I-save ang mga subtitle sa mga media folder';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction =>
-      'I-extract ang mga larawan ng kabanata';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'I-extract ang mga larawan ng kabanata habang nagsa-scan ng library';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'I-enable ang pag-extract ng larawan ng Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'I-extract ang mga larawan ng Trickplay habang nagsa-scan ng library';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'I-save ang mga larawan ng Trickplay sa mga media folder';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Awtomatikong pagsamahin ang mga seryeng nakakalat sa maraming folder';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Display name ng season zero';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'I-enable ang LUFS scan para sa audio normalization';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Piliin ang non-standard na artists tag';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Awtomatikong idagdag ang mga pelikula sa mga collection';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired =>
@@ -5044,7 +5022,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Nabigong gumawa ng library: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5071,27 +5049,27 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'I-disable si $name? Hindi na siya makakapag-sign in.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'I-enable si $name? Makakapag-sign in na siya muli.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Na-disable ang user na \"$name\"';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Na-enable ang user na \"$name\"';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Nabigong i-update ang user policy: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5108,7 +5086,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Nabigong gumawa ng user: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5130,7 +5108,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Nabigong i-save: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5141,7 +5119,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Nabigo: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5285,112 +5263,111 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Pinakamataas na pinapayagang parental rating';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Itatago sa user na ito ang nilalamang may mas mataas na rating.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Wala';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'I-block ang mga item na walang o hindi kilalang impormasyon ng rating';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Mga Aklat';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Mga Channel';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Live na TV';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Mga Pelikula';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Musika';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Mga trailer';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Mga Palabas';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Mga Schedule ng Access';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Payagan ang access lamang sa mga nakatakdang oras sa ibaba. Pinapayagan ang access buong araw kapag walang nakatakdang schedule.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Magdagdag ng Schedule';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Araw';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Simula';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Katapusan';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Araw-araw';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Araw ng pasukan';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Katapusan ng linggo';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Linggo';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Lunes';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Martes';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Miyerkules';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Huwebes';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Biyernes';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Sabado';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Mga pinapayagang tag';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Nilalamang may mga tag na ito lang ang ipinapakita. Iwanang blangko para payagan lahat.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Mga naka-block na tag';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Itinatago sa user na ito ang nilalamang may mga tag na ito.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Magdagdag ng tag';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Mga naka-enable na device';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Mga naka-enable na channel';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
   String get adminAuthProvider => 'Authentication provider';
@@ -5400,28 +5377,26 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Pinakamaraming nabigong login attempt bago mag-lockout';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Itakda sa 0 para sa default, o -1 para i-disable ang lockout.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
   String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Payagan ang paggawa at pagsali sa mga grupo';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Payagan ang pagsali sa mga grupo';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Walang access';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'Payagan ang pagtanggal ng nilalaman mula sa';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5429,22 +5404,22 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Nagbalik ang server ng HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Sigurado ka bang gusto mong tanggalin si $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Tinanggal ang user na \"$name\"';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang user: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5465,7 +5440,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Nabigong gumawa ng key: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5477,7 +5452,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Bawiin ang key para kay $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5485,7 +5460,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Nabigong bawiin ang key: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5505,29 +5480,29 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nGinawa: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Gumawa ng Backup';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Piliin kung ano ang isasama sa backup.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
   String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Palaging kasama';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
   String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Mga Subtitle';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Mga larawan ng Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Gumagawa ng backup...';
@@ -5537,7 +5512,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Nabigong gumawa ng backup: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5551,7 +5526,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Nabigong i-load ang manifest: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5562,7 +5537,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Nabigong ibalik ang backup: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5594,17 +5569,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Na-save sa $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Nabigong i-save ang file: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Nabigong i-load ang $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5615,7 +5590,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Nabigong i-load ang mga task: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5627,17 +5602,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Nabigong simulan ang task: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Nabigong ihinto ang task: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Nabigong i-load ang task: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5645,12 +5620,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Nabigong alisin ang trigger: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Nabigong magdagdag ng trigger: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5676,7 +5651,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours (na) oras';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5687,7 +5662,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Nabigong i-toggle ang plugin: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5695,27 +5670,27 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Sigurado ka bang gusto mong i-uninstall ang \"$name\"?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Nabigong i-uninstall ang plugin: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Nabigong i-install ang package: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Nabigong i-install ang update: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Nabigong i-load ang mga plugin: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5727,12 +5702,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'I-install ang update (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Nabigong i-load ang catalog: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5754,17 +5729,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return 'Aalisin ang \"$name\" pagkatapos i-restart ang server';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Nabigong i-uninstall: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Ina-update ang \"$name\" sa v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5773,7 +5748,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Nabigong i-load ang plugin: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5781,7 +5756,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Bersyon $version';
+    return 'Version $version';
   }
 
   @override
@@ -5801,17 +5776,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Sigurado ka bang gusto mong alisin ang \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Nabigong i-save ang mga repository: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Nabigong i-load ang mga repository: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5828,12 +5803,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Hindi ma-load ang mga setting ng plugin: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Hindi mabuksan ang $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5858,11 +5833,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminMetadataPath => 'path ng metadata';
 
   @override
-  String get adminLibraryScanConcurrency => 'Concurrency ng library scan';
+  String get adminLibraryScanConcurrency => 'Library scan concurrency';
 
   @override
-  String get adminParallelImageEncodingLimit =>
-      'Limitasyon ng parallel image encoding';
+  String get adminParallelImageEncodingLimit => 'Parallel image encoding limit';
 
   @override
   String get adminSlowResponseThreshold =>
@@ -6120,12 +6094,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Nabigong i-load ang metadata: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Nabigong i-save ang metadata: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6146,7 +6120,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Nabigong i-refresh ang metadata: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6160,7 +6134,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Nabigo ang remote search: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6174,7 +6148,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Nabigong i-update ang content type: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6189,12 +6163,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Na-update ang larawang $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Nabigong i-download ang larawan: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6206,27 +6180,27 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Na-upload ang larawang $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Nabigong i-upload ang larawan: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Tanggalin ang larawang $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Tinanggal ang larawang $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang larawan: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6237,14 +6211,14 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Nabigo ang tuner discovery: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Magdagdag ng Tuner';
 
   @override
-  String get adminEditTuner => 'I-edit ang Tuner';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
   String get adminTunerTypeM3u => 'M3U Tuner';
@@ -6253,52 +6227,51 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'File o URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP address ng tuner';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Friendly na pangalan';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Limitasyon ng sabayang koneksyon';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Ang pinakamaraming stream na pinapayagan ng tuner nang sabay-sabay. Itakda sa 0 para sa walang limitasyon.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Fallback na max streaming bitrate';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Mag-import lang ng mga paboritong channel';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => 'Payagan ang hardware transcoding';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Payagan ang fMP4 transcoding container';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Payagan ang stream sharing';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'I-enable ang stream looping';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Balewalain ang DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Basahin ang input sa native frame rate';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'I-edit ang Provider';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6307,26 +6280,26 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'File o URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Prefix ng pelikula';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Mga kategorya ng pelikula';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Paghiwalayin ang maraming kategorya gamit ang vertical bar.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Mga kategorya ng bata';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Mga kategorya ng balita';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Mga kategorya ng sports';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
   String get adminSdUsername => 'Username';
@@ -6335,22 +6308,22 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Bansa';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Pumili ng bansa';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
   String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Kunin ang mga listing';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Mga Listing';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'I-enable ang lahat ng tuner';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Uri ng Tuner';
@@ -6360,7 +6333,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Nabigong magdagdag ng tuner: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6374,12 +6347,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Nabigong magdagdag ng provider: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Nabigong alisin ang tuner: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6387,16 +6360,16 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Nabigong i-reset ang tuner: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Hindi sinusuportahan ng uri ng tuner na ito ang pag-reset.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Nabigong alisin ang provider: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6415,38 +6388,36 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Landas ng pag-record ng serye';
 
   @override
-  String get adminMovieRecordingPath => 'Path ng recording ng pelikula';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Mga araw ng guide data';
+  String get adminGuideDays => 'Guide data days';
 
   @override
   String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days na araw';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'Path ng post-processing application';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'Mga argumento ng post-processor';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'I-save ang NFO metadata ng recording';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'I-save ang mga larawan ng recording';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
   String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Mga path ng recording';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
   String get adminLiveTvSectionPostProcessing => 'Post-processing';
@@ -6462,7 +6433,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Nabigong i-save ang mga setting: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6479,7 +6450,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Nabigong i-update ang mga mapping: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6496,15 +6467,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminGuideProviders => 'Mga Tagabigay ng Gabay';
 
   @override
-  String get adminRefreshGuideData => 'I-refresh ang Guide Data';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Nagsimula ang pag-refresh ng guide data';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Hindi available ang guide refresh task sa server na ito.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Magdagdag ng Provider';
@@ -6515,12 +6485,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Path ng recording: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Path ng serye: $path';
+    return 'Series path: $path';
   }
 
   @override
@@ -6563,7 +6533,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Ibalik ang backup na $name ngayon?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6584,10 +6554,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Hindi available ang live TV administration sa server build na ito.';
 
   @override
-  String get adminLiveTvTitle => 'Administrasyon ng Live TV';
+  String get adminLiveTvTitle => 'Live TV Administration';
 
   @override
-  String get adminApply => 'Ilapat';
+  String get adminApply => 'Mag-apply';
 
   @override
   String get adminNotSet => 'Hindi nakatakda';
@@ -6609,27 +6579,27 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '${minutes}m ang nakalipas';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '${hours}h ang nakalipas';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '${days}d ang nakalipas';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Nabigong i-load ang $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count na tugma';
+    return '$count matches';
   }
 
   @override
@@ -6639,7 +6609,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Metadata Editor';
 
   @override
-  String get adminMetadataIdentify => 'Tukuyin';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Uri';
@@ -6654,7 +6624,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminMetadataImages => 'Mga imahe';
 
   @override
-  String get adminMetadataFieldTitle => 'Title';
+  String get adminMetadataFieldTitle => 'Pamagat';
 
   @override
   String get adminMetadataFieldSortTitle => 'Pagbukud-bukurin ang pamagat';
@@ -6739,22 +6709,22 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Na-update ang larawang $imageType';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Na-upload ang larawang $imageType';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Tinanggal ang larawang $imageType';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Nabigong i-download ang larawan: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6763,12 +6733,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Nabigong i-upload ang larawan: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Tanggalin ang larawang $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6777,19 +6747,19 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang larawan: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Pumili ng larawang $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
   String get adminMetadataUpload => 'Mag-upload';
 
   @override
-  String get adminMetadataUpdate => 'I-update';
+  String get adminMetadataUpdate => 'Update';
 
   @override
   String get adminMetadataRemoteImage => 'Malayong larawan';
@@ -6815,7 +6785,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'May available na update: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6840,7 +6810,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'I-install ang update (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6852,7 +6822,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return 'Ini-install ang \"$name\"...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6872,7 +6842,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Mga Setting ng $name';
+    return '$name Settings';
   }
 
   @override
@@ -6912,7 +6882,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Nabigong i-load ang mga repository: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6920,7 +6890,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Sigurado ka bang gusto mong alisin ang \"$name\"?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -6928,7 +6898,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Nabigong i-save ang mga repository: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6972,12 +6942,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminGeneralMetadataCountryHint => 'hal. US, DE, FR';
 
   @override
-  String get adminGeneralLibraryScanConcurrency =>
-      'Concurrency ng library scan';
+  String get adminGeneralLibraryScanConcurrency => 'Library scan concurrency';
 
   @override
-  String get adminGeneralImageEncodingLimit =>
-      'Limitasyon ng parallel image encoding';
+  String get adminGeneralImageEncodingLimit => 'Parallel image encoding limit';
 
   @override
   String get adminUnknownError => 'Hindi kilalang error';
@@ -7056,20 +7024,19 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Paganahin ang splash screen';
 
   @override
-  String get adminBrandingSplashUpload => 'Mag-upload ng larawan';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Na-update ang splashscreen';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Nabigong i-upload ang splashscreen';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Naalis ang splashscreen';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Walang custom na splashscreen';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Pagpapabilis ng Hardware';
@@ -7089,15 +7056,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'I-enable ang enhanced NVDEC decoder';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Piliin ang system native hardware decoder';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Color depth ng hardware decoding';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
   String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
@@ -7115,61 +7081,59 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Payagan ang HEVC encoding';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Payagan ang AV1 encoding';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'I-enable ang Intel low-power H.264 encoder';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'I-enable ang Intel low-power HEVC encoder';
+      'Enable Intel low-power HEVC encoder';
 
   @override
   String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'I-enable ang tone mapping';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'I-enable ang VPP tone mapping';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'I-enable ang VideoToolbox tone mapping';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Algorithm ng tone mapping';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Mode ng tone mapping';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Range ng tone mapping';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => 'Desaturation ng tone mapping';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Peak ng tone mapping';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Parameter ng tone mapping';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Brightness ng VPP tone mapping';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Contrast ng VPP tone mapping';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Mga Preset at Kalidad';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
   String get adminPlaybackEncoderPreset => 'Encoder preset';
@@ -7181,17 +7145,17 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Paraan ng deinterlace';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Doblehin ang frame rate kapag nagde-deinterlace';
+      'Double the frame rate when deinterlacing';
 
   @override
   String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'I-enable ang audio VBR encoding';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
   String get adminPlaybackDownmixBoost => 'Audio downmix boost';
@@ -7200,7 +7164,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => 'Max na laki ng muxing queue';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
   String get adminPlaybackAutoOption => 'Auto';
@@ -7324,10 +7288,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminTaskNeverRun => 'Huwag tumakbo';
 
   @override
-  String get adminTaskStop => 'Ihinto';
+  String get adminTaskStop => 'Tumigil ka';
 
   @override
-  String get adminRunningTasks => 'Mga Tumatakbong Task';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Takbo';
@@ -7349,17 +7313,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Araw-araw nang $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Tuwing $day nang $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Tuwing $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7397,8 +7361,8 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na oras',
-      one: '1 oras',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7426,17 +7390,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '${days}d ang nakalipas';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '${hours}h ang nakalipas';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '${minutes}m ang nakalipas';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7482,41 +7446,40 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Mangailangan ng HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'I-redirect ang lahat ng remote request sa HTTPS. Walang epekto kung walang valid na certificate ang server.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Password ng certificate';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Mga Setting ng IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'I-enable ang IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'I-enable ang IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'I-enable ang awtomatikong port mapping';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Mga LAN network';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Listahan ng mga IP address o CIDR subnet na pinaghihiwalay ng kuwit o linya, na ituturing na nasa lokal na network.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Mga na-publish na server URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'I-map ang isang subnet o address sa isang na-publish na URL, hal. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Landas ng sertipiko';
@@ -7547,11 +7510,11 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Pag-buffer ng throttle';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Throttle delay (segundo)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Payagan ang subtitle extraction on the fly';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Minimum na porsyento ng resume';
@@ -7601,7 +7564,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Nabigong i-update ang content type: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7609,11 +7572,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Mabagal na threshold ng pagtugon (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'I-enable ang mga babala sa mabagal na tugon';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'I-enable ang Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
   String get adminGeneralSectionServer => 'Server';
@@ -7622,7 +7584,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Mga Path';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
   String get adminGeneralSectionPerformance => 'Performance';
@@ -7637,7 +7599,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminGeneralServerName => 'Pangalan ng server';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Gustong wika ng display';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Nabigong i-load ang mga setting';
@@ -7647,19 +7609,19 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Nabigong i-update ang mga mapping: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Limitasyon sa oras: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'Mga folder';
 
   @override
-  String get libraries => 'Mga library';
+  String get libraries => 'Mga aklatan';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7689,8 +7651,8 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# na kalahok',
-      one: '# kalahok',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7782,12 +7744,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return 'Sumali si $userName sa SyncPlay group';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return 'Umalis si $userName sa SyncPlay group';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7800,7 +7762,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Nagsi-sync ng playback sa $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7840,8 +7802,8 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# na row ang natuklasan',
-      one: '# row ang natuklasan',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7882,20 +7844,20 @@ class AppLocalizationsTl extends AppLocalizations {
   String get offlineSavedMedia => 'Naka-save na Media';
 
   @override
-  String get offlineBannerTitle => 'Offline ka';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Ipinapakita ang iyong mga download';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Mga Download';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Hindi maabot ang iyong server';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Nagpe-play mula sa mga download hanggang sa bumalik ito';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7911,12 +7873,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Nabigo ang kontrol ng cast: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return 'Mga Kontrol ng $kind';
+    return '$kind Controls';
   }
 
   @override
@@ -7927,7 +7889,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return 'Ihinto ang $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7951,12 +7913,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Maglagay ng $length-digit na PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Ilagay ang iyong $length-digit na PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7969,7 +7931,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get pinForgot => 'Nakalimutan ang PIN?';
 
   @override
-  String get pinClear => 'I-clear';
+  String get pinClear => 'Maaliwalas';
 
   @override
   String get pinBackspace => 'Backspace';
@@ -8004,7 +7966,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Nabigo ang Quick Connect: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -8015,7 +7977,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Nabigo ang command: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -8044,7 +8006,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Nabigong simulan ang casting: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8055,7 +8017,7 @@ class AppLocalizationsTl extends AppLocalizations {
       'Walang available na remote playback device.\n\nSa iOS, maaaring hindi available ang mga target ng AirPlay sa simulator.';
 
   @override
-  String get trackActionPlayNext => 'I-play Susunod';
+  String get trackActionPlayNext => 'Play Next';
 
   @override
   String get trackActionAddToQueue => 'Idagdag sa Queue';
@@ -8070,7 +8032,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get trackActionDeleteFromPlaylist => 'Tanggalin sa Playlist';
 
   @override
-  String get trackActionMoveUp => 'Ilipat Pataas';
+  String get trackActionMoveUp => 'Move Up';
 
   @override
   String get trackActionMoveDown => 'Ilipat Pababa';
@@ -8089,7 +8051,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Nagda-download ng $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8109,7 +8071,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get shuffleSelectGenre => 'Piliin ang Genre';
 
   @override
-  String get shuffleLibrary => 'Library';
+  String get shuffleLibrary => 'Aklatan';
 
   @override
   String get shuffleGenre => 'Genre';
@@ -8164,21 +8126,21 @@ class AppLocalizationsTl extends AppLocalizations {
   String get upNext => 'Susunod';
 
   @override
-  String get playNext => 'I-play Susunod';
+  String get playNext => 'Play Next';
 
   @override
   String get stillWatchingContent =>
       'Na-pause ang pag-playback. Nanonood ka pa ba?';
 
   @override
-  String get stillWatchingStop => 'Ihinto';
+  String get stillWatchingStop => 'Tumigil ka';
 
   @override
   String get stillWatchingContinue => 'Magpatuloy';
 
   @override
   String skipSegment(String segment) {
-    return 'Laktawan ang $segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -8189,12 +8151,12 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Nagda-download ng $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Nagda-download ng $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8232,7 +8194,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Payagan ang pag-ikot';
 
   @override
-  String get playerTooltipPrevious => 'Nakaraan';
+  String get playerTooltipPrevious => 'Nakaraang';
 
   @override
   String get playerTooltipSeekBack => 'Balikan';
@@ -8257,13 +8219,13 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Itago mula sa Continue Watching';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Itago mula sa Next Up';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Idagdag sa Collection';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8315,18 +8277,17 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsLastUsed => 'Huling Ginamit';
 
   @override
-  String get settingsAlphabetical => 'Alpabetiko';
+  String get settingsAlphabetical => 'Alphabetical';
 
   @override
-  String get settingsConnectionSection => 'KONEKSYON';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Payagan ang mga self-signed na certificate';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Pagkatiwalaan ang mga server na gumagamit ng self-signed o private-CA na TLS certificate. I-enable lang para sa mga server na kontrolado mo. Ide-disable nito ang certificate validation para sa lahat ng koneksyon.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'PRIVACY at KALIGTASAN';
@@ -8346,7 +8307,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Istilo, background blur, at kilos ng tab';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Home Page';
@@ -8384,11 +8345,11 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Ipakita ang Seerr button sa navigation bar';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Palaging ipakita ang mga text label sa itaas na navigation bar';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8457,7 +8418,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Mag-donate ng kape sa developer';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'LEGAL';
@@ -8491,7 +8452,7 @@ class AppLocalizationsTl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# na license notice',
+      other: '# license notices',
       one: '# license notice',
     );
     return '$_temp0';
@@ -8551,10 +8512,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Wala';
+  String get settingsNone => 'None';
 
   @override
-  String get settingsPromptUser => 'Itanong sa User';
+  String get settingsPromptUser => 'Prompt User';
 
   @override
   String get settingsSkip => 'Laktawan';
@@ -8592,7 +8553,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsPlaybackEngineMpvLegacy => 'mpv (legacy)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (inirerekomenda)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Fallback';
@@ -8784,173 +8745,163 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Kamakailang Inilabas na $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode =>
-      'Awtomatikong I-play ang Susunod na Episode';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Awtomatikong i-play ang susunod na episode kapag available.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Laktawan ang katahimikan';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Awtomatikong laktawan ang mga tahimik na audio segment kapag sinusuportahan ng stream.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Payagan ang mga external na audio effect';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Payagan ang mga equalizer at effects app (hal. Wavelet) na kumabit sa mga Media3 playback session.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'I-disable ang tunneling';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Piliting non-tunneled ang playback. Kapaki-pakinabang sa mga device na may audio/video discontinuity sa tunneling.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'I-enable ang tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Advanced. Idinadaan ang audio at video sa isang coupled na hardware path. Naka-off bilang default dahil nagdudulot ito ng audio/video dropout sa ilang device.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'I-map ang Dolby Vision profile 7 sa HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'I-play ang mga Dolby Vision profile 7 stream bilang HDR10-compatible na HEVC sa mga non-DV device.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'Gamitin ang mga embedded na estilo ng subtitle';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Ilapat ang mga kulay, font, at posisyon na naka-embed sa subtitle track. I-disable para gamitin ang iyong mga kagustuhan sa estilo ng caption.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Gamitin ang mga embedded na laki ng font ng subtitle';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Ilapat ang mga font-size hint na naka-embed sa subtitle track. I-disable para gamitin ang laki ng subtitle mula sa iyong mga kagustuhan sa estilo.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage =>
-      'Ipakita ang Mga Detalye ng Media';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Ipakita ang mga detalye ng napiling item sa itaas ng mga Library page.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'Itago ang Mga Backdrop habang Nagba-browse?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings =>
-      'Gamitin ang Mga Detalyadong Sub-Heading';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Ipakita ang detalyado o minimal na subrow sa mga Library page.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle =>
-      'Tanggalin ang naka-save na theme?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Alisin ang \"$themeName\" mula sa cache ng device na ito?';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
   String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle =>
-      'Mag-browse at mag-save ng mga community theme';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Mag-save ng theme para magamit ito tulad ng iyong ibang naka-save na theme.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Walang available na theme sa ngayon.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Hindi ma-load ang Theme Store. Suriin ang iyong koneksyon at subukan muli.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'I-save';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'I-save at ilapat';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Na-save';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Hindi ma-load ang theme na ito.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Na-save ang \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Tinanggal ang \"$themeName\" mula sa device na ito.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Hindi matanggal ang \"$themeName\".';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Mga naka-save na theme';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Ito ang mga theme na na-download mula sa Moonfin plugin para sa kasalukuyang server. Ang pagtanggal ay nag-aalis lamang ng lokal na kopyang ito.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'Walang nakitang naka-save na theme para sa server na ito.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Kasalukuyang aktibo';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Tanggalin ang naka-save na theme';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Pamahalaan ang mga na-download na plugin theme sa device na ito';
+      'Manage downloaded plugin themes on this device';
 
   @override
   String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Buksan ang Moonfin Theme Editor sa iyong browser';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
   String get homeScreen => 'Home Screen';
@@ -8965,114 +8916,112 @@ class AppLocalizationsTl extends AppLocalizations {
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Mga Home Row';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Display ng Home Row';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Mga Seksyon ng Home Row';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Mga Toggle ng Home Row';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'I-enable o i-disable ang mga library-based na kategorya ng home row';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'I-enable ang mga sumusunod na toggle para ipakita ang mga row sa Mga Home Section.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Pinapanatili ng Classic ang per-row na uri ng larawan at info overlay. Gumagamit ang Modern ng mga portrait-to-backdrop na row.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Ipakita ang Mga Favorites Row';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Ipakita ang Mga Paboritong Pelikula, Serye, at iba pang paboritong row sa Mga Home Section.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Pag-sort ng Favorites Row';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'I-sort ang mga Favorites row ayon sa petsang idinagdag, petsa ng paglabas, alpabetiko, at higit pa.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Ipakita ang Mga Collections Row';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Ipakita ang mga Collections row sa Mga Home Section.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Pag-sort ng Collections Row';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'I-sort ang mga Collections row ayon sa petsang idinagdag, petsa ng paglabas, alpabetiko, at higit pa.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Ipakita ang Mga Genres Row';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Ipakita ang mga Genres row sa Mga Home Section.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Pag-sort ng Genres Row';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'I-sort ang mga Genres row ayon sa petsang idinagdag, petsa ng paglabas, alpabetiko, at higit pa.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Mga Item ng Genres Row';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Ipakita ang Mga Pelikula, Serye, o pareho sa mga Genres row.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Ipakita ang Mga Playlist Row';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Ipakita ang mga Playlist row sa Mga Home Section.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Pag-sort ng Playlist Row';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'I-sort ang mga Playlist row ayon sa petsang idinagdag, petsa ng paglabas, alpabetiko, at higit pa.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Ipakita ang Mga Audio Row';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Ipakita ang mga Audio row sa Mga Home Section.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Pag-sort ng Audio Row';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'I-sort ang mga Audio row ayon sa petsang idinagdag, petsa ng paglabas, alpabetiko, at higit pa.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Mga Audio Playlist';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Hitsura';
+  String get appearance => 'Appearance';
 
   @override
   String get layout => 'Layout';
@@ -9084,7 +9033,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Mga Button';
+  String get navButtons => 'Buttons';
 
   @override
   String get rendering => 'Rendering';
@@ -9100,18 +9049,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Magtakda ng external player para i-enable ang long-press play na opsyon';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Ipakita ang app chooser kapag nagsimula ang playback.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers =>
-      'Nilo-load ang mga naka-install na player...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Koneksyon';
+  String get connection => 'Connection';
 
   @override
   String get audioTranscodeTarget => 'Audio Transcode Target';
@@ -9120,65 +9068,65 @@ class AppLocalizationsTl extends AppLocalizations {
   String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Suportado sa device na ito';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Hindi Suportado sa device na ito';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
   String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Bitstream DTS:X (DTS UHD) sa external decoder.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD na may Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Kilos ng Media Player';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Mga Pagpapahusay sa Playback';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Palaging naka-on.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Palitan ang Skip Outro ng Next Up Display';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Ipakita ang Next Up overlay sa halip na ang Skip Outro button.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
   String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Piliin ang mga software decoder';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Gamitin ang FFmpeg (audio) at libgav1 (AV1) bago ang mga hardware decoder. I-disable kung nasisira ang HDMI audio passthrough.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Buksan ang video playback sa iyong napiling external app sa Android TV.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
   String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'Piliin ang mga SDH subtitle';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Unahin ang mga SDH/CC subtitle track kapag awtomatikong pumipili.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
   String get webDiagnostics => 'Web diagnostics';
@@ -9188,37 +9136,36 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get webDiagnosticsIntro =>
-      'Gamitin ang page na ito para i-diagnose ang mga isyu sa connectivity ng browser (CORS, mixed content, at mga discovery setting).';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Natukoy na Mixed-Content Failure';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Natukoy na CORS/Preflight Failure';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Nakakita ang Moonfin ng HTTPS page na sumusubok tumawag sa isang HTTP server URL. Bina-block ng mga browser ang request na ito bago ito umabot sa iyong server.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Nakakita ang Moonfin ng browser-level na request failure na karaniwang sanhi ng kulang na CORS o preflight header sa media server.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Target na URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'Detalye: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Kasalukuyang Runtime Context';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
@@ -9236,167 +9183,165 @@ class AppLocalizationsTl extends AppLocalizations {
   String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Default na Server URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
   String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'hindi naka-configure';
+  String get notConfigured => 'not configured';
 
   @override
   String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Nilo-load ang page na ito sa HTTPS, ngunit isa o higit pang naka-configure na URL ang HTTP. Bina-block ng mga browser ang mga HTTPS page sa pagtawag sa mga HTTP API.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Ayos: ihatid ang iyong media server o proxy endpoint sa pamamagitan ng HTTPS, o i-load ang Moonfin sa HTTP sa mga pinagkakatiwalaang lokal na network lamang.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Walang malinaw na mixed-content na configuration na natukoy mula sa kasalukuyang mga runtime setting.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
   String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Payagan ang browser origin sa Access-Control-Allow-Origin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Isama ang Authorization, X-Emby-Authorization, at X-Emby-Token sa Access-Control-Allow-Headers.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Ilantad ang Content-Range at Accept-Ranges para sa streaming at seek behavior.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Magbalik ng 204 sa mga OPTIONS preflight request.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Halimbawang Header Snippet (nginx-style)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Tandaan';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Ang diagnostics route na ito ay para sa mga web build. Kung nakikita mo ito sa ibang platform, maaaring hindi nalalapat ang mga pagsusuring ito.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Bumalik sa Pagpili ng Server';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'I-sign Out ang Lahat ng User';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Permanenteng tinanggihan ang pahintulot sa mikropono. I-enable ito sa mga system setting.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Kailangan ang pahintulot sa mikropono para sa voice search.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Hindi ko naintindihan iyon. Subukan muli.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Walang natukoy na pananalita.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Error sa mikropono.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Kailangan ng internet ang voice search.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => 'Abala ang voice service. Subukan muli.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Permanenteng tinanggihan ang pahintulot sa mikropono.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Tinanggihan ang pahintulot sa mikropono.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Hindi available ang speech recognition sa device na ito.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'Buksan ang iOS route picker';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'Hindi available ang AirPlay route picker sa device na ito.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Mga Video';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'Mga Programa';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Mga Kanta';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Mga Photo Album';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Mga Larawan';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Mga Tao';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Kamakailang Inilabas na Mga Episode';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Panoorin Muli';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Mga Guest Appearance';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Mga Appearance (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Mga Kontribusyon ng Crew (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'Manood kasama ang grupo';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Mga Error';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Mga Babala';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Buksan sa Browser';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Hindi available ang embedded browser sa platform na ito.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Sigurado ka bang gusto mong i-restart ang server?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Sigurado ka bang gusto mong i-shut down ang server? Kakailanganin mong i-restart ito nang manu-mano.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
   String get internal => 'Internal';
@@ -9408,54 +9353,52 @@ class AppLocalizationsTl extends AppLocalizations {
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Walang nakitang user';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Walang user na tumutugma sa iyong paghahanap';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Walang nakitang device';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Walang device na tumutugma sa kasalukuyang mga filter';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Naitakda ang password';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Walang naka-configure na password';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
   String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Lokal Lamang';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'Nabigong i-load ang media analytics';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Pinagsamang analytics sa lahat ng media library.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'Nangungunang Mga Artist';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'Nangungunang Mga May-akda';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'Nangungunang Mga Kontribyutor';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count na Library',
+      other: '$count Libraries',
       one: '1 Library',
     );
     return '$_temp0';
@@ -9463,19 +9406,19 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Wala pang available na indexed media total para sa piniling ito.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Mga Detalye ng Library';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Breakdown ng Library';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Walang available na library.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Administrasyon ng Server';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
   String get adminServerPathData => 'Data';
@@ -9487,7 +9430,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Mga Log';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
@@ -9500,21 +9443,21 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get adminNoServerPathsReturned =>
-      'Walang server path na ibinalik ng server na ito.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% ang nagamit';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Aktibidad ng User';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Mga Kaganapan sa System';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'Kailangan ng Atensyon';
+  String get needsAttention => 'Needs Attention';
 
   @override
   String get adminDrawerSectionServer => 'Server';
@@ -9523,28 +9466,28 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Mga Device';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
   String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'Mga Plugin';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Live na TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Mga Home Video';
+  String get homeVideos => 'Home Videos';
 
   @override
   String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Mga Home Video at Larawan';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Halong Mga Pelikula at Palabas';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9556,63 +9499,62 @@ class AppLocalizationsTl extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Walang nakitang recording';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'Walang nakitang image page sa loob ng .$extension archive.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Nabigo ang embedded renderer ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'Nabigo ang EPUB renderer ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Nawawalang lokal na file para sa reader: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status habang binubuksan ang data ng aklat mula sa $uri';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Walang available na nababasang book endpoint';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Hindi suportadong format ng comic archive: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'Hindi available ang CBR extraction plugin sa platform na ito.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      'Nabigong i-extract ang .cbr archive.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'Hindi available ang CB7 extraction sa platform na ito.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'Hindi available ang CB7 extraction plugin sa platform na ito.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Isara ang genre panel';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Nilo-load ang shuffle...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
   String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
@@ -9628,79 +9570,79 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Awtomatikong i-enable ang HDR para sa HDR video playback at ibalik ang display mode pag-labas.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Kapag fullscreen';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Palitan ang Artwork';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Nawawala';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Mga Limitasyon sa Transcoding';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'I-clear ang lahat ng artwork?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Sigurado ka bang gusto mong i-clear ang lahat ng na-download na artwork?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Kumpirmahin ang Pag-clear';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Sigurado ka bang gusto mong i-clear ang $itemType na ito?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'I-upload?';
+  String get uploadButton => 'Upload?';
 
   @override
   String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Ipakita lang ang artwork sa wika ng interface';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Kumpirmahin ang Pag-clear ng Lahat';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Matagumpay na na-upload ang larawan!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Nabigong i-upload ang larawan: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Nabigong itakda ang larawan: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Nabigong tanggalin ang larawan: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Nabigong i-clear ang lahat ng artwork: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Oo';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Mga Backdrop';
+  String get backdropsCategory => 'Backdrops';
 
   @override
   String get bannerCategory => 'Banner';
@@ -9763,7 +9705,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Lahat';
+  String get resolutionAll => 'All';
 
   @override
   String get resolutionHigh => 'High (1080p+)';
@@ -9775,16 +9717,16 @@ class AppLocalizationsTl extends AppLocalizations {
   String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Mga Source';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Mga Kabanata';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Mga Bookmark';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Mga Tala';
+  String get audiobookNotes => 'Notes';
 
   @override
   String get audiobookQueue => 'Queue';
@@ -9793,63 +9735,63 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Walang laman ang timeline';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Buong Aklat';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'I-export ang Mga Bookmark';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'I-export ang Mga Tala';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'I-export Lahat';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Na-export sa $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Nabigo ang pag-export: $error';
+    return 'Export failed: $error';
   }
 
   @override
   String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Magdagdag ng bookmark';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Magdagdag ng tala';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'I-edit ang tala';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Magsulat ng tala para sa sandaling ito';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
   String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Naka-off';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Katapusan ng kabanata';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
   String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining na natitira';
+    return '$remaining left';
   }
 
   @override
@@ -9864,51 +9806,51 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Bilis ng playback';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Natitira';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Lumipas';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Paatras ${seconds}s';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Pasulong ${seconds}s';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Nakaraang kabanata';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Susunod na kabanata';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Kabanata $current ng $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Walang kabanata';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Wala pang bookmark';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Wala pang tala';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Naidagdag ang bookmark sa $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'I-reset sa 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9916,254 +9858,249 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'I-save';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Kanselahin';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'I-delete';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Mga Kagustuhan sa Subtitle';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Baguhin ang mga subtitle mode, default na wika, hitsura, at mga rendering na opsyon.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
   String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Mga Opsyon sa Display';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Petsa ng Paglabas (Pataas)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Petsa ng Paglabas (Pababa)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Pagsama-samahin ang Mga Kontribusyon';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Pagsama-samahin ang maraming role';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => 'Babala sa Library Write Access';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Paano ito ayusin:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Magbigay ng write permission sa Jellyfin service user (hal. jellyfin o Docker PUID/PGID) para sa mga media library folder mo sa server.\n\n2. O, pumunta sa iyong Jellyfin Dashboard -> Libraries, i-edit ang library na ito, at i-disable ang \'Save artwork into media folders\' para i-store ang artwork sa internal database ng Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'I-dismiss';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Ang iyong \'$libraryName\' library ay naka-configure na mag-save ng artwork diretso sa mga media folder (naka-enable ang \'Save artwork into media folders\'). Ngunit, sinubukan ng Jellyfin ang write access at walang pahintulot na magsulat ng mga file sa directory na ito:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Mukhang nabigo ang Jellyfin na i-update ang artwork. Ang iyong library ay naka-configure na mag-save ng artwork diretso sa mga media folder (naka-enable ang \'Save artwork into media folders\'). Karaniwang nangyayari ang error na ito kapag walang pahintulot ang Jellyfin server process na magsulat ng mga file sa iyong mga media directory.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Mga External na Listahan';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'I-replay';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Impormasyon ng File';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Laki: $size  •  Format: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Ipakita Lahat ($count) na Audio Track';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Ipakita Lahat ($count) na Subtitle Track';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Sinusuri ang kakayahan sa Direct Play...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Kakayahan sa Direct Play: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
   String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Hindi suportado ng player ang container format.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported =>
-      'Hindi suportado ang video codec.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Hindi suportado ang audio codec.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Hindi suportado ang format ng subtitle (nangangailangan ng burning).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Hindi suportado ang audio profile.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Hindi suportado ang video profile.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Hindi suportado ang video level.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Hindi suportado ng device na ito ang video resolution.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Hindi suportado ang video bit depth.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Hindi suportado ang video framerate.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Lumalampas ang bitrate ng file sa streaming limit ng player.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Lumalampas ang video bitrate sa streaming limit.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Lumalampas ang audio bitrate sa streaming limit.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Hindi suportado ang bilang ng mga audio channel.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Alpabetiko';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Pagkakasunod ng Paglabas (Pataas)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Pagkakasunod ng Paglabas (Pababa)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
   String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Mga Opsyon sa Pag-sort ng Playlist';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'I-reset ang Pag-sort';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Panoorin Muli ang S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Panoorin Muli ang Playlist';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Walang nakitang subtitle.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Mga Admin Control';
+  String get adminControls => 'Admin Controls';
 
   @override
   String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Ang Impeller ay ang modernong GPU renderer ng Flutter para sa mas maayos na animation at mas kaunting stutter. Sa ilang TV box at mas lumang GPU, maaari itong magdulot ng glitch o itim na video; i-off ito kung nakikita mo ang mga iyon. Pinipili ng Automatic ang pinakamahusay na default para sa iyong device. I-restart ang Moonfin para ilapat.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
   String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Naka-on';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Naka-off';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Kailangan ng restart';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Kailangang mag-restart ang Moonfin para baguhin ang rendering engine. Isara ang app ngayon, pagkatapos ay buksang muli ito para ilapat.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Isara ang app ngayon';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'I-refresh ang Library';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'I-refresh ang Lahat ng Library';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Petsang Idinagdag (Pinakaluma Muna)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Petsang Idinagdag (Pinakabago Muna)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Alpabetiko (A hanggang Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Alpabetiko (Z hanggang A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Nilo-load ang Server Analytics... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Itugma sa source';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 na Pelikula';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 na TV Show';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Pinakasikat na Mga Pelikula';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Pinakasikat na Mga TV Show';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies =>
-      'IMDb Pinakamababang Rating na Mga Pelikula';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb Pinakamataas na Rating na Mga Pelikulang Ingles';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -32,7 +32,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Hızlı bağlantı';
 
   @override
   String get password => 'Şifre';
@@ -61,12 +61,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect kullanılamıyor: $detail';
+    return 'Hızlı Bağlantı kullanılamıyor: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect kullanılamıyor ($status): $detail';
+    return 'Hızlı Bağlantı kullanılamıyor ($status): $detail';
   }
 
   @override
@@ -113,7 +113,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cancel => 'İptal';
 
   @override
-  String get remove => 'Kaldır';
+  String get remove => 'Sil';
 
   @override
   String get connectToServer => 'Sunucuya Bağlan';
@@ -1068,7 +1068,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get version => 'Sürüm';
 
   @override
-  String get cast => 'Yayınla';
+  String get cast => 'Yansıt';
 
   @override
   String get trailer => 'Fragman';
@@ -1270,7 +1270,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get writer => 'YAZAR';
 
   @override
-  String get writers => 'SENARİSTLER';
+  String get writers => 'YAZARLAR';
 
   @override
   String get studio => 'STÜDYO';
@@ -1552,7 +1552,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get transcodeReasons => 'Kod Dönüştürme Nedenleri';
 
   @override
-  String get player => 'Oynatıcı';
+  String get player => 'Oyuncu';
 
   @override
   String get container => 'Kapsayıcı';
@@ -1827,7 +1827,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get favoriteChannel => 'Favori Kanal';
 
   @override
-  String get record => 'Kaydet';
+  String get record => 'Kayıt';
 
   @override
   String get cancelRecordingAction => 'Kaydı iptal et';
@@ -2334,10 +2334,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get scrollWheelActionSeek => 'Sar (İleri / Geri)';
 
   @override
-  String get scrollWheelActionVolume => 'Ses düzeyi';
+  String get scrollWheelActionVolume => 'Ses';
 
   @override
-  String get playerTooltipVolume => 'Ses düzeyi';
+  String get playerTooltipVolume => 'Ses';
 
   @override
   String get fit => 'Sığdır';
@@ -2352,7 +2352,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get refreshRateSwitching => 'Yenileme Hızını Değiştir';
 
   @override
-  String get disabled => 'Devre dışı';
+  String get disabled => 'Devre Dışı';
 
   @override
   String get scaleOnTv => 'TV\'de Ölçekle';
@@ -2412,7 +2412,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get transcodingAudio => 'Anlık Dönüştürme (Ses)';
 
   @override
-  String get directStreamRemux => 'Doğrudan Akış (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
@@ -3709,7 +3709,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Seerr ana sayfasında görmek istediğiniz satırları etkinleştirin. Yeniden sıralamak için sürükleyin. Özel sıralama Moonbase ile senkronize edilir.';
 
   @override
-  String get enabled => 'Etkin';
+  String get enabled => 'Etkinleştirildi';
 
   @override
   String get hidden => 'Gizli';
@@ -3970,7 +3970,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showMore => 'Daha Fazla Göster';
 
   @override
-  String get appearances => 'Rol aldığı yapımlar';
+  String get appearances => 'Görünümler';
 
   @override
   String get crewSection => 'Ekip';
@@ -4205,7 +4205,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get disable => 'Devre dışı bırak';
 
   @override
-  String get done => 'Bitti';
+  String get done => 'Tamamlandı';
 
   @override
   String get edit => 'Düzenle';
@@ -4217,7 +4217,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get error => 'Hata';
 
   @override
-  String get forward => 'İleri sar';
+  String get forward => 'İleri';
 
   @override
   String get general => 'Genel';
@@ -4265,7 +4265,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get refresh => 'Yenile';
 
   @override
-  String get remote => 'Kumanda';
+  String get remote => 'Uzak';
 
   @override
   String get rename => 'Yeniden adlandır';
@@ -4310,7 +4310,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get time => 'Zaman';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'Önizleme Resimleri';
 
   @override
   String get uninstall => 'Kaldır';
@@ -4328,7 +4328,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get unmute => 'Sesini aç';
 
   @override
-  String get mute => 'Sessize al';
+  String get mute => 'Sesini kapat';
 
   @override
   String get branding => 'Markalaşma';
@@ -4364,13 +4364,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminDrawerTranscoding => 'Kod dönüştür';
 
   @override
-  String get adminDrawerResume => 'Devam et';
+  String get adminDrawerResume => 'Sürdür';
 
   @override
   String get adminDrawerStreaming => 'Akış';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'Önizleme Resimleri';
 
   @override
   String get adminDrawerDevices => 'Cihazlar';
@@ -4541,7 +4541,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get sessionRewind => 'Geri sarma';
 
   @override
-  String get sessionForward => 'İleri sar';
+  String get sessionForward => 'İleri';
 
   @override
   String get sessionNext => 'Sonraki';
@@ -4559,7 +4559,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get nowPlaying => 'Şimdi Oynuyor';
 
   @override
-  String get volume => 'Ses düzeyi';
+  String get volume => 'Ses';
 
   @override
   String get actions => 'Eylemler';
@@ -5903,10 +5903,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminThrottleBuffering => 'Arabelleğe almayı sınırla';
 
   @override
-  String get adminTrickplaySaved => 'Trickplay ayarları kaydedildi';
+  String get adminTrickplaySaved => 'Önizleme ayarları kaydedildi';
 
   @override
-  String get adminTrickplayLoadFailed => 'Trickplay ayarları yüklenemedi';
+  String get adminTrickplayLoadFailed => 'Önizleme ayarları yüklenemedi';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6182,7 +6182,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminAddTuner => 'Tuner Ekle';
 
   @override
-  String get adminEditTuner => 'Tuner Düzenle';
+  String get adminEditTuner => 'Tuner\'i Düzenle';
 
   @override
   String get adminTunerTypeM3u => 'M3U Tuner';
@@ -6194,50 +6194,49 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminTunerFileOrUrl => 'Dosya veya URL';
 
   @override
-  String get adminTunerIpAddress => 'Tuner IP adresi';
+  String get adminTunerIpAddress => 'Tuner IP Adresi';
 
   @override
-  String get adminTunerFriendlyName => 'Görünen ad';
+  String get adminTunerFriendlyName => 'Görünen Ad';
 
   @override
-  String get adminTunerUserAgent => 'Kullanıcı aracısı';
+  String get adminTunerUserAgent => 'Kullanıcı Aracısı';
 
   @override
-  String get adminTunerCount => 'Eşzamanlı bağlantı sınırı';
+  String get adminTunerCount => 'Eşzamanlı Bağlantı Sınırı';
 
   @override
   String get adminTunerCountHelp =>
-      'Tuner\'ın aynı anda izin verdiği maksimum akış sayısı. Sınırsız için 0 girin.';
+      'Alıcının aynı anda izin verdiği maksimum akış sayısı. Sınırsız yapmak için 0 olarak ayarlayın.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Yedek maksimum akış bit hızı';
+  String get adminTunerFallbackBitrate => 'Yedek Maksimum Akış Hızı';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Yalnızca favori kanalları içe aktar';
+  String get adminTunerImportFavoritesOnly => 'Sadece favori kanalları aktar';
 
   @override
   String get adminTunerAllowHwTranscoding =>
       'Donanım kod dönüştürmeye izin ver';
 
   @override
-  String get adminTunerAllowFmp4 =>
-      'fMP4 kod dönüştürme kapsayıcısına izin ver';
+  String get adminTunerAllowFmp4 => 'fMP4 kod dönüştürme taşıyıcısına izin ver';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Akış paylaşımına izin ver';
+  String get adminTunerAllowStreamSharing => 'Yayın paylaşımına izin ver';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Akış döngüsünü etkinleştir';
+  String get adminTunerEnableStreamLooping => 'Yayın döngüsünü etkinleştir';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS yoksay';
+  String get adminTunerIgnoreDts => 'DTS Ses Desteğini Yok Say';
 
   @override
-  String get adminTunerReadAtNativeFramerate => 'Girişi doğal kare hızında oku';
+  String get adminTunerReadAtNativeFramerate =>
+      'Girdiyi yerel kare hızında oku';
 
   @override
-  String get adminEditProvider => 'Sağlayıcı Düzenle';
+  String get adminEditProvider => 'Sağlayıcıyı Düzenle';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6249,23 +6248,23 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminXmltvPath => 'Dosya veya URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Film ön eki';
+  String get adminXmltvMoviePrefix => 'Film Ön Adı';
 
   @override
-  String get adminXmltvMovieCategories => 'Film kategorileri';
+  String get adminXmltvMovieCategories => 'Film Kategorileri';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Birden fazla kategoriyi dikey çizgi ile ayırın.';
+      'Birden çok kategoriyi dikey çizgi ile ayırın.';
 
   @override
-  String get adminXmltvKidsCategories => 'Çocuk kategorileri';
+  String get adminXmltvKidsCategories => 'Çocuk Kategorileri';
 
   @override
-  String get adminXmltvNewsCategories => 'Haber kategorileri';
+  String get adminXmltvNewsCategories => 'Haber Kategorileri';
 
   @override
-  String get adminXmltvSportsCategories => 'Spor kategorileri';
+  String get adminXmltvSportsCategories => 'Spor Kategorileri';
 
   @override
   String get adminSdUsername => 'Kullanıcı Adı';
@@ -6277,19 +6276,19 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminSdCountry => 'Ülke';
 
   @override
-  String get adminSdCountrySelect => 'Bir ülke seçin';
+  String get adminSdCountrySelect => 'Ülke Seç';
 
   @override
-  String get adminSdPostalCode => 'Posta kodu';
+  String get adminSdPostalCode => 'Posta Kodu';
 
   @override
-  String get adminSdGetListings => 'Listeleri getir';
+  String get adminSdGetListings => 'Yayın Akışını Al';
 
   @override
-  String get adminSdListings => 'Listeler';
+  String get adminSdListings => 'Yayın Akışları';
 
   @override
-  String get adminEnableAllTuners => 'Tüm tuner\'ları etkinleştir';
+  String get adminEnableAllTuners => 'Tüm tunerleri aktif et';
 
   @override
   String get adminTunerType => 'Tuner Türü';
@@ -6859,7 +6858,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Kaldır';
+  String get adminReposRemove => 'Kaldırmak';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -7092,10 +7091,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP ton eşleme parlaklığı';
+      'VPP ton haritalama parlaklığı';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP ton eşleme kontrastı';
+  String get adminPlaybackVppTonemappingContrast =>
+      'VPP ton haritalama kontrastı';
 
   @override
   String get adminPlaybackPresetsQuality => 'Ön Ayar & Kalite';
@@ -7114,7 +7114,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Tarama giderirken kare hızını iki katına çıkar';
+      'Taramasızlaştırma yaparken kare hızını ikiye katla';
 
   @override
   String get adminPlaybackAudioSection => 'Ses';
@@ -7252,7 +7252,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminTaskNeverRun => 'Asla çalışma';
 
   @override
-  String get adminTaskStop => 'Durdur';
+  String get adminTaskStop => 'Dur';
 
   @override
   String get adminRunningTasks => 'Çalışan Görevler';
@@ -7392,7 +7392,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'İleri sarma önizleme küçük resimleri için Trickplay görüntü oluşturmayı yapılandırın.';
+      'Önizleme küçük resimlerini aramak için hileli görüntü oluşturmayı yapılandırın.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Genel HTTPS bağlantı noktası';
@@ -7478,7 +7478,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Anlık altyazı ayıklamaya izin ver';
+      'Anında altyazı çıkarılmasına izin ver';
 
   @override
   String get adminResumeMinPct => 'Minimum devam etme yüzdesi';
@@ -7538,7 +7538,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Yavaş yanıt uyarılarını etkinleştir';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect\'i Etkinleştir';
+  String get adminGeneralQuickConnect => 'Hızlı Bağlantıyı Etkinleştir';
 
   @override
   String get adminGeneralSectionServer => 'Sunucu';
@@ -7562,7 +7562,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminGeneralServerName => 'Sunucu adı';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Tercih edilen görüntüleme dili';
+  String get adminGeneralDisplayLanguage => 'Tercih edilen görünüm dili';
 
   @override
   String get adminSettingsLoadFailed => 'Ayarlar yüklenemedi';
@@ -7897,35 +7897,35 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pinBackspace => 'Geri tuşu';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect isteği onaylandı.';
+  String get quickConnectAuthorized => 'Hızlı Bağlantı isteği onaylandı.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect kodu geçersiz veya süresi dolmuş.';
+      'Hızlı Bağlantı kodu geçersiz veya süresi dolmuş.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect bu sunucuda desteklenmiyor.';
+      'Hızlı Bağlantı bu sunucuda desteklenmiyor.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect kodu yetkilendirilemedi.';
+      'Hızlı Bağlantı kodu yetkilendirilemedi.';
 
   @override
   String get quickConnectDisabled =>
-      'Quick Connect bu sunucuda devre dışı bırakıldı.';
+      'Hızlı Bağlantı bu sunucuda devre dışı bırakıldı.';
 
   @override
   String get quickConnectForbidden =>
-      'Hesabınız bu Quick Connect isteğine yetki veremez.';
+      'Hesabınız bu Hızlı Bağlantı isteğine yetki veremez.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect kodu bulunamadı. Yeni bir kod deneyin.';
+      'Hızlı Bağlantı kodu bulunamadı. Yeni bir kod deneyin.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect başarısız oldu: $message';
+    return 'Hızlı Bağlantı başarısız oldu: $message';
   }
 
   @override
@@ -8090,7 +8090,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Oynatma duraklatıldı. Hala izliyor musun?';
 
   @override
-  String get stillWatchingStop => 'Durdur';
+  String get stillWatchingStop => 'Dur';
 
   @override
   String get stillWatchingContinue => 'Devam et';
@@ -8152,7 +8152,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playerTooltipUnlockOrientation => 'Ekran döndürmeye izin ver';
 
   @override
-  String get playerTooltipPrevious => 'Önceki';
+  String get playerTooltipPrevious => 'Öncesi';
 
   @override
   String get playerTooltipSeekBack => 'Geri ara';
@@ -8768,7 +8768,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get hideBackdropsInLibraries =>
-      'Gezinirken Arka Plan Görselleri Gizlensin mi?';
+      'Göz atarken arka plan resimleri gizlensin mi?';
 
   @override
   String get useDetailedSubHeadings => 'Detaylı alt başlıklar kullan';
@@ -9394,7 +9394,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminServerPathLogs => 'Günlükler';
 
   @override
-  String get adminServerPathMetadata => 'Meta Veri';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
   String get adminServerPathTranscode => 'Dönüştür';
@@ -9433,7 +9433,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminDrawerSectionAdvanced => 'Gelişmiş';
 
   @override
-  String get adminDrawerSectionPlugins => 'Eklentiler';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
   String get adminDrawerSectionLiveTv => 'Canlı TV';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -12,27 +12,27 @@ class AppLocalizationsUg extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'ھېسابات مايىللىقلىرى';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'كۆرۈنمە يۈز تىلى';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'سىستېما سۈكۈتتىكىسى';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'تىزىملىتىڭ';
 
   @override
-  String get empty => 'قۇرۇق';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '$serverName غا ئۇلىنىۋاتىدۇ';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'تېز ئۇلىنىش';
 
   @override
   String get password => 'پارول';
@@ -61,12 +61,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect نى ئىشلەتكىلى بولمايدۇ: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect نى ئىشلەتكىلى بولمايدۇ ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin نەشرى $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '«$serverName» مۇلازىمېتىرلىرىڭىزدىن چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'بىكار قىلىش';
 
   @override
-  String get remove => 'چىقىرىۋېتىش';
+  String get remove => 'ئۆچۈرۈڭ';
 
   @override
   String get connectToServer => 'مۇلازىمېتىرغا ئۇلاڭ';
@@ -138,65 +138,65 @@ class AppLocalizationsUg extends AppLocalizations {
   String get ok => 'ماقۇل';
 
   @override
-  String get settingsAppearanceTheme => 'ئەپ تېمىسى';
+  String get settingsAppearanceTheme => 'App Theme';
 
   @override
-  String get detailScreenStyle => 'تەپسىلات ئېكرانى ئۇسلۇبى';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'كلاسسىك — moonfin نىڭ ئەسلى ئوتتۇرىغا توغرىلانغان ئورۇنلاشتۇرۇلۇشى. زامانىۋى — ماسلىشىشچان كىنو ئۇسلۇبىدىكى ئورۇنلاشتۇرۇلۇش.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'كلاسسىك';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'زامانىۋى';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'كېڭەيتىلگەن بەتكۈچلەر';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'بەتكۈچلەرنى كۆرگەندە مەزمۇنىنى ئۆزلۈكىدىن كۆرسىتىدۇ. تاقىۋەتسىڭىز، ھەر بىر بەتكۈچنى قولدا ئېچىپ-ياپىسىز.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'تېخنىكىلىق تەپسىلاتلار كۆرسىتىلسۇنمۇ؟';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'لەۋھە خۇلاسىسىدە كودېك، ئېنىقلىق ۋە ئېقىم ئۇچۇرلىرىنى كۆرسىتىدۇ';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'تەۋسىيە سىستېمىسى';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Moonfin Recommends يەرلىك ئامبار ئالگورىتمىنى ياكى توردىكى TMDb ئوخشاشلىق ئۆلچەملىرىنى ئىشلىتىڭ. ئەسكەرتىش: توردىكى تەۋسىيەلەرگە Seerr بىرىكمىسى كېرەك.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb ئوخشاشلىقى';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'ياش چەكلىمىسى چېكى قوللىنىلسۇنمۇ؟';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Moonfin Recommends تەۋسىيەلىرىنى نىشان مېدىيانىڭ ياش چەكلىمىسى بويىچە چەكلەيدۇ';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'كۆرۈنمە يۈز ئۇسلۇبى';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'ئاپتوماتىك ئۈسكۈنىڭىزگە ماسلىشىدۇ. مۇئەييەن كۆرۈنۈشنى تاللاش ئۈچۈن Apple ياكى Material نى تاللاڭ.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'ئاپتوماتىك';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,38 +205,38 @@ class AppLocalizationsUg extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'ئەينەك سۈپىتى';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'ئاپتوماتىك بۇ ئۈسكۈنىگە ئەڭ ماس ئەينەك ئۈنۈمىنى تاللايدۇ. تولۇق ھەقىقىي گۇڭگالاشتۇرۇشنى ئىشلىتىدۇ؛ يېنىكلىتىلگەن GPU قۇۋۋىتىنى تېجەيدىغان يېنىك ئەينەكنى ئىشلىتىدۇ.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'ئاپتوماتىك';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'تولۇق';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'يېنىكلىتىلگەن';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'بۇ دېتالنى قايتا قوزغىماي Moonfin بىلەن Neon Pulse نى ئالماشتۇرۇڭ';
 
   @override
-  String get customThemeTitle => 'ئىختىيارى تېما';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'ئىختىيارى تېمىلار Moonfin نىڭ كۆرۈنۈش ئېلېمېنتلىرىنى ئۆزگەرتىدۇ. ئۇسلۇبىڭىزغا ماس بىرىنى تاللاڭ.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'سىستېما ھەرپتاختىسىنى ئالدىن ئىشلىتىش';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'تېكىست كىرگۈزۈشتە سۈكۈتتە ئۈسكۈنىڭىزنىڭ كىرگۈزگۈچىنى ئىشلىتىدۇ';
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -246,25 +246,25 @@ class AppLocalizationsUg extends AppLocalizations {
       'ھازىرقى Moonfin قارىسىڭىز ھەممىڭىز ياخشى كۆرۈپ قالدىڭىز';
 
   @override
-  String get themeNeonPulse => 'نېئون پۇلس';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle =>
       'Magenta پارقىراقلىقى ، سىئەن تېكىستى ۋە تېخىمۇ كۈچلۈك خروم سېلىشتۇرمىسى بىلەن Synthwave ئۇسلۇبى';
 
   @override
-  String get themeGlass => 'ئەينەك';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'لەيلىمە گىرادىيېنت تەگلىك، تۇمانلاشقان يۈزلەر ۋە Apple كۆكى بېزىكى بار سۇيۇق ئەينەك ئۇسلۇبى';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-بىت قەھرىمان';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'قويۇق رەڭ تاختىسى، بۆلەكسىمان گىرۋەكلەر، قاتتىق سايىلەر ۋە پىكسېل خەت نۇسخىسى بار رېترو پىكسېل ئۇسلۇبى';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -314,7 +314,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '$target غا ئۇلانغىلى بولمىدى';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -327,36 +327,35 @@ class AppLocalizationsUg extends AppLocalizations {
   String get exit => 'چىقىش';
 
   @override
-  String get gameMenu => 'تىزىملىك';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'ۋاقىتلىق توختىتىلدى';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'ھالەتنى ساقلاش';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'ئويۇنلار';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'ھالەتنى يۈكلەش';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'تېز ئالدىغا سۈرۈش';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'ئېمۇلياتور تەڭشەكلىرى';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'بۇ يادرونىڭ تەڭشىگىلى بولىدىغان تاللانمىلىرى يوق.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'تىزىملىكنى ئېچىش ئۈچۈن بېسىپ تۇرۇڭ';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'بۇ ئۈسكۈنە ئويۇن ئوينىتىشنى تېخى قوللىمايدۇ.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'ھېچقانداق ئۆي قۇرلىرىنى يۈكلەشكە بولمايدۇ';
@@ -372,19 +371,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get guide => 'يېتەكچى';
 
   @override
-  String get recordings => 'خاتىرىلەنگەن پروگراممىلار';
+  String get recordings => 'Recordings';
 
   @override
   String get schedule => 'ۋاقىت جەدۋىلى';
 
   @override
-  String get series => 'تېلېۋىزىيە تىياتىرلىرى';
+  String get series => 'Series';
 
   @override
   String get noItemsFound => 'ھېچقانداق نەرسە تېپىلمىدى';
 
   @override
-  String get home => 'باش بەت';
+  String get home => 'ئۆي';
 
   @override
   String get browseAll => 'ھەممىنى كۆرۈڭ';
@@ -415,7 +414,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get noLibrariesFound => 'كۈتۈپخانىلار تېپىلمىدى';
 
   @override
-  String get library => 'مېدىيا ئامبىرى';
+  String get library => 'كۈتۈپخانا';
 
   @override
   String get displaySettings => 'تەڭشەكلەرنى كۆرسىتىش';
@@ -428,7 +427,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'قىسقۇچ يۈكلىنەلمىدى: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count تۈر';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count تۈر';
+    return '$count Items';
   }
 
   @override
@@ -469,7 +468,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get type => 'تىپ';
 
   @override
-  String get sortBy => 'تەرتىپلەش ئاساسى';
+  String get sortBy => 'Sort By';
 
   @override
   String get display => 'كۆرسىتىش';
@@ -494,7 +493,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — ژانىرلار';
+    return '$name — Genres';
   }
 
   @override
@@ -533,17 +532,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count مىنۇت ئىلگىرى';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count سائەت ئىلگىرى';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count كۈن ئىلگىرى';
+    return '${count}d ago';
   }
 
   @override
@@ -554,7 +553,7 @@ class AppLocalizationsUg extends AppLocalizations {
       '«بايقاش» تا قايسى مەزمۇننى كۆرسىتىدىغانلىقىنى تاللاڭ.';
 
   @override
-  String get apply => 'قوللىنىش';
+  String get apply => 'ئىلتىماس قىلىڭ';
 
   @override
   String get openLink => 'ئۇلىنىشنى ئېچىڭ';
@@ -577,7 +576,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count ئەسەر';
+    return '$count titles';
   }
 
   @override
@@ -602,7 +601,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get listen => 'ئاڭلاڭ';
 
   @override
-  String get resume => 'داۋاملاشتۇرۇش';
+  String get resume => 'ئەسلىگە كەلتۈرۈش';
 
   @override
   String get failedToLoadLibrary => 'كۈتۈپخانىنى يۈكلىيەلمىدى';
@@ -614,7 +613,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get savedForLater => 'كېيىن ساقلاندى';
 
   @override
-  String get topListens => 'ئەڭ كۆپ ئاڭلانغانلار';
+  String get topListens => 'Top Listens';
 
   @override
   String get unreadDiscoveries => 'ئوقۇلمىغان بايقاشلار';
@@ -663,17 +662,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count ئاپتور';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count ژانىر';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% تاماملاندى';
+    return '$percent% completed';
   }
 
   @override
@@ -690,7 +689,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return 'ئوقۇشقا قولايلىق كۆرۈش ئۈچۈن $count ئەسەر تىزىلدى.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -727,7 +726,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label تېپىلمىدى';
+    return 'No $label found';
   }
 
   @override
@@ -746,13 +745,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get readStatus => 'ئوقۇ';
 
   @override
-  String get watched => 'كۆرۈلگەن';
+  String get watched => 'كۆزىتىلدى';
 
   @override
   String get unread => 'ئوقۇمىغان';
 
   @override
-  String get unwatched => 'كۆرۈلمىگەن';
+  String get unwatched => 'كۆزىتىلمىگەن';
 
   @override
   String get seriesStatus => 'يۈرۈشلۈك ھالىتى';
@@ -764,43 +763,43 @@ class AppLocalizationsUg extends AppLocalizations {
   String get books => 'كىتابلار';
 
   @override
-  String get latestBooks => 'ئەڭ يېڭى كىتابلار';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'ئەڭ يېڭى ئاۋازلىق كىتابلار';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count كىتاب',
-      one: '1 كىتاب',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'كىتاب';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'ئاۋازلىق كىتاب';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% ئوقۇلدى';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time قالدى';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'ئوقۇش';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'ئاڭلاش';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'ئاپتور';
@@ -831,19 +830,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get internetArchive => 'Internet Archive';
 
   @override
-  String get rssFeed => 'RSS قانىلى';
+  String get rssFeed => 'RSS Feed';
 
   @override
   String get downloadZip => 'Zip نى چۈشۈرۈڭ';
 
   @override
   String sectionCountLabel(int count) {
-    return '$count بۆلەك';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'تۇنجى نەشرى $year';
+    return 'First published $year';
   }
 
   @override
@@ -858,7 +857,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count كىتاب';
+    return '$count books';
   }
 
   @override
@@ -869,7 +868,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count ئاپتور';
+    return '$count Authors';
   }
 
   @override
@@ -877,8 +876,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ئاۋازلىق كىتاب',
-      one: '1 ئاۋازلىق كىتاب',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -902,16 +901,16 @@ class AppLocalizationsUg extends AppLocalizations {
   String get moreLikeThis => 'بۇنىڭغا ئوخشاش';
 
   @override
-  String get castAndCrew => 'ئارتىسلار ۋە خادىملار';
+  String get castAndCrew => 'Cast & Crew';
 
   @override
-  String get collection => 'توپلام';
+  String get collection => 'Collection';
 
   @override
-  String get episodes => 'بۆلۈملەر';
+  String get episodes => 'Episodes';
 
   @override
-  String get nextUp => 'كېيىنكىسى';
+  String get nextUp => 'Next Up';
 
   @override
   String get seasons => 'پەسىللەر';
@@ -920,19 +919,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get chapters => 'باب';
 
   @override
-  String get features => 'ئالاھىدە مەزمۇنلار';
+  String get features => 'Features';
 
   @override
   String get movies => 'كىنولار';
 
   @override
-  String get musicVideos => 'مۇزىكا سىنلىرى';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'باشقىلىرى';
 
   @override
-  String get discography => 'ئالبوملار';
+  String get discography => 'Discography';
 
   @override
   String get similarArtists => 'مۇشۇنىڭغا ئوخشاش سەنئەتكارلار';
@@ -945,7 +944,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'دىسكا $number';
+    return 'Disc $number';
   }
 
   @override
@@ -969,7 +968,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'نەشرى $year';
+    return 'Published $year';
   }
 
   @override
@@ -980,52 +979,52 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count پەسىل',
-      one: '1 پەسىل',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time دە ئاخىرلىشىدۇ';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'تۈرلەر';
+  String get items => 'Items';
 
   @override
-  String get extras => 'قوشۇمچىلار';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'سەھنە ئارقىسى';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'ئۆچۈرۈلگەن كۆرۈنۈشلەر';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'قىسقا تونۇشتۇرمىلار';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'سۆھبەتلەر';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'كۆرۈنۈشلەر';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'قىسقا فىلىملەر';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'ئالدىن كۆرۈنۈشلەر';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time قالدى';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time دىن كېيىن ئاخىرلىشىدۇ';
+    return 'Ends in $time';
   }
 
   @override
@@ -1039,11 +1038,11 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '$position دىن داۋاملاشتۇرۇش';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'قويۇش';
+  String get play => 'ئويناش';
 
   @override
   String get startOver => 'باشلاش';
@@ -1058,19 +1057,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playOffline => 'Offline نى ئويناڭ';
 
   @override
-  String get audio => 'ئاۋاز';
+  String get audio => 'Audio';
 
   @override
-  String get subtitles => 'ئېكران خېتى';
+  String get subtitles => 'Subtitles';
 
   @override
   String get version => 'نەشرى';
 
   @override
-  String get cast => 'ئېكرانغا چىقىرىش';
+  String get cast => 'Cast';
 
   @override
-  String get trailer => 'ئالدىن كۆرۈنۈش';
+  String get trailer => 'Trailer';
 
   @override
   String get finished => 'تاماملاندى';
@@ -1138,7 +1137,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '«$title» نىڭ چۈشۈرۈلگەن ناخشىلىرى ئۆچۈرۈلسۇنمۇ؟';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1153,17 +1152,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel يۈكلەنمىدى';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title چۈشۈرۈلۈۋاتىدۇ ($count تۈر)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '«$name» مۇلازىمېتىردىن راستىنلا ئۆچۈرۈلسۇنمۇ؟ بۇ مەشغۇلاتنى ئەسلىگە قايتۇرغىلى بولمايدۇ.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1175,17 +1174,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'قوللىمايدىغان كىتاب فورماتى: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
-  String get audioTrack => 'ئاۋاز يولى';
+  String get audioTrack => 'Audio Track';
 
   @override
-  String get subtitleTrack => 'ئېكران خېتى يولى';
+  String get subtitleTrack => 'Subtitle Track';
 
   @override
-  String get none => 'يوق';
+  String get none => 'ياق';
 
   @override
   String get downloadSubtitlesLabel => 'Subtitles نى چۈشۈرۈڭ ...';
@@ -1202,7 +1201,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'ئېكران خېتى چۈشۈرۈلۈپ تاللاندى: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1211,7 +1210,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '$language ئۈچۈن توردىن ئېكران خېتى تېپىلمىدى.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1219,7 +1218,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'نەشر $number';
+    return 'Version $number';
   }
 
   @override
@@ -1239,7 +1238,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '$name چۈشۈرۈلۈۋاتىدۇ ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1247,7 +1246,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '$typeLabel نىڭ يەرلىك ھۆججەتلىرى ئۆچۈرۈلسۇنمۇ؟\n\nبۇ ساقلاش بوشلۇقىنى بىكارلايدۇ. كېيىن قايتا چۈشۈرەلەيسىز.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1260,28 +1259,28 @@ class AppLocalizationsUg extends AppLocalizations {
   String get deleteFiles => 'ھۆججەتلەرنى ئۆچۈرۈڭ';
 
   @override
-  String get director => 'رېژىسسور';
+  String get director => 'DIRECTOR';
 
   @override
-  String get directors => 'رېژىسسورلار';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'سىنارىيەچى';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'يازغۇچىلار';
 
   @override
-  String get studio => 'ئىستۇدىيە';
+  String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return 'يەنە +$count';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count بۆلۈم';
+    return '$count Episodes';
   }
 
   @override
@@ -1291,12 +1290,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return '$number-بۆلۈم';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '$number-باب';
+    return 'Chapter $number';
   }
 
   @override
@@ -1304,8 +1303,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ناخشا',
-      one: '1 ناخشا',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1315,25 +1314,25 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count باب',
-      one: '1 باب',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'تۇغۇلغان: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'ۋاپات بولغان: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'يېشى: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1343,20 +1342,20 @@ class AppLocalizationsUg extends AppLocalizations {
   String get readMore => 'تېخىمۇ كۆپ ئوقۇڭ';
 
   @override
-  String get shuffle => 'تەرتىپسىز قويۇش';
+  String get shuffle => 'Shuffle';
 
   @override
-  String get shuffleAllMusic => 'بارلىق مۇزىكىنى تەرتىپسىز قويۇش';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'تېلېفونىڭىزدا Moonfin غا كىرىڭ';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'مۇلازىمېتىرىڭىزغا ئۇلانغىلى بولمىدى';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count قېتىم چۈشۈرۈلگەن';
+    return '$count downloads';
   }
 
   @override
@@ -1364,43 +1363,43 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count قانال';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'مونو';
+  String get mono => 'Mono';
 
   @override
-  String get stereo => 'ستېرېئو';
+  String get stereo => 'Stereo';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'توردىن ئېكران خېتى $action مەشغۇلاتىغا بۇ ئىشلەتكۈچىنىڭ Jellyfin ئېكران خېتى باشقۇرۇش ھوقۇقى كېرەك.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'توردىن ئېكران خېتى $action ئۈچۈن بۇ تۈر مۇلازىمېتىردىن تېپىلمىدى.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'توردىن ئېكران خېتى $action مەغلۇپ بولدى: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'توردىن ئېكران خېتى $action مەغلۇپ بولدى (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'توردىكى ئېكران خېتىنى $action قىلىش مەغلۇپ بولدى.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '«$name» نىڭ بارلىق چۈشۈرۈلگەن بۆلۈملىرى';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1429,34 +1428,34 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label مەشغۇلاتى مەغلۇپ بولدى: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'ئېكرانغا يوللاش ئاۋاز مىقدارىنى تەڭشەش مەغلۇپ بولدى: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label كونتروللىرى';
+    return '$label Controls';
   }
 
   @override
   String get deviceVolume => 'ئۈسكۈنىنىڭ ھەجىمى';
 
   @override
-  String get unavailable => 'ئىشلەتكىلى بولمايدۇ';
+  String get unavailable => 'Unavailable';
 
   @override
-  String get pause => 'ۋاقىتلىق توختىتىش';
+  String get pause => 'Pause';
 
   @override
   String get syncPosition => 'ماس قەدەم ئورنى';
 
   @override
   String stopCast(String label) {
-    return '$label نى توختىتىش';
+    return 'Stop $label';
   }
 
   @override
@@ -1464,7 +1463,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '$number-ناخشا';
+    return 'Track $number';
   }
 
   @override
@@ -1481,14 +1480,14 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds سېكۇنت';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => 'قۇلۇپنى ئۇزۇن بېسىڭ';
 
   @override
-  String get off => 'تاقاق';
+  String get off => 'Off';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1504,10 +1503,10 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get bitrateOverride => 'بىت نىسبىتى قولدا بەلگىلەنگەن';
+  String get bitrateOverride => 'Bitrate Override';
 
   @override
-  String get audioDelay => 'ئاۋاز كېچىكتۈرۈش';
+  String get audioDelay => 'Audio Delay';
 
   @override
   String delayMinusMs(int value) {
@@ -1520,7 +1519,7 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get subtitleDelay => 'ئېكران خېتى كېچىكتۈرۈش';
+  String get subtitleDelay => 'Subtitle Delay';
 
   @override
   String get reset => 'ئەسلىگە قايتۇرۇش';
@@ -1538,13 +1537,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playMethod => 'ئويناش ئۇسۇلى';
 
   @override
-  String get directPlay => 'بىۋاسىتە قويۇش';
+  String get directPlay => 'Direct Play';
 
   @override
-  String get directStream => 'بىۋاسىتە ئېقىم';
+  String get directStream => 'Direct Stream';
 
   @override
-  String get transcoding => 'كود ئۆزگەرتىش';
+  String get transcoding => 'Transcoding';
 
   @override
   String get transcodeReasons => 'Transcode سەۋەبلىرى';
@@ -1556,10 +1555,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get container => 'كونتېينېر';
 
   @override
-  String get bitrate => 'بىت نىسبىتى';
+  String get bitrate => 'Bitrate';
 
   @override
-  String get video => 'سىن';
+  String get video => 'Video';
 
   @override
   String get resolution => 'قارار';
@@ -1568,19 +1567,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
-  String get codec => 'كودېك';
+  String get codec => 'Codec';
 
   @override
-  String get videoBitrate => 'سىن بىت نىسبىتى';
+  String get videoBitrate => 'Video Bitrate';
 
   @override
-  String get track => 'ئاۋاز يولى';
+  String get track => 'ئىز قوغلاش';
 
   @override
   String get channels => 'قاناللار';
 
   @override
-  String get audioBitrate => 'ئاۋاز بىت نىسبىتى';
+  String get audioBitrate => 'Audio Bitrate';
 
   @override
   String get sampleRate => 'ئۈلگە نىسبىتى';
@@ -1596,12 +1595,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol سېئانس خاتالىقى';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'كىتاب تەپسىلاتلىرى يۈكلىنەلمىدى: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1610,7 +1609,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'بۇ فورماتنى (.$extension) ئەپ ئىچىدە تېخى كۆرسەتكىلى بولمايدۇ.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1622,17 +1621,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'ئەپ ئىچىدىكى ئوقۇغۇچ ئېچىلمىدى: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label دا خەتكۈش ئاللىبۇرۇن ساقلانغان.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'خەتكۈش قوشۇلدى: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1644,7 +1643,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '$number-بەت';
+    return 'Page $number';
   }
 
   @override
@@ -1655,12 +1654,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'فورماتى: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% ئوقۇلدى';
+    return '$percent% read';
   }
 
   @override
@@ -1683,7 +1682,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'چوڭايتىشنى ئەسلىگە قايتۇرۇش (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1706,7 +1705,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'ئوقۇلغان ھالەتنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1739,7 +1738,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'بۇ سۇپا $extension ھۆججەتلىرى ئۈچۈن قىستۇرما پۈتۈك ماتورىنى قوللىمايدۇ.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1756,7 +1755,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get readerNotReady => 'ئوقۇرمەن تەييار ئەمەس.';
 
   @override
-  String get seriesRecordings => 'تىياتىر خاتىرىلەنمىلىرى';
+  String get seriesRecordings => 'Series Recordings';
 
   @override
   String get now => 'ھازىر';
@@ -1771,44 +1770,44 @@ class AppLocalizationsUg extends AppLocalizations {
   String get kids => 'بالىلار';
 
   @override
-  String get premiere => 'تۇنجى قويۇلۇش';
+  String get premiere => 'Premiere';
 
   @override
   String get guideTimeline => 'يېتەكچى ۋاقىت';
 
   @override
   String failedToLoadGuide(String error) {
-    return 'پروگرامما جەدۋىلى يۈكلىنەلمىدى: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
   String get noChannelsFound => 'ھېچقانداق قانال تېپىلمىدى';
 
   @override
-  String get liveBadge => 'بىۋاسىتە';
+  String get liveBadge => 'LIVE';
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'كېيىنكىسى: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '$minutes مىنۇت قالدى';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '$hours سائەت قالدى';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '$hours سائەت $minutes مىنۇت قالدى';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
-  String get movie => 'كىنو';
+  String get movie => 'Movie';
 
   @override
   String get removedFromFavoriteChannels =>
@@ -1828,29 +1827,29 @@ class AppLocalizationsUg extends AppLocalizations {
   String get favoriteChannel => 'ياقتۇرىدىغان قانال';
 
   @override
-  String get record => 'خاتىرىلەش';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'خاتىرىلەشنى بىكار قىلىش';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'پروگرامما خاتىرىلەشكە بەلگىلەندى';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'خاتىرىلەش بىكار قىلىندى';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'خاتىرىلەش قۇرغىلى بولمىدى';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'كۆرۈش';
+  String get watch => 'قاراڭ';
 
   @override
   String get close => 'تاقاش';
 
   @override
   String failedToPlayChannel(String name) {
-    return '$name نى قويغىلى بولمىدى';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1864,7 +1863,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get recentRecordings => 'يېقىنقى خاتىرىلەر';
 
   @override
-  String get tvSeries => 'تېلېۋىزىيە تىياتىرلىرى';
+  String get tvSeries => 'TV Series';
 
   @override
   String get failedToLoadSchedule => 'ۋاقىت جەدۋىلىنى يۈكلىيەلمىدى';
@@ -1877,7 +1876,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '«$name» نىڭ پىلانلانغان خاتىرىلىشى بىكار قىلىنسۇنمۇ؟';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1905,7 +1904,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '«$name» نى خاتىرىلەش توختىتىلسۇنمۇ؟';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1920,12 +1919,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '«$query» ئۈچۈن نەتىجە يوق';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'ئىزدەش مەغلۇپ بولدى: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1966,28 +1965,28 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '«$name» ۋە ھۆججەتلىرى چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count ناخشا';
+    return '$count tracks';
   }
 
   @override
-  String get album => 'ئالبوم';
+  String get album => 'Album';
 
   @override
   String get playAlbum => 'پىلاستىنكا قويۇڭ';
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'ئالبوم يۈكلىنەلمىدى: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '$name ئۈچۈن چۈشۈرۈلگەن ناخشا تېپىلمىدى.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2004,12 +2003,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '«$name» چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes مىنۇت';
+    return '$minutes min';
   }
 
   @override
@@ -2019,7 +2018,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String episodeNumber(int number) {
-    return '$number-بۆلۈم';
+    return 'Episode $number';
   }
 
   @override
@@ -2033,7 +2032,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return '$number-پەسىل';
+    return 'Season $number';
   }
 
   @override
@@ -2049,7 +2048,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '$season دىكى بارلىق چۈشۈرۈلگەن بۆلۈملەر ئۆچۈرۈلسۇنمۇ؟';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2057,8 +2056,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count بۆلۈم',
-      one: '1 بۆلۈم',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2067,7 +2066,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get storageManagement => 'ساقلاش باشقۇرۇش';
 
   @override
-  String get storageBreakdown => 'ساقلاش بوشلۇقى تەپسىلاتى';
+  String get storageBreakdown => 'Storage Breakdown';
 
   @override
   String get downloadedItems => 'چۈشۈرۈلگەن تۈرلەر';
@@ -2093,7 +2092,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '$count چۈشۈرۈلگەن تۈر ئۆچۈرۈلسۇنمۇ؟';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2107,7 +2106,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '$limit چېكىدىن';
+    return 'of $limit limit';
   }
 
   @override
@@ -2121,7 +2120,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئاپتوماتىك كىرىش ، مۇلازىمېتىر باشقۇرۇش';
 
   @override
-  String get pinCode => 'PIN كودى';
+  String get pinCode => 'PIN Code';
 
   @override
   String get setUpPinCodeProtection => 'PIN كود قوغداشنى تەڭشەڭ';
@@ -2133,7 +2132,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get contentRatingRestrictions => 'مەزمۇن دەرىجىسىنى چەكلەش';
 
   @override
-  String get bitRateResolutionBehavior => 'بىت نىسبىتى، ئېنىقلىق، ھەرىكەت';
+  String get bitRateResolutionBehavior => 'Bitrate, resolution, behavior';
 
   @override
   String get languageSizeAppearance => 'تىل ، چوڭ-كىچىكلىكى ، كۆرۈنۈشى';
@@ -2164,7 +2163,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get signInAndSecurity => 'كىرىش ۋە بىخەتەرلىك';
 
   @override
-  String get administration => 'باشقۇرۇش';
+  String get administration => 'Administration';
 
   @override
   String get serverSettingsUsersLibraries =>
@@ -2177,7 +2176,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get themeAndLayout => 'تېما ۋە ئورۇنلاشتۇرۇش';
 
   @override
-  String get videoAndSubtitles => 'سىن ۋە ئېكران خېتى';
+  String get videoAndSubtitles => 'Video and subtitles';
 
   @override
   String get integrations => 'بىرىكتۈرۈش';
@@ -2191,7 +2190,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count تاللانما';
+    return '$count options';
   }
 
   @override
@@ -2210,7 +2209,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get hideUnwatched => 'كۆزىتىلمىگەننى يوشۇر';
 
   @override
-  String get episodesOnly => 'بۆلۈملەرلا';
+  String get episodesOnly => 'Episodes Only';
 
   @override
   String get never => 'ھەرگىز بولمايدۇ';
@@ -2269,7 +2268,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get fireworks => 'پوجاڭزا';
 
   @override
-  String get confetti => 'رەڭلىك قەغەزلەر';
+  String get confetti => 'Confetti';
 
   @override
   String get fallingLeaves => 'يىقىلىپ چۈشۈش';
@@ -2286,7 +2285,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'تەپسىلات بەتلىرى، باش بەت قۇرلىرى ۋە ئاۋاز مىقدارى';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2300,11 +2299,11 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'ئائىلە ئېكرانىنى كۆرگەندە ئويناڭ';
 
   @override
-  String get loopThemeMusic => 'تېما مۇزىكىسىنى تەكرارلاش';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'بىر قېتىملا قويماي، ناخشىنى تەكرار قويىدۇ';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'تەپسىلاتى ئارقا كۆرۈنۈش';
@@ -2318,47 +2317,47 @@ class AppLocalizationsUg extends AppLocalizations {
   String get browsingBackgroundBlur => 'ئارقا كۆرۈنۈشنى كۆرۈش';
 
   @override
-  String get maxStreamingBitrate => 'ئەڭ يۇقىرى ئېقىم بىت نىسبىتى';
+  String get maxStreamingBitrate => 'Max Streaming Bitrate';
 
   @override
-  String get maxResolution => 'ئەڭ يۇقىرى ئېنىقلىق';
+  String get maxResolution => 'Max Resolution';
 
   @override
   String get playerZoomMode => 'قويغۇچ چوڭايتىش ھالىتى';
 
   @override
-  String get settingsScrollWheelAction => 'مائۇس سىيرىش چاقى';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'قويۇش جەريانىدا مائۇس چاقىنى سىن ئۈستىدە سىيرىغاندا نېمە بولىدىغانلىقىنى تاللاڭ.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'تاقاق';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'ئاتلاش (ئالدىغا / كەينىگە)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'ئاۋاز مىقدارى';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'ئاۋاز مىقدارى';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
 
   @override
-  String get autoCrop => 'ئاپتوماتىك كېسىش';
+  String get autoCrop => 'Auto Crop';
 
   @override
-  String get stretch => 'سوزۇش';
+  String get stretch => 'Stretch';
 
   @override
   String get refreshRateSwitching => 'باھا ئالماشتۇرۇشنى يېڭىلاش';
 
   @override
-  String get disabled => 'تاقالغان';
+  String get disabled => 'چەكلەنگەن';
 
   @override
   String get scaleOnTv => 'تېلېۋىزوردىكى كۆلەم';
@@ -2388,47 +2387,46 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئۇزۇن ۋاقىت بېسىلغۇچە چەكمە كىرگۈزۈشنى چەكلەيدىغان قۇلۇپ كۇنۇپكىسىنى كۆرسىتىڭ';
 
   @override
-  String get audioBehavior => 'ئاۋاز ھەرىكىتى';
+  String get audioBehavior => 'Audio Behavior';
 
   @override
-  String get downmixToStereo => 'ستېرېئوغا تۆۋەنلىتىش';
+  String get downmixToStereo => 'Downmix to Stereo';
 
   @override
   String get defaultAudioLanguage => 'كۆڭۈلدىكى ئاۋاز تىلى';
 
   @override
-  String get fallbackAudioLanguage => 'زاپاس ئاۋاز تىلى';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'سۈكۈتتىكى ئاۋاز يولىنى ئالدىن تاللاش';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'يەرلىكلەشتۈرۈلگەن دۇبلياژدىن كۆرە ئەسلى ئاۋاز يولىنى ئالدىن تاللايدۇ.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription =>
-      'ئاۋازلىق چۈشەندۈرۈش يوللىرىنى ئالدىن تاللاش';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'نورمال يوللاردىن كۆرە ئاۋازلىق چۈشەندۈرۈش يوللىرىنى ئالدىن تاللايدۇ.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'كود ئۆزگەرتىش (ئاۋاز)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'بىۋاسىتە ئېقىم (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'كود ئۆزگەرتىش (بىت نىسبىتى ياكى ئېنىقلىق)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'كود ئۆزگەرتىش (سىن ۋە ئاۋاز)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'كود ئۆزگەرتىش (سىن)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'ئاپتوماتىك (مۇلازىمېتىر سۈكۈتتىكى)';
@@ -2443,10 +2441,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get french => 'فىرانسۇزچە';
 
   @override
-  String get german => 'گېرمانچە';
+  String get german => 'German';
 
   @override
-  String get italian => 'ئىتالىيانچە';
+  String get italian => 'Italian';
 
   @override
   String get portuguese => 'پورتۇگال تىلى';
@@ -2467,7 +2465,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get arabic => 'ئەرەبچە';
 
   @override
-  String get hindi => 'ھىندىچە';
+  String get hindi => 'Hindi';
 
   @override
   String get dutch => 'گوللاندىيە';
@@ -2479,7 +2477,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get norwegian => 'نورۋېگچە';
 
   @override
-  String get danish => 'دانىيەچە';
+  String get danish => 'Danish';
 
   @override
   String get finnish => 'فىنلاندىيە';
@@ -2488,10 +2486,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get polish => 'پولشا';
 
   @override
-  String get ac3Passthrough => 'AC3 بىۋاسىتە ئۆتكۈزۈش';
+  String get ac3Passthrough => 'AC3 Passthrough';
 
   @override
-  String get dtsPassthrough => 'DTS بىۋاسىتە ئۆتكۈزۈش';
+  String get dtsPassthrough => 'DTS Passthrough';
 
   @override
   String get trueHdSupport => 'TrueHD قوللاش';
@@ -2505,27 +2503,27 @@ class AppLocalizationsUg extends AppLocalizations {
       'TrueHD ئاۋازىنى قوزغىتىڭ (بارلىق سۇپىلاردا ئىشلىمەسلىكى مۇمكىن)';
 
   @override
-  String get settingsAudioOutputMode => 'ئاۋاز چىقىرىش ھالىتى';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'ئاۋازنىڭ قانداق كودسىزلىنىدىغانلىقىنى تاللاڭ. AVR بىۋاسىتە ئۆتكۈزۈش خام Dolby/DTS ئېقىملىرىنى قوبۇللىغۇچىڭىزغا ئەۋەتىدۇ؛ ئاپتوماتىك ياكى تۆۋەنلىتىش يەرلىك كودسىزلايدۇ.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'زاپاس ئاۋاز كودېكى';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'مەنبە ئېقىمنى بىۋاسىتە قويغىلى ياكى بىۋاسىتە ئۆتكۈزگىلى بولمىغاندا، كۆپ قاناللىق ئاۋازنى كود ئۆزگەرتىدىغان نىشان فورماتنى تاللاڭ.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'ئاپتوماتىك تونۇش\n(تەۋسىيە)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(سۈكۈتتىكى)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2534,116 +2532,113 @@ class AppLocalizationsUg extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(يوقىتىشسىز)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(پەقەت ستېرېئو)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ئۈنۈملۈك)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(يوقىتىشسىز)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'ئەڭ كۆپ ئاۋاز قاناللىرى';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'ئاۋاز ئۈسكۈنىڭىزنىڭ ئەڭ كۆپ قانال سانىنى تەڭشەڭ. بۇ چەكتىن ئاشقان كۆپ قاناللىق ئېقىملار تۆۋەنلىتىلىدۇ ياكى كود ئۆزگەرتىلىدۇ.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'ئاپتوماتىك تونۇش\n(قاتتىق دېتال سۈكۈتتىكىسى)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 مونو';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 ستېرېئو';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 ئورام ئاۋاز';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 تۆت قاناللىق';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 ئورام ئاۋاز';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 ئورام ئاۋاز';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 ئورام ئاۋاز';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 ئورام ئاۋاز';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'بىۋاسىتە ئۆتكۈزۈش (ئالىي)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'كودېك بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'پەقەت AVR ياكى HDMI ئۈسكۈنىڭىز قوللايدىغان فورماتلارنىلا قوزغىتىڭ.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough =>
-      'EAC3 JOC (Atmos) بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS يادرو بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough =>
-      'TrueHD Atmos بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) بىت ئېقىمىنى سىرتقى كودسىزلىغۇچقا ئەۋەتىدۇ.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) ئۈستىدىكى Dolby Atmos بىت ئېقىمىنى سىرتقى كودسىزلىغۇچقا ئەۋەتىدۇ.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS-HD MA (DTS يادروسى بىلەن) بىت ئېقىمىنى سىرتقى كودسىزلىغۇچقا ئەۋەتىدۇ.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos مېتا ئۇچۇرلۇق Dolby TrueHD بىت ئېقىمىنى سىرتقى كودسىزلىغۇچقا ئەۋەتىدۇ.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'تونۇلغان ئاۋاز ئىقتىدارلىرى';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'ئىجرا ۋاقتى ئىقتىدار كۆرۈنۈشى تېخى يوق.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'يۆنىلىش';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'كودسىزلاش';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD ئاۋاز يۆنىلىشى';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2658,54 +2653,53 @@ class AppLocalizationsUg extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'ياڭراتقۇ';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'تىڭشىغۇچ';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count قانال PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'دىئاگنوز';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'سىن دەرىجىسى';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'سىن دائىرىسى';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'ئېكران خېتى كودېكى';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'رۇخسەت قىلىنغان ئاۋاز كودېكلىرى';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS ئاۋاز كودېكلىرى';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 ئاۋاز كودېكلىرى';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif بىۋاسىتە ئۆتكۈزۈش';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'ئاكتىپ ئاۋاز يۆنىلىشى';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'يۆنىلىشنىڭ HD ئاۋاز قوللىشى';
+      'Route HD Audio Support';
 
   @override
-  String get nightMode => 'كېچە ھالىتى';
+  String get nightMode => 'Night Mode';
 
   @override
   String get compressDynamicRange => 'ھەرىكەتچان دائىرىنى پىرىسلاش';
@@ -2738,16 +2732,16 @@ class AppLocalizationsUg extends AppLocalizations {
   String get nextUpAndQueuing => 'كېيىنكى Up & ئۆچرەت';
 
   @override
-  String get nextUpDisplay => 'كېيىنكىسى كۆرسىتىلىشى';
+  String get nextUpDisplay => 'Next Up Display';
 
   @override
   String get extended => 'كېڭەيتىلگەن';
 
   @override
-  String get minimal => 'ئاددىي';
+  String get minimal => 'Minimal';
 
   @override
-  String get nextUpTimeout => 'كېيىنكىسى ۋاقىت چېكى';
+  String get nextUpTimeout => 'Next Up Timeout';
 
   @override
   String secondsValue(int value) {
@@ -2765,7 +2759,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes بۆلۈم / $hours سائەتتىن كېيىن';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2796,14 +2790,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get skipForwardLength => 'ئالغا ئىلگىرىلەش ئۇزۇنلۇقىدىن ئاتلاڭ';
 
   @override
-  String get customMpvConfPath => 'خاسلاشتۇرۇلغان mpv.conf يولى';
+  String get customMpvConfPath => 'Custom __ARB_TERM_0 __. يول';
 
   @override
   String get notSetMpvConf =>
       'تەڭشەلمىدى. Moonfin ئەپ / سانلىق مەلۇمات قىسقۇچتا سۈكۈتتىكى mpv.conf نى سىنايدۇ.';
 
   @override
-  String get selectMpvConf => 'mpv.conf نى تاللاڭ';
+  String get selectMpvConf => '__ARB_TERM_0 __ نى تاللاڭ';
 
   @override
   String get pathToMpvConf => '/path/to/mpv.conf';
@@ -2822,7 +2816,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get turnOffSubtitlesByDefault => 'سۈكۈتتىكى مەزمۇنلارنى ئېتىۋېتىڭ';
 
   @override
-  String get subtitleSize => 'ئېكران خېتى چوڭلۇقى';
+  String get subtitleSize => 'Subtitle Size';
 
   @override
   String get textFillColor => 'تېكىست تولدۇرۇش رەڭگى';
@@ -2831,64 +2825,64 @@ class AppLocalizationsUg extends AppLocalizations {
   String get backgroundColor => 'تەگلىك رەڭگى';
 
   @override
-  String get textStrokeColor => 'خەت گىرۋەك رەڭگى';
+  String get textStrokeColor => 'Text Stroke Color';
 
   @override
-  String get subtitleCustomization => 'ئېكران خېتىنى خاسلاشتۇرۇش';
+  String get subtitleCustomization => 'Subtitle Customization';
 
   @override
   String get subtitleCustomizationDescription => 'تارماق كۆرۈنۈشنى خاسلاشتۇرۇڭ';
 
   @override
-  String get subtitleMode => 'ئېكران خېتى ھالىتى';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'بەلگىلەنگەن';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'ھەمىشە';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'چەت تىلى';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'مەجبۇرىي';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'مېدىيا ھۆججىتىنىڭ مېتا ئۇچۇرىدا «سۈكۈتتىكى» ياكى «مەجبۇرىي» دەپ بەلگىلەنگەن يوللارنى قويىدۇ.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'سىن ھەر قېتىم باشلانغاندا ئېكران خېتىنى ئۆزلۈكىدىن يۈكلەپ كۆرسىتىدۇ.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'سۈكۈتتىكى ئاۋاز يولى چەت تىلىدا بولسا، ئېكران خېتىنى ئۆزلۈكىدىن ئاچىدۇ.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'پەقەت مەجبۇرىي مېتا بەلگىسى قويۇلغان ئېكران خەتلىرىنىلا يۈكلەيدۇ.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'ئېكران خېتىنى ئۆزلۈكىدىن يۈكلەشنى پۈتۈنلەي تاقايدۇ.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'زاپاس ئېكران خېتى تىلى';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'ئېكران خېتى ئېقىمى';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
       'تېز قوڭۇر تۈلكە ھورۇن ئىتنىڭ ئۈستىگە سەكرىدى';
 
   @override
-  String get verticalOffset => 'تىك يۆنىلىشتىكى ئېغىش';
+  String get verticalOffset => 'Vertical Offset';
 
   @override
-  String get pgsDirectPlay => 'PGS بىۋاسىتە قويۇش';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'بىۋاسىتە PGS تارماق تېمىسى';
@@ -2913,7 +2907,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get green => 'يېشىل';
 
   @override
-  String get cyan => 'يېشىل كۆك';
+  String get cyan => 'Cyan';
 
   @override
   String get red => 'قىزىل';
@@ -2925,7 +2919,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get semiTransparentBlack => 'يېرىم سۈزۈك قارا';
 
   @override
-  String get global => 'ئومۇمىي';
+  String get global => 'Global';
 
   @override
   String get desktop => 'ئۈستەل يۈزى';
@@ -2938,17 +2932,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile ئارخىپىنىڭ تەڭشەكلىرى يۈكلەندى.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile ئارخىپىنىڭ تەڭشەكلىرىنى يۈكلەش مەغلۇپ بولدى.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'يەرلىك تەڭشەكلەر $profile ئارخىپىغا ماسقەدەملەندى.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3083,14 +3077,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get showLibrariesInToolbar => 'قورالبالدىقىدا كۈتۈپخانىلارنى كۆرسەت';
 
   @override
-  String get navbarAlwaysExpanded =>
-      'يولباشچى بالداق خەتلىرىنى ھەمىشە كۆرسىتىش';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Seerr كۇنۇپكىسىنى كۆرسىتىش';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
-  String get navbarOpacity => 'يولباشچى بالداق تۇتۇقلۇقى';
+  String get navbarOpacity => 'Navbar Opacity';
 
   @override
   String get navbarColor => 'Navbar رەڭ';
@@ -3105,7 +3098,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get purple => 'بىنەپشە';
 
   @override
-  String get teal => 'كۆكۈش يېشىل';
+  String get teal => 'Teal';
 
   @override
   String get navy => 'دېڭىز ئارمىيىسى';
@@ -3123,19 +3116,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get darkGreen => 'قېنىق يېشىل';
 
   @override
-  String get slate => 'تاش كۈلرەڭ';
+  String get slate => 'Slate';
 
   @override
-  String get indigo => 'كۆك بىنەپشە';
+  String get indigo => 'Indigo';
 
   @override
   String get libraryDisplay => 'كۈتۈپخانا كۆرسىتىش';
 
   @override
-  String get posterLabel => 'پوستېر';
+  String get posterLabel => 'Poster';
 
   @override
-  String get thumbnailLabel => 'كىچىك كۆرۈنۈش';
+  String get thumbnailLabel => 'Thumbnail';
 
   @override
   String get bannerLabel => 'بايراق';
@@ -3163,19 +3156,18 @@ class AppLocalizationsUg extends AppLocalizations {
       'ھۆججەت قىسقۇچنى كۆرۈش تاللانمىسىنى كۆرسەت';
 
   @override
-  String get groupItemsIntoCollections => 'تۈرلەرنى توپلاملارغا گۇرۇپپىلاش';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'ئامبارلارنى كۆرگەندە توپلامغا تەۋە تۈرلەرنى يوشۇرىدۇ';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'ئامبار گۇرۇپپىلاش ئەسكەرتىشى';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'بۇ تەڭشەكنى ئىشلىتىش ئۈچۈن، Jellyfin ياكى Emby مۇلازىمېتىرىڭىزدىكى ئامبارنىڭ كۆرسىتىش تەڭشەكلىرىدە «كىنولارنى توپلاملارغا گۇرۇپپىلاش» ۋە/ياكى «تىياتىرلارنى توپلاملارغا گۇرۇپپىلاش» تاللانمىلىرىنىڭ قوزغىتىلغانلىقىنى جەزملەڭ.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'كۈتۈپخانىنىڭ كۆرۈنۈشچانلىقى';
@@ -3204,11 +3196,11 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count تاللاندى';
+    return '$count selected';
   }
 
   @override
-  String get mediaBar => 'مېدىيا بالدىقى';
+  String get mediaBar => 'Media Bar';
 
   @override
   String get mediaSources => 'Media Source';
@@ -3227,7 +3219,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'يوللانما ، مېدىيا ۋە ئاۋازلىق ئالدىن كۆرۈشنى سەپلەڭ.';
 
   @override
-  String get mediaBarMode => 'مېدىيا بالدىقى ئۇسلۇبى';
+  String get mediaBarMode => 'Media Bar Style';
 
   @override
   String get mediaBarModeDescription =>
@@ -3240,7 +3232,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'تاقاق';
+  String get mediaBarModeOff => 'Off';
 
   @override
   String get enableMediaBar => 'Media Bar نى قوزغىتىڭ';
@@ -3271,7 +3263,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get noneExcluded => 'ھېچكىم چىقىرىۋېتىلمىدى';
 
   @override
-  String get autoAdvance => 'ئاپتوماتىك ئىلگىرىلەش';
+  String get autoAdvance => 'Auto Advance';
 
   @override
   String get autoAdvanceSlides =>
@@ -3281,21 +3273,20 @@ class AppLocalizationsUg extends AppLocalizations {
   String get autoAdvanceInterval => 'ئاپتوماتىك ئىلگىرىلەش ئارىلىقى';
 
   @override
-  String get trailerPreview => 'ئالدىن كۆرسىتىلمە قويۇش';
+  String get trailerPreview => 'Trailer Preview';
 
   @override
   String get autoPlayTrailers =>
       'مېدىيا ستونىدا 3 سېكۇنتتىن كېيىن ئاپتوماتىك ئويناش';
 
   @override
-  String get trailerAudio => 'ئالدىن كۆرسىتىلمە ئاۋازى';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'مېدىيا بالداقتىكى ئالدىن كۆرسىتىلمىلەرنىڭ ئاۋازىنى قوزغىتىدۇ';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
-  String get episodePreview => 'بۆلۈمنى ئالدىن كۆرۈش';
+  String get episodePreview => 'Episode Preview';
 
   @override
   String get mediaPreview => 'مېدىيا ئالدىن كورۇش';
@@ -3343,7 +3334,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playlists => 'قويۇش تىزىملىكى';
 
   @override
-  String get liveTV => 'بىۋاسىتە تېلېۋىزىيە';
+  String get liveTV => 'Live TV';
 
   @override
   String get homeSections => 'ئائىلە بۆلەكلىرى';
@@ -3352,7 +3343,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get resetToDefaults => 'سۈكۈتتىكى ھالەتكە قايتىڭ';
 
   @override
-  String get homeRowPosterSize => 'باش بەت قۇرى پوستېر چوڭلۇقى';
+  String get homeRowPosterSize => 'Home Row Poster Size';
 
   @override
   String get perRowImageTypeSelection => 'ھەر بىر قۇر رەسىم تىپى تاللاش';
@@ -3369,11 +3360,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get combineBothRows => 'ھەر ئىككى قۇرنى بىر ئۆي بۆلىكىگە بىرلەشتۈرۈڭ';
 
   @override
-  String get fullScreenRows => 'كېڭەيتىلگەن باش بەت قۇرلىرى';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'ھەر ئېكرانغا باش بەت قۇرىنى 1 قۇر بىلەن چەكلەيدۇ';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'ھەر بىر قۇر رەسىم تىپى';
@@ -3388,7 +3378,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get lastUser => 'ئاخىرقى ئىشلەتكۈچى';
 
   @override
-  String get currentUser => 'نۆۋەتتىكى ئىشلەتكۈچى';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ھەمىشە دەلىللەش';
@@ -3447,13 +3437,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get enableBuiltInScreensaver => 'قاچىلانغان ئېكراننى قوزغىتىڭ';
 
   @override
-  String get mode => 'ھالەت';
+  String get mode => 'Mode';
 
   @override
   String get libraryArt => 'كۈتۈپخانا سەنئىتى';
 
   @override
-  String get logo => 'لوگو';
+  String get logo => 'Logo';
 
   @override
   String get clock => 'سائەت';
@@ -3463,14 +3453,14 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes مىنۇت';
+    return '$minutes min';
   }
 
   @override
-  String get dimmingLevel => 'غۇۋالاشتۇرۇش دەرىجىسى';
+  String get dimmingLevel => 'Dimming Level';
 
   @override
-  String get maxAgeRating => 'ئەڭ يۇقىرى ياش چەكلىمىسى';
+  String get maxAgeRating => 'Max Age Rating';
 
   @override
   String get any => 'ھەر قانداق';
@@ -3494,10 +3484,10 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئېكران ئېكرانىدا سائەتنى كۆرسىتىش';
 
   @override
-  String get clockModeStatic => 'مۇقىم';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'سەكرەيدىغان';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'چىرىگەن پەمىدۇر (تەنقىدچىلەر)';
@@ -3533,7 +3523,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get communityRating => 'مەھەللە دەرىجىسى';
 
   @override
-  String get ratings => 'باھالار';
+  String get ratings => 'Ratings';
 
   @override
   String get additionalRatings => 'قوشۇمچە باھا';
@@ -3556,7 +3546,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'باھانىڭ ئارقىسىدىكى بېزەك بەلگىسىنى كۆرسىتىڭ';
 
   @override
-  String get episodeRatings => 'بۆلۈم باھالىرى';
+  String get episodeRatings => 'Episode Ratings';
 
   @override
   String get showRatingsOnEpisodes => 'ئايرىم بۆلەكلەرگە باھا كۆرسەت';
@@ -3569,7 +3559,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'پۈتۈن دېتالدا كۆرسىتىلگەن باھالاش مەنبەلىرىنى قوزغىتىڭ ۋە رەتلەڭ';
 
   @override
-  String get pluginLabel => 'Moonbase قىستۇرمىسى';
+  String get pluginLabel => 'قىستۇرما';
 
   @override
   String get pluginDetected => 'قىستۇرما بايقالدى';
@@ -3587,7 +3577,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nنەشرى: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3620,19 +3610,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get popularMovies => 'داڭلىق كىنولار';
 
   @override
-  String get movieGenres => 'كىنو ژانىرلىرى';
+  String get movieGenres => 'Movie Genres';
 
   @override
   String get upcomingMovies => 'كەلگۈسىدىكى كىنولار';
 
   @override
-  String get studios => 'ئىستۇدىيەلەر';
+  String get studios => 'Studios';
 
   @override
   String get popularSeries => 'ئاممىباب يۈرۈشلۈكلىرى';
 
   @override
-  String get seriesGenres => 'تىياتىر ژانىرلىرى';
+  String get seriesGenres => 'Series Genres';
 
   @override
   String get upcomingSeries => 'كېلەچەك';
@@ -3641,7 +3631,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get networks => 'تور';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr بايقاش قۇرلىرى';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'قۇرلارنى سۈكۈتتىكى ھالەتكە قايتۇرۇش';
@@ -3664,47 +3654,47 @@ class AppLocalizationsUg extends AppLocalizations {
   String get hideAdultContent => 'نەتىجىدە چوڭلارنىڭ مەزمۇنىنى يوشۇرۇش';
 
   @override
-  String get seerrNotificationsSection => 'ئۇقتۇرۇشلار';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'يېڭى ئىلتىماس ئۇقتۇرۇشلىرى';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'بىرسى ئىلتىماس يوللىغاندا ماڭا ئۇقتۇرسۇن';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'ئىلتىماس يېڭىلانمىلىرى';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'تەستىقلانغان، رەت قىلىنغان ۋە ئامبىرىڭىزغا قوشۇلغانلار';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'مەسىلە يېڭىلانمىلىرى';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'يېڭى مەسىلىلەر، جاۋابلار ۋە ھەل قىلىنىشلار';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'كىرگەن ھېسابات: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr بايقاش بېتى';
+  String get discoverRows => 'قۇرلارنى بايقاش';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Seerr باش بېتىدە كۆرسىتىلىدىغان قۇرلارنى قوزغىتىڭ. تەرتىپىنى سۆرەپ ئۆزگەرتىڭ. ئىختىيارى تەرتىپ Moonbase بىلەن ماسقەدەملىنىدۇ.';
+      'قايتا تەرتىپكە سېلىش. قۇرلارنى قوزغىتىش ياكى چەكلەش. Moonfin قىستۇرمىسى بىلەن قۇر رەت تەرتىپى ماسقەدەملىنىدۇ.';
 
   @override
   String get discoverRowsDescription =>
-      'Seerr باش بېتىدە كۆرسىتىلىدىغان قۇرلارنى قوزغىتىڭ. تەرتىپىنى سۆرەپ ئۆزگەرتىڭ. ئىختىيارى تەرتىپ Moonbase بىلەن ماسقەدەملىنىدۇ.';
+      'قايتا تەرتىپكە سېلىش. قۇرلارنى قوزغىتىش ياكى چەكلەش.';
 
   @override
-  String get enabled => 'قوزغىتىلغان';
+  String get enabled => 'قوزغىتىلدى';
 
   @override
   String get hidden => 'يۇشۇرۇن';
@@ -3714,7 +3704,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'نەشر $version';
+    return 'Version $version';
   }
 
   @override
@@ -3763,7 +3753,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'يېڭىلانما بار: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3775,7 +3765,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version چىقتى';
+    return 'v$version Available';
   }
 
   @override
@@ -3839,7 +3829,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get imageCacheCleared => 'رەسىم غەملىكى تازىلاندى';
 
   @override
-  String get clear => 'تازىلاش';
+  String get clear => 'ئېنىق';
 
   @override
   String get browse => 'توركۆرگۈ';
@@ -3855,15 +3845,15 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'چۈشۈرۈلۈۋاتىدۇ · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'ئەكىرىلىۋاتىدۇ';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count تۈر';
+    return '$count Items';
   }
 
   @override
@@ -3883,7 +3873,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name ئىلتىماس قىلغان';
+    return 'Requested by $name';
   }
 
   @override
@@ -3900,12 +3890,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '«$title» ئۈچۈن ئىلتىماس بىكار قىلىنسۇنمۇ؟';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '«$title» ئۈچۈن $count ئىلتىماس بىكار قىلىنسۇنمۇ؟';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3919,12 +3909,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'مەبلىغى: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'كىرىمى: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3934,7 +3924,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '$type ئىلتىماس قىلىش';
+    return 'Request $type';
   }
 
   @override
@@ -3944,7 +3934,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get allSeasons => 'بارلىق پەسىللەر';
 
   @override
-  String get advancedOptions => 'ئالىي تاللانمىلار';
+  String get advancedOptions => 'Advanced Options';
 
   @override
   String get noServiceServersConfigured => 'ھېچقانداق مۇلازىمېتىر سەپلەنمىگەن';
@@ -3956,20 +3946,20 @@ class AppLocalizationsUg extends AppLocalizations {
   String get qualityProfile => 'سۈپەت ئارخىپى';
 
   @override
-  String get rootFolder => 'غول قىسقۇچ';
+  String get rootFolder => 'Root Folder';
 
   @override
   String get showMore => 'تېخىمۇ كۆپ كۆرسىتىش';
 
   @override
-  String get appearances => 'قاتناشقان ئەسەرلەر';
+  String get appearances => 'تاشقى كۆرۈنۈش';
 
   @override
-  String get crewSection => 'خادىملار';
+  String get crewSection => 'Crew';
 
   @override
   String ageValue(int age) {
-    return 'يېشى $age';
+    return 'age $age';
   }
 
   @override
@@ -4000,147 +3990,148 @@ class AppLocalizationsUg extends AppLocalizations {
   String get deletedStatus => 'ئۆچۈرۈلدى';
 
   @override
-  String get failedStatus => 'مەغلۇپ بولدى';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'بىر تەرەپ قىلىنىۋاتىدۇ';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name ئۆزگەرتكەن';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'تاماملاندى';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'بۇ ئەسەر ئاللىبۇرۇن ئىلتىماس قىلىنغان';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'ئىلتىماس چېكىگە يېتىلدى';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'بۇ ئەسەر قارا تىزىملىكتە';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'ئىلتىماس قىلغۇدەك پەسىل قالمىدى';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'بۇ ئىلتىماسنى قىلىش ھوقۇقىڭىز يوق';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'ئىلتىماسلار';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'مەسىلىلەر';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'ئەڭ يېڭى';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'ئەڭ يېڭى ئۆزگەرتىلگەن';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'مەسىلە يوق';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$limit كىنو ئىلتىماسىدىن $remaining قالدى';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$limit پەسىل ئىلتىماسىدىن $remaining قالدى';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name نىڭ بىر قىسمى';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'توپلامنى كۆرۈش';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'توپلامنى ئىلتىماس قىلىش';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total كىنو · $available بار';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count كىنونى ئىلتىماس قىلىش';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '$total دىن $current ئىلتىماس قىلىنىۋاتىدۇ...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count كىنو ئىلتىماس قىلىندى';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total كىنودىن $ok سى ئىلتىماس قىلىندى';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'بارلىق كىنولار ئاللىبۇرۇن بار ياكى ئىلتىماس قىلىنغان';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'مەسىلە مەلۇم قىلىش';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'سىن';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'ئاۋاز';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'نېمە مەسىلە بار؟';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'بارلىق بۆلۈملەر';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'بۆلۈم';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'ئوچۇق';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'ھەل قىلىندى';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'ھەل قىلىش';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'قايتا ئېچىش';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name مەلۇم قىلغان';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count ئىنكاس';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'ئىنكاس يېزىڭ';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'بۇ مەسىلە ئۆچۈرۈلسۇنمۇ؟';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'دوكلات يوللاش';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB نومۇر';
@@ -4155,7 +4146,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get revenueLabel => 'كىرىم';
 
   @override
-  String get runtimeLabel => 'ئۇزۇنلۇقى';
+  String get runtimeLabel => 'Runtime';
 
   @override
   String get budgetLabel => 'خامچوت';
@@ -4167,19 +4158,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get seasonsLabel => 'پەسىللەر';
 
   @override
-  String get episodesLabel => 'بۆلۈملەر';
+  String get episodesLabel => 'Episodes';
 
   @override
   String get access => 'زىيارەت';
 
   @override
-  String get add => 'قوشۇش';
+  String get add => 'قوش';
 
   @override
   String get address => 'ئادرېس';
 
   @override
-  String get analytics => 'ئىستاتىستىكا';
+  String get analytics => 'Analytics';
 
   @override
   String get catalog => 'مۇندەرىجە';
@@ -4200,7 +4191,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get done => 'تامام';
 
   @override
-  String get edit => 'تەھرىرلەش';
+  String get edit => 'تەھرىر';
 
   @override
   String get encoding => 'كودلاش';
@@ -4209,10 +4200,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get error => 'خاتالىق';
 
   @override
-  String get forward => 'ئالغا سۈرۈش';
+  String get forward => 'ئالدىغا';
 
   @override
-  String get general => 'ئادەتتىكى';
+  String get general => 'General';
 
   @override
   String get go => 'كەت';
@@ -4236,7 +4227,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get next => 'كېيىنكى';
 
   @override
-  String get path => 'يول';
+  String get path => 'Path';
 
   @override
   String get paused => 'توختاپ قالدى';
@@ -4257,7 +4248,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get refresh => 'يېڭىلاش';
 
   @override
-  String get remote => 'يىراقتىن باشقۇرۇش';
+  String get remote => 'Remote';
 
   @override
   String get rename => 'ئىسىم ئۆزگەرتىش';
@@ -4293,10 +4284,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get status => 'ھالەت';
 
   @override
-  String get stop => 'توختىتىش';
+  String get stop => 'توختاڭ';
 
   @override
-  String get streaming => 'ئېقىم قويۇش';
+  String get streaming => 'Streaming';
 
   @override
   String get time => 'ۋاقىت';
@@ -4317,10 +4308,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get upload => 'يۈكلەش';
 
   @override
-  String get unmute => 'ئاۋازنى ئېچىش';
+  String get unmute => 'Unmute';
 
   @override
-  String get mute => 'ئۈنسىز';
+  String get mute => 'Mute';
 
   @override
   String get branding => 'ماركا';
@@ -4329,7 +4320,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminDrawerDashboard => 'باش تاختا';
 
   @override
-  String get adminDrawerAnalytics => 'ئىستاتىستىكا';
+  String get adminDrawerAnalytics => 'Analytics';
 
   @override
   String get adminDrawerSettings => 'تەڭشەك';
@@ -4341,25 +4332,25 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminDrawerUsers => 'ئىشلەتكۈچى';
 
   @override
-  String get adminDrawerLibraries => 'مېدىيا ئامبارلىرى';
+  String get adminDrawerLibraries => 'كۈتۈپخانىلار';
 
   @override
-  String get adminDrawerDisplay => 'كۆرسىتىش';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'مېتا ئۇچۇر';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO تەڭشەكلىرى';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
-  String get adminDrawerTranscoding => 'كود ئۆزگەرتىش';
+  String get adminDrawerTranscoding => 'Transcoding';
 
   @override
-  String get adminDrawerResume => 'داۋاملاشتۇرۇش';
+  String get adminDrawerResume => 'ئەسلىگە كەلتۈرۈش';
 
   @override
-  String get adminDrawerStreaming => 'ئېقىم قويۇش';
+  String get adminDrawerStreaming => 'Streaming';
 
   @override
   String get adminDrawerTrickplay => 'Trickplay';
@@ -4392,7 +4383,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminDrawerRepositories => 'ئامبار';
 
   @override
-  String get adminDrawerLiveTv => 'بىۋاسىتە تېلېۋىزىيە';
+  String get adminDrawerLiveTv => 'Live TV';
 
   @override
   String get adminExitTooltip => 'باشقۇرغۇچىدىن چېكىنىش';
@@ -4401,7 +4392,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminDashboardLoadFailed => 'باشقۇرۇش تاختىسىنى يۈكلىيەلمىدى';
 
   @override
-  String get adminMediaOverview => 'مېدىيا ئومۇمىي كۆرۈنۈشى';
+  String get adminMediaOverview => 'Media Overview';
 
   @override
   String get adminMediaTotalsError =>
@@ -4413,38 +4404,38 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'يېڭىلانمىسى بار قىستۇرمىلار: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'قايتا قوزغىتىش كېرەك قىستۇرمىلار: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'مەغلۇپ بولغان پىلانلىق ۋەزىپىلەر: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'يېقىنقى ئاگاھلاندۇرۇش/خاتالىق خاتىرىلىرى: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
-  String get analyticsMediaDistribution => 'مېدىيا تەقسىماتى';
+  String get analyticsMediaDistribution => 'Media Distribution';
 
   @override
-  String get analyticsVideoCodecs => 'سىن كودېكلىرى';
+  String get analyticsVideoCodecs => 'Video Codecs';
 
   @override
-  String get analyticsAudioCodecs => 'ئاۋاز كودېكلىرى';
+  String get analyticsAudioCodecs => 'Audio Codecs';
 
   @override
   String get analyticsContainers => 'كونتېينېر';
 
   @override
-  String get analyticsTopGenres => 'ئالدىنقى ژانىرلار';
+  String get analyticsTopGenres => 'Top Genres';
 
   @override
   String get analyticsReleaseYears => 'يىللارنى قويۇپ بېرىش';
@@ -4453,7 +4444,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get analyticsContentRatings => 'مەزمۇن دەرىجىسى';
 
   @override
-  String get analyticsRuntimeBuckets => 'ئۇزۇنلۇق ئارىلىقلىرى';
+  String get analyticsRuntimeBuckets => 'Runtime Buckets';
 
   @override
   String get analyticsFileFormats => 'ھۆججەت فورماتى';
@@ -4487,7 +4478,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'خاتالىق: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4514,7 +4505,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'بۇيرۇق مەغلۇپ بولدى: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4533,7 +4524,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get sessionRewind => 'مۇكاپاتلاش';
 
   @override
-  String get sessionForward => 'ئالغا سۈرۈش';
+  String get sessionForward => 'ئالدىغا';
 
   @override
   String get sessionNext => 'كېيىنكى';
@@ -4542,7 +4533,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get sessionVolumeDown => 'Vol -';
 
   @override
-  String get sessionVolumeUp => 'ئاۋاز +';
+  String get sessionVolumeUp => 'Vol +';
 
   @override
   String get uhd4k => '4K';
@@ -4551,19 +4542,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get nowPlaying => 'ھازىر ئويناۋاتىدۇ';
 
   @override
-  String get volume => 'ئاۋاز مىقدارى';
+  String get volume => 'ھەجىم';
 
   @override
   String get actions => 'ھەرىكەتلەر';
 
   @override
-  String get videoCodec => 'سىن كودېكى';
+  String get videoCodec => 'Video Codec';
 
   @override
-  String get audioCodec => 'ئاۋاز كودېكى';
+  String get audioCodec => 'Audio Codec';
 
   @override
-  String get hwAccel => 'قاتتىق دېتال تېزلىتىش';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'تامام';
@@ -4578,14 +4569,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminClearDates => 'چېسلانى ئېنىقلاش';
 
   @override
-  String get adminActivitySeverityAll => 'بارلىق دەرىجىلەر';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'چېسلا دائىرىسى';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'پائالىيەت خاتىرىسى يۈكلىنەلمىدى: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4595,14 +4586,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminEditDeviceName => 'ئۈسكۈنىنىڭ نامىنى تەھرىرلەش';
 
   @override
-  String get adminCustomName => 'ئىختىيارى ئىسىم';
+  String get adminCustomName => 'Custom Name';
 
   @override
   String get adminDeviceNameUpdated => 'ئۈسكۈنىنىڭ ئىسمى يېڭىلاندى';
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'ئۈسكۈنىنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4613,28 +4604,28 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'ئۈسكۈنىنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '«$name» ئۈسكۈنىسى چىقىرىۋېتىلسۇنمۇ؟ ئىشلەتكۈچى بۇ ئۈسكۈنىدە قايتا كىرىشى كېرەك بولىدۇ.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'بارلىق ئۈسكۈنىلەرنى ئۆچۈرۈش';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '$count ئۈسكۈنە چىقىرىۋېتىلسۇنمۇ؟ مۇناسىۋەتلىك ئىشلەتكۈچىلەر قايتا كىرىشى كېرەك بولىدۇ. نۆۋەتتىكى ئۈسكۈنىڭىزگە تەسىر يەتمەيدۇ.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'ئۈسكۈنىلەر چىقىرىۋېتىلدى';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'بىر قىسىم ئۈسكۈنىلەر چىقىرىۋېتىلدى؛ $count ئۈسكۈنىنى چىقىرىۋەتكىلى بولمىدى.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4663,7 +4654,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'سايىلەشنى باشلاش مەغلۇپ بولدى: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4674,12 +4665,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'ئامبار ئىسمى «$name» غا ئۆزگەرتىلدى';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'ئىسىم ئۆزگەرتىش مەغلۇپ بولدى: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4687,17 +4678,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '«$name» ئامبىرى ئۆچۈرۈلدى';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'ئامبارنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'يول قوشۇش مەغلۇپ بولدى: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4705,12 +4696,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '«$path» بۇ ئامباردىن چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'يولنى چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4718,7 +4709,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'تاللانمىلارنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4750,260 +4741,251 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminMetadataCountryHint => 'مەسىلەن US, DE, FR';
 
   @override
-  String get adminLibraryTabPaths => 'يوللار';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'تاللانمىلار';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'چۈشۈرگۈچلەر';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'مېتا ئۇچۇر ساقلىغۇچلار';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'ئېكران خېتى چۈشۈرگۈچلەر';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'ناخشا تېكىستى چۈشۈرگۈچلەر';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'مېتا ئۇچۇر چۈشۈرگۈچلەر: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'رەسىم ئالغۇچلار: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'بۇ مۇلازىمېتىر بۇ ئامبار تىپى ئۈچۈن چۈشۈرگۈچ تەمىنلىمەيدۇ.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'ئادەتتىكى';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'مېتا ئۇچۇر';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'سىڭدۈرۈلگەن ئۇچۇر';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'ئېكران خېتى';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'رەسىملەر';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'تېلېۋىزىيە تىياتىرلىرى';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'مۇزىكا';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'كىنولار';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'دەل ۋاقىتلىق كۆزىتىشنى قوزغىتىش';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'ھۆججەت ئۆزگىرىشلىرىنى بايقاپ ئۆزلۈكىدىن بىر تەرەپ قىلىدۇ.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles =>
-      'ئارخىپ ھۆججەتلىرىنى مېدىيا ھۆججىتى دەپ قاراش';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'سۈرەتلەرنى كۆرسىتىش';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata =>
-      'بېزەك رەسىملىرىنى مېدىيا قىسقۇچلىرىغا ساقلاش';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'مېتا ئۇچۇرنى ئاپتوماتىك يېڭىلاش';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'ھەرگىز';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'سۈكۈتتىكى';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'كۆرسىتىش';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'ئامبار كۆرسىتىلىشى';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'ئاددىي مېدىيا قىسقۇچلىرىنى كۆرسىتىدىغان قىسقۇچ كۆرۈنۈشىنى كۆرسىتىش';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'ئالاھىدە بۆلۈملەرنى تارقىتىلغان پەسىللىرى ئىچىدە كۆرسىتىش';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'كىنولارنى توپلاملارغا گۇرۇپپىلاش';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'تىياتىرلارنى توپلاملارغا گۇرۇپپىلاش';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'تەۋسىيەلەردە سىرتقى مەزمۇنلارنى كۆرسىتىش';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'قوشۇلغان چېسلا ھەرىكىتى';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'قوشۇلغان چېسلا مەنبەسى';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'ئامبارغا سايىلانغان چېسلا';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'ھۆججەت قۇرۇلغان چېسلا';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'مېتا ئۇچۇر ۋە رەسىملەر';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'ئالدىن تاللانغان مېتا ئۇچۇر تىلى';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'بابلار';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'ساختا باب ئۇزۇنلۇقى (سېكۇنت)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'بابى يوق مېدىيا ئۈچۈن ھاسىللىنىدىغان بابلارنىڭ ئۇزۇنلۇقى. تاقاش ئۈچۈن 0 قىلىڭ.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'باب رەسىمى ئېنىقلىقى';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO تەڭشەكلىرى';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO مېتا ئۇچۇرى Kodi ۋە شۇنىڭغا ئوخشاش خېرىدارلار بىلەن ماس كېلىدۇ. تەڭشەكلەر NFO مېتا ئۇچۇرى ساقلايدىغان بارلىق ئامبارلارغا قوللىنىلىدۇ.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'NFO ھۆججەتلىرىدە كۆرۈش سانلىق مەلۇماتى ساقلىنىدىغان ئىشلەتكۈچى';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'رەسىم يوللىرىنى NFO ھۆججەتلىرى ئىچىگە ساقلاش';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'NFO رەسىم يوللىرى ئۈچۈن يول ئالماشتۇرۇشنى قوزغىتىش';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'extrafanart رەسىملىرىنى extrathumbs قىسقۇچىغا كۆچۈرۈش';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'يوق';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days كۈن';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'سىڭدۈرۈلگەن ماۋزۇلارنى ئىشلىتىش';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'قوشۇمچىلار ئۈچۈن سىڭدۈرۈلگەن ماۋزۇلارنى ئىشلىتىش';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'سىڭدۈرۈلگەن بۆلۈم ئۇچۇرىنى ئىشلىتىش';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles =>
-      'سىڭدۈرۈلگەن ئېكران خېتىگە يول قويۇش';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'ھەممىسىگە يول قويۇش';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'پەقەت تېكىست';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'پەقەت رەسىم';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'يوق';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'سىڭدۈرۈلگەن ئېكران خېتى بولسا چۈشۈرۈشتىن ئاتلاش';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'ئاۋاز يولى چۈشۈرۈش تىلىغا ماس كەلسە چۈشۈرۈشتىن ئاتلاش';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch =>
-      'ئېكران خېتىنىڭ پۈتۈنلەي ماس كېلىشىنى تەلەپ قىلىش';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'ئېكران خېتىنى مېدىيا قىسقۇچلىرىغا ساقلاش';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'باب رەسىملىرىنى ئاجرىتىش';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'ئامبار سايىلەش جەريانىدا باب رەسىملىرىنى ئاجرىتىش';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Trickplay رەسىم ئاجرىتىشنى قوزغىتىش';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'ئامبار سايىلەش جەريانىدا trickplay رەسىملىرىنى ئاجرىتىش';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Trickplay رەسىملىرىنى مېدىيا قىسقۇچلىرىغا ساقلاش';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'كۆپ قىسقۇچقا تارقالغان تىياتىرلارنى ئاپتوماتىك بىرلەشتۈرۈش';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'نۆل-پەسىل كۆرسىتىلىش ئىسمى';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'ئاۋاز نورمىلاش ئۈچۈن LUFS سايىلەشنى قوزغىتىش';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'ئۆلچەمدىن باشقا سەنئەتكار بەلگىسىنى ئالدىن تاللاش';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'كىنولارنى توپلاملارغا ئاپتوماتىك قوشۇش';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'كۈتۈپخانىنىڭ ئىسمى تەلەپ قىلىنىدۇ';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'ئامبار قۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5030,27 +5012,27 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '$name چەكلەنسۇنمۇ؟ ئۇ كىرەلمەيدىغان بولىدۇ.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '$name قوزغىتىلسۇنمۇ؟ ئۇ قايتا كىرەلەيدىغان بولىدۇ.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '«$name» ئىشلەتكۈچى چەكلەندى';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '«$name» ئىشلەتكۈچى قوزغىتىلدى';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'ئىشلەتكۈچى تۈزۈمىنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5067,7 +5049,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'ئىشلەتكۈچى قۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5087,7 +5069,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5098,7 +5080,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'مەغلۇپ بولدى: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5234,146 +5216,143 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminEnableAllChannels => 'بارلىق قاناللارنى زىيارەت قىلىڭ';
 
   @override
-  String get adminParentalControl => 'ئاتا-ئانا كونتروللۇقى';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'يول قويۇلىدىغان ئەڭ يۇقىرى ياش چەكلىمىسى';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'بۇنىڭدىن يۇقىرى باھالانغان مەزمۇنلار بۇ ئىشلەتكۈچىدىن يوشۇرۇلىدۇ.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'يوق';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'باھا ئۇچۇرى يوق ياكى تونۇلمايدىغان تۈرلەرنى چەكلەش';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'كىتابلار';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'قاناللار';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'بىۋاسىتە تېلېۋىزىيە';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'كىنولار';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'مۇزىكا';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'ئالدىن كۆرۈنۈشلەر';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'تىياتىرلار';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'زىيارەت ۋاقىت جەدۋەللىرى';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'پەقەت تۆۋەندىكى بەلگىلەنگەن ۋاقىتلاردىلا زىيارەتكە يول قويىدۇ. جەدۋەل بەلگىلەنمىسە پۈتۈن كۈن زىيارەتكە يول قويۇلىدۇ.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'جەدۋەل قوشۇش';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'كۈن';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'باشلىنىش';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'ئاخىرلىشىش';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'ھەر كۈنى';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'خىزمەت كۈنلىرى';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'ھەپتە ئاخىرى';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'يەكشەنبە';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'دۈشەنبە';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'سەيشەنبە';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'چارشەنبە';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'پەيشەنبە';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'جۈمە';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'شەنبە';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'يول قويۇلغان بەلگىلەر';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'پەقەت بۇ بەلگىلەر بار مەزمۇنلارلا كۆرسىتىلىدۇ. ھەممىسىگە يول قويۇش ئۈچۈن قۇرۇق قويۇڭ.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'چەكلەنگەن بەلگىلەر';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'بۇ بەلگىلەر بار مەزمۇنلار بۇ ئىشلەتكۈچىدىن يوشۇرۇلىدۇ.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'بەلگە قوشۇش';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'قوزغىتىلغان ئۈسكۈنىلەر';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'قوزغىتىلغان قاناللار';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'كىملىك دەلىللەش تەمىنلىگۈچى';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'پارول ئەسلىگە قايتۇرۇش تەمىنلىگۈچى';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'قۇلۇپلىنىشتىن بۇرۇنقى ئەڭ كۆپ مەغلۇپ كىرىش سىنىقى';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'سۈكۈتتىكى ئۈچۈن 0، قۇلۇپلاشنى تاقاش ئۈچۈن -1 قىلىڭ.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay زىيارىتى';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'گۇرۇپپا قۇرۇش ۋە قوشۇلۇشقا يول قويۇش';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'گۇرۇپپىغا قوشۇلۇشقا يول قويۇش';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'زىيارەت يوق';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders =>
-      'مەزمۇن ئۆچۈرۈشكە يول قويۇلىدىغان جايلار';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5381,22 +5360,22 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'مۇلازىمېتىر HTTP $status قايتۇردى';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name نى راستىنلا ئۆچۈرەمسىز؟';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '«$name» ئىشلەتكۈچى ئۆچۈرۈلدى';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'ئىشلەتكۈچىنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5417,7 +5396,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'ئاچقۇچ قۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5429,7 +5408,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name نىڭ ئاچقۇچى بىكار قىلىنسۇنمۇ؟';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5437,7 +5416,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'ئاچقۇچنى بىكار قىلىش مەغلۇپ بولدى: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5457,30 +5436,29 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nقۇرۇلغان: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'زاپاس نۇسخا قۇرۇش';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude =>
-      'زاپاس نۇسخىغا نېمىلەرنىڭ كىرىدىغانلىقىنى تاللاڭ.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'ساندان';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'ھەمىشە كىرىدۇ';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'مېتا ئۇچۇر';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'ئېكران خېتى';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay رەسىملىرى';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'زاپاسلاش ...';
@@ -5490,7 +5468,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'زاپاس نۇسخا قۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5504,7 +5482,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Manifest نى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5515,7 +5493,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'زاپاس نۇسخىنى ئەسلىگە كەلتۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5547,17 +5525,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path غا ساقلاندى';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'ھۆججەتنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '$fileName نى يۈكلەش مەغلۇپ بولدى';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5568,7 +5546,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'ۋەزىپىلەرنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5580,17 +5558,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'ۋەزىپىنى باشلاش مەغلۇپ بولدى: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'ۋەزىپىنى توختىتىش مەغلۇپ بولدى: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'ۋەزىپىنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5598,19 +5576,19 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'قوزغاتقۇچنى چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'قوزغاتقۇچ قوشۇش مەغلۇپ بولدى: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
   String get adminLastExecution => 'ئاخىرقى ئىجرا';
 
   @override
-  String get adminTriggers => 'قوزغاتقۇچلار';
+  String get adminTriggers => 'Triggers';
 
   @override
   String get adminAddTrigger => 'Trigger نى قوشۇڭ';
@@ -5629,7 +5607,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours سائەت';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5640,7 +5618,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'قىستۇرمىنى ئالماشتۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5648,27 +5626,27 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '«$name» راستىنلا قاچىلاشتىن چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'قىستۇرمىنى چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'بوغچىنى قاچىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'يېڭىلانمىنى قاچىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'قىستۇرمىلارنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5680,12 +5658,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'يېڭىلانمىنى قاچىلاش (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'كاتالوگنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5707,17 +5685,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '«$name» مۇلازىمېتىر قايتا قوزغىتىلغاندىن كېيىن چىقىرىۋېتىلىدۇ';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '«$name» v$version گە يېڭىلىنىۋاتىدۇ...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5726,7 +5704,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'قىستۇرمىنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5734,7 +5712,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'نەشر $version';
+    return 'Version $version';
   }
 
   @override
@@ -5754,17 +5732,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '«$name» نى راستىنلا چىقىرىۋېتەمسىز؟';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'خەزىنىلەرنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'خەزىنىلەرنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5781,12 +5759,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'قىستۇرما تەڭشەكلىرىنى يۈكلىگىلى بولمىدى: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri نى ئاچقىلى بولمىدى';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5809,7 +5787,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminCachePath => 'كەش يولى';
 
   @override
-  String get adminMetadataPath => 'مېتا ئۇچۇر يولى';
+  String get adminMetadataPath => 'Metadata path';
 
   @override
   String get adminLibraryScanConcurrency => 'كۈتۈپخانىنى سىكانىرلاش';
@@ -5834,7 +5812,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'كىرىش جەدۋىلىنىڭ ئاستىدا HTML كۆرسىتىلدى';
 
   @override
-  String get adminCustomCss => 'ئىختىيارى CSS';
+  String get adminCustomCss => 'Custom CSS';
 
   @override
   String get adminCustomCssHint =>
@@ -5903,14 +5881,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminSegmentKeepSeconds => 'بۆلەك ساقلاش (سېكۇنت)';
 
   @override
-  String get adminThrottleBuffering => 'غەملەشنى چەكلەش';
+  String get adminThrottleBuffering => 'Throttle buffering';
 
   @override
   String get adminTrickplaySaved => 'Trickplay تەڭشەكلىرى ساقلاندى';
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Trickplay تەڭشەكلىرىنى يۈكلەش مەغلۇپ بولدى';
+      'ئالدامچىلىق تەڭشەكلىرىنى يۈكلىيەلمىدى';
 
   @override
   String get adminEnableHardwareAcceleration => 'قاتتىق دېتالنى تېزلىتىش';
@@ -5933,7 +5911,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminImageSettings => 'رەسىم تەڭشىكى';
 
   @override
-  String get adminIntervalMs => 'ئارىلىق (ms)';
+  String get adminIntervalMs => 'Interval (ms)';
 
   @override
   String get adminCaptureFrameSubtitle => 'رامكىنى قانچە قېتىم تۇتۇش';
@@ -6051,7 +6029,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminCertificatePath => 'گۇۋاھنامە يولى';
 
   @override
-  String get whitelist => 'ئاق تىزىملىك';
+  String get whitelist => 'Whitelist';
 
   @override
   String get blacklist => 'قارا تىزىملىك';
@@ -6064,12 +6042,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'مېتا ئۇچۇرنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'مېتا ئۇچۇرنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6090,7 +6068,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'مېتا ئۇچۇرنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6105,7 +6083,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'يىراقتىن ئىزدەش مەغلۇپ بولدى: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6119,7 +6097,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'مەزمۇن تىپىنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6134,12 +6112,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType رەسىمى يېڭىلاندى';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'رەسىم چۈشۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6150,27 +6128,27 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType رەسىمى يوللاندى';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'رەسىم يوللاش مەغلۇپ بولدى: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '$imageType رەسىمىنى ئۆچۈرۈش';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType رەسىمى ئۆچۈرۈلدى';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'رەسىمنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6181,69 +6159,67 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'تيۇنېر بايقاش مەغلۇپ بولدى: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Tuner نى قوشۇڭ';
 
   @override
-  String get adminEditTuner => 'تيۇنېرنى تەھرىرلەش';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U تيۇنېرى';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'ھۆججەت ياكى URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'تيۇنېر IP ئادرېسى';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'قولايلىق ئىسىم';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'بىرلا ۋاقىتتىكى ئۇلىنىش چېكى';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'تيۇنېرنىڭ بىرلا ۋاقىتتا يول قويىدىغان ئەڭ كۆپ ئېقىم سانى. چەكسىز ئۈچۈن 0 قىلىڭ.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'زاپاس ئەڭ يۇقىرى ئېقىم بىت نىسبىتى';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'پەقەت ئامراق قاناللارنىلا ئەكىرىش';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'قاتتىق دېتاللىق كود ئۆزگەرتىشكە يول قويۇش';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'fMP4 كود ئۆزگەرتىش قاچىسىغا يول قويۇش';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'ئېقىم ھەمبەھىرلەشكە يول قويۇش';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'ئېقىم دەۋرىيلىكىنى قوزغىتىش';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'DTS نى نەزەردىن ساقىت قىلىش';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'كىرگۈزۈشنى ئەسلى كادر تېزلىكىدە ئوقۇش';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'تەمىنلىگۈچىنى تەھرىرلەش';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6252,49 +6228,50 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'ھۆججەت ياكى URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'كىنو ئالدى قوشۇلغۇچىسى';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'كىنو تۈرلىرى';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => 'كۆپ تۈرنى تىك سىزىق بىلەن ئايرىڭ.';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'بالىلار تۈرلىرى';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'خەۋەر تۈرلىرى';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'تەنتەربىيە تۈرلىرى';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'ئىشلەتكۈچى ئىسمى';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'پارول';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'دۆلەت';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'دۆلەت تاللاڭ';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'پوچتا نومۇرى';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'پروگرامما تىزىملىكىنى ئېلىش';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'پروگرامما تىزىملىكلىرى';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'بارلىق تيۇنېرلارنى قوزغىتىش';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'تەڭشىگۈچ تىپى';
@@ -6304,7 +6281,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'تيۇنېر قوشۇش مەغلۇپ بولدى: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6318,12 +6295,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'تەمىنلىگۈچى قوشۇش مەغلۇپ بولدى: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'تيۇنېرنى چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6332,16 +6309,16 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'تيۇنېرنى ئەسلىگە قايتۇرۇش مەغلۇپ بولدى: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'بۇ تيۇنېر تىپى ئەسلىگە قايتۇرۇشنى قوللىمايدۇ.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'تەمىنلىگۈچىنى چىقىرىۋېتىش مەغلۇپ بولدى: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6360,45 +6337,43 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminSeriesRecordingPath => 'يۈرۈشلۈك خاتىرىلەش يولى';
 
   @override
-  String get adminMovieRecordingPath => 'كىنو خاتىرىلەش يولى';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'جەدۋەل سانلىق مەلۇمات كۈنلىرى';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'ئاپتوماتىك';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days كۈن';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor =>
-      'كېيىنكى بىر تەرەپ قىلىش پروگراممىسىنىڭ يولى';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs =>
-      'كېيىنكى بىر تەرەپ قىلغۇچ پارامېتىرلىرى';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'خاتىرىلەنمە NFO مېتا ئۇچۇرىنى ساقلاش';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'خاتىرىلەنمە رەسىملىرىنى ساقلاش';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'ۋاقىت تەڭشىكى';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'خاتىرىلەش يوللىرى';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'كېيىنكى بىر تەرەپ قىلىش';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'جەدۋەل سانلىق مەلۇماتى: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6406,7 +6381,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'تەڭشەكلەرنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6423,7 +6398,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'ماسلاشتۇرۇشلارنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6440,15 +6415,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminGuideProviders => 'يېتەكچى تەمىنلىگۈچىلەر';
 
   @override
-  String get adminRefreshGuideData => 'جەدۋەل سانلىق مەلۇماتىنى يېڭىلاش';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'جەدۋەل سانلىق مەلۇماتىنى يېڭىلاش باشلاندى';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'بۇ مۇلازىمېتىردا جەدۋەل يېڭىلاش ۋەزىپىسى يوق.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'تەمىنلىگۈچىنى قوشۇڭ';
@@ -6458,29 +6432,29 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'خاتىرىلەش يولى: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'تىياتىر يولى: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'ئالدى قوشۇمچە ۋاقىت: $minutes مىنۇت';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'ئارقا قوشۇمچە ۋاقىت: $minutes مىنۇت';
+    return 'Post-padding: $minutes min';
   }
 
   @override
-  String get adminTunerDiscovery => 'تيۇنېر بايقاش';
+  String get adminTunerDiscovery => 'Tuner Discovery';
 
   @override
-  String get adminChannelMappings => 'قانال ماسلاشتۇرۇشلىرى';
+  String get adminChannelMappings => 'Channel Mappings';
 
   @override
   String get adminNoDiscoveredTuners => 'تېخى بايقالمىغان تەڭشىگۈچ يوق';
@@ -6506,7 +6480,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name زاپاس نۇسخىسى ھازىر ئەسلىگە كەلتۈرۈلسۇنمۇ؟';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6530,7 +6504,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminLiveTvTitle => 'نەق مەيدان تېلېۋىزىيە باشقۇرۇش';
 
   @override
-  String get adminApply => 'قوللىنىش';
+  String get adminApply => 'ئىلتىماس قىلىڭ';
 
   @override
   String get adminNotSet => 'تەڭشەلمىدى';
@@ -6545,44 +6519,44 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminLogsNewestFirst => 'ئەڭ يېڭى بىرىنچى';
 
   @override
-  String get adminLogsOldestFirst => 'كونىسى ئالدىدا';
+  String get adminLogsOldestFirst => 'Oldest First';
 
   @override
   String get adminLogsJustNow => 'ھازىر';
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes مىنۇت ئىلگىرى';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours سائەت ئىلگىرى';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days كۈن ئىلگىرى';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName نى يۈكلەش مەغلۇپ بولدى';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count نەتىجە';
+    return '$count matches';
   }
 
   @override
   String get adminLogViewerNoMatches => 'ماس كېلىدىغان قۇر يوق';
 
   @override
-  String get adminMetadataEditorTitle => 'مېتا ئۇچۇر تەھرىرلىگۈچ';
+  String get adminMetadataEditorTitle => 'Metadata Editor';
 
   @override
-  String get adminMetadataIdentify => 'تونۇش';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'تىپ';
@@ -6636,7 +6610,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminMetadataTags => 'خەتكۈچ';
 
   @override
-  String get adminMetadataStudios => 'ئىستۇدىيەلەر';
+  String get adminMetadataStudios => 'Studios';
 
   @override
   String get adminMetadataPeople => 'كىشىلەر';
@@ -6660,19 +6634,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminMetadataRole => 'رولى';
 
   @override
-  String get adminMetadataImagePrimary => 'ئاساسىي';
+  String get adminMetadataImagePrimary => 'Primary';
 
   @override
   String get adminMetadataImageBackdrop => 'ئارقا كۆرۈنۈش';
 
   @override
-  String get adminMetadataImageLogo => 'لوگو';
+  String get adminMetadataImageLogo => 'Logo';
 
   @override
   String get adminMetadataImageBanner => 'بايراق';
 
   @override
-  String get adminMetadataImageThumb => 'كىچىك كۆرۈنۈش';
+  String get adminMetadataImageThumb => 'Thumb';
 
   @override
   String get adminMetadataRecursive => 'تەكرار';
@@ -6682,22 +6656,22 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType رەسىمى يېڭىلاندى';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType رەسىمى يوللاندى';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType رەسىمى ئۆچۈرۈلدى';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'رەسىم چۈشۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6706,12 +6680,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'رەسىم يوللاش مەغلۇپ بولدى: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '$imageType رەسىمىنى ئۆچۈرۈش';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6720,12 +6694,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'رەسىمنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType رەسىمى تاللاش';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6758,7 +6732,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'يېڭىلانما بار: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6783,7 +6757,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'يېڭىلانمىنى قاچىلاش (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6795,7 +6769,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '«$name» قاچىلىنىۋاتىدۇ...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6815,14 +6789,14 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name تەڭشەكلىرى';
+    return '$name Settings';
   }
 
   @override
   String get adminPluginDetailDetails => 'تەپسىلاتى';
 
   @override
-  String get adminPluginDetailDeveloper => 'ئىجادىيەتچى';
+  String get adminPluginDetailDeveloper => 'Developer';
 
   @override
   String get adminPluginDetailRepository => 'ئامبار';
@@ -6855,7 +6829,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'خەزىنىلەرنى يۈكلەش مەغلۇپ بولدى: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6863,15 +6837,15 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '«$name» نى راستىنلا چىقىرىۋېتەمسىز؟';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'چىقىرىۋېتىش';
+  String get adminReposRemove => 'ئۆچۈرۈڭ';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'خەزىنىلەرنى ساقلاش مەغلۇپ بولدى: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6969,7 +6943,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminNetworkingProxyHint => 'مەسىلەن 10.0.0.1';
 
   @override
-  String get adminNetworkingWhitelist => 'ئاق تىزىملىك';
+  String get adminNetworkingWhitelist => 'Whitelist';
 
   @override
   String get adminNetworkingBlacklist => 'قارا تىزىملىك';
@@ -6988,7 +6962,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'كىرىش جەدۋىلىنىڭ ئاستىدا HTML كۆرسىتىلدى';
 
   @override
-  String get adminBrandingCustomCss => 'ئىختىيارى CSS';
+  String get adminBrandingCustomCss => 'Custom CSS';
 
   @override
   String get adminBrandingCustomCssHint =>
@@ -6998,20 +6972,19 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminBrandingEnableSplash => 'چاقماق ئېكرانىنى قوزغىتىڭ';
 
   @override
-  String get adminBrandingSplashUpload => 'رەسىم يوللاش';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'قوزغىلىش ئېكرانى يېڭىلاندى';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'قوزغىلىش ئېكرانىنى يوللاش مەغلۇپ بولدى';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'قوزغىلىش ئېكرانى چىقىرىۋېتىلدى';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'ئىختىيارى قوزغىلىش ئېكرانى يوق';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'قاتتىق دېتالنى تېزلىتىش';
@@ -7026,130 +6999,121 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'قاتتىق دېتال يېشىشنى قوزغىتىڭ:';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV ئۈسكۈنىسى';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec =>
-      'كۈچەيتىلگەن NVDEC كودسىزلىغۇچنى قوزغىتىش';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'سىستېمىنىڭ ئۆز قاتتىق دېتال كودسىزلىغۇچىنى ئالدىن تاللاش';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'قاتتىق دېتال كودسىزلاش رەڭ چوڭقۇرلۇقى';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10 بىتلىق HEVC كودسىزلاش';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10 بىتلىق VP9 كودسىزلاش';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      'HEVC RExt 8/10 بىتلىق كودسىزلاش';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      'HEVC RExt 12 بىتلىق كودسىزلاش';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'قاتتىق دېتال كودلاش';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'HEVC كودلاشقا يول قويۇش';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'AV1 كودلاشقا يول قويۇش';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Intel تۆۋەن قۇۋۋەتلىك H.264 كودلىغۇچنى قوزغىتىش';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Intel تۆۋەن قۇۋۋەتلىك HEVC كودلىغۇچنى قوزغىتىش';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'رەڭ تونى خەرىتىلەش';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'رەڭ تونى خەرىتىلەشنى قوزغىتىش';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'VPP رەڭ تونى خەرىتىلەشنى قوزغىتىش';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'VideoToolbox رەڭ تونى خەرىتىلەشنى قوزغىتىش';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'رەڭ تونى خەرىتىلەش ئالگورىتمى';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'رەڭ تونى خەرىتىلەش ھالىتى';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'رەڭ تونى خەرىتىلەش دائىرىسى';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'رەڭ تونى خەرىتىلەش رەڭسىزلەندۈرۈشى';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'رەڭ تونى خەرىتىلەش چوققىسى';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'رەڭ تونى خەرىتىلەش پارامېتىرى';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'VPP رەڭ تونى خەرىتىلەش يورۇقلۇقى';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'VPP رەڭ تونى خەرىتىلەش سېلىشتۇرمىسى';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'ئالدىن تەڭشەكلەر ۋە سۈپەت';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'كودلىغۇچ ئالدىن تەڭشىكى';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 كودلاش CRF قىممىتى';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265 (HEVC) كودلاش CRF قىممىتى';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod =>
-      'ئارىلاشما سىزىقنى يوقىتىش ئۇسۇلى';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'ئارىلاشما سىزىقنى يوقىتىشتا كادر تېزلىكىنى ھەسسىلەش';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'ئاۋاز';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'ئاۋاز VBR كودلاشنى قوزغىتىش';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'ئاۋاز تۆۋەنلىتىش كۈچەيتىشى';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'ستېرېئوغا تۆۋەنلىتىش ئالگورىتمى';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'ئەڭ چوڭ بىرلەشتۈرۈش ئۆچرىتىنىڭ چوڭلۇقى';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'ئاپتوماتىك';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'كودلاش';
@@ -7164,10 +7128,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminPlaybackFallbackFontPath => 'خاتالىق خەت شەكلى';
 
   @override
-  String get adminPlaybackStreaming => 'ئېقىم قويۇش';
+  String get adminPlaybackStreaming => 'Streaming';
 
   @override
-  String get adminResumeVideo => 'سىن';
+  String get adminResumeVideo => 'Video';
 
   @override
   String get adminResumeAudiobooks => 'ئۈندىدار';
@@ -7226,7 +7190,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminTrickplayImageSettings => 'رەسىم تەڭشىكى';
 
   @override
-  String get adminTrickplayInterval => 'ئارىلىق (ms)';
+  String get adminTrickplayInterval => 'Interval (ms)';
 
   @override
   String get adminTrickplayIntervalSubtitle => 'رامكىنى قانچە قېتىم تۇتۇش';
@@ -7268,10 +7232,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminTaskNeverRun => 'ھەرگىز يۈگۈرمەڭ';
 
   @override
-  String get adminTaskStop => 'توختىتىش';
+  String get adminTaskStop => 'توختاڭ';
 
   @override
-  String get adminRunningTasks => 'ئىجرا بولۇۋاتقان ۋەزىپىلەر';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'ئىجرا';
@@ -7286,24 +7250,24 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminTaskDetailEnded => 'ئاخىرلاشتى';
 
   @override
-  String get adminTaskDetailDuration => 'داۋاملىشىش ۋاقتى';
+  String get adminTaskDetailDuration => 'Duration';
 
   @override
   String get adminTaskDetailErrorLabel => 'خاتالىق:';
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'ھەر كۈنى $time دە';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'ھەر $day $time دە';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'ھەر $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7341,8 +7305,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count سائەت',
-      one: '1 سائەت',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7366,21 +7330,21 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminActivityYesterday => 'تۈنۈگۈن';
 
   @override
-  String get adminActivityOlder => 'بۇرۇنقىلار';
+  String get adminActivityOlder => 'Older';
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days كۈن ئىلگىرى';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours سائەت ئىلگىرى';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes مىنۇت ئىلگىرى';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7388,17 +7352,17 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes مىنۇت';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours سائەت';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days كۈن';
+    return '${days}d';
   }
 
   @override
@@ -7408,7 +7372,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get adminTrickplayDescription =>
-      'ئاتلاپ كۆرۈشتىكى ئالدىن كۆرۈش كىچىك رەسىملىرى ئۈچۈن trickplay رەسىم ھاسىللاشنى تەڭشەڭ.';
+      'كىچىك كۆرۈنۈشلۈك كۆرۈنۈش ھاسىل قىلىش ئۈچۈن ئالدامچىلىق رەسىم ھاسىل قىلىڭ.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'ئاممىۋى HTTPS ئېغىزى';
@@ -7423,45 +7387,43 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'ئاممىۋى HTTP ئېغىزى';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'HTTPS تەلەپ قىلىش';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'بارلىق يىراقتىن كەلگەن تەلەپلەرنى HTTPS قا يۆتكەيدۇ. مۇلازىمېتىردا ئىناۋەتلىك گۇۋاھنامە بولمىسا كۈچكە ئىگە ئەمەس.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'گۇۋاھنامە پارولى';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP تەڭشەكلىرى';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'IPv4 نى قوزغىتىش';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'IPv6 نى قوزغىتىش';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'ئاپتوماتىك ئېغىز خەرىتىلەشنى قوزغىتىش';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'LAN تورلىرى';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'يەرلىك توردا دەپ قارىلىدىغان IP ئادرېسلار ياكى CIDR تارماق تورلىرىنىڭ پەش ياكى قۇر بىلەن ئايرىلغان تىزىملىكى.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris =>
-      'ئېلان قىلىنغان مۇلازىمېتىر URI لىرى';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'تارماق تور ياكى ئادرېسنى ئېلان قىلىنغان URL غا خەرىتىلەڭ، مەسىلەن all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'گۇۋاھنامە يولى';
@@ -7488,14 +7450,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminPlaybackSegmentKeep => 'بۆلەك ساقلاش (سېكۇنت)';
 
   @override
-  String get adminPlaybackThrottleBuffering => 'غەملەشنى چەكلەش';
+  String get adminPlaybackThrottleBuffering => 'Throttle buffering';
 
   @override
-  String get adminPlaybackThrottleDelay => 'چەكلەش كېچىكتۈرۈشى (سېكۇنت)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'ئېكران خېتىنى شۇئان ئاجرىتىشقا يول قويۇش';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'ئەڭ تۆۋەن ئەسلىگە كەلتۈرۈش نىسبىتى';
@@ -7545,7 +7507,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'مەزمۇن تىپىنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -7553,35 +7515,34 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئاستا جاۋاب قايتۇرۇش چېكى (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'ئاستا ئىنكاس ئاگاھلاندۇرۇشلىرىنى قوزغىتىش';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Quick Connect نى قوزغىتىش';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'مۇلازىمېتىر';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'مېتا ئۇچۇر';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'يوللار';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'ئۈنۈم';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'كەش يولى';
 
   @override
-  String get adminGeneralMetadataPath => 'مېتا ئۇچۇر يولى';
+  String get adminGeneralMetadataPath => 'Metadata path';
 
   @override
   String get adminGeneralServerName => 'مۇلازىمېتىر ئىسمى';
 
   @override
-  String get adminGeneralDisplayLanguage => 'ئالدىن تاللانغان كۆرسىتىش تىلى';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'تەڭشەكلەرنى يۈكلىيەلمىدى';
@@ -7591,19 +7552,19 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'ماسلاشتۇرۇشلارنى يېڭىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'ۋاقىت چېكى: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => 'ھۆججەت قىسقۇچ';
 
   @override
-  String get libraries => 'مېدىيا ئامبارلىرى';
+  String get libraries => 'كۈتۈپخانىلار';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7633,8 +7594,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# قاتناشقۇچى',
-      one: '# قاتناشقۇچى',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7657,7 +7618,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get syncPlayRepeatOne => 'بىرى';
 
   @override
-  String get syncPlayShuffleModeShuffled => 'تەرتىپسىز';
+  String get syncPlayShuffleModeShuffled => 'Shuffled';
 
   @override
   String get syncPlayShuffleModeSorted => 'تەرتىپلەنگەن';
@@ -7678,7 +7639,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return 'تۈر $index';
+    return 'Item $index';
   }
 
   @override
@@ -7726,12 +7687,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay گۇرۇپپىسىغا قوشۇلدى';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay گۇرۇپپىسىدىن ئايرىلدى';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7743,7 +7704,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'قويۇش $groupName بىلەن ماسقەدەملىنىۋاتىدۇ';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7781,8 +7742,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# قۇر بايقالدى',
-      one: '# قۇر بايقالدى',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7823,21 +7784,20 @@ class AppLocalizationsUg extends AppLocalizations {
   String get offlineSavedMedia => 'ساقلانغان مېدىيا';
 
   @override
-  String get offlineBannerTitle => 'توردا ئەمەسسىز';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'چۈشۈرۈلمىلىرىڭىز كۆرسىتىلىۋاتىدۇ';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'چۈشۈرۈلمىلەر';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'مۇلازىمېتىرىڭىزغا ئۇلانغىلى بولمىدى';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'قايتا ئۇلانغۇچە چۈشۈرۈلمىلەردىن قويۇلىدۇ';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7853,30 +7813,30 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'ئېكرانغا يوللاش كونترولى مەغلۇپ بولدى: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind كونتروللىرى';
+    return '$kind Controls';
   }
 
   @override
   String get castDeviceVolume => 'ئۈسكۈنىنىڭ ھەجىمى';
 
   @override
-  String get castVolumeUnavailable => 'ئىشلەتكىلى بولمايدۇ';
+  String get castVolumeUnavailable => 'Unavailable';
 
   @override
   String castStopKind(String kind) {
-    return '$kind نى توختىتىش';
+    return 'Stop $kind';
   }
 
   @override
-  String get audioLabel => 'ئاۋاز';
+  String get audioLabel => 'Audio';
 
   @override
-  String get subtitlesLabel => 'ئېكران خېتى';
+  String get subtitlesLabel => 'Subtitles';
 
   @override
   String get pinConfirmTitle => 'PIN نى جەزملەشتۈرۈڭ';
@@ -7892,12 +7852,12 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length خانىلىق PIN كىرگۈزۈڭ';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'ئۆزىڭىزنىڭ $length خانىلىق PIN كودىنى كىرگۈزۈڭ';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7910,40 +7870,40 @@ class AppLocalizationsUg extends AppLocalizations {
   String get pinForgot => 'PIN نى ئۇنتۇپ قالدىڭىزمۇ؟';
 
   @override
-  String get pinClear => 'تازىلاش';
+  String get pinClear => 'ئېنىق';
 
   @override
-  String get pinBackspace => 'ئۆچۈرۈش كۇنۇپكىسى';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect تەلىپى تەستىقلاندى.';
+  String get quickConnectAuthorized => 'تېز ئۇلىنىش تەلىپى ھوقۇق بېرىلگەن.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Quick Connect كودى ئىناۋەتسىز ياكى ۋاقتى ئۆتكەن.';
+      'تېز ئۇلىنىش كودى ئىناۋەتسىز ياكى ۋاقتى ئۆتكەن.';
 
   @override
   String get quickConnectNotSupported =>
-      'بۇ مۇلازىمېتىر Quick Connect نى قوللىمايدۇ.';
+      'بۇ مۇلازىمېتىردا تېز ئۇلىنىش قوللىمايدۇ.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Quick Connect كودىنى تەستىقلاش مەغلۇپ بولدى.';
+      'تېز ئۇلىنىش كودىغا ھوقۇق بېرىلمىدى.';
 
   @override
-  String get quickConnectDisabled => 'بۇ مۇلازىمېتىردا Quick Connect تاقالغان.';
+  String get quickConnectDisabled => 'بۇ مۇلازىمېتىردا تېز ئۇلىنىش چەكلەنگەن.';
 
   @override
   String get quickConnectForbidden =>
-      'ھېساباتىڭىز بۇ Quick Connect تەلىپىنى تەستىقلىيالمايدۇ.';
+      'ھېساباتىڭىز بۇ تېز ئۇلىنىش تەلىپىگە ھوقۇق بېرەلمەيدۇ.';
 
   @override
   String get quickConnectNotFound =>
-      'Quick Connect كودى تېپىلمىدى. يېڭى كود سىناڭ.';
+      'تېز ئۇلىنىش كودى تېپىلمىدى. يېڭى كودنى سىناپ بېقىڭ.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect مەغلۇپ بولدى: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7954,7 +7914,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'بۇيرۇق مەغلۇپ بولدى: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7983,7 +7943,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'ئېكرانغا يوللاشنى باشلاش مەغلۇپ بولدى: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -8028,7 +7988,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name چۈشۈرۈلۈۋاتىدۇ...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -8038,7 +7998,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get trackActionDeleteFileFailed => 'چۈشۈرۈلگەن ھۆججەتنى ئۆچۈرەلمىدى';
 
   @override
-  String get shuffleBy => 'تەرتىپسىز قويۇش ئاساسى';
+  String get shuffleBy => 'Shuffle By';
 
   @override
   String get shuffleSelectLibrary => 'كۈتۈپخانىنى تاللاڭ';
@@ -8047,7 +8007,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get shuffleSelectGenre => 'ژانىرنى تاللاڭ';
 
   @override
-  String get shuffleLibrary => 'مېدىيا ئامبىرى';
+  String get shuffleLibrary => 'كۈتۈپخانا';
 
   @override
   String get shuffleGenre => 'ژانىر';
@@ -8066,10 +8026,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get posterImageType => 'رەسىم تىپى';
 
   @override
-  String get imageTypePoster => 'پوستېر';
+  String get imageTypePoster => 'Poster';
 
   @override
-  String get imageTypeThumbnail => 'كىچىك كۆرۈنۈش';
+  String get imageTypeThumbnail => 'Thumbnail';
 
   @override
   String get imageTypeBanner => 'بايراق';
@@ -8099,7 +8059,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get lyricsNotAvailable => 'تېكىست يوق';
 
   @override
-  String get upNext => 'كېيىنكىسى';
+  String get upNext => 'Up Next';
 
   @override
   String get playNext => 'كېيىنكى ئوينى';
@@ -8108,30 +8068,30 @@ class AppLocalizationsUg extends AppLocalizations {
   String get stillWatchingContent => 'قويۇش توختىتىلدى. ھازىرمۇ كۆرۈۋاتامسىز؟';
 
   @override
-  String get stillWatchingStop => 'توختىتىش';
+  String get stillWatchingStop => 'توختاڭ';
 
   @override
   String get stillWatchingContinue => 'داۋاملاشتۇر';
 
   @override
   String skipSegment(String segment) {
-    return '$segment دىن ئاتلاش';
+    return 'Skip $segment';
   }
 
   @override
-  String get liveTv => 'بىۋاسىتە تېلېۋىزىيە';
+  String get liveTv => 'Live TV';
 
   @override
   String get continueWatchingAndNextUp => 'داۋاملىق كۆرۈش ۋە كېيىنكى باسقۇچ';
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'چۈشۈرۈلۈۋاتىدۇ $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName چۈشۈرۈلۈۋاتىدۇ';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -8147,7 +8107,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playerTooltipCastControls => 'كونترول كونتروللىرى';
 
   @override
-  String get playerTooltipPlaybackQuality => 'بىت نىسبىتى';
+  String get playerTooltipPlaybackQuality => 'Bitrate';
 
   @override
   String get playerTooltipEnterFullscreen => 'پۈتۈن ئېكراننى كىرگۈزۈڭ';
@@ -8193,13 +8153,13 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'كۆرۈشنى داۋاملاشتۇرۇشتىن يوشۇرۇش';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'كېيىنكىسىدىن يوشۇرۇش';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'توپلامغا قوشۇش';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8241,7 +8201,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئەپ نۇسخىسى ، قانۇنىي ئۇچۇرلار ۋە ئىناۋەت';
 
   @override
-  String get settingsAuthenticationSection => 'كىملىك دەلىللەش';
+  String get settingsAuthenticationSection => 'AUTHENTICATION';
 
   @override
   String get settingsSortServersBy => 'مۇلازىمېتىرلارنى تەرتىپلەش';
@@ -8253,18 +8213,17 @@ class AppLocalizationsUg extends AppLocalizations {
   String get settingsAlphabetical => 'ئېلىپبە';
 
   @override
-  String get settingsConnectionSection => 'ئۇلىنىش';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'ئۆزى ئىمزالانغان گۇۋاھنامىلەرگە يول قويۇش';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'ئۆزى ئىمزالانغان ياكى شەخسىي CA TLS گۇۋاھنامىسى ئىشلىتىدىغان مۇلازىمېتىرلارغا ئىشىنىدۇ. پەقەت ئۆزىڭىز باشقۇرىدىغان مۇلازىمېتىرلار ئۈچۈنلا قوزغىتىڭ. بۇ بارلىق ئۇلىنىشلاردا گۇۋاھنامە دەلىللەشنى تاقايدۇ.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
-  String get settingsPrivacyAndSafetySection => 'شەخسىيەت ۋە بىخەتەرلىك';
+  String get settingsPrivacyAndSafetySection => 'PRIVACY & SAFETY';
 
   @override
   String get settingsBlockedRatings => 'چەكلەنگەن باھا';
@@ -8277,11 +8236,11 @@ class AppLocalizationsUg extends AppLocalizations {
       'تېما تەلەپپۇزى ، ئارقا كۆرۈنۈش ، كۆرگەن كۆرسەتكۈچ ۋە تېما مۇزىكىسى';
 
   @override
-  String get settingsDetailsScreen => 'تەپسىلات ئېكرانى';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'ئۇسلۇب، تەگلىك گۇڭگالاشتۇرۇش ۋە بەتكۈچ ھەرىكىتى';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'باش بەت';
@@ -8319,28 +8278,27 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Seerr كۇنۇپكىسىنى يولباشچى بالداقتا كۆرسىتىش';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'ئۈستى يولباشچى بالداقتا تېكىست خەتلىرىنى ھەمىشە كۆرسىتىش';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
       'ھەر بىر كۈتۈپخانىنىڭ باش بېتىنىڭ كۆرۈنۈشىنى توغرىلاڭ. ئۆزگەرتىشنىڭ كۈچكە ئىگە بولۇشى ئۈچۈن Moonfin نى قايتا قوزغىتىڭ.';
 
   @override
-  String get settingsMediaBarAndLocalPreviews =>
-      'مېدىيا بالدىقى ۋە يەرلىك ئالدىن كۆرۈشلەر';
+  String get settingsMediaBarAndLocalPreviews => 'Media Bar & Local Previews';
 
   @override
-  String get settingsVisualOverlays => 'كۆرۈنۈش قاپلىمىلىرى';
+  String get settingsVisualOverlays => 'Visual Overlays';
 
   @override
   String get settingsSeasonalSurprise => 'پەسىل خاراكتېرلىك ھەيران قېلىش';
 
   @override
-  String get settingsMetadataAndRatings => 'مېتا ئۇچۇر ۋە باھالار';
+  String get settingsMetadataAndRatings => 'Metadata & Ratings';
 
   @override
   String get settingsPluginScreenDescription =>
@@ -8356,7 +8314,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get settingsLow => 'تۆۋەن';
 
   @override
-  String get settingsCustomPath => 'ئىختىيارى يول';
+  String get settingsCustomPath => 'Custom Path';
 
   @override
   String get settingsEnterDownloadFolderPath =>
@@ -8370,7 +8328,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'بىراقلا چۈشۈرەلەيدىغان ئەڭ كۆپ تۈر.';
 
   @override
-  String get settingsAppInfo => 'ئەپ ئۇچۇرى';
+  String get settingsAppInfo => 'APP INFO';
 
   @override
   String get settingsReportAnIssue => 'مەلۇم بىر مەسىلىنى دوكلات قىلىڭ';
@@ -8393,10 +8351,10 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'ئىجادىيەتچىگە بىر چىنە قەھۋە ئىئانە قىلىڭ';
+      'Donate a coffee to the developer';
 
   @override
-  String get settingsLegal => 'قانۇنىي ئۇچۇرلار';
+  String get settingsLegal => 'LEGAL';
 
   @override
   String get settingsLicenses => 'ئىجازەتنامە';
@@ -8427,8 +8385,8 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ئىجازەتنامە ئۇقتۇرۇشى',
-      one: '# ئىجازەتنامە ئۇقتۇرۇشى',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8477,16 +8435,16 @@ class AppLocalizationsUg extends AppLocalizations {
       'Intros ۋە Outros نى ئاتلاپ ئۆتۈپ كېتەمسىز؟';
 
   @override
-  String get settingsMediaSegmentCountdown => 'مېدىيا بۆلىكى تەتۈر ساناش';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'ئىلگىرىلەش بالدىقى';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'ۋاقىت ساناقچىسى';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'يوق';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'تېز ئىشلەتكۈچى';
@@ -8521,13 +8479,13 @@ class AppLocalizationsUg extends AppLocalizations {
       'Media3 (تەۋسىيە قىلىنغان)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (كونا)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (مىراس)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (تەۋسىيە)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision چۈشۈش';
@@ -8597,7 +8555,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'Bitstream AC3 دىن سىرتقى كود يەشكۈچ';
 
   @override
-  String get settingsCinemaMode => 'كىنوخانا ھالىتى';
+  String get settingsCinemaMode => 'Cinema Mode';
 
   @override
   String get settingsCinemaModeSubtitle =>
@@ -8617,7 +8575,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get settingsVeryLong => 'بەك ئۇزۇن';
 
   @override
-  String get settingsVideoStartDelay => 'سىن باشلىنىش كېچىكتۈرۈشى';
+  String get settingsVideoStartDelay => 'Video Start Delay';
 
   @override
   String settingsMillisecondsValue(int value) {
@@ -8625,7 +8583,7 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get settingsLiveTvDirect => 'بىۋاسىتە تېلېۋىزىيەنى بىۋاسىتە قويۇش';
+  String get settingsLiveTvDirect => 'Live TV Direct';
 
   @override
   String get settingsLiveTvDirectSubtitle =>
@@ -8653,7 +8611,7 @@ class AppLocalizationsUg extends AppLocalizations {
       'يولباشچى ستونىدا SyncPlay كۇنۇپكىسىنى كۆرسەت';
 
   @override
-  String get settingsSyncplayAdvancedCorrection => 'ئالىي تۈزىتىش';
+  String get settingsSyncplayAdvancedCorrection => 'Advanced Correction';
 
   @override
   String get settingsSyncplayAdvancedCorrectionSubtitle =>
@@ -8701,7 +8659,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get collections => 'توپلام';
 
   @override
-  String get lastPlayed => 'ئەڭ ئاخىرقى قويۇلغان';
+  String get lastPlayed => 'Last Played';
 
   @override
   String libraryNameWithServer(String libraryName, String serverName) {
@@ -8715,436 +8673,427 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'يېقىندا تارقىتىلغان $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'كېيىنكى بۆلۈمنى ئاپتوماتىك قويۇش';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'كېيىنكى بۆلۈم بار بولسا ئۆزلۈكىدىن قويىدۇ.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'جىمجىتلىقتىن ئاتلاش';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'ئېقىم قوللىغاندا ئۈنسىز ئاۋاز بۆلەكلىرىدىن ئۆزلۈكىدىن ئاتلايدۇ.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'سىرتقى ئاۋاز ئۈنۈملىرىگە يول قويۇش';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'تەڭشىگۈچ ۋە ئۈنۈم ئەپلىرىنىڭ (مەسىلەن Wavelet) Media3 قويۇش سېئانسلىرىغا ئۇلىنىشىغا يول قويىدۇ.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'تونېللاشنى تاقاش';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'تونېلسىز قويۇشقا زورلايدۇ. تونېللىق ئاۋاز/سىن ئۈزۈلۈشى بار ئۈسكۈنىلەردە پايدىلىق.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'تونېللاشنى قوزغىتىش';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'ئالىي تەڭشەك. ئاۋاز ۋە سىننى ماسلاشقان قاتتىق دېتال يولى ئارقىلىق ئۆتكۈزىدۇ. بەزى ئۈسكۈنىلەردە ئاۋاز/سىن ئۈزۈلۈشى پەيدا قىلغاچقا، سۈكۈتتە تاقاق.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision profile 7 نى HEVC قا خەرىتىلەش';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Dolby Vision profile 7 ئېقىملىرىنى DV يوق ئۈسكۈنىلەردە HDR10 غا ماس HEVC سۈپىتىدە قويىدۇ.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles =>
-      'سىڭدۈرۈلگەن ئېكران خېتى ئۇسلۇبلىرىنى ئىشلىتىش';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'ئېكران خېتى يولىغا سىڭدۈرۈلگەن رەڭ، خەت نۇسخىسى ۋە ئورۇنلاشتۇرۇشنى قوللىنىدۇ. ئۆزىڭىزنىڭ ئۇسلۇب مايىللىقلىرىنى ئىشلىتىش ئۈچۈن تاقاڭ.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'سىڭدۈرۈلگەن ئېكران خېتى خەت چوڭلۇقىنى ئىشلىتىش';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'ئېكران خېتى يولىغا سىڭدۈرۈلگەن خەت چوڭلۇقى ئۇچۇرلىرىنى قوللىنىدۇ. ئۇسلۇب مايىللىقىڭىزدىكى ئېكران خېتى چوڭلۇقىنى ئىشلىتىش ئۈچۈن تاقاڭ.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'مېدىيا تەپسىلاتلىرىنى كۆرسىتىش';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'ئامبار بەتلىرىنىڭ ئۈستىدە تاللانغان تۈرنىڭ تەپسىلاتلىرىنى كۆرسىتىدۇ.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries =>
-      'كۆرگەندە تەگلىك رەسىملىرى يوشۇرۇلسۇنمۇ؟';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => 'تەپسىلىي تارماق ماۋزۇلارنى ئىشلىتىش';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'ئامبار بەتلىرىدە تەپسىلىي ياكى ئاددىي تارماق قۇرنى كۆرسىتىدۇ.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'ساقلانغان تېما ئۆچۈرۈلسۇنمۇ؟';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '«$themeName» بۇ ئۈسكۈنىنىڭ غەملىكىدىن چىقىرىۋېتىلسۇنمۇ؟';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => 'تېما دۇكىنى';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'جامائەت تېمىلىرىنى كۆرۈپ ساقلاڭ';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'تېمىنى ساقلىسىڭىز، باشقا ساقلانغان تېمىلىرىڭىزدەك ئىشلىتەلەيسىز.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'ھازىرچە تېما يوق.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'تېما دۇكىنىنى يۈكلىگىلى بولمىدى. ئۇلىنىشىڭىزنى تەكشۈرۈپ قايتا سىناڭ.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'ساقلاش';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'ساقلاپ قوللىنىش';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'ساقلاندى';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'بۇ تېمىنى يۈكلىگىلى بولمىدى.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '«$themeName» ساقلاندى.';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '«$themeName» بۇ ئۈسكۈنىدىن ئۆچۈرۈلدى.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '«$themeName» نى ئۆچۈرگىلى بولمىدى.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'ساقلانغان تېمىلار';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'بۇلار نۆۋەتتىكى مۇلازىمېتىرنىڭ Moonfin قىستۇرمىسىدىن چۈشۈرۈلگەن تېمىلار. ئۆچۈرسىڭىز پەقەت بۇ يەرلىك نۇسخىلا چىقىرىۋېتىلىدۇ.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty =>
-      'بۇ مۇلازىمېتىر ئۈچۈن ساقلانغان تېما تېپىلمىدى.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • ھازىر ئاكتىپ';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'ساقلانغان تېمىنى ئۆچۈرۈش';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'بۇ ئۈسكۈنىدىكى چۈشۈرۈلگەن قىستۇرما تېمىلىرىنى باشقۇرۇش';
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => 'تېما تەھرىرلىگۈچ';
+  String get themeEditor => 'Theme Editor';
 
   @override
   String get themeEditorSubtitle =>
-      'Moonfin تېما تەھرىرلىگۈچىنى تور كۆرگۈچىڭىزدە ئېچىش';
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'باش ئېكران';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'ئاستى بالداق';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'كلاسسىك';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => 'زامانىۋى';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'باش بەت قۇرلىرى';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'باش بەت قۇرى كۆرسىتىلىشى';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'باش بەت قۇر بۆلەكلىرى';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'باش بەت قۇر ئۈزچاتلىرى';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'ئامبار ئاساسىدىكى باش بەت قۇر تۈرلىرىنى قوزغىتىڭ ياكى تاقاڭ';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'باش بەت بۆلەكلىرىدە قۇرلارنى كۆرسىتىش ئۈچۈن تۆۋەندىكى ئۈزچاتلارنى قوزغىتىڭ.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'كلاسسىك ھەر قۇرنىڭ رەسىم تىپى ۋە ئۇچۇر قاپلىمىسىنى ساقلايدۇ. زامانىۋى بوي پوستېردىن تەگلىككە ئۆتىدىغان قۇرلارنى ئىشلىتىدۇ.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'ئامراقلار قۇرلىرىنى كۆرسىتىش';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'باش بەت بۆلەكلىرىدە ئامراق كىنولار، تىياتىرلار ۋە باشقا ئامراق قۇرلارنى كۆرسىتىدۇ.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'ئامراقلار قۇرى تەرتىپلىنىشى';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'ئامراقلار قۇرلىرىنى قوشۇلغان چېسلا، تارقىتىلغان چېسلا، ئېلىپبە تەرتىپى ۋە باشقىلار بويىچە تەرتىپلەيدۇ.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'توپلام قۇرلىرىنى كۆرسىتىش';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'باش بەت بۆلەكلىرىدە توپلام قۇرلىرىنى كۆرسىتىدۇ.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'توپلام قۇرى تەرتىپلىنىشى';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'توپلام قۇرلىرىنى قوشۇلغان چېسلا، تارقىتىلغان چېسلا، ئېلىپبە تەرتىپى ۋە باشقىلار بويىچە تەرتىپلەيدۇ.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'ژانىر قۇرلىرىنى كۆرسىتىش';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'باش بەت بۆلەكلىرىدە ژانىر قۇرلىرىنى كۆرسىتىدۇ.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'ژانىر قۇرى تەرتىپلىنىشى';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'ژانىر قۇرلىرىنى قوشۇلغان چېسلا، تارقىتىلغان چېسلا، ئېلىپبە تەرتىپى ۋە باشقىلار بويىچە تەرتىپلەيدۇ.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'ژانىر قۇرى تۈرلىرى';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'ژانىر قۇرلىرىدا كىنو، تىياتىر ياكى ھەر ئىككىسىنى كۆرسىتىدۇ.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'قويۇش تىزىملىكى قۇرلىرىنى كۆرسىتىش';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'باش بەت بۆلەكلىرىدە قويۇش تىزىملىكى قۇرلىرىنى كۆرسىتىدۇ.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'قويۇش تىزىملىكى قۇرى تەرتىپلىنىشى';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'قويۇش تىزىملىكى قۇرلىرىنى قوشۇلغان چېسلا، تارقىتىلغان چېسلا، ئېلىپبە تەرتىپى ۋە باشقىلار بويىچە تەرتىپلەيدۇ.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'ئاۋاز قۇرلىرىنى كۆرسىتىش';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'باش بەت بۆلەكلىرىدە ئاۋاز قۇرلىرىنى كۆرسىتىدۇ.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'ئاۋاز قۇرلىرى تەرتىپلىنىشى';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'ئاۋاز قۇرلىرىنى قوشۇلغان چېسلا، تارقىتىلغان چېسلا، ئېلىپبە تەرتىپى ۋە باشقىلار بويىچە تەرتىپلەيدۇ.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'ئاۋاز قويۇش تىزىملىكلىرى';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'كۆرۈنۈش';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => 'ئورۇنلاشتۇرۇش';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'تېما';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'ھەرپتاختا';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'كۇنۇپكىلار';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'سىزىش';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV سەپلىمىسى';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'سىرتقى قويغۇچ ئەپ';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'ئۇزۇن بېسىپ قويۇش تاللانمىسىنى ئېچىش ئۈچۈن سىرتقى قويغۇچنى تەڭشەڭ';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'قويۇش باشلانغاندا ئەپ تاللىغۇچنى كۆرسىتىدۇ.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'قاچىلانغان قويغۇچلار يۈكلىنىۋاتىدۇ...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'ئۇلىنىش';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'ئاۋاز كود ئۆزگەرتىش نىشانى';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'بىۋاسىتە ئۆتكۈزۈش';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'بۇ ئۈسكۈنە قوللايدۇ';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'بۇ ئۈسكۈنە قوللىمايدۇ';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough =>
-      'DTS:X (DTS UHD) بىۋاسىتە ئۆتكۈزۈش';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) بىت ئېقىمىنى سىرتقى كودسىزلىغۇچقا ئەۋەتىدۇ.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'Atmos (JOC) لىق TrueHD بىۋاسىتە ئۆتكۈزۈش';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'مېدىيا قويغۇچ ھەرىكىتى';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'قويۇش كۈچەيتمىلىرى';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'ھەمىشە ئوچۇق.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'ئاخىرقى قىسىمدىن ئاتلاشنى كېيىنكىسى كۆرسىتىلىشىگە ئالماشتۇرۇش';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'ئاخىرقى قىسىمدىن ئاتلاش كۇنۇپكىسىنىڭ ئورنىغا كېيىنكىسى قاپلىمىسىنى كۆرسىتىدۇ.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'قويغۇچ يۆنىلىشى';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders =>
-      'يۇمشاق دېتال كودسىزلىغۇچلارنى ئالدىن تاللاش';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'قاتتىق دېتال كودسىزلىغۇچتىن بۇرۇن FFmpeg (ئاۋاز) ۋە libgav1 (AV1) نى ئىشلىتىدۇ. HDMI ئاۋاز بىۋاسىتە ئۆتكۈزۈش بۇزۇلسا تاقاڭ.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV دا سىن قويۇشنى تاللانغان سىرتقى ئەپتە ئاچىدۇ.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'ئاپتوماتىك ئۆچرەتكە قوشۇش';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH ئېكران خېتىنى ئالدىن تاللاش';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'ئۆزلۈكىدىن تاللىغاندا SDH/CC ئېكران خېتى يوللىرىنى ئالدىنقى ئورۇنغا قويىدۇ.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'تور دىئاگنوزى';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin تور دىئاگنوزى';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'بۇ بەتنى تور كۆرگۈچ ئۇلىنىش مەسىلىلىرىنى (CORS، ئارىلاش مەزمۇن ۋە بايقاش تەڭشەكلىرى) دىئاگنوز قىلىشقا ئىشلىتىڭ.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'ئارىلاش مەزمۇن خاتالىقى بايقالدى';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Preflight خاتالىقى بايقالدى';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin بىر HTTPS بەتنىڭ HTTP مۇلازىمېتىر URL ئادرېسىنى چاقىرماقچى بولغانلىقىنى بايقىدى. تور كۆرگۈچلەر بۇ تەلەپنى مۇلازىمېتىرىڭىزغا يېتىشتىن بۇرۇن توسىدۇ.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin كۆپىنچە مېدىيا مۇلازىمېتىرىدا CORS ياكى preflight قېشى كەم بولغاندا كۆرۈلىدىغان تور كۆرگۈچ دەرىجىلىك تەلەپ خاتالىقىنى بايقىدى.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'نىشان URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return 'تەپسىلات: $detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'نۆۋەتتىكى ئىجرا مۇھىتى';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
   String get webDiagnosticsOrigin => 'Origin';
@@ -9153,322 +9102,320 @@ class AppLocalizationsUg extends AppLocalizations {
   String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'قىستۇرما ھالىتى';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC سايىلەش';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'مەجبۇرىي مۇلازىمېتىر URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'سۈكۈتتىكى مۇلازىمېتىر URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'بايقاش ۋاكالەتچى URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'سەپلەنمىگەن';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'ئارىلاش مەزمۇن';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'بۇ بەت HTTPS ئارقىلىق يۈكلەنگەن، ئەمما سەپلەنگەن بىر ياكى بىرنەچچە URL بولسا HTTP. تور كۆرگۈچلەر HTTPS بەتلەرنىڭ HTTP API چاقىرىشىنى توسىدۇ.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'ھەل قىلىش: مېدىيا مۇلازىمېتىرىڭىز ياكى ۋاكالەتچى ئېغىزىڭىزنى HTTPS ئارقىلىق تەمىنلەڭ، ياكى Moonfin نى پەقەت ئىشەنچلىك يەرلىك تورلاردىلا HTTP ئارقىلىق ئېچىڭ.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'نۆۋەتتىكى ئىجرا تەڭشەكلىرىدىن ئېنىق ئارىلاش مەزمۇن سەپلىمىسى بايقالمىدى.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS تەكشۈرۈش تىزىملىكى';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• تور كۆرگۈچ Origin نى Access-Control-Allow-Origin غا كىرگۈزۈڭ.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Authorization، X-Emby-Authorization ۋە X-Emby-Token نى Access-Control-Allow-Headers غا كىرگۈزۈڭ.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• ئېقىم قويۇش ۋە ئاتلاش ئۈچۈن Content-Range ۋە Accept-Ranges نى ئاشكارىلاڭ.';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS preflight تەلەپلىرىگە 204 قايتۇرۇڭ.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'قاش مىسال پارچىسى (nginx ئۇسلۇبى)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'ئەسكەرتىش';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'بۇ دىئاگنوز بېتى تور نەشرى ئۈچۈن. باشقا سۇپىدا كۆرۈۋاتقان بولسىڭىز، بۇ تەكشۈرۈشلەر ماس كەلمەسلىكى مۇمكىن.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'مۇلازىمېتىر تاللاشقا قايتىش';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'بارلىق ئىشلەتكۈچىلەرنى چىقىرىش';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'مىكروفون ھوقۇقى مەڭگۈلۈك رەت قىلىنغان. سىستېما تەڭشەكلىرىدىن قوزغىتىڭ.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'ئاۋازلىق ئىزدەشكە مىكروفون ھوقۇقى كېرەك.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'ئېنىق ئاڭلانمىدى. قايتا سىناڭ.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'سۆز بايقالمىدى.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'مىكروفون خاتالىقى.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => 'ئاۋازلىق ئىزدەشكە تور كېرەك.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'ئاۋاز مۇلازىمىتى ئالدىراش. قايتا سىناڭ.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'مىكروفون ھوقۇقى مەڭگۈلۈك رەت قىلىنغان.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'مىكروفون ھوقۇقى رەت قىلىندى.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'بۇ ئۈسكۈنىدە سۆز تونۇش ئىقتىدارى يوق.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS يۆنىلىش تاللىغۇچنى ئېچىش';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'بۇ ئۈسكۈنىدە AirPlay يۆنىلىش تاللىغۇچ يوق.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'سىنلار';
+  String get videos => 'Videos';
 
   @override
-  String get programs => 'پروگراممىلار';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'ناخشىلار';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'سۈرەت ئالبوملىرى';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'سۈرەتلەر';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'كىشىلەر';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'يېقىندا تارقىتىلغان بۆلۈملەر';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'قايتا كۆرۈش';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'مېھمان روللىرى';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'قاتناشقان ئەسەرلەر (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'خادىم تۆھپىلىرى (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => 'گۇرۇپپا بىلەن كۆرۈش';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'خاتالىقلار';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'ئاگاھلاندۇرۇشلار';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => 'دىسكا';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'تور كۆرگۈچتە ئېچىش';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'بۇ سۇپىدا قىستۇرما تور كۆرگۈچ يوق.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'مۇلازىمېتىرنى راستىنلا قايتا قوزغىتامسىز؟';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'مۇلازىمېتىرنى راستىنلا تاقامسىز؟ ئۇنى قولدا قايتا قوزغىتىشىڭىز كېرەك بولىدۇ.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'ئىچكى';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'بىكار';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'ئىشلەتكۈچى تېپىلمىدى';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => 'ئىزدىگىنىڭىزگە ماس ئىشلەتكۈچى يوق';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'ئۈسكۈنە تېپىلمىدى';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'نۆۋەتتىكى سۈزگۈچلەرگە ماس ئۈسكۈنە يوق';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'پارول تەڭشەلگەن';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'پارول تەڭشەلمىگەن';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'يىراقتىن زىيارەت';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'پەقەت يەرلىك';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed =>
-      'مېدىيا ئىستاتىستىكىسىنى يۈكلەش مەغلۇپ بولدى';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'بارلىق مېدىيا ئامبارلىرىنىڭ بىرلەشتۈرۈلگەن ئىستاتىستىكىسى.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'ئالدىنقى سەنئەتكارلار';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'ئالدىنقى ئاپتورلار';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'ئالدىنقى تۆھپىكارلار';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ئامبار',
-      one: '1 ئامبار',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'بۇ تاللاش ئۈچۈن ئىندېكسلانغان مېدىيا ئومۇمىي سانلىرى تېخى يوق.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'ئامبار تەپسىلاتلىرى';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'ئامبار تەقسىماتى';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'ئامبار يوق.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'مۇلازىمېتىر باشقۇرۇش';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'سانلىق مەلۇمات';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'رەسىم غەملىكى';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'غەملەك';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'خاتىرىلەر';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => 'مېتا ئۇچۇر';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'كود ئۆزگەرتىش';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'بۇ مۇلازىمېتىر ھېچقانداق يول قايتۇرمىدى.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% ئىشلىتىلگەن';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'ئىشلەتكۈچى پائالىيىتى';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'سىستېما ھادىسىلىرى';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'دىققەت تەلەپ قىلىدۇ';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'مۇلازىمېتىر';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'قويۇش';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'ئۈسكۈنىلەر';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'ئالىي';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => 'قىستۇرمىلار';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'بىۋاسىتە تېلېۋىزىيە';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'ئائىلە سىنلىرى';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'ئارىلاش مەزمۇن';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'ئائىلە سىنلىرى ۋە سۈرەتلەر';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'ئارىلاش كىنو ۋە تىياتىرلار';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9480,300 +9427,299 @@ class AppLocalizationsUg extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'خاتىرىلەنمە تېپىلمىدى';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension ئارخىپىدىن رەسىم بەتلىرى تېپىلمىدى.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'قىستۇرما سىزغۇچ مەغلۇپ بولدى ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB سىزغۇچى مەغلۇپ بولدى ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'ئوقۇغۇچ ئۈچۈن يەرلىك ھۆججەت كەم: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri دىن كىتاب سانلىق مەلۇماتىنى ئېچىۋاتقاندا HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'ئوقۇغىلى بولىدىغان كىتاب ئېغىزى يوق';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'قوللىمايدىغان كومىكس ئارخىپى فورماتى: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'بۇ سۇپىدا CBR ئاجرىتىش قىستۇرمىسى يوق.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive =>
-      '.cbr ئارخىپىنى ئاجرىتىش مەغلۇپ بولدى.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'بۇ سۇپىدا CB7 ئاجرىتىش ئىقتىدارى يوق.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'بۇ سۇپىدا CB7 ئاجرىتىش قىستۇرمىسى يوق.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'ژانىر تاختىسىنى تاقاش';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'تەرتىپسىز قويۇش يۈكلىنىۋاتىدۇ...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'ئامبار تەرتىپسىز قويۇش';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'خالىغانچە تەرتىپسىز قويۇش';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ژانىر تەرتىپسىز قويۇش';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'ئاپتوماتىك HDR ئالماشتۇرۇش';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR سىن قويۇلغاندا HDR نى ئۆزلۈكىدىن قوزغىتىپ، چېكىنگەندە ئېكران ھالىتىنى ئەسلىگە قايتۇرىدۇ.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'پۈتۈن ئېكران بولغاندا';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'بېزەك رەسىمىنى ئۆزگەرتىش';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'كەم';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'كود ئۆزگەرتىش چەكلىمىلىرى';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'بارلىق بېزەك رەسىملىرى تازىلانسۇنمۇ؟';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'بارلىق چۈشۈرۈلگەن بېزەك رەسىملىرىنى راستىنلا تازىلامسىز؟';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'تازىلاشنى جەزملەش';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'بۇ $itemType نى راستىنلا تازىلامسىز؟';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'يوللامسىز؟';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'ئېنىقلىق: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'پەقەت كۆرۈنمە يۈز تىلىدىكى بېزەك رەسىملىرىنىلا كۆرسىتىش';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'ھەممىنى تازىلاشنى جەزملەش';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'رەسىم مۇۋەپپەقىيەتلىك يوللاندى!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'رەسىم يوللاش مەغلۇپ بولدى: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'رەسىمنى تەڭشەش مەغلۇپ بولدى: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'رەسىمنى ئۆچۈرۈش مەغلۇپ بولدى: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'بارلىق بېزەك رەسىملىرىنى تازىلاش مەغلۇپ بولدى: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'ھەئە';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'پوستېر';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'تەگلىكلەر';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'لەۋھە';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'لوگو';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'كىچىك كۆرۈنۈش';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'بېزەك';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'دىسكا بېزىكى';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'ئېكران كۆرۈنۈشى';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'قاپ مۇقاۋىسى';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'قاپ ئارقا مۇقاۋىسى';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'تىزىملىك بېزىكى';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'پوستېر';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'تەگلىك';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'لەۋھە';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'لوگو';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'كىچىك كۆرۈنۈش';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'بېزەك';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'دىسكا بېزىكى';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ئېكران كۆرۈنۈشى';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'قاپ مۇقاۋىسى';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'قاپ ئارقا مۇقاۋىسى';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'تىزىملىك بېزىكى';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'ھەممىسى';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'يۇقىرى (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'ئوتتۇرا (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'تۆۋەن (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'مەنبەلەر';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'بابلار';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'خەتكۈشلەر';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'ئىزاھاتلار';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'ئۆچرەت';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'ۋاقىت ئوقى';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'ۋاقىت ئوقى قۇرۇق';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'پۈتۈن كىتاب';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'مەركەزلەشكەن ۋاقىت ئوقى';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'خەتكۈشلەرنى چىقىرىش';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'ئىزاھاتلارنى چىقىرىش';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'ھەممىنى چىقىرىش';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '$path غا چىقىرىلدى';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'چىقىرىش مەغلۇپ بولدى: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'ناخشا تېكىستى';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'خەتكۈش قوشۇش';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'ئىزاھات قوشۇش';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'ئىزاھاتنى تەھرىرلەش';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'بۇ پەيت ئۈچۈن ئىزاھات يېزىڭ';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'ئۇيقۇ ۋاقىت ساناقچىسى';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'تاقاق';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'باب ئاخىرى';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'ئىختىيارى';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '$remaining قالدى';
+    return '$remaining left';
   }
 
   @override
@@ -9781,58 +9727,58 @@ class AppLocalizationsUg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count مىنۇت',
-      one: '1 مىنۇت',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'قويۇش سۈرئىتى';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'قالغىنى';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'ئۆتكىنى';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '$seconds سېكۇنت كەينىگە';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '$seconds سېكۇنت ئالدىغا';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'ئالدىنقى باب';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'كېيىنكى باب';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '$total بابتىن $current-باب';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'باب يوق';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'تېخى خەتكۈش يوق';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'تېخى ئىزاھات يوق';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '$position غا خەتكۈش قوشۇلدى';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '1.0x قا قايتۇرۇش';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9840,251 +9786,249 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'ساقلاش';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'بىكار قىلىش';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'ئۆچۈرۈش';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'ئېكران خېتى مايىللىقلىرى';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'ئېكران خېتى ھالەتلىرى، سۈكۈتتىكى تىللار، كۆرۈنۈش ۋە سىزىش تاللانمىلىرىنى ئۆزگەرتىڭ.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'ئېكران خېتى سىزىلىشى';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'كۆرسىتىش تاللانمىلىرى';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'تارقىتىلغان چېسلا (ئۆسۈش تەرتىپى)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'تارقىتىلغان چېسلا (كېمىيىش تەرتىپى)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'تۆھپىلەرنى گۇرۇپپىلاش';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'كۆپ روللارنى گۇرۇپپىلاش';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'ئامبارغا يېزىش ھوقۇقى ئاگاھلاندۇرۇشى';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'ھەل قىلىش ئۇسۇلى:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. مۇلازىمېتىردىكى مېدىيا ئامبار قىسقۇچلىرىڭىز ئۈچۈن Jellyfin مۇلازىمەت ئىشلەتكۈچىسىگە (مەسىلەن jellyfin ياكى Docker PUID/PGID) يېزىش ھوقۇقى بېرىڭ.\n\n2. ياكى Jellyfin باشقۇرۇش تاختىسى -> ئامبارلار غا بېرىپ، بۇ ئامبارنى تەھرىرلەپ، بېزەك رەسىملىرىنى Jellyfin نىڭ ئىچكى ساندانىدا ساقلاش ئۈچۈن «بېزەك رەسىملىرىنى مېدىيا قىسقۇچلىرىغا ساقلاش» نى تاقاڭ.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'يېپىش';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '«$libraryName» ئامبىرىڭىز بېزەك رەسىملىرىنى بىۋاسىتە مېدىيا قىسقۇچلىرىغا ساقلايدىغان قىلىپ سەپلەنگەن («بېزەك رەسىملىرىنى مېدىيا قىسقۇچلىرىغا ساقلاش» قوزغىتىلغان). ئەمما Jellyfin يېزىش ھوقۇقىنى سىناپ كۆردى ۋە بۇ مۇندەرىجىگە ھۆججەت يازالمايدۇ:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Jellyfin بېزەك رەسىمىنى يېڭىلىيالمىغاندەك قىلىدۇ. ئامبىرىڭىز بېزەك رەسىملىرىنى بىۋاسىتە مېدىيا قىسقۇچلىرىغا ساقلايدىغان قىلىپ سەپلەنگەن («بېزەك رەسىملىرىنى مېدىيا قىسقۇچلىرىغا ساقلاش» قوزغىتىلغان). بۇ خاتالىق ئادەتتە Jellyfin مۇلازىمېتىر جەريانىنىڭ مېدىيا مۇندەرىجىلىرىڭىزگە ھۆججەت يېزىش ھوقۇقى بولمىغاندا كۆرۈلىدۇ.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'سىرتقى تىزىملىكلەر';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'قايتا قويۇش';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'ھۆججەت ئۇچۇرى';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'چوڭلۇقى: $size  •  فورماتى: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'بارلىق ($count) ئاۋاز يوللىرىنى كۆرسىتىش';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'بارلىق ($count) ئېكران خېتى يوللىرىنى كۆرسىتىش';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'بىۋاسىتە قويۇش ئىقتىدارى تەكشۈرۈلۈۋاتىدۇ...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'بىۋاسىتە قويۇش ئىقتىدارى: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'مەجبۇرىي';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'قاچا فورماتىنى قويغۇچ قوللىمايدۇ.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'سىن كودېكىنى قوللىمايدۇ.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'ئاۋاز كودېكىنى قوللىمايدۇ.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'ئېكران خېتى فورماتىنى قوللىمايدۇ (كۆيدۈرۈش كېرەك).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => 'ئاۋاز پروفىلىنى قوللىمايدۇ.';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => 'سىن پروفىلىنى قوللىمايدۇ.';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => 'سىن دەرىجىسىنى قوللىمايدۇ.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'بۇ ئۈسكۈنە سىن ئېنىقلىقىنى قوللىمايدۇ.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'سىن بىت چوڭقۇرلۇقىنى قوللىمايدۇ.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'سىن كادر تېزلىكىنى قوللىمايدۇ.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'ھۆججەت بىت نىسبىتى قويغۇچنىڭ ئېقىم چېكىدىن ئېشىپ كەتتى.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'سىن بىت نىسبىتى ئېقىم چېكىدىن ئېشىپ كەتتى.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'ئاۋاز بىت نىسبىتى ئېقىم چېكىدىن ئېشىپ كەتتى.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'ئاۋاز قاناللىرىنىڭ سانىنى قوللىمايدۇ.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'ئېلىپبە تەرتىپى';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'تارقىتىلىش تەرتىپى (ئۆسۈش)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'تارقىتىلىش تەرتىپى (كېمىيىش)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'ئىختىيارى (سۆرەپ-تاشلاش)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'قويۇش تىزىملىكى تەرتىپلەش تاللانمىلىرى';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'تەرتىپنى ئەسلىگە قايتۇرۇش';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'S$season:E$episode نى قايتا كۆرۈش';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'قايتا كۆرۈش تىزىملىكى';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'ئېكران خېتى تېپىلمىدى.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'باشقۇرغۇچى كونتروللىرى';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'سىزىش ماتورى (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller بولسا Flutter نىڭ زامانىۋى GPU سىزغۇچى بولۇپ، ھەرىكەتلەرنى تېخىمۇ سىلىق قىلىپ توختاپ قېلىشنى ئازايتىدۇ. بەزى TV قۇتىلىرى ۋە كونا GPU لاردا خاتالىق ياكى قارا سىن پەيدا قىلىشى مۇمكىن؛ شۇنداق ئەھۋال كۆرۈلسە ئۇنى تاقاق قىلىڭ. ئاپتوماتىك ئۈسكۈنىڭىزگە ئەڭ ماس سۈكۈتتىكىنى تاللايدۇ. قوللىنىش ئۈچۈن Moonfin نى قايتا قوزغىتىڭ.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'ئاپتوماتىك';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'ئوچۇق';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'تاقاق';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'قايتا قوزغىتىش كېرەك';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'سىزىش ماتورىنى ئۆزگەرتىش ئۈچۈن Moonfin قايتا قوزغىتىلىشى كېرەك. ئەپنى ھازىر تاقاپ، ئاندىن قايتا ئېچىڭ.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'ئەپنى ھازىر تاقاش';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'ئامبارنى يېڭىلاش';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'بارلىق ئامبارلارنى يېڭىلاش';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'قوشۇلغان چېسلا (كونىسى ئالدىدا)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'قوشۇلغان چېسلا (يېڭىسى ئالدىدا)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'ئېلىپبە تەرتىپى (A دىن Z گە)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'ئېلىپبە تەرتىپى (Z دىن A غا)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'مۇلازىمېتىر ئىستاتىستىكىسى يۈكلىنىۋاتىدۇ... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'مەنبەگە ماسلاش';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb ئالدىنقى 250 كىنو';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb ئالدىنقى 250 تېلېۋىزىيە تىياتىرى';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb ئەڭ ئالقىشلانغان كىنولار';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows =>
-      'IMDb ئەڭ ئالقىشلانغان تېلېۋىزىيە تىياتىرلىرى';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb ئەڭ تۆۋەن باھالانغان كىنولار';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'IMDb ئەڭ يۇقىرى باھالانغان ئىنگلىزچە كىنولار';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -9,30 +9,30 @@ class AppLocalizationsUk extends AppLocalizations {
   AppLocalizationsUk([String locale = 'uk']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Місячне плавник';
 
   @override
-  String get accountPreferences => 'НАЛАШТУВАННЯ ОБЛІКОВОГО ЗАПИСУ';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Мова інтерфейсу';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Як у системі';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Увійти';
 
   @override
-  String get empty => 'Порожньо';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Підключення до $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Швидке підключення';
 
   @override
   String get password => 'Пароль';
@@ -61,12 +61,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect недоступний: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect недоступний ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,7 +80,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Версія Moonfin $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -106,14 +106,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Видалити «$serverName» зі списку ваших серверів?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => 'Скасувати';
 
   @override
-  String get remove => 'Прибрати';
+  String get remove => 'видалити';
 
   @override
   String get connectToServer => 'Підключитися до сервера';
@@ -141,62 +141,62 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsAppearanceTheme => 'Тема програми';
 
   @override
-  String get detailScreenStyle => 'Стиль екрана деталей';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '«Класичний» — це початковий центрований макет moonfin. «Сучасний» — адаптивний кінематографічний макет.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Класичний';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Сучасний';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Розгорнуті вкладки';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Автоматично показувати вміст вкладки під час її перегляду. Вимкніть, щоб відкривати й закривати кожну вкладку вручну.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Показувати технічні деталі?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Показувати кодек, роздільну здатність і відомості про потік у зведенні банера';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Система рекомендацій';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Використовуйте локальний алгоритм «Moonfin рекомендує» або онлайн-метрики схожості TMDb. Примітка: онлайн-рекомендації потребують інтеграції з Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin рекомендує';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Схожість TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Обмежувати за віковим рейтингом?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Обмежувати пропозиції «Moonfin рекомендує» за віковим рейтингом цільового медіа';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Стиль інтерфейсу';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '«Автоматично» відповідає вашому пристрою. Виберіть Apple або Material, щоб задати вигляд примусово.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Автоматично';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,42 +205,41 @@ class AppLocalizationsUk extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Якість скла';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '«Авто» добирає найкращий ефект скла для цього пристрою. «Повна» вмикає справжнє розмиття; «Знижена» використовує полегшене скло, що заощаджує ресурс GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Авто';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Повна';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Знижена';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Перемикайтеся між Moonfin і Neon Pulse без перезапуску програми';
 
   @override
-  String get customThemeTitle => 'Власна тема';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Власні теми змінюють візуальні елементи в усьому Moonfin. Виберіть один із варіантів на свій смак.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme =>
-      'Віддавати перевагу системній клавіатурі';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Типово використовувати метод введення вашого пристрою для введення тексту';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Місячне плавник';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -254,18 +253,18 @@ class AppLocalizationsUk extends AppLocalizations {
       'Стиль Synthwave із пурпуровим сяйвом, блакитним текстом і сильнішим хромованим контрастом';
 
   @override
-  String get themeGlass => 'Скло';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Стиль рідкого скла з плинним градієнтним тлом, матовими поверхнями та синім акцентом Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-бітний герой';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Ретростиль піксель-арту з насиченою палітрою, масивними рамками, різкими тінями та піксельним шрифтом';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -315,7 +314,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Не вдалося підключитися до $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -328,35 +327,35 @@ class AppLocalizationsUk extends AppLocalizations {
   String get exit => 'Вихід';
 
   @override
-  String get gameMenu => 'Меню';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Призупинено';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Зберегти стан';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Ігри';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Завантажити стан';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Перемотування вперед';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Налаштування емулятора';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => 'Це ядро не має налаштовуваних параметрів.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Утримуйте, щоб відкрити меню';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Запуск ігор поки що не підтримується на цьому пристрої.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Не вдалося завантажити домашні рядки';
@@ -378,13 +377,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get schedule => 'розклад';
 
   @override
-  String get series => 'Серіали';
+  String get series => 'Серія';
 
   @override
   String get noItemsFound => 'Елементів не знайдено';
 
   @override
-  String get home => 'Головна';
+  String get home => 'додому';
 
   @override
   String get browseAll => 'Переглянути все';
@@ -415,7 +414,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get noLibrariesFound => 'Бібліотеки не знайдено';
 
   @override
-  String get library => 'Медіатека';
+  String get library => 'Бібліотека';
 
   @override
   String get displaySettings => 'Налаштування дисплея';
@@ -428,7 +427,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Не вдалося завантажити теку: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -436,7 +435,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count елементів';
+    return '$count items';
   }
 
   @override
@@ -453,7 +452,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count елементів';
+    return '$count Items';
   }
 
   @override
@@ -494,7 +493,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — жанри';
+    return '$name — Genres';
   }
 
   @override
@@ -507,7 +506,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get albumArtists => 'Виконавці альбому';
 
   @override
-  String get artists => 'Виконавці';
+  String get artists => 'Художники';
 
   @override
   String get bookmarks => 'Закладки';
@@ -533,17 +532,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count хв тому';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count год тому';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count дн тому';
+    return '${count}d ago';
   }
 
   @override
@@ -578,7 +577,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count назв';
+    return '$count titles';
   }
 
   @override
@@ -603,7 +602,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get listen => 'Слухай';
 
   @override
-  String get resume => 'Продовжити';
+  String get resume => 'Резюме';
 
   @override
   String get failedToLoadLibrary => 'Не вдалося завантажити бібліотеку';
@@ -665,17 +664,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count авторів';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count жанрів';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% завершено';
+    return '$percent% completed';
   }
 
   @override
@@ -692,11 +691,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count назв, упорядкованих для перегляду з фокусом на читанні.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => 'Назви';
+  String get titles => 'Титули';
 
   @override
   String get allTitles => 'Усі назви';
@@ -729,7 +728,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '$label не знайдено';
+    return 'No $label found';
   }
 
   @override
@@ -748,13 +747,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get readStatus => 'Прочитайте';
 
   @override
-  String get watched => 'Переглянуто';
+  String get watched => 'Дивився';
 
   @override
   String get unread => 'Непрочитаний';
 
   @override
-  String get unwatched => 'Не переглянуто';
+  String get unwatched => 'Непереглянуто';
 
   @override
   String get seriesStatus => 'Статус серії';
@@ -766,45 +765,43 @@ class AppLocalizationsUk extends AppLocalizations {
   String get books => 'Книги';
 
   @override
-  String get latestBooks => 'Найновіші книги';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Найновіші аудіокниги';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count книги',
-      many: '$count книг',
-      few: '$count книги',
-      one: '$count книга',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Книга';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Аудіокнига';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Залишилось $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Читати';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Слухати';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Автор';
@@ -841,12 +838,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count розділів';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Перше видання: $year';
+    return 'First published $year';
   }
 
   @override
@@ -861,7 +858,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count книг';
+    return '$count books';
   }
 
   @override
@@ -872,7 +869,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count авторів';
+    return '$count Authors';
   }
 
   @override
@@ -880,10 +877,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count аудіокниги',
-      many: '$count аудіокниг',
-      few: '$count аудіокниги',
-      one: '$count аудіокнига',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -901,7 +896,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get delete => 'Видалити';
 
   @override
-  String get save => 'Зберегти';
+  String get save => 'зберегти';
 
   @override
   String get moreLikeThis => 'Більше подібного';
@@ -919,7 +914,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get nextUp => 'Далі';
 
   @override
-  String get seasons => 'Сезони';
+  String get seasons => 'Пори року';
 
   @override
   String get chapters => 'Розділи';
@@ -931,7 +926,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get movies => 'фільми';
 
   @override
-  String get musicVideos => 'Музичні відео';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => 'інше';
@@ -950,7 +945,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Диск $number';
+    return 'Disc $number';
   }
 
   @override
@@ -974,7 +969,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Видано $year';
+    return 'Published $year';
   }
 
   @override
@@ -985,54 +980,52 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count сезону',
-      many: '$count сезонів',
-      few: '$count сезони',
-      one: '$count сезон',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Закінчиться о $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Елементи';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Додаткові матеріали';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'За лаштунками';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Вилучені сцени';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Мініфільми';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Інтерв\'ю';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Сцени';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Короткометражки';
+  String get shorts => 'Shorts';
 
   @override
   String get trailers => 'Трейлери';
 
   @override
   String timeRemaining(String time) {
-    return 'Залишилось $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Завершиться через $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1046,11 +1039,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Продовжити з $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Відтворити';
+  String get play => 'грати';
 
   @override
   String get startOver => 'Почніть спочатку';
@@ -1074,7 +1067,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get version => 'Версія';
 
   @override
-  String get cast => 'Транслювати';
+  String get cast => 'акторський склад';
 
   @override
   String get trailer => 'Трейлер';
@@ -1145,7 +1138,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Видалити завантажені треки для «$title»?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1160,17 +1153,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '$itemLabel не завантажено';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Завантаження $title ($count елементів)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Ви впевнені, що хочете видалити «$name» із сервера? Цю дію неможливо скасувати.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1182,7 +1175,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Непідтримуваний формат книги: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1192,7 +1185,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get subtitleTrack => 'Доріжка субтитрів';
 
   @override
-  String get none => 'Немає';
+  String get none => 'Жодного';
 
   @override
   String get downloadSubtitlesLabel => 'Завантажити субтитри...';
@@ -1209,7 +1202,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Субтитри завантажено та вибрано: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1218,7 +1211,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Віддалених субтитрів для мови $language не знайдено.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1226,7 +1219,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return 'Версія $number';
+    return 'Version $number';
   }
 
   @override
@@ -1247,7 +1240,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Завантаження $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1255,7 +1248,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Видалити локальні файли для $typeLabel?\n\nЦе звільнить місце у сховищі. Ви зможете завантажити їх знову пізніше.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1271,25 +1264,25 @@ class AppLocalizationsUk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
-  String get directors => 'РЕЖИСЕРИ';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'СЦЕНАРИСТ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'СЦЕНАРИСТИ';
+  String get writers => 'ПИСЬМЕННИКИ';
 
   @override
   String get studio => 'СТУДІЯ';
 
   @override
   String studioMoreCount(int count) {
-    return '+ще $count';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count епізодів';
+    return '$count Episodes';
   }
 
   @override
@@ -1299,12 +1292,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Епізод $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Розділ $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1312,10 +1305,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count треку',
-      many: '$count треків',
-      few: '$count треки',
-      one: '$count трек',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1325,27 +1316,25 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count розділу',
-      many: '$count розділів',
-      few: '$count розділи',
-      one: '$count розділ',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Народження: $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Смерть: $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Вік: $age';
+    return 'Age $age';
   }
 
   @override
@@ -1355,20 +1344,20 @@ class AppLocalizationsUk extends AppLocalizations {
   String get readMore => 'Детальніше';
 
   @override
-  String get shuffle => 'Перемішати';
+  String get shuffle => 'Перетасувати';
 
   @override
-  String get shuffleAllMusic => 'Перемішати всю музику';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Увійдіть у Moonfin на телефоні';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Не вдається зв\'язатися з вашим сервером';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count завантажень';
+    return '$count downloads';
   }
 
   @override
@@ -1376,43 +1365,43 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count кан.';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Моно';
+  String get mono => 'Мононуклеоз';
 
   @override
   String get stereo => 'Стерео';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Для дії «$action» з віддаленими субтитрами цьому користувачеві потрібен дозвіл Jellyfin на керування субтитрами.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Не вдалося знайти цей елемент на сервері для дії «$action» з віддаленими субтитрами.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Не вдалося виконати дію «$action» з віддаленими субтитрами: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Не вдалося виконати дію «$action» з віддаленими субтитрами (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Не вдалося виконати дію «$action» з віддаленими субтитрами.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'усі завантажені епізоди для «$name»';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1443,17 +1432,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return 'Не вдалося виконати дію $label: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Не вдалося встановити гучність трансляції: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return 'Керування $label';
+    return '$label Controls';
   }
 
   @override
@@ -1470,7 +1459,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return 'Зупинити $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1478,7 +1467,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Трек $number';
+    return 'Track $number';
   }
 
   @override
@@ -1495,7 +1484,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds секунд';
+    return '$seconds seconds';
   }
 
   @override
@@ -1514,7 +1503,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String bitrateValueMbps(int mbps) {
-    return '$mbps Мбіт/с';
+    return '$mbps Mbps';
   }
 
   @override
@@ -1525,12 +1514,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String delayMinusMs(int value) {
-    return '-$value мс';
+    return '-${value}ms';
   }
 
   @override
   String delayPlusMs(int value) {
-    return '+$value мс';
+    return '+${value}ms';
   }
 
   @override
@@ -1564,7 +1553,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get transcodeReasons => 'Причини перекодування';
 
   @override
-  String get player => 'Програвач';
+  String get player => 'гравець';
 
   @override
   String get container => 'Контейнер';
@@ -1588,7 +1577,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get videoBitrate => 'Бітрейт відео';
 
   @override
-  String get track => 'Доріжка';
+  String get track => 'Трек';
 
   @override
   String get channels => 'Канали';
@@ -1610,12 +1599,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return 'Помилка сеансу $protocol';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Не вдалося завантажити відомості про книгу: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1624,7 +1613,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Цей формат (.$extension) поки що не можна відобразити у програмі.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1637,17 +1626,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Не вдалося відкрити вбудовану читалку: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Закладку вже збережено на $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Закладку додано: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1659,7 +1648,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Сторінка $number';
+    return 'Page $number';
   }
 
   @override
@@ -1670,12 +1659,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return 'Формат: .$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '$percent% прочитано';
+    return '$percent% read';
   }
 
   @override
@@ -1699,7 +1688,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Скинути масштаб (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1722,7 +1711,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Не вдалося оновити стан прочитання: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1756,7 +1745,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ця платформа не підтримує вбудований рушій документів для файлів $extension.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1795,7 +1784,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Не вдалося завантажити телепрограму: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1806,22 +1795,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Далі: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Залишилось $minutes хв';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Залишилось $hours год';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Залишилось $hours год $minutes хв';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1844,19 +1833,19 @@ class AppLocalizationsUk extends AppLocalizations {
   String get favoriteChannel => 'Улюблений канал';
 
   @override
-  String get record => 'Записати';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Скасувати запис';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Програму поставлено на запис';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Запис скасовано';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Не вдалося створити запис';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
   String get watch => 'Дивитися';
@@ -1866,7 +1855,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Не вдалося відтворити $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1893,11 +1882,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Скасувати запланований запис «$name»?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => 'Ні';
+  String get no => 'немає';
 
   @override
   String get yesCancel => 'Так, скасувати';
@@ -1920,7 +1909,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Зупинити запис «$name»?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1935,12 +1924,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Немає результатів за запитом «$query»';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Помилка пошуку: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1981,12 +1970,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Видалити «$name» та його файли?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count треків';
+    return '$count tracks';
   }
 
   @override
@@ -1997,12 +1986,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Не вдалося завантажити альбом: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Для $name не знайдено завантажених треків.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2019,22 +2008,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Видалити «$name»?';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes хв';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'С$season Е$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Епізод $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2048,12 +2037,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Сезон $number';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return 'С$number';
+    return 'S$number';
   }
 
   @override
@@ -2064,7 +2053,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Видалити всі завантажені епізоди в $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2072,10 +2061,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count епізоду',
-      many: '$count епізодів',
-      few: '$count епізоди',
-      one: '$count епізод',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2110,7 +2097,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Видалити $count завантажених елементів?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2124,7 +2111,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'з ліміту $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2167,7 +2154,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mediaRequestIntegration => 'Інтеграція медіа-запитів';
 
   @override
-  String get switchServer => 'Змінити сервер';
+  String get switchServer => 'Switch Server';
 
   @override
   String get signOut => 'Вийти';
@@ -2209,7 +2196,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count параметрів';
+    return '$count options';
   }
 
   @override
@@ -2303,7 +2290,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Сторінки деталей, рядки на головній та гучність';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2318,18 +2305,18 @@ class AppLocalizationsUk extends AppLocalizations {
       'Грайте під час перегляду головного екрана';
 
   @override
-  String get loopThemeMusic => 'Зациклити музичну тему';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Повторювати трек, а не відтворювати його лише раз';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Розмиття фону деталей';
 
   @override
   String pixelValue(int value) {
-    return '$value пкс';
+    return '${value}px';
   }
 
   @override
@@ -2345,23 +2332,23 @@ class AppLocalizationsUk extends AppLocalizations {
   String get playerZoomMode => 'Режим масштабування гравця';
 
   @override
-  String get settingsScrollWheelAction => 'Коліщатко миші';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Виберіть, що робитиме прокручування коліщатком миші над відео під час відтворення.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Вимкнено';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Перемотування (вперед / назад)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Гучність';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Гучність';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Fit';
@@ -2415,38 +2402,37 @@ class AppLocalizationsUk extends AppLocalizations {
   String get defaultAudioLanguage => 'Мова аудіо за замовчуванням';
 
   @override
-  String get fallbackAudioLanguage => 'Резервна мова аудіо';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack =>
-      'Віддавати перевагу типовій аудіодоріжці';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Віддавати перевагу оригінальній аудіодоріжці замість локалізованого дубляжу.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Віддавати перевагу доріжкам аудіоопису';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Віддавати перевагу доріжкам аудіоопису замість звичайних доріжок.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Транскодування (аудіо)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Прямий потік (ремуксування)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Транскодування (бітрейт або роздільна здатність)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Транскодування (відео та аудіо)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Транскодування (відео)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Автоматично (за умовчанням для сервера)';
@@ -2523,28 +2509,27 @@ class AppLocalizationsUk extends AppLocalizations {
       'Увімкнути аудіо TrueHD (може працювати не на всіх платформах)';
 
   @override
-  String get settingsAudioOutputMode => 'Режим виведення звуку';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Виберіть, як декодується звук. «Пряма передача на AVR» надсилає необроблені потоки Dolby/DTS на ваш ресивер; «Авто» чи «Мікшування» декодують локально.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Пряма передача на AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Резервний аудіокодек';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Виберіть цільовий формат для транскодування багатоканального звуку, коли вихідний потік не можна відтворити напряму або передати без обробки.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Автовизначення\n(рекомендовано)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(типово)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2553,116 +2538,113 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(без втрат)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(лише стерео)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(ефективний)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(без втрат)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Максимум аудіоканалів';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Налаштуйте максимальну кількість каналів вашої аудіосистеми. Багатоканальні потоки, що перевищують цей ліміт, буде змікшовано або транскодовано.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Автовизначення\n(типово для обладнання)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 моно';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 стерео';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 об\'ємний';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 квадрофонія';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 об\'ємний';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 об\'ємний';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 об\'ємний';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 об\'ємний';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Пряма передача (додатково)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Пряма передача кодеків';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Вмикайте лише формати, які підтримує ваш AVR або HDMI-приймач.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Пряма передача EAC3';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough =>
-      'Пряма передача EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Пряма передача DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Пряма передача DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Пряма передача TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough =>
-      'Пряма передача TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Передавати бітпотік Dolby Digital Plus (EAC3) на зовнішній декодер.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Передавати бітпотік Dolby Atmos через EAC3 (JOC) на зовнішній декодер.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Передавати бітпотік DTS-HD MA (разом із ядром DTS) на зовнішній декодер.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Передавати бітпотік Dolby TrueHD з метаданими Atmos на зовнішній декодер.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Виявлені аудіоможливості';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Знімок можливостей середовища ще недоступний.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Маршрут';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Декодування';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Пряма передача';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Маршрут HD-аудіо';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2677,51 +2659,50 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Динамік';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Навушники';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count кан. PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Діагностика';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Рівень відео';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Діапазон відео';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Кодек субтитрів';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Дозволені аудіокодеки';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'Аудіокодеки HLS MPEG-TS';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'Аудіокодеки HLS fMP4';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'пряма передача audio-spdif';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Активний аудіомаршрут';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Підтримка HD-аудіо маршрутом';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Нічний режим';
@@ -2770,7 +2751,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value с';
+    return '${value}s';
   }
 
   @override
@@ -2785,7 +2766,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'Після $episodes епізодів / $hours год';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2860,45 +2841,45 @@ class AppLocalizationsUk extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Налаштувати вигляд субтитрів';
 
   @override
-  String get subtitleMode => 'Режим субтитрів';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Позначені';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Завжди';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Іншомовні';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Примусові';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Відтворює доріжки, позначені в метаданих медіафайлу як «default» або «forced».';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Автоматично завантажує й показує субтитри щоразу під час запуску відео.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Автоматично вмикає субтитри, якщо типова аудіодоріжка іншою мовою.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Завантажує лише субтитри з явною позначкою «forced» у метаданих.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Повністю вимикає автоматичне завантаження субтитрів.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Резервна мова субтитрів';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Потік субтитрів';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText =>
@@ -2908,7 +2889,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get verticalOffset => 'Вертикальне зміщення';
 
   @override
-  String get pgsDirectPlay => 'Пряме відтворення PGS';
+  String get pgsDirectPlay => 'PGS Direct Play';
 
   @override
   String get directPlayPgsSubtitles => 'Пряме відтворення субтитрів PGS';
@@ -2957,17 +2938,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Завантажено налаштування профілю $profile.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Не вдалося завантажити налаштування профілю $profile.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Локальні налаштування синхронізовано з профілем $profile.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -3104,10 +3085,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показати бібліотеки на панелі інструментів';
 
   @override
-  String get navbarAlwaysExpanded => 'Завжди показувати підписи в навігації';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Показувати кнопку Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Непрозорість навігаційної панелі';
@@ -3182,19 +3163,18 @@ class AppLocalizationsUk extends AppLocalizations {
   String get showFolderBrowsingOption => 'Показати опцію перегляду папок';
 
   @override
-  String get groupItemsIntoCollections => 'Групувати елементи в колекції';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Приховувати елементи бібліотеки, що входять до колекцій, під час перегляду бібліотек';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle =>
-      'Примітка щодо групування бібліотеки';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Щоб скористатися цим налаштуванням, переконайтеся, що параметри «Group movies into collections» та/або «Group shows into collections» увімкнено в налаштуваннях відображення вашої бібліотеки на сервері Jellyfin або Emby.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Видимість бібліотеки';
@@ -3223,7 +3203,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return 'Вибрано: $count';
+    return '$count selected';
   }
 
   @override
@@ -3253,7 +3233,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Виберіть Moonfin, MakD або вимкніть медіа-панель';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Місячне плавник';
 
   @override
   String get mediaBarModeMakd => 'МакД';
@@ -3306,10 +3286,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Автоматичне відтворення трейлерів на медіа-панелі через 3 секунди';
 
   @override
-  String get trailerAudio => 'Звук трейлера';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => 'Увімкнути звук для трейлерів у медіапанелі';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Попередній перегляд епізоду';
@@ -3386,11 +3366,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get combineBothRows => 'Об’єднайте обидва ряди в одну домашню секцію';
 
   @override
-  String get fullScreenRows => 'Розгорнуті рядки головної';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Обмежити головну до 1 рядка на екран';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Тип зображення на рядок';
@@ -3405,7 +3384,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get lastUser => 'Останній користувач';
 
   @override
-  String get currentUser => 'Поточний користувач';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Завжди автентифікувати';
@@ -3481,7 +3460,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes хв';
+    return '$minutes min';
   }
 
   @override
@@ -3512,10 +3491,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Відображення годинника під час заставки';
 
   @override
-  String get clockModeStatic => 'Статичний';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Рухомий';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Критики)';
@@ -3536,7 +3515,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get metacriticUser => 'Metacritic (користувач)';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => 'тракт';
 
   @override
   String get letterboxd => 'Letterboxd';
@@ -3587,7 +3566,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Увімкніть і змініть порядок джерел рейтингів, які відображаються в додатку';
 
   @override
-  String get pluginLabel => 'Плагін Moonbase';
+  String get pluginLabel => 'Плагін';
 
   @override
   String get pluginDetected => 'Плагін виявлено';
@@ -3605,7 +3584,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\nВерсія: $version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3659,7 +3638,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get networks => 'мережі';
 
   @override
-  String get seerrDiscoveryRows => 'Рядки відкриттів Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Скинути рядки до значень за замовчуванням';
@@ -3682,44 +3661,44 @@ class AppLocalizationsUk extends AppLocalizations {
   String get hideAdultContent => 'Приховати вміст для дорослих у результатах';
 
   @override
-  String get seerrNotificationsSection => 'Сповіщення';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Сповіщення про нові запити';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Повідомляти мене, коли хтось надсилає запит';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Оновлення запитів';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Схвалено, відхилено та додано до вашої бібліотеки';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Оновлення проблем';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
   String get seerrNotifyIssuesSubtitle =>
-      'Нові проблеми, відповіді та розв\'язання';
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return 'Вхід виконано як: $username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Сторінка огляду Seerr';
+  String get discoverRows => 'Відкрийте рядки';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Увімкніть рядки, які будуть показані на головній сторінці Seerr. Перетягніть, щоб змінити порядок. Власний порядок синхронізується з Moonbase.';
+      'Перетягніть, щоб змінити порядок. Увімкніть або вимкніть рядки. Увімкнений порядок рядків синхронізується з плагіном Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Увімкніть рядки, які будуть показані на головній сторінці Seerr. Перетягніть, щоб змінити порядок. Власний порядок синхронізується з Moonbase.';
+      'Перетягніть, щоб змінити порядок. Увімкніть або вимкніть рядки.';
 
   @override
   String get enabled => 'Увімкнено';
@@ -3732,7 +3711,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return 'Версія $version';
+    return 'Version $version';
   }
 
   @override
@@ -3782,7 +3761,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Доступне оновлення: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3793,7 +3772,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'Доступна v$version';
+    return 'v$version Available';
   }
 
   @override
@@ -3840,7 +3819,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String gbValue(String value) {
-    return '$value ГБ';
+    return '$value GB';
   }
 
   @override
@@ -3858,7 +3837,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get imageCacheCleared => 'Кеш зображень очищено';
 
   @override
-  String get clear => 'Очистити';
+  String get clear => 'ясно';
 
   @override
   String get browse => 'переглядати';
@@ -3874,15 +3853,15 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Завантаження · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Імпортування';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count елементів';
+    return '$count Items';
   }
 
   @override
@@ -3902,7 +3881,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Запит від $name';
+    return 'Requested by $name';
   }
 
   @override
@@ -3919,12 +3898,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Скасувати запит на «$title»?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Скасувати $count запитів на «$title»?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3939,12 +3918,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Бюджет: \$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Збори: \$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3954,7 +3933,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Запитати $type';
+    return 'Request $type';
   }
 
   @override
@@ -3983,14 +3962,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get showMore => 'Показати більше';
 
   @override
-  String get appearances => 'Фільмографія';
+  String get appearances => 'Поява';
 
   @override
   String get crewSection => 'Екіпаж';
 
   @override
   String ageValue(int age) {
-    return 'вік $age';
+    return 'age $age';
   }
 
   @override
@@ -4021,147 +4000,148 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deletedStatus => 'Видалено';
 
   @override
-  String get failedStatus => 'Не вдалося';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Обробляється';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Змінив $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Завершено';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Цю назву вже запитано';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Досягнуто ліміту запитів';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Цю назву заблоковано';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Не залишилось сезонів для запиту';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'У вас немає дозволу надсилати цей запит';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Запити';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Проблеми';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Найновіші';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Останні зміни';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Немає проблем';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Залишилось $remaining із $limit запитів на фільми';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Залишилось $remaining із $limit запитів на сезони';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Частина $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Переглянути колекцію';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Запитати колекцію';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total фільмів · $available доступно';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Запитати $count фільмів';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Надсилання запиту $current з $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Запитано $count фільмів';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Запитано $ok із $total фільмів';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'Усі фільми вже доступні або запитані';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Повідомити про проблему';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => 'Відео';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Аудіо';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Що не так?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Усі епізоди';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Епізод';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Відкрито';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Розв\'язано';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Розв\'язати';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Відкрити знову';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Повідомив $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count коментарів';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Додати коментар';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Видалити цю проблему?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Надіслати звіт';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Оцінка TMDB';
@@ -4185,7 +4165,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get originalLanguageLabel => 'Мова оригіналу';
 
   @override
-  String get seasonsLabel => 'Сезони';
+  String get seasonsLabel => 'Пори року';
 
   @override
   String get episodesLabel => 'Епізоди';
@@ -4194,7 +4174,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get access => 'Доступ';
 
   @override
-  String get add => 'Додати';
+  String get add => 'додати';
 
   @override
   String get address => 'Адреса';
@@ -4230,10 +4210,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get error => 'Помилка';
 
   @override
-  String get forward => 'Вперед';
+  String get forward => 'вперед';
 
   @override
-  String get general => 'Загальні';
+  String get general => 'Загальний';
 
   @override
   String get go => 'Іди';
@@ -4278,7 +4258,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get refresh => 'Оновити';
 
   @override
-  String get remote => 'Пульт';
+  String get remote => 'Дистанційний';
 
   @override
   String get rename => 'Перейменувати';
@@ -4314,7 +4294,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get status => 'Статус';
 
   @override
-  String get stop => 'Зупинити';
+  String get stop => 'СТІЙ';
 
   @override
   String get streaming => 'Потокове передавання';
@@ -4362,22 +4342,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminDrawerUsers => 'Користувачі';
 
   @override
-  String get adminDrawerLibraries => 'Медіатеки';
+  String get adminDrawerLibraries => 'Бібліотеки';
 
   @override
-  String get adminDrawerDisplay => 'Відображення';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Метадані';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Налаштування NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Перекодування';
 
   @override
-  String get adminDrawerResume => 'Відновлення';
+  String get adminDrawerResume => 'Резюме';
 
   @override
   String get adminDrawerStreaming => 'Потокове передавання';
@@ -4435,22 +4415,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Доступні оновлення плагінів: $count';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Плагіни, що потребують перезапуску: $count';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Невдалі заплановані завдання: $count';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Нещодавні попередження/помилки: $count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4509,7 +4489,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return 'Помилка: $error';
+    return 'Error: $error';
   }
 
   @override
@@ -4536,7 +4516,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Не вдалося виконати команду: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4555,7 +4535,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sessionRewind => 'Перемотати назад';
 
   @override
-  String get sessionForward => 'Вперед';
+  String get sessionForward => 'вперед';
 
   @override
   String get sessionNext => 'Далі';
@@ -4573,7 +4553,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get nowPlaying => 'Зараз грає';
 
   @override
-  String get volume => 'Гучність';
+  String get volume => 'Обсяг';
 
   @override
   String get actions => 'Дії';
@@ -4585,7 +4565,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audioCodec => 'Аудіокодек';
 
   @override
-  String get hwAccel => 'Апаратне прискорення';
+  String get hwAccel => 'HW Accel';
 
   @override
   String get completion => 'Завершення';
@@ -4600,14 +4580,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminClearDates => 'Чіткі дати';
 
   @override
-  String get adminActivitySeverityAll => 'Усі рівні';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Діапазон дат';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Не вдалося завантажити журнал активності: $error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4624,7 +4604,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Не вдалося оновити пристрій: $error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4635,28 +4615,28 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Не вдалося видалити пристрій: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Видалити пристрій «$name»? Користувачеві доведеться знову увійти на цьому пристрої.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Видалити всі пристрої';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Видалити $count пристроїв? Відповідним користувачам доведеться увійти знову. Вашого поточного пристрою це не стосується.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Пристрої видалено';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Деякі пристрої видалено; $count видалити не вдалося.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4685,7 +4665,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Не вдалося почати сканування: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4696,12 +4676,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Бібліотеку перейменовано на «$name»';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Не вдалося перейменувати: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4709,17 +4689,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Бібліотеку «$name» видалено';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Не вдалося видалити бібліотеку: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Не вдалося додати шлях: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4727,12 +4707,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Видалити «$path» з цієї бібліотеки?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Не вдалося видалити шлях: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4740,7 +4720,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Не вдалося зберегти параметри: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4771,259 +4751,251 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminMetadataCountryHint => 'напр. США, Німеччина, Франція';
 
   @override
-  String get adminLibraryTabPaths => 'Шляхи';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Параметри';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Завантажувачі';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Збереження метаданих';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Завантажувачі субтитрів';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Завантажувачі текстів пісень';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Завантажувачі метаданих: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Джерела зображень: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Цей сервер не надає завантажувачів для цього типу бібліотеки.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Загальні';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Метадані';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Вбудована інформація';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Субтитри';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Зображення';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Серіали';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Музика';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Фільми';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Увімкнути моніторинг у реальному часі';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Виявляти зміни файлів і обробляти їх автоматично.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Вважати архіви медіафайлами';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Показувати фотографії';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Зберігати обкладинки в теках медіа';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Автоматичне оновлення метаданих';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Ніколи';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Типово';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Відображення';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Відображення бібліотеки';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Показувати вигляд тек для звичайних медіатек';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Показувати спецвипуски в сезонах, у яких вони виходили';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Групувати фільми в колекції';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Групувати серіали в колекції';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Показувати зовнішній вміст у пропозиціях';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Поведінка дати додавання';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Використовувати дату додавання з';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Дата сканування до бібліотеки';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Дата створення файлу';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Метадані та зображення';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Бажана мова метаданих';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Розділи';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration =>
-      'Тривалість фіктивних розділів (секунди)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Довжина розділів, що генеруються для медіа без них. Установіть 0, щоб вимкнути.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution =>
-      'Роздільна здатність зображень розділів';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Налаштування NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Метадані NFO сумісні з Kodi та подібними клієнтами. Налаштування застосовуються до всіх бібліотек, які зберігають метадані NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Користувач, для якого зберігати дані перегляду у файлах NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths =>
-      'Зберігати шляхи до зображень у файлах NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Увімкнути заміну шляхів для шляхів зображень NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Копіювати зображення extrafanart до теки extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Немає';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days днів';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Використовувати вбудовані назви';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Використовувати вбудовані назви для додаткових матеріалів';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Використовувати вбудовану інформацію про епізоди';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Дозволити вбудовані субтитри';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Дозволити всі';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Лише текстові';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Лише графічні';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Немає';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Пропускати завантаження, якщо є вбудовані субтитри';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Пропускати завантаження, якщо аудіодоріжка збігається з мовою завантаження';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Вимагати точний збіг субтитрів';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Зберігати субтитри в теках медіа';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Витягувати зображення розділів';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Витягувати зображення розділів під час сканування бібліотеки';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction =>
-      'Увімкнути витягування зображень trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Витягувати зображення trickplay під час сканування бібліотеки';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Зберігати зображення trickplay у теках медіа';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Автоматично об\'єднувати серіали, розподілені між кількома теками';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Назва нульового сезону';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan =>
-      'Увімкнути сканування LUFS для нормалізації гучності';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Віддавати перевагу нестандартному тегу виконавців';
+      'Prefer non-standard artists tag';
 
   @override
   String get adminLibAutoAddToCollection =>
-      'Автоматично додавати фільми до колекцій';
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Потрібно вказати назву бібліотеки';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Не вдалося створити бібліотеку: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -5049,27 +5021,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Вимкнути $name? Користувач не зможе увійти.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Увімкнути $name? Користувач знову зможе увійти.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'Користувача «$name» вимкнено';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'Користувача «$name» увімкнено';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Не вдалося оновити політику користувача: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -5086,7 +5058,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Не вдалося створити користувача: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -5106,7 +5078,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Не вдалося зберегти: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -5117,7 +5089,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Помилка: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5255,145 +5227,143 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminEnableAllChannels => 'Увімкнути доступ до всіх каналів';
 
   @override
-  String get adminParentalControl => 'Батьківський контроль';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating =>
-      'Максимальний дозволений віковий рейтинг';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Вміст із вищим рейтингом буде приховано від цього користувача.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Немає';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Блокувати елементи без рейтингу або з нерозпізнаним рейтингом';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Книги';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Канали';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'Пряме телебачення';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Фільми';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Музика';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Трейлери';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Серіали';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Розклади доступу';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Дозволяти доступ лише в зазначені нижче години. Якщо розклад не задано, доступ дозволено цілодобово.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Додати розклад';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'День';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Початок';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Кінець';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Щодня';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Будній день';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Вихідні';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Неділя';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Понеділок';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Вівторок';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Середа';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Четвер';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'П\'ятниця';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Субота';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Дозволені теги';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Показується лише вміст із цими тегами. Залиште порожнім, щоб дозволити все.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Заблоковані теги';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Вміст із цими тегами приховано від цього користувача.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Додати тег';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Увімкнені пристрої';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Увімкнені канали';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Постачальник автентифікації';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Постачальник скидання пароля';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Максимум невдалих спроб входу до блокування';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Установіть 0 для типового значення або -1, щоб вимкнути блокування.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Доступ до SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin =>
-      'Дозволити створювати групи та приєднуватися до них';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Дозволити приєднуватися до груп';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Без доступу';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Дозволити видалення вмісту з';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5401,22 +5371,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Сервер повернув HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Ви впевнені, що хочете видалити $name?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'Користувача «$name» видалено';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Не вдалося видалити користувача: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5437,7 +5407,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Не вдалося створити ключ: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5449,7 +5419,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Відкликати ключ для $name?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5457,7 +5427,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Не вдалося відкликати ключ: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5477,29 +5447,29 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Токен: $token\\nСтворено: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Створити резервну копію';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Виберіть, що включити до резервної копії.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'База даних';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Завжди включено';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Метадані';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Субтитри';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Зображення trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Створення резервної копії...';
@@ -5509,7 +5479,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Не вдалося створити резервну копію: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5518,12 +5488,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return 'Маніфест: $name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Не вдалося завантажити маніфест: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5534,7 +5504,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Не вдалося відновити з резервної копії: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5566,17 +5536,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Збережено до $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Не вдалося зберегти файл: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Не вдалося завантажити $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5587,7 +5557,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Не вдалося завантажити завдання: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5599,17 +5569,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Не вдалося запустити завдання: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Не вдалося зупинити завдання: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Не вдалося завантажити завдання: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5617,12 +5587,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Не вдалося видалити тригер: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Не вдалося додати тригер: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5648,7 +5618,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours год';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5659,7 +5629,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Не вдалося перемкнути плагін: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5667,27 +5637,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Ви впевнені, що хочете видалити «$name»?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Не вдалося видалити плагін: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Не вдалося встановити пакет: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Не вдалося встановити оновлення: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Не вдалося завантажити плагіни: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5699,12 +5669,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return 'Встановити оновлення (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Не вдалося завантажити каталог: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5726,17 +5696,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '«$name» буде видалено після перезапуску сервера';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Не вдалося видалити: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Оновлення «$name» до v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5745,7 +5715,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Не вдалося завантажити плагін: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5753,7 +5723,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return 'Версія $version';
+    return 'Version $version';
   }
 
   @override
@@ -5773,17 +5743,17 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Ви впевнені, що хочете видалити «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Не вдалося зберегти репозиторії: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Не вдалося завантажити репозиторії: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5800,12 +5770,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Не вдалося завантажити налаштування плагіна: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Не вдалося відкрити $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5936,7 +5906,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get adminTrickplayLoadFailed =>
-      'Не вдалося завантажити налаштування Trickplay';
+      'Не вдалося завантажити налаштування трикплея';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6052,7 +6022,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminBaseUrl => 'Базовий URL';
 
   @override
-  String get adminBaseUrlHint => 'напр. /jellyfin';
+  String get adminBaseUrlHint => 'напр. /желеподібний';
 
   @override
   String get https => 'HTTPS';
@@ -6092,12 +6062,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Не вдалося завантажити метадані: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Не вдалося зберегти метадані: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -6118,7 +6088,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Не вдалося оновити метадані: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -6132,7 +6102,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Помилка віддаленого пошуку: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -6146,7 +6116,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Не вдалося оновити тип вмісту: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6161,12 +6131,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return 'Зображення $imageType оновлено';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Не вдалося завантажити зображення: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6177,27 +6147,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return 'Зображення $imageType вивантажено';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Не вдалося вивантажити зображення: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return 'Видалити зображення $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return 'Зображення $imageType видалено';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Не вдалося видалити зображення: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -6208,71 +6178,67 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Не вдалося виявити тюнери: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => 'Додати тюнер';
 
   @override
-  String get adminEditTuner => 'Редагувати тюнер';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Тюнер M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Файл або URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'IP-адреса тюнера';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Зрозуміла назва';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Ліміт одночасних підключень';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Максимальна кількість потоків, які тюнер дозволяє одночасно. Установіть 0 для необмеженої кількості.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate =>
-      'Резервний максимальний бітрейт потоку';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly =>
-      'Імпортувати лише улюблені канали';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Дозволити апаратне транскодування';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Дозволити контейнер транскодування fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing =>
-      'Дозволити спільне використання потоку';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Увімкнути зациклення потоку';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Ігнорувати DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Читати вхідний потік із власною частотою кадрів';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Редагувати постачальника';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6281,50 +6247,50 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Файл або URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Префікс фільмів';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Категорії фільмів';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Розділяйте кілька категорій вертикальною рискою.';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Дитячі категорії';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Категорії новин';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Спортивні категорії';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Ім\'я користувача';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Пароль';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Країна';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Виберіть країну';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Поштовий індекс';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Отримати списки';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Списки';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Увімкнути всі тюнери';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Тип тюнера';
@@ -6334,7 +6300,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Не вдалося додати тюнер: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6348,12 +6314,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Не вдалося додати постачальника: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Не вдалося видалити тюнер: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6361,16 +6327,16 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Не вдалося скинути тюнер: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String get adminTunerResetNotSupported =>
-      'Цей тип тюнера не підтримує скидання.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Не вдалося видалити постачальника: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6389,43 +6355,43 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Шлях запису серії';
 
   @override
-  String get adminMovieRecordingPath => 'Шлях для запису фільмів';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Кількість днів телепрограми';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Автоматично';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days днів';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Шлях до програми постобробки';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Аргументи постобробника';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Зберігати метадані NFO для записів';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Зберігати зображення записів';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Час';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Шляхи для записів';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Постобробка';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Дані телепрограми: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6433,7 +6399,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Не вдалося зберегти налаштування: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6451,7 +6417,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Не вдалося оновити зіставлення: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6468,15 +6434,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminGuideProviders => 'Постачальники посібників';
 
   @override
-  String get adminRefreshGuideData => 'Оновити дані телепрограми';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Оновлення даних телепрограми розпочато';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Завдання оновлення телепрограми недоступне на цьому сервері.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Додати постачальника';
@@ -6487,22 +6452,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Шлях для записів: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Шлях для серіалів: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Запас на початку: $minutes хв';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Запас у кінці: $minutes хв';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6535,7 +6500,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Відновити резервну копію $name зараз?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6581,27 +6546,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes хв тому';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours год тому';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days дн тому';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Не вдалося завантажити $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count збігів';
+    return '$count matches';
   }
 
   @override
@@ -6611,7 +6576,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Редактор метаданих';
 
   @override
-  String get adminMetadataIdentify => 'Ідентифікувати';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Тип';
@@ -6711,22 +6676,22 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return 'Зображення $imageType оновлено';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return 'Зображення $imageType вивантажено';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return 'Зображення $imageType видалено';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Не вдалося завантажити зображення: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6735,12 +6700,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Не вдалося вивантажити зображення: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return 'Видалити зображення $imageType';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6749,12 +6714,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Не вдалося видалити зображення: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Виберіть зображення $imageType';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6787,7 +6752,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Доступне оновлення: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6811,7 +6776,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return 'Встановити оновлення (v$version)';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6823,7 +6788,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '«$name» встановлюється...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6843,7 +6808,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return 'Налаштування $name';
+    return '$name Settings';
   }
 
   @override
@@ -6883,7 +6848,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Не вдалося завантажити репозиторії: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6891,15 +6856,15 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Ви впевнені, що хочете видалити «$name»?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => 'Прибрати';
+  String get adminReposRemove => 'видалити';
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Не вдалося зберегти репозиторії: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -7026,20 +6991,19 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Увімкнути заставку';
 
   @override
-  String get adminBrandingSplashUpload => 'Вивантажити зображення';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Заставку оновлено';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Не вдалося вивантажити заставку';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Заставку видалено';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Немає власної заставки';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Апаратне прискорення';
@@ -7055,133 +7019,121 @@ class AppLocalizationsUk extends AppLocalizations {
       'Увімкнути апаратне декодування для:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Пристрій QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Увімкнути покращений декодер NVDEC';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Віддавати перевагу системному апаратному декодеру';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth =>
-      'Глибина кольору апаратного декодування';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-бітне декодування HEVC';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-бітне декодування VP9';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext =>
-      '8/10-бітне декодування HEVC RExt';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext =>
-      '12-бітне декодування HEVC RExt';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Апаратне кодування';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Дозволити кодування HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Дозволити кодування AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Увімкнути енергоощадний кодер Intel H.264';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Увімкнути енергоощадний кодер Intel HEVC';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Тональне відображення';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping =>
-      'Увімкнути тональне відображення';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping =>
-      'Увімкнути тональне відображення VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Увімкнути тональне відображення VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm =>
-      'Алгоритм тонального відображення';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Режим тонального відображення';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange =>
-      'Діапазон тонального відображення';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Знебарвлення тонального відображення';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Пік тонального відображення';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam =>
-      'Параметр тонального відображення';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Яскравість тонального відображення VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Контрастність тонального відображення VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Пресети та якість';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Пресет кодера';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF кодування H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF кодування H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Метод деінтерлейсингу';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Подвоювати частоту кадрів під час деінтерлейсингу';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Аудіо';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr =>
-      'Увімкнути кодування аудіо зі змінним бітрейтом (VBR)';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Підсилення при мікшуванні аудіо';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Алгоритм мікшування в стерео';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Максимальний розмір черги мультиплексування';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Авто';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Кодування';
@@ -7300,10 +7252,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminTaskNeverRun => 'Ніколи не бігайте';
 
   @override
-  String get adminTaskStop => 'Зупинити';
+  String get adminTaskStop => 'СТІЙ';
 
   @override
-  String get adminRunningTasks => 'Активні завдання';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'бігти';
@@ -7373,10 +7325,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count години',
-      many: '$count годин',
-      few: '$count години',
-      one: '$count година',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7422,27 +7372,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes хв';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours год';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days дн';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day.$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Налаштуйте створення зображень Trickplay для ескізів попереднього перегляду під час перемотування.';
+      'Налаштуйте генерацію зображень підказки для ескізів попереднього перегляду пошуку.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Загальнодоступний порт HTTPS';
@@ -7451,50 +7401,49 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'Базовий URL';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'напр. /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'напр. /желеподібний';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Публічний порт HTTP';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Вимагати HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Перенаправляти всі віддалені запити на HTTPS. Не діє, якщо сервер не має дійсного сертифіката.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Пароль сертифіката';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Налаштування IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Увімкнути IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Увімкнути IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery =>
-      'Увімкнути автоматичне зіставлення портів';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Мережі LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Список IP-адрес або підмереж CIDR, розділених комами чи новими рядками, які вважаються локальною мережею.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'Опубліковані URI сервера';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Зіставте підмережу або адресу з опублікованою URL-адресою, напр. all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Шлях сертифіката';
@@ -7525,11 +7474,11 @@ class AppLocalizationsUk extends AppLocalizations {
       'Буферізація дросельної заслінки';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Затримка тротлінгу (секунди)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Дозволити витягування субтитрів на льоту';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Мінімальний відсоток резюме';
@@ -7587,23 +7536,22 @@ class AppLocalizationsUk extends AppLocalizations {
       'Поріг повільної реакції (мс)';
 
   @override
-  String get adminGeneralEnableSlowResponse =>
-      'Увімкнути попередження про повільну відповідь';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Увімкнути Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Сервер';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Метадані';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Шляхи';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Продуктивність';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Шлях до кешу';
@@ -7615,7 +7563,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminGeneralServerName => 'Ім\'я сервера';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Бажана мова відображення';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Не вдалося завантажити налаштування';
@@ -7637,7 +7585,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get folders => 'Папки';
 
   @override
-  String get libraries => 'Медіатеки';
+  String get libraries => 'Бібліотеки';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7667,10 +7615,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# учасника',
-      many: '# учасників',
-      few: '# учасники',
-      one: '# учасник',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7817,10 +7763,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'виявлено # рядка',
-      many: 'виявлено # рядків',
-      few: 'виявлено # рядки',
-      one: 'виявлено # рядок',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7855,27 +7799,26 @@ class AppLocalizationsUk extends AppLocalizations {
   String get offlineFileNotAvailable => 'Файл недоступний';
 
   @override
-  String get offlineSwitchServer => 'Змінити сервер';
+  String get offlineSwitchServer => 'Switch Server';
 
   @override
   String get offlineSavedMedia => 'Збережені медіа';
 
   @override
-  String get offlineBannerTitle => 'Ви офлайн';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Показуємо ваші завантаження';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Завантаження';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Не вдається зв\'язатися з вашим сервером';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Відтворюємо із завантажень, доки він не повернеться';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7949,40 +7892,42 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pinForgot => 'Забули PIN-код?';
 
   @override
-  String get pinClear => 'Очистити';
+  String get pinClear => 'ясно';
 
   @override
-  String get pinBackspace => 'Стерти';
+  String get pinBackspace => 'Backspace';
 
   @override
-  String get quickConnectAuthorized => 'Запит Quick Connect авторизовано.';
+  String get quickConnectAuthorized =>
+      'Запит на швидке підключення авторизовано.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Код Quick Connect недійсний або термін його дії минув.';
+      'Код швидкого підключення недійсний або термін дії минув.';
 
   @override
   String get quickConnectNotSupported =>
-      'Quick Connect не підтримується на цьому сервері.';
+      'Швидке підключення не підтримується на цьому сервері.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Не вдалося авторизувати код Quick Connect.';
+      'Не вдалося авторизувати код швидкого підключення.';
 
   @override
-  String get quickConnectDisabled => 'Quick Connect вимкнено на цьому сервері.';
+  String get quickConnectDisabled =>
+      'Швидке підключення вимкнено на цьому сервері.';
 
   @override
   String get quickConnectForbidden =>
-      'Ваш обліковий запис не може авторизувати цей запит Quick Connect.';
+      'Ваш обліковий запис не може авторизувати цей запит швидкого підключення.';
 
   @override
   String get quickConnectNotFound =>
-      'Код Quick Connect не знайдено. Спробуйте новий код.';
+      'Код швидкого підключення не знайдено. Спробуйте новий код.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Помилка Quick Connect: $message';
+    return 'Помилка швидкого підключення: $message';
   }
 
   @override
@@ -8079,7 +8024,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Не вдалося видалити завантажений файл';
 
   @override
-  String get shuffleBy => 'Перемішати за';
+  String get shuffleBy => 'Shuffle By';
 
   @override
   String get shuffleSelectLibrary => 'Виберіть Бібліотека';
@@ -8088,7 +8033,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shuffleSelectGenre => 'Виберіть Жанр';
 
   @override
-  String get shuffleLibrary => 'Медіатека';
+  String get shuffleLibrary => 'Бібліотека';
 
   @override
   String get shuffleGenre => 'Жанр';
@@ -8150,7 +8095,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Відтворення призупинено. Ви все ще дивитесь?';
 
   @override
-  String get stillWatchingStop => 'Зупинити';
+  String get stillWatchingStop => 'СТІЙ';
 
   @override
   String get stillWatchingContinue => 'Продовжити';
@@ -8235,13 +8180,13 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get contextMenuHideFromContinueWatching =>
-      'Приховати з «Продовжити перегляд»';
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Приховати з «Далі»';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Додати до колекції';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle =>
@@ -8296,15 +8241,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsAlphabetical => 'Алфавітний';
 
   @override
-  String get settingsConnectionSection => 'ПІДКЛЮЧЕННЯ';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts =>
-      'Дозволити самопідписані сертифікати';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Довіряти серверам із самопідписаними сертифікатами TLS або сертифікатами приватного ЦС. Вмикайте лише для серверів, які ви контролюєте. Це вимикає перевірку сертифікатів для всіх підключень.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'КОНФІДЕНЦІЙНІСТЬ ТА БЕЗПЕКА';
@@ -8320,11 +8264,11 @@ class AppLocalizationsUk extends AppLocalizations {
       'Тематичні акценти, фони, індикатори спостереження та тематична музика';
 
   @override
-  String get settingsDetailsScreen => 'Екран деталей';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Стиль, розмиття тла та поведінка вкладок';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Домашня сторінка';
@@ -8362,11 +8306,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Показувати кнопку Seerr на панелі навігації';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Завжди показувати текстові підписи у верхній панелі навігації';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8435,7 +8379,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsSupportMoonfin => 'Підтримка Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => 'Пригостіть розробника кавою';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'ЮРИДИЧНИЙ';
@@ -8468,10 +8413,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# ліцензійного повідомлення',
-      many: '# ліцензійних повідомлень',
-      few: '# ліцензійні повідомлення',
-      one: '# ліцензійне повідомлення',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8521,16 +8464,16 @@ class AppLocalizationsUk extends AppLocalizations {
       'Пропустити введення та завершення?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Відлік медіасегментів';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Смуга прогресу';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Таймер';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Немає';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Підказка користувача';
@@ -8667,7 +8610,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value мс';
+    return '$value ms';
   }
 
   @override
@@ -8764,7 +8707,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return 'Нещодавно вийшло: $libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8798,11 +8741,11 @@ class AppLocalizationsUk extends AppLocalizations {
       'Примусове нетунельоване відтворення. Корисно на пристроях з розривами аудіо/відео тунелювання.';
 
   @override
-  String get enableTunnelingTitle => 'Увімкнути тунелювання';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Для досвідчених. Спрямовує аудіо та відео через спарений апаратний шлях. Типово вимкнено, бо на деяких пристроях спричиняє випадання аудіо/відео.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Зіставте Dolby Vision профіль 7 із HEVC';
@@ -8828,14 +8771,14 @@ class AppLocalizationsUk extends AppLocalizations {
       'Застосуйте підказки щодо розміру шрифту, вбудовані в доріжку субтитрів. Вимкніть використання розміру субтитрів у ваших налаштуваннях стилю.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Показувати деталі медіа';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Показувати деталі вибраного елемента вгорі сторінок бібліотеки.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Приховувати тла під час перегляду?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Використовуйте детальні підзаголовки';
@@ -8853,37 +8796,37 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Магазин тем';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Переглядайте та зберігайте теми спільноти';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Збережіть тему, щоб користуватися нею, як іншими збереженими темами.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Наразі немає доступних тем.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Не вдалося завантажити Магазин тем. Перевірте підключення та спробуйте ще раз.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Зберегти';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Зберегти й застосувати';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Збережено';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Не вдалося завантажити цю тему.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Збережено «$themeName».';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8942,21 +8885,21 @@ class AppLocalizationsUk extends AppLocalizations {
   String get homeRowsSection => 'Домашні ряди';
 
   @override
-  String get homeRowDisplay => 'Відображення рядків головної';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Розділи рядків головної';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Перемикачі рядків головної';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Увімкніть або вимкніть категорії рядків головної на основі бібліотек';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Увімкніть наведені нижче перемикачі, щоб показувати рядки в розділах головної.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Тип рядків';
@@ -9015,56 +8958,55 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показувати фільми, серіали або обидва в рядках жанрів.';
 
   @override
-  String get displayPlaylistsRows => 'Показувати рядки списків відтворення';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Показувати рядки списків відтворення в розділах головної.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Сортування рядків списків відтворення';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Сортуйте рядки списків відтворення за датою додавання, датою випуску, за алфавітом тощо.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Показувати аудіорядки';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Показувати аудіорядки в розділах головної.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Сортування аудіорядків';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Сортуйте аудіорядки за датою додавання, датою випуску, за алфавітом тощо.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Аудіосписки відтворення';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get appearance => 'Зовнішній вигляд';
 
   @override
-  String get layout => 'Макет';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Тема';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Клавіатура';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Кнопки';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Рендеринг';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Конфігурація MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Розмір картки';
@@ -9074,7 +9016,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Установіть зовнішній програвач, щоб увімкнути відтворення довгим натисканням';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9345,7 +9287,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appearancesSeerr => 'Поява (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Внесок знімальної групи (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Дивіться з групою';
@@ -9431,10 +9373,8 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count бібліотеки',
-      many: '$count бібліотек',
-      few: '$count бібліотеки',
-      one: '$count бібліотека',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9592,13 +9532,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get loadingShuffle => 'Завантаження перемішування...';
 
   @override
-  String get libraryShuffleLabel => 'ПЕРЕМІШУВАННЯ БІБЛІОТЕКИ';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'ВИПАДКОВЕ ПЕРЕМІШУВАННЯ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'ПЕРЕМІШУВАННЯ ЖАНРІВ';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Автоматичне перемикання HDR';
@@ -9611,222 +9551,222 @@ class AppLocalizationsUk extends AppLocalizations {
   String get whenFullscreen => 'У повноекранному режимі';
 
   @override
-  String get changeArtwork => 'Змінити обкладинку';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Відсутнє';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Обмеження перекодування';
 
   @override
-  String get clearAllArtworkButton => 'Очистити всі обкладинки?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Ви впевнені, що хочете очистити всі завантажені обкладинки?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Підтвердити очищення';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Ви впевнені, що хочете очистити це зображення ($itemType)?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Вивантажити?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Роздільна здатність: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Показувати лише обкладинки мовою інтерфейсу';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Підтвердити очищення всього';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Зображення успішно вивантажено!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Не вдалося вивантажити зображення: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Не вдалося встановити зображення: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Не вдалося видалити зображення: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Не вдалося очистити всі обкладинки: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Так';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Постер';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Тла';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Банер';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => 'Логотип';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Мініатюра';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Ілюстрація';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Зображення диска';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Знімок екрана';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Обкладинка коробки';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Задня обкладинка коробки';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Ілюстрація меню';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'постер';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'тло';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'банер';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => 'логотип';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'мініатюра';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ілюстрація';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'зображення диска';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'знімок екрана';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'обкладинка коробки';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'задня обкладинка коробки';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ілюстрація меню';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Усі';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Висока (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Середня (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Низька (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Джерела';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Розділи';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Закладки';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Нотатки';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Черга';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Хронологія';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Хронологія порожня';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Уся книга';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Сфокусована хронологія';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Експортувати закладки';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Експортувати нотатки';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Експортувати все';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Експортовано до $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Помилка експорту: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Текст';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Додати закладку';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Додати нотатку';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Редагувати нотатку';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Напишіть нотатку для цього моменту';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Таймер сну';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Вимкнено';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Кінець розділу';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Власний';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Залишилось $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9834,58 +9774,58 @@ class AppLocalizationsUk extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count хв',
-      one: '1 хв',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Швидкість відтворення';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Залишилось';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Минуло';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Назад $seconds с';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Вперед $seconds с';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Попередній розділ';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Наступний розділ';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Розділ $current з $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Немає розділів';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Поки що немає закладок';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Поки що немає нотаток';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Закладку додано на $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Скинути до 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9893,252 +9833,249 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Зберегти';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Скасувати';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Видалити';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Параметри субтитрів';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Змініть режими субтитрів, типові мови, вигляд і параметри рендерингу.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Рендеринг субтитрів';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Параметри відображення';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Дата виходу (за зростанням)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Дата виходу (за спаданням)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Групувати внески';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Групувати кілька ролей';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Попередження про доступ на запис до бібліотеки';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Як це виправити:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Надайте службовому користувачу Jellyfin (напр., jellyfin або PUID/PGID у Docker) права на запис до тек вашої медіабібліотеки на сервері.\n\n2. Або відкрийте Jellyfin Dashboard -> Libraries, відредагуйте цю бібліотеку та вимкніть параметр «Save artwork into media folders», щоб зберігати обкладинки у внутрішній базі даних Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Закрити';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Вашу бібліотеку «$libraryName» налаштовано зберігати обкладинки безпосередньо в теках медіа (параметр «Save artwork into media folders» увімкнено). Проте Jellyfin перевірив доступ на запис і не має дозволу записувати файли до цього каталогу:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Схоже, Jellyfin не вдалося оновити обкладинку. Вашу бібліотеку налаштовано зберігати обкладинки безпосередньо в теках медіа (параметр «Save artwork into media folders» увімкнено). Ця помилка зазвичай виникає, коли процес сервера Jellyfin не має дозволу записувати файли до ваших каталогів медіа.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Зовнішні списки';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Відтворити знову';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Інформація про файл';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Розмір: $size  •  Формат: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Показати всі аудіодоріжки ($count)';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Показати всі доріжки субтитрів ($count)';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay =>
-      'Перевірка можливості прямого відтворення...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Можливість прямого відтворення: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Примусові';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Формат контейнера не підтримується програвачем.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Відеокодек не підтримується.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => 'Аудіокодек не підтримується.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Формат субтитрів не підтримується (потребує вшивання).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Аудіопрофіль не підтримується.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Відеопрофіль не підтримується.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Рівень відео не підтримується.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Роздільна здатність відео не підтримується цим пристроєм.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Глибина кольору відео не підтримується.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Частота кадрів відео не підтримується.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Бітрейт файлу перевищує ліміт потоку програвача.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Бітрейт відео перевищує ліміт потоку.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Бітрейт аудіо перевищує ліміт потоку.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Кількість аудіоканалів не підтримується.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'За алфавітом';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Порядок виходу (за зростанням)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Порядок виходу (за спаданням)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Власний (перетягуванням)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Параметри сортування списку відтворення';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Скинути сортування';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Переглянути знову С$season:Е$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Переглянути список відтворення знову';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Субтитрів не знайдено.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Керування адміністратора';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Рушій рендерингу (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller — це сучасний GPU-рендерер Flutter для плавніших анімацій і меншого підгальмовування. На деяких ТВ-боксах і старих GPU він може спричиняти артефакти або чорне відео; вимкніть його, якщо це помітите. «Автоматично» добирає найкраще значення для вашого пристрою. Перезапустіть Moonfin, щоб застосувати.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Автоматично';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Увімкнено';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Вимкнено';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Потрібен перезапуск';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin потрібно перезапустити, щоб змінити рушій рендерингу. Закрийте програму зараз, а потім відкрийте її знову, щоб застосувати зміни.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Закрити програму зараз';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Оновити бібліотеку';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Оновити всі бібліотеки';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Дата додавання (спочатку старі)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Дата додавання (спочатку нові)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'За алфавітом (А–Я)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'За алфавітом (Я–А)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Завантаження аналітики сервера... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Як у джерелі';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb Топ-250 фільмів';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Топ-250 серіалів';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Найпопулярніші фільми';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Найпопулярніші серіали';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Фільми з найнижчим рейтингом';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb Найкращі англомовні фільми';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -9,22 +9,22 @@ class AppLocalizationsVi extends AppLocalizations {
   AppLocalizationsVi([String locale = 'vi']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Vây trăng';
 
   @override
-  String get accountPreferences => 'TÙY CHỌN TÀI KHOẢN';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Ngôn ngữ giao diện';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Mặc định của hệ thống';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Đăng nhập';
 
   @override
-  String get empty => 'Trống';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -32,7 +32,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => 'Kết nối nhanh';
 
   @override
   String get password => 'Mật khẩu';
@@ -51,7 +51,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get waitingForAuthorization => 'Đang chờ cấp phép...';
 
   @override
-  String get back => 'Quay lại';
+  String get back => 'Mặt sau';
 
   @override
   String get serverUnavailable => 'Máy chủ không khả dụng';
@@ -113,7 +113,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get cancel => 'Hủy bỏ';
 
   @override
-  String get remove => 'Gỡ bỏ';
+  String get remove => 'Di dời';
 
   @override
   String get connectToServer => 'Kết nối với máy chủ';
@@ -141,62 +141,62 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsAppearanceTheme => 'Chủ đề ứng dụng';
 
   @override
-  String get detailScreenStyle => 'Kiểu màn hình chi tiết';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Cổ điển là bố cục Moonfin gốc căn giữa. Hiện đại là bố cục điện ảnh tự điều chỉnh.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Cổ điển';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Hiện đại';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Thẻ mở rộng';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Tự động hiển thị nội dung thẻ khi bạn duyệt qua các thẻ. Tắt để tự mở và đóng từng thẻ.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Hiển thị chi tiết kỹ thuật?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Hiển thị thông tin codec, độ phân giải và luồng trong phần tóm tắt biểu ngữ';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Hệ thống gợi ý';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Dùng thuật toán Moonfin Gợi ý dựa trên thư viện cục bộ hoặc Chỉ số tương đồng trực tuyến của TMDb. Lưu ý: Gợi ý trực tuyến cần tích hợp Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
-  String get recommendationSystemMoonfin => 'Moonfin Gợi ý';
+  String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Độ tương đồng TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Giới hạn theo xếp hạng độ tuổi?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Giới hạn gợi ý của Moonfin Gợi ý theo xếp hạng độ tuổi của nội dung đích';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Kiểu giao diện';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Tự động sẽ khớp với thiết bị của bạn. Chọn Apple hoặc Material để dùng một giao diện cố định.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Tự động';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,31 +205,31 @@ class AppLocalizationsVi extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Chất lượng hiệu ứng kính';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Tự động sẽ chọn hiệu ứng kính phù hợp nhất cho thiết bị này. Đầy đủ buộc dùng làm mờ thật; Giảm bớt dùng hiệu ứng kính nhẹ giúp tiết kiệm GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => 'Tự động';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Đầy đủ';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Giảm bớt';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       'Chuyển đổi giữa Moonfin và Neon Pulse mà không cần khởi động lại ứng dụng';
 
   @override
-  String get customThemeTitle => 'Chủ đề tùy chỉnh';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Chủ đề tùy chỉnh thay đổi các thành phần giao diện trên toàn Moonfin. Hãy chọn một tùy chọn hợp với phong cách của bạn.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
   String get keyboardPreferSystemIme => 'Ưu tiên bàn phím hệ thống';
@@ -239,7 +239,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Sử dụng phương thức nhập thiết bị của bạn theo mặc định để nhập văn bản';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Vây trăng';
 
   @override
   String get themeMoonfinSubtitle =>
@@ -253,18 +253,18 @@ class AppLocalizationsVi extends AppLocalizations {
       'Kiểu dáng Synthwave với ánh sáng đỏ tươi, văn bản màu lục lam và độ tương phản chrome mạnh hơn';
 
   @override
-  String get themeGlass => 'Kính';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Phong cách kính lỏng với nền chuyển sắc chuyển động nhẹ, bề mặt mờ và điểm nhấn xanh Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => 'Người hùng 8-bit';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Phong cách pixel-art hoài cổ với bảng màu đậm, viền khối, đổ bóng sắc nét và phông chữ pixel';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -331,33 +331,32 @@ class AppLocalizationsVi extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Đã tạm dừng';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Lưu trạng thái';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => 'Trò chơi';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => 'Tải trạng thái';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => 'Tua nhanh';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => 'Cài đặt trình giả lập';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions =>
-      'Nhân này không có tùy chọn nào để điều chỉnh.';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => 'Giữ để mở menu';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Thiết bị này chưa hỗ trợ chơi trò chơi.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Không thể tải hàng nhà nào';
@@ -373,13 +372,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get guide => 'Hướng dẫn';
 
   @override
-  String get recordings => 'Bản ghi';
+  String get recordings => 'Bản ghi âm';
 
   @override
   String get schedule => 'Lịch trình';
 
   @override
-  String get series => 'Phim bộ';
+  String get series => 'Loạt';
 
   @override
   String get noItemsFound => 'Không tìm thấy mục nào';
@@ -510,7 +509,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get albumArtists => 'Nghệ sĩ album';
 
   @override
-  String get artists => 'Nghệ sĩ';
+  String get artists => 'nghệ sĩ';
 
   @override
   String get bookmarks => 'Dấu trang';
@@ -606,7 +605,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get listen => 'Nghe';
 
   @override
-  String get resume => 'Tiếp tục';
+  String get resume => 'Bản tóm tắt';
 
   @override
   String get failedToLoadLibrary => 'Không tải được thư viện';
@@ -699,7 +698,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get titles => 'Tựa đề';
+  String get titles => 'Tiêu đề';
 
   @override
   String get allTitles => 'Tất cả các tiêu đề';
@@ -769,43 +768,43 @@ class AppLocalizationsVi extends AppLocalizations {
   String get books => 'Sách';
 
   @override
-  String get latestBooks => 'Sách mới nhất';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Sách nói mới nhất';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count cuốn sách',
-      one: '1 cuốn sách',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Sách';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => 'Sách nói';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return 'Đã đọc $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return 'Còn $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Đọc';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Nghe';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Tác giả';
@@ -882,8 +881,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count sách nói',
-      one: '1 sách nói',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -898,10 +897,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get failedToLoad => 'Không tải được';
 
   @override
-  String get delete => 'Xóa';
+  String get delete => 'Xóa bỏ';
 
   @override
-  String get save => 'Lưu';
+  String get save => 'Cứu';
 
   @override
   String get moreLikeThis => 'Tương tự thế này';
@@ -986,8 +985,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Mùa',
-      one: '1 Mùa',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -998,40 +997,40 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get items => 'Mục';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Nội dung thêm';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Hậu trường';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Cảnh bị cắt';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Phim ngắn giới thiệu';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Phỏng vấn';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Cảnh phim';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Phim ngắn';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Trailer';
+  String get trailers => 'Xe kéo';
 
   @override
   String timeRemaining(String time) {
-    return 'Còn $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Kết thúc sau $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1049,7 +1048,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get play => 'Phát';
+  String get play => 'Chơi';
 
   @override
   String get startOver => 'Bắt đầu lại';
@@ -1073,10 +1072,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get version => 'Phiên bản';
 
   @override
-  String get cast => 'Truyền';
+  String get cast => 'Dàn diễn viên';
 
   @override
-  String get trailer => 'Trailer';
+  String get trailer => 'Đoạn phim giới thiệu';
 
   @override
   String get finished => 'Hoàn thành';
@@ -1267,13 +1266,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get director => 'GIÁM ĐỐC';
 
   @override
-  String get directors => 'ĐẠO DIỄN';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'BIÊN KỊCH';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'BIÊN KỊCH';
+  String get writers => 'nhà văn';
 
   @override
   String get studio => 'PHÒNG THU';
@@ -1308,8 +1307,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count bản nhạc',
-      one: '1 bản nhạc',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1319,8 +1318,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count chương',
-      one: '1 chương',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1347,16 +1346,16 @@ class AppLocalizationsVi extends AppLocalizations {
   String get readMore => 'Đọc thêm';
 
   @override
-  String get shuffle => 'Phát ngẫu nhiên';
+  String get shuffle => 'Trộn bài';
 
   @override
-  String get shuffleAllMusic => 'Phát ngẫu nhiên toàn bộ nhạc';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Đăng nhập Moonfin trên điện thoại của bạn';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Không kết nối được máy chủ của bạn';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
@@ -1368,14 +1367,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count kênh';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Mono';
+  String get mono => 'Bệnh tăng bạch cầu đơn nhân';
 
   @override
-  String get stereo => 'Stereo';
+  String get stereo => 'Âm thanh nổi';
 
   @override
   String remoteSubtitlePermissionError(String action) {
@@ -1529,7 +1528,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get subtitleDelay => 'Độ trễ phụ đề';
 
   @override
-  String get reset => 'Đặt lại';
+  String get reset => 'Cài lại';
 
   @override
   String get unknown => 'Không xác định';
@@ -1556,7 +1555,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get transcodeReasons => 'Lý do chuyển mã';
 
   @override
-  String get player => 'Trình phát';
+  String get player => 'Người chơi';
 
   @override
   String get container => 'thùng chứa';
@@ -1580,7 +1579,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get videoBitrate => 'Tốc độ bit của video';
 
   @override
-  String get track => 'Track';
+  String get track => 'Theo dõi';
 
   @override
   String get channels => 'Kênh';
@@ -1796,22 +1795,22 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Tiếp theo: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return 'Còn $minutes phút';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return 'Còn $hours giờ';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return 'Còn $hours giờ $minutes phút';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1834,7 +1833,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get favoriteChannel => 'Kênh yêu thích';
 
   @override
-  String get record => 'Ghi hình';
+  String get record => 'Ghi';
 
   @override
   String get cancelRecordingAction => 'Hủy ghi âm';
@@ -1849,7 +1848,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get unableToCreateRecording => 'Không thể tạo bản ghi';
 
   @override
-  String get watch => 'Xem';
+  String get watch => 'Đồng hồ';
 
   @override
   String get close => 'Đóng';
@@ -1886,7 +1885,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get no => 'Không';
+  String get no => 'KHÔNG';
 
   @override
   String get yesCancel => 'Có, Hủy';
@@ -2059,8 +2058,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tập',
-      one: '1 tập',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2287,7 +2286,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Trang chi tiết, hàng trang chủ và âm lượng';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2301,11 +2300,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Chơi khi duyệt màn hình chính';
 
   @override
-  String get loopThemeMusic => 'Lặp nhạc chủ đề';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Lặp lại bản nhạc thay vì chỉ phát một lần';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Chi tiết Làm mờ nền';
@@ -2328,23 +2327,23 @@ class AppLocalizationsVi extends AppLocalizations {
   String get playerZoomMode => 'Chế độ thu phóng trình phát';
 
   @override
-  String get settingsScrollWheelAction => 'Con lăn chuột';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Chọn hành động khi lăn chuột trên video trong lúc phát.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Tắt';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Tua (tiến / lùi)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Âm lượng';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Âm lượng';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => 'Phù hợp';
@@ -2359,7 +2358,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get refreshRateSwitching => 'Chuyển đổi tốc độ làm mới';
 
   @override
-  String get disabled => 'Đã tắt';
+  String get disabled => 'Tàn tật';
 
   @override
   String get scaleOnTv => 'Cân trên TV';
@@ -2398,37 +2397,37 @@ class AppLocalizationsVi extends AppLocalizations {
   String get defaultAudioLanguage => 'Ngôn ngữ âm thanh mặc định';
 
   @override
-  String get fallbackAudioLanguage => 'Ngôn ngữ âm thanh dự phòng';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Ưu tiên bản âm thanh mặc định';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Ưu tiên bản âm thanh gốc thay vì bản lồng tiếng.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Ưu tiên bản thuyết minh mô tả';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Ưu tiên bản thuyết minh mô tả thay vì bản âm thanh thường.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Chuyển mã (Âm thanh)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Truyền trực tiếp (Remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Chuyển mã (Tốc độ bit hoặc Độ phân giải)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Chuyển mã (Video & Âm thanh)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Chuyển mã (Video)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Tự động (Mặc định máy chủ)';
@@ -2509,7 +2508,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Chọn cách giải mã âm thanh. AVR Passthrough gửi luồng Dolby/DTS thô đến bộ thu của bạn; Tự động hoặc Trộn xuống sẽ giải mã ngay trên thiết bị.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'Truyền qua AVR';
@@ -2519,14 +2518,13 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Chọn định dạng đích để chuyển mã âm thanh đa kênh khi luồng gốc không thể phát trực tiếp hoặc truyền thẳng.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Tự động nhận diện\n(Khuyên dùng)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Mặc định)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2535,27 +2533,26 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Không mất dữ liệu)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Chỉ Stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Hiệu quả)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Không mất dữ liệu)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Số kênh âm thanh tối đa';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Thiết lập số kênh tối đa của hệ thống âm thanh của bạn. Các luồng đa kênh vượt quá giới hạn này sẽ được trộn xuống hoặc chuyển mã.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Tự động nhận diện\n(Mặc định phần cứng)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2564,22 +2561,22 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Vòm';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
   String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Vòm';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 Vòm';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 Vòm';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 Vòm';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
   String get settingsAudioPassthroughAdvanced => 'Truyền qua (Nâng cao)';
@@ -2607,7 +2604,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsAudioTrueHdPassthrough => 'Truyền qua TrueHD';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Truyền thẳng TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough =>
+      'Dòng bit Dolby Digital Plus (EAC3) tới bộ giải mã bên ngoài.';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2661,11 +2659,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Loa';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Tai nghe';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return 'PCM $count kênh';
+    return '${count}ch PCM';
   }
 
   @override
@@ -2751,7 +2749,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value giây';
+    return '${value}s';
   }
 
   @override
@@ -2840,45 +2838,45 @@ class AppLocalizationsVi extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Tùy chỉnh giao diện phụ đề';
 
   @override
-  String get subtitleMode => 'Chế độ phụ đề';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Theo đánh dấu';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Luôn luôn';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'Tiếng nước ngoài';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Bắt buộc';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Phát các bản được đánh dấu \"default\" hoặc \"forced\" trong siêu dữ liệu của tệp phương tiện.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Tự động tải và hiển thị phụ đề mỗi khi bắt đầu phát video.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Tự động bật phụ đề nếu bản âm thanh mặc định là tiếng nước ngoài.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>
-      'Chỉ tải phụ đề được gắn cờ siêu dữ liệu forced.';
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
   String get subtitleModeNoneDescription =>
-      'Tắt hoàn toàn việc tự động tải phụ đề.';
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => 'Ngôn ngữ phụ đề dự phòng';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => 'Luồng phụ đề';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => 'Cáo nâu nhanh nhẹn nhảy qua chó lười';
@@ -3081,10 +3079,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showLibrariesInToolbar => 'Hiển thị Thư viện trong Thanh công cụ';
 
   @override
-  String get navbarAlwaysExpanded => 'Luôn hiển thị nhãn thanh điều hướng';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => 'Hiển thị nút Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Độ mờ của thanh điều hướng';
@@ -3158,18 +3156,18 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showFolderBrowsingOption => 'Hiển thị tùy chọn duyệt thư mục';
 
   @override
-  String get groupItemsIntoCollections => 'Nhóm các mục thành bộ sưu tập';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
   String get hideCollectionAssociatedItems =>
-      'Ẩn các mục thuộc bộ sưu tập khi duyệt thư viện';
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => 'Lưu ý về nhóm thư viện';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      'Để dùng thiết lập này, hãy đảm bảo các tùy chọn thư viện \"Group movies into collections\" và/hoặc \"Group shows into collections\" đã được bật trong phần cài đặt Hiển thị của thư viện trên máy chủ Jellyfin hoặc Emby của bạn.';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => 'Hiển thị thư viện';
@@ -3229,7 +3227,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chọn giữa Moonfin, MakD hoặc tắt thanh phương tiện';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Vây trăng';
 
   @override
   String get mediaBarModeMakd => 'MakD';
@@ -3282,11 +3280,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Tự động phát đoạn giới thiệu trên thanh phương tiện sau 3 giây';
 
   @override
-  String get trailerAudio => 'Âm thanh trailer';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Bật âm thanh cho trailer trong thanh phương tiện';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Xem trước tập';
@@ -3364,11 +3361,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Kết hợp cả hai hàng thành một phần nhà duy nhất';
 
   @override
-  String get fullScreenRows => 'Hàng trang chủ mở rộng';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Giới hạn còn 1 hàng trang chủ mỗi màn hình';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Loại hình ảnh trên mỗi hàng';
@@ -3383,7 +3379,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get lastUser => 'Người dùng cuối cùng';
 
   @override
-  String get currentUser => 'Người dùng hiện tại';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Luôn xác thực';
@@ -3444,7 +3440,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Kích hoạt trình bảo vệ màn hình tích hợp';
 
   @override
-  String get mode => 'Chế độ';
+  String get mode => 'Cách thức';
 
   @override
   String get libraryArt => 'Thư viện nghệ thuật';
@@ -3491,10 +3487,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị đồng hồ trong khi bảo vệ màn hình';
 
   @override
-  String get clockModeStatic => 'Cố định';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Chuyển động';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Nhà phê bình)';
@@ -3567,7 +3563,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Bật và sắp xếp lại các nguồn xếp hạng được hiển thị trên toàn bộ ứng dụng';
 
   @override
-  String get pluginLabel => 'Plugin Moonbase';
+  String get pluginLabel => 'Trình cắm';
 
   @override
   String get pluginDetected => 'Đã phát hiện plugin';
@@ -3638,13 +3634,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get networks => 'Mạng';
 
   @override
-  String get seerrDiscoveryRows => 'Hàng khám phá Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Đặt lại các hàng về mặc định';
 
   @override
-  String get enableSeerr => 'Bật Seerr';
+  String get enableSeerr => 'Kích hoạt Seer';
 
   @override
   String get showSeerrInNavigation =>
@@ -3661,27 +3657,28 @@ class AppLocalizationsVi extends AppLocalizations {
   String get hideAdultContent => 'Ẩn nội dung người lớn trong kết quả';
 
   @override
-  String get seerrNotificationsSection => 'Thông báo';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => 'Thông báo yêu cầu mới';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
   String get seerrNotifyNewRequestsSubtitle =>
-      'Báo cho tôi khi có người gửi yêu cầu';
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => 'Cập nhật yêu cầu';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
   String get seerrNotifyLibraryAddedSubtitle =>
-      'Đã duyệt, bị từ chối và đã thêm vào thư viện của bạn';
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Cập nhật sự cố';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Sự cố mới, phản hồi và cách xử lý';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3689,15 +3686,15 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Trang khám phá Seerr';
+  String get discoverRows => 'Khám phá hàng';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Bật các hàng muốn hiển thị trên trang chính Seerr. Kéo để sắp xếp lại. Thứ tự tùy chỉnh sẽ đồng bộ với Moonbase.';
+      'Kéo để sắp xếp lại. Bật hoặc tắt hàng. Thứ tự hàng đã bật sẽ đồng bộ hóa với plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Bật các hàng muốn hiển thị trên trang chính Seerr. Kéo để sắp xếp lại. Thứ tự tùy chỉnh sẽ đồng bộ với Moonbase.';
+      'Kéo để sắp xếp lại. Bật hoặc tắt hàng.';
 
   @override
   String get enabled => 'Đã bật';
@@ -3832,7 +3829,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get imageCacheCleared => 'Đã xóa bộ nhớ đệm hình ảnh';
 
   @override
-  String get clear => 'Xóa';
+  String get clear => 'Thông thoáng';
 
   @override
   String get browse => 'Duyệt qua';
@@ -3848,11 +3845,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Đang tải xuống · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'Đang nhập';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3860,7 +3857,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get seerrSettings => 'Cài đặt Seerr';
+  String get seerrSettings => 'Cài đặt Seer';
 
   @override
   String get requestMore => 'Yêu cầu thêm';
@@ -3957,7 +3954,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showMore => 'Hiển thị thêm';
 
   @override
-  String get appearances => 'Tác phẩm tham gia';
+  String get appearances => 'Xuất hiện';
 
   @override
   String get crewSection => 'Phi hành đoàn';
@@ -3995,147 +3992,148 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deletedStatus => 'Đã xóa';
 
   @override
-  String get failedStatus => 'Thất bại';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'Đang xử lý';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return 'Được sửa bởi $name';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Hoàn tất';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Tựa đề này đã được yêu cầu';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'Đã đạt giới hạn yêu cầu';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Tựa đề này nằm trong danh sách chặn';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Không còn mùa nào để yêu cầu';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => 'Bạn không có quyền gửi yêu cầu này';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'Yêu cầu';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Sự cố';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'Mới nhất';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Sửa gần nhất';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Không có sự cố';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Còn $remaining trên $limit lượt yêu cầu phim';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Còn $remaining trên $limit lượt yêu cầu mùa';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Thuộc $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Xem bộ sưu tập';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Yêu cầu cả bộ sưu tập';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total phim · $available phim có sẵn';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Yêu cầu $count phim';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Đang yêu cầu $current trên $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Đã yêu cầu $count phim';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Đã yêu cầu $ok trên $total phim';
+    return 'Requested $ok of $total movies';
   }
 
   @override
   String get collectionAllRequested =>
-      'Tất cả phim đều đã có sẵn hoặc đã được yêu cầu';
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Báo cáo sự cố';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Âm thanh';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Có vấn đề gì?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Tất cả các tập';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Tập';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Đang mở';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Đã xử lý';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Đánh dấu đã xử lý';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Mở lại';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return 'Được báo cáo bởi $name';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count bình luận';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Thêm bình luận';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Xóa sự cố này?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Gửi báo cáo';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'Điểm TMDB';
@@ -4168,7 +4166,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get access => 'Truy cập';
 
   @override
-  String get add => 'Thêm';
+  String get add => 'Thêm vào';
 
   @override
   String get address => 'Địa chỉ';
@@ -4195,7 +4193,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get done => 'Xong';
 
   @override
-  String get edit => 'Chỉnh sửa';
+  String get edit => 'Biên tập';
 
   @override
   String get encoding => 'Mã hóa';
@@ -4204,10 +4202,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get error => 'Lỗi';
 
   @override
-  String get forward => 'Tua tới';
+  String get forward => 'Phía trước';
 
   @override
-  String get general => 'Chung';
+  String get general => 'Tổng quan';
 
   @override
   String get go => 'Đi';
@@ -4228,7 +4226,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get networking => 'Mạng';
 
   @override
-  String get next => 'Tiếp theo';
+  String get next => 'Kế tiếp';
 
   @override
   String get path => 'Con đường';
@@ -4252,7 +4250,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get refresh => 'Làm cho khỏe lại';
 
   @override
-  String get remote => 'Điều khiển từ xa';
+  String get remote => 'Xa';
 
   @override
   String get rename => 'Đổi tên';
@@ -4288,7 +4286,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get status => 'Trạng thái';
 
   @override
-  String get stop => 'Dừng';
+  String get stop => 'Dừng lại';
 
   @override
   String get streaming => 'Truyền phát';
@@ -4297,7 +4295,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get time => 'Thời gian';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => 'trò lừa';
 
   @override
   String get uninstall => 'Gỡ cài đặt';
@@ -4339,25 +4337,25 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminDrawerLibraries => 'Thư viện';
 
   @override
-  String get adminDrawerDisplay => 'Hiển thị';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => 'Siêu dữ liệu';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'Cài đặt NFO';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => 'Chuyển mã';
 
   @override
-  String get adminDrawerResume => 'Tiếp tục xem';
+  String get adminDrawerResume => 'Bản tóm tắt';
 
   @override
   String get adminDrawerStreaming => 'Truyền phát';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => 'trò lừa';
 
   @override
   String get adminDrawerDevices => 'Thiết bị';
@@ -4528,10 +4526,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get sessionRewind => 'Tua lại';
 
   @override
-  String get sessionForward => 'Tua tới';
+  String get sessionForward => 'Phía trước';
 
   @override
-  String get sessionNext => 'Tiếp theo';
+  String get sessionNext => 'Kế tiếp';
 
   @override
   String get sessionVolumeDown => 'Tập –';
@@ -4573,10 +4571,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminClearDates => 'Xóa ngày';
 
   @override
-  String get adminActivitySeverityAll => 'Mọi mức độ';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => 'Khoảng thời gian';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
@@ -4613,23 +4611,23 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return 'Gỡ thiết bị \'$name\'? Người dùng sẽ phải đăng nhập lại trên thiết bị này.';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => 'Xóa tất cả thiết bị';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return 'Gỡ $count thiết bị? Những người dùng bị ảnh hưởng sẽ phải đăng nhập lại. Thiết bị hiện tại của bạn không bị ảnh hưởng.';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => 'Đã gỡ thiết bị';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return 'Đã gỡ một số thiết bị; không thể gỡ $count thiết bị.';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4745,246 +4743,244 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminMetadataCountryHint => 'ví dụ. Mỹ, Đức, Pháp';
 
   @override
-  String get adminLibraryTabPaths => 'Đường dẫn';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => 'Tùy chọn';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => 'Trình tải xuống';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => 'Trình lưu siêu dữ liệu';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => 'Trình tải phụ đề';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => 'Trình tải lời bài hát';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return 'Trình tải siêu dữ liệu: $type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return 'Trình lấy hình ảnh: $type';
+    return 'Image fetchers: $type';
   }
 
   @override
   String get adminLibNoDownloaders =>
-      'Máy chủ này không cung cấp trình tải nào cho loại thư viện này.';
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => 'Chung';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => 'Siêu dữ liệu';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => 'Thông tin nhúng';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => 'Phụ đề';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => 'Hình ảnh';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => 'Phim bộ';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => 'Nhạc';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => 'Phim';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => 'Bật giám sát theo thời gian thực';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
   String get adminLibRealtimeMonitorHint =>
-      'Phát hiện thay đổi của tệp và tự động xử lý.';
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => 'Xem tệp nén như tệp phương tiện';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => 'Hiển thị ảnh';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => 'Lưu ảnh bìa vào thư mục phương tiện';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => 'Tự động làm mới siêu dữ liệu';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => 'Không bao giờ';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => 'Mặc định';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => 'Hiển thị';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => 'Hiển thị thư viện';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
   String get adminLibFolderView =>
-      'Hiển thị dạng thư mục để xem các thư mục phương tiện thuần túy';
+      'Display a folder view to show plain media folders';
 
   @override
   String get adminLibSpecialsInSeasons =>
-      'Hiển thị tập đặc biệt trong mùa mà chúng được phát sóng';
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => 'Nhóm phim lẻ thành bộ sưu tập';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => 'Nhóm phim bộ thành bộ sưu tập';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
   String get adminLibExternalSuggestions =>
-      'Hiển thị nội dung bên ngoài trong phần gợi ý';
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => 'Cách xác định ngày thêm';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => 'Lấy ngày thêm từ';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => 'Ngày quét vào thư viện';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => 'Ngày tệp được tạo';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => 'Siêu dữ liệu và hình ảnh';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => 'Ngôn ngữ siêu dữ liệu ưu tiên';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => 'Chương';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => 'Thời lượng chương giả (giây)';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
   String get adminLibDummyChapterDurationHint =>
-      'Độ dài của các chương được tạo cho nội dung không có chương. Đặt 0 để tắt.';
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => 'Độ phân giải ảnh chương';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'Cài đặt NFO';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'Siêu dữ liệu NFO tương thích với Kodi và các ứng dụng tương tự. Các thiết lập này áp dụng cho mọi thư viện có lưu siêu dữ liệu NFO.';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser =>
-      'Người dùng được lưu dữ liệu xem trong tệp NFO';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => 'Lưu đường dẫn hình ảnh trong tệp NFO';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
   String get adminLibPathSubstitution =>
-      'Bật thay thế đường dẫn cho đường dẫn hình ảnh NFO';
+      'Enable path substitution for NFO image paths';
 
   @override
   String get adminLibExtraThumbs =>
-      'Sao chép ảnh extrafanart vào thư mục extrathumbs';
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => 'Không có';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days ngày';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => 'Dùng tựa đề nhúng trong tệp';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles =>
-      'Dùng tựa đề nhúng cho nội dung thêm';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos =>
-      'Dùng thông tin tập nhúng trong tệp';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => 'Cho phép phụ đề nhúng';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => 'Cho phép tất cả';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => 'Chỉ dạng văn bản';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => 'Chỉ dạng hình ảnh';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => 'Không có';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
   String get adminLibSkipIfEmbeddedSubs =>
-      'Bỏ qua tải xuống nếu đã có phụ đề nhúng';
+      'Skip download if embedded subtitles are present';
 
   @override
   String get adminLibSkipIfAudioMatches =>
-      'Bỏ qua tải xuống nếu bản âm thanh trùng với ngôn ngữ tải xuống';
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => 'Yêu cầu phụ đề khớp hoàn toàn';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
   String get adminLibSaveSubtitlesWithMedia =>
-      'Lưu phụ đề vào thư mục phương tiện';
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => 'Trích xuất ảnh chương';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
   String get adminLibChapterImagesDuringScan =>
-      'Trích xuất ảnh chương trong lúc quét thư viện';
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => 'Bật trích xuất ảnh Trickplay';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
   String get adminLibTrickplayDuringScan =>
-      'Trích xuất ảnh Trickplay trong lúc quét thư viện';
+      'Extract trickplay images during the library scan';
 
   @override
   String get adminLibSaveTrickplayWithMedia =>
-      'Lưu ảnh Trickplay vào thư mục phương tiện';
+      'Save trickplay images into media folders';
 
   @override
   String get adminLibAutomaticSeriesGrouping =>
-      'Tự động gộp các phim bộ nằm rải rác ở nhiều thư mục';
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => 'Tên hiển thị của mùa 0';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => 'Bật quét LUFS để chuẩn hóa âm lượng';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
   String get adminLibPreferNonstandardArtist =>
-      'Ưu tiên thẻ nghệ sĩ không chuẩn';
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => 'Tự động thêm phim vào bộ sưu tập';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => 'Tên thư viện là bắt buộc';
@@ -5224,143 +5220,143 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminEnableAllChannels => 'Cho phép truy cập vào tất cả các kênh';
 
   @override
-  String get adminParentalControl => 'Kiểm soát của phụ huynh';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => 'Xếp hạng độ tuổi tối đa được phép';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
   String get adminMaxParentalRatingHint =>
-      'Nội dung có xếp hạng cao hơn sẽ bị ẩn với người dùng này.';
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => 'Không có';
+  String get adminParentalRatingNone => 'None';
 
   @override
   String get adminBlockUnratedItems =>
-      'Chặn các mục không có hoặc có thông tin xếp hạng không xác định';
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => 'Sách';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => 'Kênh';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => 'TV trực tiếp';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => 'Phim';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => 'Nhạc';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => 'Trailer';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => 'Phim bộ';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => 'Lịch truy cập';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
   String get adminAccessSchedulesHint =>
-      'Chỉ cho phép truy cập trong các khung giờ bên dưới. Nếu không đặt lịch, người dùng được truy cập cả ngày.';
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => 'Thêm lịch';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => 'Ngày';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => 'Bắt đầu';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => 'Kết thúc';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => 'Mỗi ngày';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => 'Ngày trong tuần';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => 'Cuối tuần';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => 'Chủ Nhật';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => 'Thứ Hai';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => 'Thứ Ba';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => 'Thứ Tư';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => 'Thứ Năm';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => 'Thứ Sáu';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => 'Thứ Bảy';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => 'Thẻ được phép';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
   String get adminAllowedTagsHint =>
-      'Chỉ hiển thị nội dung có các thẻ này. Để trống để cho phép tất cả.';
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => 'Thẻ bị chặn';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
   String get adminBlockedTagsHint =>
-      'Nội dung có các thẻ này sẽ bị ẩn với người dùng này.';
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => 'Thêm thẻ';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => 'Thiết bị được bật';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => 'Kênh được bật';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => 'Nhà cung cấp xác thực';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => 'Nhà cung cấp đặt lại mật khẩu';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
   String get adminLoginAttemptsBeforeLockout =>
-      'Số lần đăng nhập thất bại tối đa trước khi khóa';
+      'Maximum failed login attempts before lockout';
 
   @override
   String get adminLoginAttemptsHint =>
-      'Đặt 0 để dùng mặc định, hoặc -1 để tắt tính năng khóa.';
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'Quyền truy cập SyncPlay';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => 'Cho phép tạo và tham gia nhóm';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => 'Cho phép tham gia nhóm';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => 'Không có quyền truy cập';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => 'Cho phép xóa nội dung từ';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning =>
@@ -5448,25 +5444,25 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get adminBackupOptionsTitle => 'Tạo bản sao lưu';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => 'Chọn những gì cần đưa vào bản sao lưu.';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => 'Cơ sở dữ liệu';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => 'Luôn được bao gồm';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => 'Siêu dữ liệu';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => 'Phụ đề';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Ảnh Trickplay';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => 'Đang tạo bản sao lưu...';
@@ -5894,10 +5890,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminThrottleBuffering => 'Bộ đệm ga';
 
   @override
-  String get adminTrickplaySaved => 'Đã lưu cài đặt Trickplay';
+  String get adminTrickplaySaved => 'Đã lưu cài đặt trò chơi lừa';
 
   @override
-  String get adminTrickplayLoadFailed => 'Không tải được cài đặt Trickplay';
+  String get adminTrickplayLoadFailed => 'Không tải được cài đặt trò chơi lừa';
 
   @override
   String get adminEnableHardwareAcceleration =>
@@ -6007,7 +6003,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminBaseUrl => 'URL cơ sở';
 
   @override
-  String get adminBaseUrlHint => 'ví dụ: /jellyfin';
+  String get adminBaseUrlHint => 'ví dụ. /vây thạch';
 
   @override
   String get https => 'HTTPS';
@@ -6170,61 +6166,60 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminAddTuner => 'Thêm bộ chỉnh';
 
   @override
-  String get adminEditTuner => 'Sửa bộ thu';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'Bộ thu M3U';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => 'Tệp hoặc URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => 'Địa chỉ IP của bộ thu';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => 'Tên thân thiện';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
   String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => 'Giới hạn kết nối đồng thời';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
   String get adminTunerCountHelp =>
-      'Số luồng tối đa mà bộ thu cho phép cùng lúc. Đặt 0 để không giới hạn.';
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => 'Tốc độ bit truyền tối đa dự phòng';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => 'Chỉ nhập các kênh yêu thích';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding =>
-      'Cho phép chuyển mã bằng phần cứng';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => 'Cho phép vùng chứa chuyển mã fMP4';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => 'Cho phép chia sẻ luồng';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => 'Bật lặp luồng';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => 'Bỏ qua DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
   String get adminTunerReadAtNativeFramerate =>
-      'Đọc đầu vào theo tốc độ khung hình gốc';
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => 'Sửa nhà cung cấp';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6233,50 +6228,50 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => 'Tệp hoặc URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => 'Tiền tố phim';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => 'Danh mục phim';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
   String get adminXmltvCategoriesHelp =>
-      'Phân tách nhiều danh mục bằng dấu gạch đứng (|).';
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => 'Danh mục thiếu nhi';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => 'Danh mục tin tức';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => 'Danh mục thể thao';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => 'Tên người dùng';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => 'Mật khẩu';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => 'Quốc gia';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => 'Chọn quốc gia';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => 'Mã bưu chính';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => 'Lấy danh sách kênh';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => 'Danh sách kênh';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => 'Bật tất cả bộ thu';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => 'Loại bộ chỉnh';
@@ -6318,7 +6313,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get adminTunerResetNotSupported =>
-      'Loại bộ thu này không hỗ trợ đặt lại.';
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
@@ -6341,43 +6336,43 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminSeriesRecordingPath => 'Đường dẫn ghi sê-ri';
 
   @override
-  String get adminMovieRecordingPath => 'Đường dẫn ghi phim';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => 'Số ngày dữ liệu lịch phát sóng';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => 'Tự động';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days ngày';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => 'Đường dẫn ứng dụng hậu xử lý';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => 'Tham số của trình hậu xử lý';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => 'Lưu siêu dữ liệu NFO của bản ghi';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => 'Lưu hình ảnh của bản ghi';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => 'Thời gian';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => 'Đường dẫn ghi hình';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => 'Hậu xử lý';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return 'Dữ liệu lịch phát sóng: $value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6420,15 +6415,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminGuideProviders => 'Nhà cung cấp hướng dẫn';
 
   @override
-  String get adminRefreshGuideData => 'Làm mới dữ liệu lịch phát sóng';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted =>
-      'Đã bắt đầu làm mới dữ liệu lịch phát sóng';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
   String get adminGuideRefreshUnavailable =>
-      'Tác vụ làm mới lịch phát sóng không khả dụng trên máy chủ này.';
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => 'Thêm nhà cung cấp';
@@ -6518,7 +6512,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminNotSet => 'Chưa đặt';
 
   @override
-  String get adminReset => 'Đặt lại';
+  String get adminReset => 'Cài lại';
 
   @override
   String get adminLogsTitle => 'Nhật ký máy chủ';
@@ -6564,7 +6558,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminMetadataEditorTitle => 'Trình chỉnh sửa siêu dữ liệu';
 
   @override
-  String get adminMetadataIdentify => 'Nhận dạng';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => 'Kiểu';
@@ -6848,7 +6842,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get adminReposRemove => 'Gỡ bỏ';
+  String get adminReposRemove => 'Di dời';
 
   @override
   String adminReposSaveFailed(String error) {
@@ -6979,20 +6973,19 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminBrandingEnableSplash => 'Bật màn hình giật gân';
 
   @override
-  String get adminBrandingSplashUpload => 'Tải hình ảnh lên';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => 'Đã cập nhật màn hình chờ';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed =>
-      'Không tải được màn hình chờ lên';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => 'Đã gỡ màn hình chờ';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => 'Không có màn hình chờ tùy chỉnh';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => 'Tăng tốc phần cứng';
@@ -7007,124 +7000,121 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => 'Bật giải mã phần cứng cho:';
 
   @override
-  String get adminPlaybackQsvDevice => 'Thiết bị QSV';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => 'Bật bộ giải mã NVDEC nâng cao';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
   String get adminPlaybackPreferNativeDecoder =>
-      'Ưu tiên bộ giải mã phần cứng gốc của hệ thống';
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => 'Độ sâu màu khi giải mã bằng phần cứng';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => 'Giải mã HEVC 10-bit';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => 'Giải mã VP9 10-bit';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'Giải mã HEVC RExt 8/10-bit';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'Giải mã HEVC RExt 12-bit';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => 'Mã hóa bằng phần cứng';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => 'Cho phép mã hóa HEVC';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => 'Cho phép mã hóa AV1';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
   String get adminPlaybackIntelLowPowerH264 =>
-      'Bật bộ mã hóa H.264 tiết kiệm điện của Intel';
+      'Enable Intel low-power H.264 encoder';
 
   @override
   String get adminPlaybackIntelLowPowerHevc =>
-      'Bật bộ mã hóa HEVC tiết kiệm điện của Intel';
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => 'Ánh xạ tông màu';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => 'Bật ánh xạ tông màu';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => 'Bật ánh xạ tông màu VPP';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
   String get adminPlaybackEnableVtTonemapping =>
-      'Bật ánh xạ tông màu VideoToolbox';
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => 'Thuật toán ánh xạ tông màu';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => 'Chế độ ánh xạ tông màu';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => 'Dải ánh xạ tông màu';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat =>
-      'Độ giảm bão hòa của ánh xạ tông màu';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => 'Đỉnh sáng của ánh xạ tông màu';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => 'Tham số ánh xạ tông màu';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
   String get adminPlaybackVppTonemappingBrightness =>
-      'Độ sáng ánh xạ tông màu VPP';
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast =>
-      'Độ tương phản ánh xạ tông màu VPP';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => 'Cấu hình sẵn & Chất lượng';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => 'Cấu hình sẵn của bộ mã hóa';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'CRF mã hóa H.264';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'CRF mã hóa H.265 (HEVC)';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => 'Phương pháp khử xen kẽ';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
   String get adminPlaybackDeinterlaceDoubleRate =>
-      'Nhân đôi tốc độ khung hình khi khử xen kẽ';
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => 'Âm thanh';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => 'Bật mã hóa âm thanh VBR';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => 'Tăng âm khi trộn xuống';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => 'Thuật toán trộn xuống Stereo';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue =>
-      'Kích thước hàng đợi ghép kênh tối đa';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => 'Tự động';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => 'Mã hóa';
@@ -7241,10 +7231,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminTaskNeverRun => 'Không bao giờ chạy';
 
   @override
-  String get adminTaskStop => 'Dừng';
+  String get adminTaskStop => 'Dừng lại';
 
   @override
-  String get adminRunningTasks => 'Tác vụ đang chạy';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => 'Chạy';
@@ -7314,8 +7304,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count giờ',
-      one: '1 giờ',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7361,27 +7351,27 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes phút';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours giờ';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days ngày';
+    return '${days}d';
   }
 
   @override
   String adminActivityDateShort(int month, int day) {
-    return '$day/$month';
+    return '$month/$day';
   }
 
   @override
   String get adminTrickplayDescription =>
-      'Thiết lập việc tạo ảnh Trickplay cho hình thu nhỏ xem trước khi tua.';
+      'Định cấu hình tạo hình ảnh thủ thuật để tìm kiếm hình thu nhỏ xem trước.';
 
   @override
   String get adminNetworkingPublicHttpsPort => 'Cổng HTTPS công cộng';
@@ -7390,49 +7380,49 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminNetworkingBaseUrl => 'URL cơ sở';
 
   @override
-  String get adminNetworkingBaseUrlHint => 'ví dụ: /jellyfin';
+  String get adminNetworkingBaseUrlHint => 'ví dụ. /vây thạch';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => 'Cổng HTTP công khai';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => 'Bắt buộc HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      'Chuyển hướng mọi yêu cầu từ xa sang HTTPS. Không có tác dụng nếu máy chủ không có chứng chỉ hợp lệ.';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => 'Mật khẩu chứng chỉ';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'Cài đặt IP';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => 'Bật IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => 'Bật IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => 'Bật ánh xạ cổng tự động';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => 'Mạng LAN';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      'Danh sách địa chỉ IP hoặc dải mạng CIDR được xem là thuộc mạng nội bộ, phân tách bằng dấu phẩy hoặc xuống dòng.';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => 'URI máy chủ được công bố';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      'Ánh xạ một dải mạng hoặc địa chỉ tới một URL được công bố, ví dụ: all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => 'Đường dẫn chứng chỉ';
@@ -7462,11 +7452,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => 'Bộ đệm ga';
 
   @override
-  String get adminPlaybackThrottleDelay => 'Độ trễ điều tiết (giây)';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
   String get adminPlaybackEnableSubtitleExtraction =>
-      'Cho phép trích xuất phụ đề tức thời';
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => 'Tỷ lệ sơ yếu lý lịch tối thiểu';
@@ -7522,22 +7512,22 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminGeneralSlowResponseThreshold => 'Ngưỡng phản hồi chậm (ms)';
 
   @override
-  String get adminGeneralEnableSlowResponse => 'Bật cảnh báo phản hồi chậm';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => 'Bật Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => 'Máy chủ';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => 'Siêu dữ liệu';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => 'Đường dẫn';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => 'Hiệu năng';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => 'Đường dẫn bộ đệm';
@@ -7549,7 +7539,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminGeneralServerName => 'Tên máy chủ';
 
   @override
-  String get adminGeneralDisplayLanguage => 'Ngôn ngữ hiển thị ưu tiên';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => 'Không tải được cài đặt';
@@ -7601,8 +7591,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# người tham gia',
-      one: '# người tham gia',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7750,8 +7740,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Đã tìm thấy # hàng',
-      one: 'Đã tìm thấy # hàng',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7792,21 +7782,20 @@ class AppLocalizationsVi extends AppLocalizations {
   String get offlineSavedMedia => 'Phương tiện đã lưu';
 
   @override
-  String get offlineBannerTitle => 'Bạn đang ngoại tuyến';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'Đang hiển thị các mục đã tải xuống';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'Tải xuống';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle =>
-      'Không kết nối được máy chủ của bạn';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Đang phát từ các mục đã tải xuống cho đến khi máy chủ hoạt động lại';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7879,41 +7868,40 @@ class AppLocalizationsVi extends AppLocalizations {
   String get pinForgot => 'Quên mã PIN?';
 
   @override
-  String get pinClear => 'Xóa';
+  String get pinClear => 'Thông thoáng';
 
   @override
   String get pinBackspace => 'Phím lùi';
 
   @override
-  String get quickConnectAuthorized => 'Đã phê duyệt yêu cầu Quick Connect.';
+  String get quickConnectAuthorized => 'Yêu cầu kết nối nhanh được ủy quyền.';
 
   @override
   String get quickConnectInvalidOrExpired =>
-      'Mã Quick Connect không hợp lệ hoặc đã hết hạn.';
+      'Mã Kết nối nhanh không hợp lệ hoặc đã hết hạn.';
 
   @override
   String get quickConnectNotSupported =>
-      'Máy chủ này không hỗ trợ Quick Connect.';
+      'Kết nối nhanh không được hỗ trợ trên máy chủ này.';
 
   @override
   String get quickConnectAuthorizeFailed =>
-      'Không phê duyệt được mã Quick Connect.';
+      'Không thể ủy quyền mã Kết nối nhanh.';
 
   @override
-  String get quickConnectDisabled =>
-      'Quick Connect đã bị tắt trên máy chủ này.';
+  String get quickConnectDisabled => 'Kết nối nhanh bị tắt trên máy chủ này.';
 
   @override
   String get quickConnectForbidden =>
-      'Tài khoản của bạn không thể phê duyệt yêu cầu Quick Connect này.';
+      'Tài khoản của bạn không thể ủy quyền yêu cầu Kết nối nhanh này.';
 
   @override
   String get quickConnectNotFound =>
-      'Không tìm thấy mã Quick Connect. Hãy thử mã mới.';
+      'Không tìm thấy mã Kết nối nhanh. Hãy thử một mã mới.';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect thất bại: $message';
+    return 'Kết nối nhanh không thành công: $message';
   }
 
   @override
@@ -8080,7 +8068,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Việc phát lại đã bị tạm dừng. Bạn vẫn đang xem chứ?';
 
   @override
-  String get stillWatchingStop => 'Dừng';
+  String get stillWatchingStop => 'Dừng lại';
 
   @override
   String get stillWatchingContinue => 'Tiếp tục';
@@ -8164,13 +8152,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get contextMenuGoToSeries => 'Đi tới loạt bài';
 
   @override
-  String get contextMenuHideFromContinueWatching => 'Ẩn khỏi Tiếp tục xem';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => 'Ẩn khỏi Tiếp theo';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => 'Thêm vào bộ sưu tập';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => 'Truy cập bảng quản trị máy chủ';
@@ -8223,14 +8212,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsAlphabetical => 'theo bảng chữ cái';
 
   @override
-  String get settingsConnectionSection => 'KẾT NỐI';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => 'Cho phép chứng chỉ tự ký';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      'Tin cậy các máy chủ dùng chứng chỉ TLS tự ký hoặc từ CA riêng. Chỉ bật với những máy chủ bạn kiểm soát. Tùy chọn này sẽ tắt việc xác thực chứng chỉ cho mọi kết nối.';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => 'RIÊNG TƯ & AN TOÀN';
@@ -8246,11 +8235,11 @@ class AppLocalizationsVi extends AppLocalizations {
       'Điểm nhấn của chủ đề, phông nền, chỉ báo đã xem và nhạc chủ đề';
 
   @override
-  String get settingsDetailsScreen => 'Màn hình chi tiết';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
   String get settingsDetailsScreenSubtitle =>
-      'Kiểu, làm mờ nền và cách hoạt động của thẻ';
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => 'Trang chủ';
@@ -8288,11 +8277,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Hiển thị nút Seerr trên thanh điều hướng';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsAlwaysExpandNavbarLabels =>
-      'Luôn hiển thị nhãn chữ trên thanh điều hướng phía trên';
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8362,7 +8351,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Mời nhà phát triển một ly cà phê';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'HỢP PHÁP';
@@ -8395,8 +8384,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# thông báo giấy phép',
-      one: '# thông báo giấy phép',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8445,16 +8434,16 @@ class AppLocalizationsVi extends AppLocalizations {
       'Bỏ qua phần giới thiệu và phần kết thúc?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Đếm ngược phân đoạn phương tiện';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Thanh tiến trình';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Bộ đếm giờ';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Không có';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Nhắc người dùng';
@@ -8681,7 +8670,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '$libraryName mới phát hành';
+    return 'Recently Released $libraryName';
   }
 
   @override
@@ -8714,11 +8703,11 @@ class AppLocalizationsVi extends AppLocalizations {
       'Buộc phát lại không theo đường hầm. Hữu ích trên các thiết bị có sự gián đoạn về âm thanh/video trong đường hầm.';
 
   @override
-  String get enableTunnelingTitle => 'Bật tunneling';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Nâng cao. Định tuyến âm thanh và video qua một đường phần cứng ghép đôi. Mặc định tắt vì gây mất tiếng hoặc mất hình trên một số thiết bị.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
   String get mapDolbyVisionP7Title => 'Ánh xạ hồ sơ Dolby Vision 7 tới HEVC';
@@ -8743,14 +8732,14 @@ class AppLocalizationsVi extends AppLocalizations {
       'Áp dụng gợi ý về kích thước phông chữ được nhúng trong phụ đề. Tắt để sử dụng kích thước phụ đề từ tùy chọn kiểu của bạn.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Hiển thị chi tiết nội dung';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Hiển thị chi tiết của mục đang chọn ở đầu trang Thư viện.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => 'Ẩn ảnh nền khi duyệt?';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Sử dụng các tiêu đề phụ chi tiết';
@@ -8768,37 +8757,37 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Kho chủ đề';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => 'Duyệt và lưu các chủ đề từ cộng đồng';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
   String get themeStoreDescription =>
-      'Lưu một chủ đề để dùng như các chủ đề đã lưu khác của bạn.';
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => 'Hiện chưa có chủ đề nào.';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
   String get themeStoreLoadFailed =>
-      'Không tải được Kho chủ đề. Hãy kiểm tra kết nối và thử lại.';
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => 'Lưu';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => 'Lưu & áp dụng';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => 'Đã lưu';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => 'Không tải được chủ đề này.';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return 'Đã lưu \"$themeName\".';
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -8857,21 +8846,21 @@ class AppLocalizationsVi extends AppLocalizations {
   String get homeRowsSection => 'Hàng nhà';
 
   @override
-  String get homeRowDisplay => 'Hiển thị hàng trang chủ';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Các mục hàng trang chủ';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Bật/tắt hàng trang chủ';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Bật hoặc tắt các danh mục hàng trang chủ dựa trên thư viện';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Bật các mục sau để hiển thị các hàng trong phần Trang chủ.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Loại hàng';
@@ -8930,56 +8919,55 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị Phim, Bộ hoặc cả hai trong hàng Thể loại.';
 
   @override
-  String get displayPlaylistsRows => 'Hiển thị hàng danh sách phát';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Hiển thị các hàng danh sách phát trong phần Trang chủ.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Sắp xếp hàng danh sách phát';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sắp xếp hàng danh sách phát theo ngày thêm, ngày phát hành, theo bảng chữ cái và nhiều tiêu chí khác.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Hiển thị hàng âm thanh';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle =>
-      'Hiển thị các hàng âm thanh trong phần Trang chủ.';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => 'Sắp xếp hàng âm thanh';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
   String get audioRowsSortingDescription =>
-      'Sắp xếp hàng âm thanh theo ngày thêm, ngày phát hành, theo bảng chữ cái và nhiều tiêu chí khác.';
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => 'Danh sách phát âm thanh';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => 'Giao diện';
+  String get appearance => 'Vẻ bề ngoài';
 
   @override
-  String get layout => 'Bố cục';
+  String get layout => 'Layout';
 
   @override
-  String get theme => 'Chủ đề';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => 'Bàn phím';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => 'Nút';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => 'Kết xuất';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'Cấu hình MPV';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Kích thước thẻ';
@@ -8989,7 +8977,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get externalPlayerAppDescription =>
-      'Thiết lập trình phát ngoài để bật tùy chọn phát khi nhấn giữ';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -9257,7 +9245,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get appearancesSeerr => 'Xuất hiện (Seerr)';
 
   @override
-  String get crewContributionsSeerr => 'Đóng góp của ê-kíp (Seerr)';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
   String get watchWithGroup => 'Xem cùng nhóm';
@@ -9343,8 +9331,8 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Thư viện',
-      one: '1 Thư viện',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
@@ -9435,7 +9423,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mixedMoviesAndShows => 'Phim và chương trình tổng hợp';
 
   @override
-  String get intelQuickSync => 'Intel Quick Sync';
+  String get intelQuickSync => 'Đồng bộ hóa nhanh Intel';
 
   @override
   String get rockchipMpp => 'Rockchip MPP';
@@ -9503,13 +9491,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get loadingShuffle => 'Đang tải ngẫu nhiên...';
 
   @override
-  String get libraryShuffleLabel => 'PHÁT NGẪU NHIÊN THƯ VIỆN';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'PHÁT NGẪU NHIÊN TOÀN BỘ';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'PHÁT NGẪU NHIÊN THEO THỂ LOẠI';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
   String get autoHdrSwitching => 'Tự động chuyển đổi HDR';
@@ -9522,222 +9510,222 @@ class AppLocalizationsVi extends AppLocalizations {
   String get whenFullscreen => 'Khi toàn màn hình';
 
   @override
-  String get changeArtwork => 'Đổi ảnh bìa';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Chưa có';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Giới hạn chuyển mã';
 
   @override
-  String get clearAllArtworkButton => 'Xóa toàn bộ ảnh bìa?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Bạn có chắc muốn xóa toàn bộ ảnh bìa đã tải xuống không?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Xác nhận xóa';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Bạn có chắc muốn xóa $itemType này không?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Tải lên?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Độ phân giải: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Chỉ hiển thị ảnh bìa theo ngôn ngữ giao diện';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Xác nhận xóa tất cả';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Đã tải hình ảnh lên thành công!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Không tải được hình ảnh lên: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Không đặt được hình ảnh: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Không xóa được hình ảnh: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Không xóa được toàn bộ ảnh bìa: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Có';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Áp phích';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Ảnh nền';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Biểu ngữ';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Hình thu nhỏ';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Ảnh minh họa';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Ảnh mặt đĩa';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ảnh chụp màn hình';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Bìa hộp';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Bìa sau hộp';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Ảnh menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'áp phích';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'ảnh nền';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'biểu ngữ';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'hình thu nhỏ';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'ảnh minh họa';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'ảnh mặt đĩa';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ảnh chụp màn hình';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'bìa hộp';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'bìa sau hộp';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'ảnh menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Tất cả';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Cao (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Trung bình (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Thấp (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Nguồn';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => 'Chương';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => 'Dấu trang';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => 'Ghi chú';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => 'Hàng đợi';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => 'Dòng thời gian';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => 'Dòng thời gian trống';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Toàn bộ sách';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => 'Dòng thời gian thu hẹp';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => 'Xuất dấu trang';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => 'Xuất ghi chú';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => 'Xuất tất cả';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return 'Đã xuất tới $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return 'Xuất thất bại: $error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => 'Lời bài hát';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => 'Thêm dấu trang';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => 'Thêm ghi chú';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => 'Sửa ghi chú';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => 'Viết ghi chú cho khoảnh khắc này';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => 'Hẹn giờ tắt';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => 'Tắt';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => 'Hết chương';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => 'Tùy chỉnh';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return 'Còn $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9745,58 +9733,58 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count phút',
-      one: '1 phút',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => 'Tốc độ phát';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => 'Còn lại';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => 'Đã phát';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return 'Lùi $seconds giây';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return 'Tiến $seconds giây';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => 'Chương trước';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => 'Chương sau';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return 'Chương $current trên $total';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => 'Không có chương';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => 'Chưa có dấu trang nào';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => 'Chưa có ghi chú nào';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return 'Đã thêm dấu trang tại $position';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => 'Đặt lại về 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9804,254 +9792,249 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => 'Lưu';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => 'Hủy';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => 'Xóa';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => 'Tùy chọn phụ đề';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
   String get subtitlePreferencesDescription =>
-      'Thay đổi chế độ phụ đề, ngôn ngữ mặc định, giao diện và các tùy chọn kết xuất.';
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => 'Kết xuất phụ đề';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => 'Tùy chọn hiển thị';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => 'Ngày phát hành (Tăng dần)';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => 'Ngày phát hành (Giảm dần)';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => 'Nhóm các đóng góp';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => 'Nhóm nhiều vai trò';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle =>
-      'Cảnh báo quyền ghi vào thư viện';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => 'Cách khắc phục:';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. Cấp quyền ghi cho người dùng dịch vụ Jellyfin (ví dụ: jellyfin hoặc PUID/PGID của Docker) đối với các thư mục thư viện phương tiện của bạn trên máy chủ.\n\n2. Hoặc vào Bảng điều khiển Jellyfin -> Thư viện, sửa thư viện này và tắt \'Save artwork into media folders\' để lưu ảnh bìa trong cơ sở dữ liệu nội bộ của Jellyfin.';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => 'Bỏ qua';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return 'Thư viện \'$libraryName\' của bạn được cấu hình để lưu ảnh bìa trực tiếp vào thư mục phương tiện (tùy chọn \'Save artwork into media folders\' đang bật). Tuy nhiên, Jellyfin đã kiểm tra quyền ghi và không có quyền ghi tệp vào thư mục này:\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      'Có vẻ Jellyfin không cập nhật được ảnh bìa. Thư viện của bạn được cấu hình để lưu ảnh bìa trực tiếp vào thư mục phương tiện (tùy chọn \'Save artwork into media folders\' đang bật). Lỗi này thường xảy ra khi tiến trình máy chủ Jellyfin không có quyền ghi tệp vào các thư mục phương tiện của bạn.';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'Danh sách bên ngoài';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => 'Phát lại';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => 'Thông tin tệp';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return 'Kích thước: $size  •  Định dạng: $format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return 'Hiện tất cả ($count) bản âm thanh';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return 'Hiện tất cả ($count) bản phụ đề';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => 'Đang kiểm tra khả năng Phát trực tiếp...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => 'Khả năng Phát trực tiếp: ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => 'Bắt buộc';
+  String get forced => 'Forced';
 
   @override
   String get transcodeContainerNotSupported =>
-      'Trình phát không hỗ trợ định dạng vùng chứa này.';
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => 'Không hỗ trợ codec video này.';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported =>
-      'Không hỗ trợ codec âm thanh này.';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
   String get transcodeSubtitleCodecNotSupported =>
-      'Không hỗ trợ định dạng phụ đề này (cần ghi đè vào hình).';
+      'Subtitle format is not supported (requires burning).';
 
   @override
   String get transcodeAudioProfileNotSupported =>
-      'Không hỗ trợ hồ sơ âm thanh này.';
+      'Audio profile is not supported.';
 
   @override
   String get transcodeVideoProfileNotSupported =>
-      'Không hỗ trợ hồ sơ video này.';
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported =>
-      'Không hỗ trợ cấp độ video này.';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
   String get transcodeVideoResolutionNotSupported =>
-      'Thiết bị này không hỗ trợ độ phân giải video này.';
+      'Video resolution is not supported by this device.';
 
   @override
   String get transcodeVideoBitDepthNotSupported =>
-      'Không hỗ trợ độ sâu bit của video này.';
+      'Video bit depth is not supported.';
 
   @override
   String get transcodeVideoFramerateNotSupported =>
-      'Không hỗ trợ tốc độ khung hình của video này.';
+      'Video framerate is not supported.';
 
   @override
   String get transcodeContainerBitrateExceedsLimit =>
-      'Tốc độ bit của tệp vượt quá giới hạn truyền của trình phát.';
+      'File bitrate exceeds player streaming limit.';
 
   @override
   String get transcodeVideoBitrateExceedsLimit =>
-      'Tốc độ bit video vượt quá giới hạn truyền.';
+      'Video bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioBitrateExceedsLimit =>
-      'Tốc độ bit âm thanh vượt quá giới hạn truyền.';
+      'Audio bitrate exceeds streaming limit.';
 
   @override
   String get transcodeAudioChannelsNotSupported =>
-      'Không hỗ trợ số kênh âm thanh này.';
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => 'Theo bảng chữ cái';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => 'Thứ tự phát hành (Tăng dần)';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => 'Thứ tự phát hành (Giảm dần)';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => 'Tùy chỉnh (Kéo và thả)';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => 'Tùy chọn sắp xếp danh sách phát';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => 'Đặt lại sắp xếp';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return 'Xem lại S$season:E$episode';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => 'Danh sách phát xem lại';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => 'Không tìm thấy phụ đề.';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => 'Điều khiển quản trị';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => 'Công cụ kết xuất (Impeller)';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller là bộ kết xuất GPU hiện đại của Flutter, cho hoạt ảnh mượt hơn và ít giật hơn. Trên một số hộp TV và GPU đời cũ, nó có thể gây lỗi hiển thị hoặc video đen; hãy Tắt nếu bạn gặp tình trạng đó. Tự động sẽ chọn mặc định phù hợp nhất cho thiết bị của bạn. Khởi động lại Moonfin để áp dụng.';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => 'Tự động';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => 'Bật';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => 'Tắt';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => 'Cần khởi động lại';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin cần khởi động lại để đổi công cụ kết xuất. Hãy đóng ứng dụng ngay bây giờ, sau đó mở lại để áp dụng.';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => 'Đóng ứng dụng ngay';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => 'Làm mới thư viện';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => 'Làm mới tất cả thư viện';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => 'Ngày thêm (Cũ nhất trước)';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => 'Ngày thêm (Mới nhất trước)';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => 'Theo bảng chữ cái (A đến Z)';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => 'Theo bảng chữ cái (Z đến A)';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return 'Đang tải phân tích máy chủ... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => 'Theo nguồn';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => '250 phim hàng đầu trên IMDb';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => '250 chương trình TV hàng đầu trên IMDb';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'Phim phổ biến nhất trên IMDb';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows =>
-      'Chương trình TV phổ biến nhất trên IMDb';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'Phim bị đánh giá thấp nhất trên IMDb';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies =>
-      'Phim tiếng Anh được đánh giá cao nhất trên IMDb';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -12,27 +12,27 @@ class AppLocalizationsYue extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => '帳戶偏好設定';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => '介面語言';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => '系統預設';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => '登入';
 
   @override
-  String get empty => '空';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return '連接緊 $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => '快速連接';
 
   @override
   String get password => '密碼';
@@ -50,7 +50,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get waitingForAuthorization => '等待授權...';
 
   @override
-  String get back => '返回';
+  String get back => '後退';
 
   @override
   String get serverUnavailable => '伺服器不可用';
@@ -60,12 +60,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect 用唔到：$detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect 用唔到（$status）：$detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -79,7 +79,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin 版本 $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -105,14 +105,14 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '確定要喺你嘅伺服器清單度移除「$serverName」？';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => '取消';
 
   @override
-  String get remove => '移除';
+  String get remove => '消除';
 
   @override
   String get connectToServer => '連接到伺服器';
@@ -140,59 +140,62 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsAppearanceTheme => '應用主題';
 
   @override
-  String get detailScreenStyle => '詳細資料頁樣式';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      '「經典」係 Moonfin 原本嘅置中版面。「現代」係自適應嘅電影感版面。';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => '經典';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => '現代';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => '展開分頁';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
-  String get expandedTabsSubtitle => '瀏覽分頁嗰陣自動顯示內容。閂咗就要自己逐個分頁開合。';
+  String get expandedTabsSubtitle =>
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => '顯示技術詳情？';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
-  String get showTechnicalDetailsSubtitle => '喺橫幅摘要度顯示編解碼器、解析度同串流資訊';
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => '推薦系統';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      '用 Moonfin Recommends 嘅本機媒體庫演算法，或者網上 TMDb 嘅相似度指標。注意：網上推薦需要整合 Seerr。';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb 相似度';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
-  String get recommendationsApplyParentalRatingCap => '套用家長分級上限？';
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      '根據目標媒體嘅家長分級嚟限制 Moonfin Recommends 嘅建議';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => '介面風格';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      '「自動」會配合你部裝置。揀「Apple」或者「Material」就可以指定外觀。';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => '自動';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -201,36 +204,38 @@ class AppLocalizationsYue extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => '玻璃效果品質';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      '「自動」會為呢部裝置揀最啱嘅玻璃效果。「完整」會強制用真實模糊；「精簡」用輕量玻璃，慳返 GPU 電力。';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
-  String get glassQualityAuto => '自動';
+  String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => '完整';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => '精簡';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
       '在 Moonfin 和 Neon Pulse 之間切換，無需重新啟動應用程式';
 
   @override
-  String get customThemeTitle => '自訂主題';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
-  String get customThemeSubtitle => '自訂主題會改變成個 Moonfin 嘅視覺元素。揀一個啱你風格嘅選項啦。';
+  String get customThemeSubtitle =>
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => '優先用系統鍵盤';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
-  String get keyboardPreferSystemImeDescription => '預設用你部裝置嘅輸入法嚟打字';
+  String get keyboardPreferSystemImeDescription =>
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -239,22 +244,24 @@ class AppLocalizationsYue extends AppLocalizations {
   String get themeMoonfinSubtitle => '目前的 Moonfin 外觀你們都喜歡';
 
   @override
-  String get themeNeonPulse => '霓虹脈動';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle => 'Synthwave 風格具有洋紅色發光、青色文字和更強的鍍鉻對比度';
 
   @override
-  String get themeGlass => '玻璃';
+  String get themeGlass => 'Glass';
 
   @override
-  String get themeGlassSubtitle => '液態玻璃風格，配流動漸層背景、霧面表面同 Apple 藍點綴';
+  String get themeGlassSubtitle =>
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
-  String get theme8BitHero => '8-bit 英雄';
+  String get theme8BitHero => '8-bit Hero';
 
   @override
-  String get theme8BitHeroSubtitle => '復古像素風格，配粗獷色盤、方塊邊框、硬陰影同像素字體';
+  String get theme8BitHeroSubtitle =>
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle => '使用您的 Emby Connect 帳戶登入';
@@ -297,7 +304,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return '連接唔到 $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -310,34 +317,35 @@ class AppLocalizationsYue extends AppLocalizations {
   String get exit => '出口';
 
   @override
-  String get gameMenu => '選單';
+  String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => '已暫停';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => '即時存檔';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get games => '遊戲';
+  String get games => 'Games';
 
   @override
-  String get gameLoadState => '讀取存檔';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameFastForward => '快進';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameEmulatorSettings => '模擬器設定';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameNoCoreOptions => '呢個核心冇任何可以調整嘅選項。';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
 
   @override
-  String get gameHoldToOpenMenu => '撳住開選單';
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
-  String get gamePlaybackUnsupported => '呢部裝置暫時仲未支援玩遊戲。';
+  String get gamePlaybackUnsupported =>
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => '無法載入主行';
@@ -352,19 +360,19 @@ class AppLocalizationsYue extends AppLocalizations {
   String get guide => '指導';
 
   @override
-  String get recordings => '錄影';
+  String get recordings => '錄音';
 
   @override
   String get schedule => '行程';
 
   @override
-  String get series => '劇集';
+  String get series => '系列';
 
   @override
   String get noItemsFound => '沒有找到物品';
 
   @override
-  String get home => '主頁';
+  String get home => '家';
 
   @override
   String get browseAll => '瀏覽全部';
@@ -394,7 +402,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get noLibrariesFound => '沒有找到庫';
 
   @override
-  String get library => '媒體庫';
+  String get library => '圖書館';
 
   @override
   String get displaySettings => '顯示設定';
@@ -407,7 +415,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return '載入唔到資料夾：$error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -415,7 +423,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count 個項目';
+    return '$count items';
   }
 
   @override
@@ -432,7 +440,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count 個項目';
+    return '$count Items';
   }
 
   @override
@@ -473,7 +481,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — 類型';
+    return '$name — Genres';
   }
 
   @override
@@ -486,7 +494,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get albumArtists => '專輯藝人';
 
   @override
-  String get artists => '歌手';
+  String get artists => '藝術家';
 
   @override
   String get bookmarks => '書籤';
@@ -511,17 +519,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return '$count 分鐘前';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count 小時前';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count 日前';
+    return '${count}d ago';
   }
 
   @override
@@ -531,7 +539,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get pickDiscoverySubjects => '選擇要在「發現」中顯示的主題來源。';
 
   @override
-  String get apply => '套用';
+  String get apply => '申請';
 
   @override
   String get openLink => '打開連結';
@@ -553,7 +561,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String titlesCount(int count) {
-    return '$count 部作品';
+    return '$count titles';
   }
 
   @override
@@ -578,7 +586,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get listen => '聽';
 
   @override
-  String get resume => '繼續';
+  String get resume => '恢復';
 
   @override
   String get failedToLoadLibrary => '載入庫失敗';
@@ -633,17 +641,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count 位作者';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count 種類型';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '已完成 $percent%';
+    return '$percent% completed';
   }
 
   @override
@@ -660,11 +668,11 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count 部作品，以閱讀為先嘅方式排好。';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => '作品';
+  String get titles => '標題';
 
   @override
   String get allTitles => '所有標題';
@@ -695,7 +703,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return '搵唔到$label';
+    return 'No $label found';
   }
 
   @override
@@ -714,13 +722,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get readStatus => '讀';
 
   @override
-  String get watched => '睇咗';
+  String get watched => '看過';
 
   @override
   String get unread => '未讀';
 
   @override
-  String get unwatched => '未睇';
+  String get unwatched => '無人看管';
 
   @override
   String get seriesStatus => '系列狀態';
@@ -732,43 +740,43 @@ class AppLocalizationsYue extends AppLocalizations {
   String get books => '圖書';
 
   @override
-  String get latestBooks => '最新書籍';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => '最新有聲書';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 本書',
-      one: '1 本書',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => '書籍';
+  String get bookFormatBook => 'Book';
 
   @override
-  String get bookFormatAudiobook => '有聲書';
+  String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '已讀 $percent%';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '仲有 $time';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => '閱讀';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => '收聽';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => '作者';
@@ -805,12 +813,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count 個章節';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return '首次出版於 $year';
+    return 'First published $year';
   }
 
   @override
@@ -824,7 +832,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String booksCount(int count) {
-    return '$count 本書';
+    return '$count books';
   }
 
   @override
@@ -835,7 +843,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count 位作者';
+    return '$count Authors';
   }
 
   @override
@@ -843,8 +851,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 本有聲書',
-      one: '1 本有聲書',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -862,7 +870,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get delete => '刪除';
 
   @override
-  String get save => '儲存';
+  String get save => '節省';
 
   @override
   String get moreLikeThis => '更多類似的';
@@ -880,7 +888,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get nextUp => '下一步';
 
   @override
-  String get seasons => '季';
+  String get seasons => '季節';
 
   @override
   String get chapters => '章節';
@@ -892,7 +900,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get movies => '電影';
 
   @override
-  String get musicVideos => '音樂影片';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => '其他';
@@ -911,7 +919,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return '第 $number 碟';
+    return 'Disc $number';
   }
 
   @override
@@ -934,7 +942,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String published(int year) {
-    return '$year 年出版';
+    return 'Published $year';
   }
 
   @override
@@ -945,52 +953,52 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 季',
-      one: '1 季',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time 結束';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => '項目';
+  String get items => 'Items';
 
   @override
-  String get extras => '特別收錄';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => '幕後花絮';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => '刪剪片段';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => '特輯';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => '訪談';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => '片段';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => '短片';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => '預告片';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '仲有 $time';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return '$time 後結束';
+    return 'Ends in $time';
   }
 
   @override
@@ -1004,11 +1012,11 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return '由 $position 繼續播放';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => '播放';
+  String get play => '玩';
 
   @override
   String get startOver => '重新開始';
@@ -1032,10 +1040,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get version => '版本';
 
   @override
-  String get cast => '投放';
+  String get cast => '投擲';
 
   @override
-  String get trailer => '預告片';
+  String get trailer => '拖車';
 
   @override
   String get finished => '完成的';
@@ -1102,7 +1110,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '確定要刪除「$title」已下載嘅曲目？';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1116,17 +1124,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '未載入到任何$itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '下載緊 $title（$count 個項目）...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '你確定要喺伺服器度刪除「$name」？呢個動作冇得復原。';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -1137,7 +1145,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return '唔支援嘅書籍格式：.$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1147,7 +1155,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get subtitleTrack => '字幕軌道';
 
   @override
-  String get none => '冇';
+  String get none => '沒有任何';
 
   @override
   String get downloadSubtitlesLabel => '下載字幕...';
@@ -1163,7 +1171,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return '字幕已下載並選用：$name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1172,7 +1180,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '搵唔到 $language 嘅遠端字幕。';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -1180,7 +1188,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String versionNumber(int number) {
-    return '版本 $number';
+    return 'Version $number';
   }
 
   @override
@@ -1200,7 +1208,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '下載緊 $name（$quality）...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1208,7 +1216,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '確定要刪除$typeLabel嘅本機檔案？\n\n咁樣可以騰返啲儲存空間。你之後可以再下載返。';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1224,25 +1232,25 @@ class AppLocalizationsYue extends AppLocalizations {
   String get director => '導演';
 
   @override
-  String get directors => '導演';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => '編劇';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => '編劇';
+  String get writers => '作家';
 
   @override
   String get studio => '工作室';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count 個';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count 集';
+    return '$count Episodes';
   }
 
   @override
@@ -1252,12 +1260,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return '第 $number 集';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '第 $number 章';
+    return 'Chapter $number';
   }
 
   @override
@@ -1265,8 +1273,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 首曲目',
-      one: '1 首曲目',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1276,25 +1284,25 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 個章節',
-      one: '1 個章節',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return '$date 出世';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return '$date 逝世';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return '$age 歲';
+    return 'Age $age';
   }
 
   @override
@@ -1307,17 +1315,17 @@ class AppLocalizationsYue extends AppLocalizations {
   String get shuffle => '隨機播放';
 
   @override
-  String get shuffleAllMusic => '隨機播放所有音樂';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => '用你部電話登入 Moonfin';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => '連唔到你個伺服器';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count 次下載';
+    return '$count downloads';
   }
 
   @override
@@ -1325,43 +1333,43 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '$count 聲道';
+    return '${count}ch';
   }
 
   @override
-  String get mono => '單聲道';
+  String get mono => '單核白血球增多症';
 
   @override
   String get stereo => '立體聲';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '遠端字幕$action需要呢個使用者有 Jellyfin 嘅字幕管理權限。';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return '喺伺服器度搵唔到呢個項目，冇辦法$action遠端字幕。';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '遠端字幕$action失敗：$detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '遠端字幕$action失敗（HTTP $status）。';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return '冇辦法$action遠端字幕。';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '「$name」所有已下載嘅集數';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1389,17 +1397,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label 動作失敗：$error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return '設定唔到投放音量：$error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label 控制';
+    return '$label Controls';
   }
 
   @override
@@ -1416,7 +1424,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String stopCast(String label) {
-    return '停止 $label';
+    return 'Stop $label';
   }
 
   @override
@@ -1424,7 +1432,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return '曲目 $number';
+    return 'Track $number';
   }
 
   @override
@@ -1441,14 +1449,14 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds 秒';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => '長按解鎖';
 
   @override
-  String get off => '關';
+  String get off => '離開';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1483,7 +1491,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get subtitleDelay => '字幕延遲';
 
   @override
-  String get reset => '重設';
+  String get reset => '重置';
 
   @override
   String get unknown => '未知';
@@ -1510,7 +1518,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get transcodeReasons => '轉碼原因';
 
   @override
-  String get player => '播放器';
+  String get player => '玩家';
 
   @override
   String get container => '容器';
@@ -1534,7 +1542,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get videoBitrate => '視訊比特率';
 
   @override
-  String get track => '音軌';
+  String get track => '追蹤';
 
   @override
   String get channels => '頻道';
@@ -1556,12 +1564,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol 工作階段錯誤';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return '載入唔到書籍詳情：$error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1569,7 +1577,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return '呢個格式（.$extension）暫時仲未可以喺應用程式入面顯示。';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1580,17 +1588,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return '開唔到應用程式內閱讀器：$error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label 度已經有書籤喇。';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return '已加入書籤：$label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1601,7 +1609,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return '第 $number 頁';
+    return 'Page $number';
   }
 
   @override
@@ -1612,12 +1620,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String formatExtension(String extension) {
-    return '格式：.$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '已讀 $percent%';
+    return '$percent% read';
   }
 
   @override
@@ -1640,7 +1648,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return '重設縮放（${zoom}x）';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -1663,7 +1671,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return '更新唔到閱讀狀態：$error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -1695,7 +1703,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '呢個平台冇辦法載入 $extension 檔案嘅內嵌文件引擎。';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1734,7 +1742,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return '載入唔到節目表：$error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1745,22 +1753,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return '下一個：$time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '仲有 $minutes 分鐘';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '仲有 $hours 小時';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '仲有 $hours 小時 $minutes 分鐘';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1782,29 +1790,29 @@ class AppLocalizationsYue extends AppLocalizations {
   String get favoriteChannel => '最喜歡的頻道';
 
   @override
-  String get record => '錄影';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => '取消錄影';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => '已排定錄影';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => '已取消錄影';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => '冇辦法建立錄影';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => '睇';
+  String get watch => '手錶';
 
   @override
   String get close => '關閉';
 
   @override
   String failedToPlayChannel(String name) {
-    return '播放唔到 $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1830,11 +1838,11 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '確定要取消「$name」嘅排定錄影？';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => '唔係';
+  String get no => '不';
 
   @override
   String get yesCancel => '是，取消';
@@ -1856,7 +1864,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return '確定要停止錄影「$name」？';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1870,19 +1878,19 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return '搵唔到「$query」嘅結果';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return '搜尋失敗：$error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr 帳戶類型';
+  String get seerrAccountType => '西爾帳戶類型';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -1916,12 +1924,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String removeItemAndFiles(String name) {
-    return '確定要移除「$name」同埋佢嘅檔案？';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count 首曲目';
+    return '$count tracks';
   }
 
   @override
@@ -1932,16 +1940,16 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return '載入唔到專輯：$error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '搵唔到 $name 已下載嘅曲目。';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => '季';
+  String get season => '季節';
 
   @override
   String get errorLoadingEpisodes => '載入劇集時出錯';
@@ -1954,22 +1962,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return '確定要移除「$name」？';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes 分鐘';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return '第$season季 第$episode集';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return '第 $number 集';
+    return 'Episode $number';
   }
 
   @override
@@ -1983,12 +1991,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return '第 $number 季';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return '第$number季';
+    return 'S$number';
   }
 
   @override
@@ -1999,7 +2007,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '確定要刪除 $season 所有已下載嘅集數？';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2007,8 +2015,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 集',
-      one: '1 集',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2042,7 +2050,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return '確定要刪除 $count 個已下載嘅項目？';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2056,7 +2064,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return '上限 $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -2136,7 +2144,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count 個選項';
+    return '$count options';
   }
 
   @override
@@ -2224,7 +2232,8 @@ class AppLocalizationsYue extends AppLocalizations {
   String get themeMusicVolume => '主題音樂音量';
 
   @override
-  String get themeMusicSettingsSubtitle => '詳細資料頁、主畫面列表同音量';
+  String get themeMusicSettingsSubtitle =>
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2238,10 +2247,11 @@ class AppLocalizationsYue extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => '瀏覽主畫面時播放';
 
   @override
-  String get loopThemeMusic => '循環播放主題音樂';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
-  String get loopThemeMusicSubtitle => '重複播放呢首曲目，唔係淨係播一次';
+  String get loopThemeMusicSubtitle =>
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => '細節背景模糊';
@@ -2264,22 +2274,23 @@ class AppLocalizationsYue extends AppLocalizations {
   String get playerZoomMode => '播放器縮放模式';
 
   @override
-  String get settingsScrollWheelAction => '滑鼠滾輪';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
-  String get settingsScrollWheelActionDescription => '揀播放嗰陣喺畫面上面碌滑鼠滾輪會做啲乜。';
+  String get settingsScrollWheelActionDescription =>
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => '關';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => '跳轉（前 / 後）';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => '音量';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => '音量';
+  String get playerTooltipVolume => 'Volume';
 
   @override
   String get fit => '合身';
@@ -2294,7 +2305,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get refreshRateSwitching => '刷新率切換';
 
   @override
-  String get disabled => '已停用';
+  String get disabled => '殘障人士';
 
   @override
   String get scaleOnTv => '在電視上縮放';
@@ -2330,34 +2341,37 @@ class AppLocalizationsYue extends AppLocalizations {
   String get defaultAudioLanguage => '預設音訊語言';
 
   @override
-  String get fallbackAudioLanguage => '備用音訊語言';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => '優先用預設音軌';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
-  String get preferDefaultAudioTrackDescription => '優先用原聲音軌，唔用本地配音。';
+  String get preferDefaultAudioTrackDescription =>
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => '優先用口述影像音軌';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
-  String get preferAudioDescriptionDescription => '優先用口述影像音軌，唔用普通音軌。';
+  String get preferAudioDescriptionDescription =>
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => '轉碼（音訊）';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => '直接串流（重新封裝）';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
-  String get transcodingBitrateOrResolution => '轉碼（位元率或解析度）';
+  String get transcodingBitrateOrResolution =>
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => '轉碼（視訊同音訊）';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => '轉碼（視訊）';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => '自動（伺服器預設）';
@@ -2432,141 +2446,142 @@ class AppLocalizationsYue extends AppLocalizations {
   String get enableTrueHdAudio => '啟用 TrueHD 音訊（可能不適用於所有平台）';
 
   @override
-  String get settingsAudioOutputMode => '音訊輸出模式';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      '揀點樣解碼音訊。「AVR 直通」會將原始嘅 Dolby/DTS 串流送去你部擴音機；「自動」或者「縮混」就會喺本機解碼。';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR 直通';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => '備用音訊編解碼器';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      '揀當來源串流冇辦法直接播放或者直通嗰陣，多聲道音訊要轉碼成咩格式。';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => '自動偵測\n（建議）';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n（預設）';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
-  String get settingsAudioFallbackCodecAc3 => 'AC3\n（Dolby Digital）';
+  String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
 
   @override
-  String get settingsAudioFallbackCodecEac3 => 'EAC3\n（Dolby Digital Plus）';
+  String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n（無損）';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n（淨係支援立體聲）';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n（高效率）';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n（無損）';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => '最大音訊聲道數';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      '設定你音響系統嘅最大聲道數。超過呢個上限嘅多聲道串流會縮混或者轉碼。';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => '自動偵測\n（硬件預設）';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
-  String get settingsMaxAudioChannelsMono => '1.0 單聲道';
+  String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 立體聲';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 環繞聲';
+  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 四聲道';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 環繞聲';
+  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels5_1 => '5.1 環繞聲';
+  String get settingsMaxAudioChannels5_1 => '5.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels6_1 => '6.1 環繞聲';
+  String get settingsMaxAudioChannels6_1 => '6.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels7_1 => '7.1 環繞聲';
+  String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => '直通（進階）';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => '編解碼器直通';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      '淨係啟用你部 AVR 或者 HDMI 接收裝置支援嘅格式。';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 直通';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC（Atmos）直通';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core 直通';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA 直通';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD 直通';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos 直通';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      '將 Dolby Digital Plus（EAC3）位元流送去外部解碼器。';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      '將 EAC3（JOC）承載嘅 Dolby Atmos 位元流送去外部解碼器。';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      '將 DTS-HD MA（包括 DTS core）位元流送去外部解碼器。';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      '將帶 Atmos 中繼資料嘅 Dolby TrueHD 位元流送去外部解碼器。';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => '偵測到嘅音訊能力';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
-  String get settingsDetectedAudioCapabilitiesUnavailable => '暫時仲未有執行階段嘅能力快照。';
+  String get settingsDetectedAudioCapabilitiesUnavailable =>
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => '路由';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => '解碼';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => '直通';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD 音訊路由';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2581,46 +2596,50 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => '喇叭';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => '耳機';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count 聲道 PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => '診斷';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => '視訊等級';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => '視訊範圍';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => '字幕編解碼器';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => '允許嘅音訊編解碼器';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS 音訊編解碼器';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs => 'HLS fMP4 音訊編解碼器';
+  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
+      'HLS fMP4 Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsAudioSpdifPassthrough => 'audio-spdif 直通';
+  String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => '使用中嘅音訊路由';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
-  String get settingsAudioDiagnosticsRouteHdAudioSupport => '路由 HD 音訊支援';
+  String get settingsAudioDiagnosticsRouteHdAudioSupport =>
+      'Route HD Audio Support';
 
   @override
   String get nightMode => '夜間模式';
@@ -2666,7 +2685,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String secondsValue(int value) {
-    return '$value 秒';
+    return '${value}s';
   }
 
   @override
@@ -2680,7 +2699,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '睇咗 $episodes 集 / $hours 小時之後';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2754,41 +2773,45 @@ class AppLocalizationsYue extends AppLocalizations {
   String get subtitleCustomizationDescription => '自訂字幕外觀';
 
   @override
-  String get subtitleMode => '字幕模式';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => '已標記';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => '永遠';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => '外語';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => '強制';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      '播放喺媒體檔案中繼資料入面標示為「default」或者「forced」嘅字幕軌。';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
-  String get subtitleModeAlwaysDescription => '每次開始播片都自動載入同顯示字幕。';
+  String get subtitleModeAlwaysDescription =>
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
-  String get subtitleModeForeignDescription => '如果預設音軌係外語，就自動開字幕。';
+  String get subtitleModeForeignDescription =>
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
-  String get subtitleModeForcedDescription => '淨係載入明確標咗 forced 中繼資料旗標嘅字幕。';
+  String get subtitleModeForcedDescription =>
+      'Only loads subtitles explicitly tagged with the forced metadata flag.';
 
   @override
-  String get subtitleModeNoneDescription => '完全停用自動載入字幕。';
+  String get subtitleModeNoneDescription =>
+      'Completely disables automatic subtitle loading.';
 
   @override
-  String get fallbackSubtitleLanguage => '備用字幕語言';
+  String get fallbackSubtitleLanguage => 'Fallback Subtitle Language';
 
   @override
-  String get subtitleStream => '字幕串流';
+  String get subtitleStream => 'Subtitle Stream';
 
   @override
   String get subtitlePreviewText => '敏捷的棕色狐狸跳過了懶狗';
@@ -2846,17 +2869,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '已載入 $profile 設定檔嘅設定。';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '載入唔到 $profile 設定檔嘅設定。';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return '已將本機設定同步去 $profile 設定檔。';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -2986,10 +3009,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showLibrariesInToolbar => '在工具列中顯示庫';
 
   @override
-  String get navbarAlwaysExpanded => '永遠展開導覽列標籤';
+  String get navbarAlwaysExpanded => 'Always Expand Navbar Labels';
 
   @override
-  String get showSeerrButton => '顯示 Seerr 按鈕';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => '導覽列不透明度';
@@ -3061,17 +3084,18 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showFolderBrowsingOption => '顯示資料夾瀏覽選項';
 
   @override
-  String get groupItemsIntoCollections => '將項目歸入合輯';
+  String get groupItemsIntoCollections => 'Group Items into Collections';
 
   @override
-  String get hideCollectionAssociatedItems => '瀏覽媒體庫嗰陣隱藏已歸入合輯嘅項目';
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => '媒體庫分組須知';
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
 
   @override
   String get groupItemsIntoCollectionsDialogMessage =>
-      '想用呢個設定，請確認喺你部 Jellyfin 或者 Emby 伺服器嘅媒體庫「顯示」設定入面，已經啟用咗「Group movies into collections」同／或者「Group shows into collections」。';
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
 
   @override
   String get libraryVisibility => '圖書館可見性';
@@ -3099,7 +3123,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '已揀 $count 個';
+    return '$count selected';
   }
 
   @override
@@ -3133,7 +3157,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get mediaBarModeMakd => '馬克D';
 
   @override
-  String get mediaBarModeOff => '關';
+  String get mediaBarModeOff => '離開';
 
   @override
   String get enableMediaBar => '啟用媒體欄';
@@ -3178,10 +3202,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get autoPlayTrailers => '3 秒後在媒體列中自動播放預告片';
 
   @override
-  String get trailerAudio => '預告片聲音';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio => '喺媒體列嘅預告片開聲';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => '劇集預覽';
@@ -3253,10 +3277,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get combineBothRows => '將兩行合併為一個主頁部分';
 
   @override
-  String get fullScreenRows => '展開主畫面列表';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription => '每個畫面淨係顯示一行主畫面列表';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => '每行圖像類型';
@@ -3271,7 +3295,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get lastUser => '最後一個用戶';
 
   @override
-  String get currentUser => '目前使用者';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '始終進行身份驗證';
@@ -3341,7 +3365,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes 分鐘';
+    return '$minutes min';
   }
 
   @override
@@ -3371,10 +3395,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get displayClockDuringScreensaver => '螢幕保護期間顯示時鐘';
 
   @override
-  String get clockModeStatic => '固定';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => '彈跳';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => '爛番茄（評論家）';
@@ -3383,10 +3407,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get rottenTomatoesAudience => '爛番茄（觀眾）';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => '網路醫學資料庫';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'TM資料庫';
 
   @override
   String get metacritic => '元評論家';
@@ -3395,7 +3419,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get metacriticUser => '元評論家（使用者）';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => '特拉克特';
 
   @override
   String get letterboxd => '信箱';
@@ -3443,7 +3467,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get ratingSourcesDescription => '啟用並重新排序整個應用程式中顯示的評級來源';
 
   @override
-  String get pluginLabel => 'Moonbase 外掛程式';
+  String get pluginLabel => '外掛';
 
   @override
   String get pluginDetected => '偵測到插件';
@@ -3459,7 +3483,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\n版本：$version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -3512,13 +3536,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get networks => '網路';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr 探索列表';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => '將行重設為預設值';
 
   @override
-  String get enableSeerr => '啟用 Seerr';
+  String get enableSeerr => '啟用搜尋器';
 
   @override
   String get showSeerrInNavigation => '在導航中顯示 Seerr（需要伺服器插件）';
@@ -3533,44 +3557,46 @@ class AppLocalizationsYue extends AppLocalizations {
   String get hideAdultContent => '在結果中隱藏成人內容';
 
   @override
-  String get seerrNotificationsSection => '通知';
+  String get seerrNotificationsSection => 'Notifications';
 
   @override
-  String get seerrNotifyNewRequestsTitle => '新請求通知';
+  String get seerrNotifyNewRequestsTitle => 'New request notifications';
 
   @override
-  String get seerrNotifyNewRequestsSubtitle => '有人提交請求嗰陣通知我';
+  String get seerrNotifyNewRequestsSubtitle =>
+      'Alert me when someone submits a request';
 
   @override
-  String get seerrNotifyLibraryAddedTitle => '請求進度更新';
+  String get seerrNotifyLibraryAddedTitle => 'Request updates';
 
   @override
-  String get seerrNotifyLibraryAddedSubtitle => '已批准、已拒絕，同埋已加入你嘅媒體庫';
+  String get seerrNotifyLibraryAddedSubtitle =>
+      'Approved, declined, and added to your library';
 
   @override
-  String get seerrNotifyIssuesTitle => '問題更新';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => '新問題、回覆同解決結果';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
-    return '已登入身分：$username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr 探索頁';
+  String get discoverRows => '發現行';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      '揀要喺 Seerr 主頁顯示嘅列表。拖曳就可以重新排序。自訂順序會同 Moonbase 同步。';
+      '拖曳以重新排序。啟用或停用行。啟用與 Moonfin 插件的行順序同步。';
 
   @override
-  String get discoverRowsDescription =>
-      '揀要喺 Seerr 主頁顯示嘅列表。拖曳就可以重新排序。自訂順序會同 Moonbase 同步。';
+  String get discoverRowsDescription => '拖曳以重新排序。啟用或停用行。';
 
   @override
-  String get enabled => '已啟用';
+  String get enabled => '啟用';
 
   @override
   String get hidden => '隱';
@@ -3580,7 +3606,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String versionValue(String version) {
-    return '版本 $version';
+    return 'Version $version';
   }
 
   @override
@@ -3624,7 +3650,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return '有更新：v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3635,7 +3661,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version 已推出';
+    return 'v$version Available';
   }
 
   @override
@@ -3710,19 +3736,19 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return '下載緊 · $percent%';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => '匯入緊';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
-    return '$count 個項目';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr 設定';
+  String get seerrSettings => '搜尋者設定';
 
   @override
   String get requestMore => '請求更多';
@@ -3738,7 +3764,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '由 $name 請求';
+    return 'Requested by $name';
   }
 
   @override
@@ -3755,12 +3781,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '確定要取消「$title」嘅請求？';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '確定要取消「$title」嘅 $count 個請求？';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3774,12 +3800,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return '預算：\$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return '票房：\$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3789,7 +3815,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '請求$type';
+    return 'Request $type';
   }
 
   @override
@@ -3817,14 +3843,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showMore => '顯示更多';
 
   @override
-  String get appearances => '演出作品';
+  String get appearances => '出場次數';
 
   @override
   String get crewSection => '全體人員';
 
   @override
   String ageValue(int age) {
-    return '$age 歲';
+    return 'age $age';
   }
 
   @override
@@ -3855,146 +3881,148 @@ class AppLocalizationsYue extends AppLocalizations {
   String get deletedStatus => '已刪除';
 
   @override
-  String get failedStatus => '失敗';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => '處理緊';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '由 $name 修改';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => '已完成';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => '呢個作品已經請求咗喇';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => '已經去到請求上限';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => '呢個作品喺封鎖名單入面';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => '冇季數可以請求';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
-  String get requestErrorPermission => '你冇權限提出呢個請求';
+  String get requestErrorPermission =>
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => '請求';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => '問題';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => '最新';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => '最後修改';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => '冇問題';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '電影請求仲剩返 $remaining / $limit 個';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '季數請求仲剩返 $remaining / $limit 個';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '屬於 $name';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => '睇合輯';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => '請求成個合輯';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total 部電影 · $available 部可以睇';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '請求 $count 部電影';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '請求緊第 $current / $total 個...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '已請求 $count 部電影';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '$total 部電影入面已請求咗 $ok 部';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => '所有電影都已經可以睇，或者已經請求咗';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => '回報問題';
+  String get reportIssue => 'Report Issue';
 
   @override
-  String get issueTypeVideo => '畫面';
+  String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => '聲音';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => '有咩問題？';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => '所有集數';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => '集數';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => '未解決';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => '已解決';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => '標為已解決';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => '重開';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '由 $name 回報';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count 則留言';
+    return '$count comments';
   }
 
   @override
-  String get addComment => '加個留言';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => '確定要刪除呢個問題？';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => '提交回報';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB分數';
@@ -4018,7 +4046,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get originalLanguageLabel => '原始語言';
 
   @override
-  String get seasonsLabel => '季數';
+  String get seasonsLabel => '季節';
 
   @override
   String get episodesLabel => '劇集數';
@@ -4027,7 +4055,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get access => '使用權';
 
   @override
-  String get add => '新增';
+  String get add => '添加';
 
   @override
   String get address => '地址';
@@ -4051,7 +4079,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get disable => '停用';
 
   @override
-  String get done => '完成';
+  String get done => '完畢';
 
   @override
   String get edit => '編輯';
@@ -4063,10 +4091,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get error => '錯誤';
 
   @override
-  String get forward => '快進';
+  String get forward => '向前';
 
   @override
-  String get general => '一般';
+  String get general => '一般的';
 
   @override
   String get go => '去';
@@ -4111,7 +4139,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get refresh => '重新整理';
 
   @override
-  String get remote => '遙控';
+  String get remote => '偏僻的';
 
   @override
   String get rename => '重新命名';
@@ -4156,7 +4184,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get time => '時間';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => '特技遊戲';
 
   @override
   String get uninstall => '解除安裝';
@@ -4174,7 +4202,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get unmute => '取消靜音';
 
   @override
-  String get mute => '靜音';
+  String get mute => '沉默的';
 
   @override
   String get branding => '品牌推廣';
@@ -4195,28 +4223,28 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminDrawerUsers => '使用者';
 
   @override
-  String get adminDrawerLibraries => '媒體庫';
+  String get adminDrawerLibraries => '圖書館';
 
   @override
-  String get adminDrawerDisplay => '顯示';
+  String get adminDrawerDisplay => 'Display';
 
   @override
-  String get adminDrawerMetadata => '中繼資料';
+  String get adminDrawerMetadata => 'Metadata';
 
   @override
-  String get adminDrawerNfo => 'NFO 設定';
+  String get adminDrawerNfo => 'NFO Settings';
 
   @override
   String get adminDrawerTranscoding => '轉碼';
 
   @override
-  String get adminDrawerResume => '繼續播放';
+  String get adminDrawerResume => '恢復';
 
   @override
   String get adminDrawerStreaming => '串流媒體';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => '特技遊戲';
 
   @override
   String get adminDrawerDevices => '裝置';
@@ -4265,22 +4293,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return '有外掛程式更新：$count 個';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return '需要重新啟動嘅外掛程式：$count 個';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return '失敗咗嘅排程工作：$count 個';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return '最近嘅警告／錯誤紀錄：$count 項';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -4339,7 +4367,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String errorGeneric(String error) {
-    return '錯誤：$error';
+    return 'Error: $error';
   }
 
   @override
@@ -4365,7 +4393,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return '指令失敗：$error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4384,7 +4412,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get sessionRewind => '倒帶';
 
   @override
-  String get sessionForward => '快進';
+  String get sessionForward => '向前';
 
   @override
   String get sessionNext => '下一個';
@@ -4402,7 +4430,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get nowPlaying => '正在播放';
 
   @override
-  String get volume => '音量';
+  String get volume => '體積';
 
   @override
   String get actions => '行動';
@@ -4429,14 +4457,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminClearDates => '明確日期';
 
   @override
-  String get adminActivitySeverityAll => '所有嚴重程度';
+  String get adminActivitySeverityAll => 'All severities';
 
   @override
-  String get adminActivityDateRange => '日期範圍';
+  String get adminActivityDateRange => 'Date range';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return '載入唔到活動紀錄：$error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4453,7 +4481,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return '更新唔到裝置：$error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4464,28 +4492,28 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return '刪除唔到裝置：$error';
+    return 'Failed to delete device: $error';
   }
 
   @override
   String adminRemoveDeviceConfirm(String name) {
-    return '確定要移除裝置「$name」？使用者要喺呢部裝置度重新登入。';
+    return 'Remove device \'$name\'? The user will need to sign in again on this device.';
   }
 
   @override
-  String get adminDeleteAllDevices => '刪除所有裝置';
+  String get adminDeleteAllDevices => 'Delete all devices';
 
   @override
   String adminDeleteAllDevicesConfirm(int count) {
-    return '確定要移除 $count 部裝置？受影響嘅使用者要重新登入。你而家用緊嘅裝置唔會受影響。';
+    return 'Remove $count devices? Affected users will need to sign in again. Your current device is not affected.';
   }
 
   @override
-  String get adminDevicesDeletedAll => '已移除裝置';
+  String get adminDevicesDeletedAll => 'Devices removed';
 
   @override
   String adminDevicesDeletedPartial(int count) {
-    return '已移除部分裝置；有 $count 部移除唔到。';
+    return 'Removed some devices; $count could not be removed.';
   }
 
   @override
@@ -4514,7 +4542,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return '開始唔到掃描：$error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4525,12 +4553,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return '媒體庫已改名做「$name」';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return '改唔到名：$error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4538,17 +4566,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '已刪除媒體庫「$name」';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return '刪除唔到媒體庫：$error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return '加入唔到路徑：$error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4556,12 +4584,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '確定要喺呢個媒體庫度移除「$path」？';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return '移除唔到路徑：$error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4569,7 +4597,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return '儲存唔到選項：$error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4600,234 +4628,251 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminMetadataCountryHint => '例如美國、德國、法國';
 
   @override
-  String get adminLibraryTabPaths => '路徑';
+  String get adminLibraryTabPaths => 'Paths';
 
   @override
-  String get adminLibraryTabOptions => '選項';
+  String get adminLibraryTabOptions => 'Options';
 
   @override
-  String get adminLibraryTabDownloaders => '下載器';
+  String get adminLibraryTabDownloaders => 'Downloaders';
 
   @override
-  String get adminLibMetadataSavers => '中繼資料儲存器';
+  String get adminLibMetadataSavers => 'Metadata savers';
 
   @override
-  String get adminLibSubtitleDownloaders => '字幕下載器';
+  String get adminLibSubtitleDownloaders => 'Subtitle downloaders';
 
   @override
-  String get adminLibLyricDownloaders => '歌詞下載器';
+  String get adminLibLyricDownloaders => 'Lyric downloaders';
 
   @override
   String adminLibMetadataDownloadersFor(String type) {
-    return '中繼資料下載器：$type';
+    return 'Metadata downloaders: $type';
   }
 
   @override
   String adminLibImageFetchersFor(String type) {
-    return '圖片擷取器：$type';
+    return 'Image fetchers: $type';
   }
 
   @override
-  String get adminLibNoDownloaders => '呢部伺服器冇為呢種媒體庫提供任何下載器。';
+  String get adminLibNoDownloaders =>
+      'This server exposes no downloaders for this library type.';
 
   @override
-  String get adminLibrarySectionGeneral => '一般';
+  String get adminLibrarySectionGeneral => 'General';
 
   @override
-  String get adminLibrarySectionMetadata => '中繼資料';
+  String get adminLibrarySectionMetadata => 'Metadata';
 
   @override
-  String get adminLibrarySectionEmbedded => '內嵌資訊';
+  String get adminLibrarySectionEmbedded => 'Embedded Info';
 
   @override
-  String get adminLibrarySectionSubtitles => '字幕';
+  String get adminLibrarySectionSubtitles => 'Subtitles';
 
   @override
-  String get adminLibrarySectionImages => '圖片';
+  String get adminLibrarySectionImages => 'Images';
 
   @override
-  String get adminLibrarySectionSeries => '劇集';
+  String get adminLibrarySectionSeries => 'Series';
 
   @override
-  String get adminLibrarySectionMusic => '音樂';
+  String get adminLibrarySectionMusic => 'Music';
 
   @override
-  String get adminLibrarySectionMovies => '電影';
+  String get adminLibrarySectionMovies => 'Movies';
 
   @override
-  String get adminLibRealtimeMonitor => '啟用即時監控';
+  String get adminLibRealtimeMonitor => 'Enable real-time monitoring';
 
   @override
-  String get adminLibRealtimeMonitorHint => '偵測檔案變動，然後自動處理。';
+  String get adminLibRealtimeMonitorHint =>
+      'Detect file changes and process them automatically.';
 
   @override
-  String get adminLibArchiveMediaFiles => '將壓縮檔當做媒體檔案';
+  String get adminLibArchiveMediaFiles => 'Treat archives as media files';
 
   @override
-  String get adminLibEnablePhotos => '顯示相片';
+  String get adminLibEnablePhotos => 'Display photos';
 
   @override
-  String get adminLibSaveLocalMetadata => '將封面圖存入媒體資料夾';
+  String get adminLibSaveLocalMetadata => 'Save artwork into media folders';
 
   @override
-  String get adminLibRefreshInterval => '自動重新整理中繼資料';
+  String get adminLibRefreshInterval => 'Automatic metadata refresh';
 
   @override
-  String get adminLibRefreshNever => '永不';
+  String get adminLibRefreshNever => 'Never';
 
   @override
-  String get adminLibDefault => '預設';
+  String get adminLibDefault => 'Default';
 
   @override
-  String get adminLibDisplayTitle => '顯示';
+  String get adminLibDisplayTitle => 'Display';
 
   @override
-  String get adminLibDisplaySection => '媒體庫顯示';
+  String get adminLibDisplaySection => 'Library display';
 
   @override
-  String get adminLibFolderView => '顯示資料夾檢視，展示原始嘅媒體資料夾';
+  String get adminLibFolderView =>
+      'Display a folder view to show plain media folders';
 
   @override
-  String get adminLibSpecialsInSeasons => '將特別篇顯示喺佢哋首播嗰季入面';
+  String get adminLibSpecialsInSeasons =>
+      'Display specials within seasons they aired in';
 
   @override
-  String get adminLibGroupMovies => '將電影歸入合輯';
+  String get adminLibGroupMovies => 'Group movies into collections';
 
   @override
-  String get adminLibGroupShows => '將劇集歸入合輯';
+  String get adminLibGroupShows => 'Group shows into collections';
 
   @override
-  String get adminLibExternalSuggestions => '喺建議入面顯示外部內容';
+  String get adminLibExternalSuggestions =>
+      'Show external content in suggestions';
 
   @override
-  String get adminLibDateAddedSection => '加入日期行為';
+  String get adminLibDateAddedSection => 'Date added behavior';
 
   @override
-  String get adminLibDateAddedLabel => '加入日期嘅來源';
+  String get adminLibDateAddedLabel => 'Use date added from';
 
   @override
-  String get adminLibDateAddedImport => '掃描入媒體庫嗰日';
+  String get adminLibDateAddedImport => 'Date scanned into the library';
 
   @override
-  String get adminLibDateAddedFile => '檔案建立嗰日';
+  String get adminLibDateAddedFile => 'Date the file was created';
 
   @override
-  String get adminLibMetadataTitle => '中繼資料同圖片';
+  String get adminLibMetadataTitle => 'Metadata and Images';
 
   @override
-  String get adminLibMetadataLangSection => '偏好嘅中繼資料語言';
+  String get adminLibMetadataLangSection => 'Preferred metadata language';
 
   @override
-  String get adminLibChaptersSection => '章節';
+  String get adminLibChaptersSection => 'Chapters';
 
   @override
-  String get adminLibDummyChapterDuration => '虛擬章節長度（秒）';
+  String get adminLibDummyChapterDuration => 'Dummy chapter duration (seconds)';
 
   @override
-  String get adminLibDummyChapterDurationHint => '為冇章節嘅媒體產生嘅章節長度。設做 0 就停用。';
+  String get adminLibDummyChapterDurationHint =>
+      'Length of chapters generated for media that has none. Set to 0 to disable.';
 
   @override
-  String get adminLibChapterImageResolution => '章節圖片解析度';
+  String get adminLibChapterImageResolution => 'Chapter image resolution';
 
   @override
-  String get adminLibNfoTitle => 'NFO 設定';
+  String get adminLibNfoTitle => 'NFO Settings';
 
   @override
   String get adminLibNfoHelp =>
-      'NFO 中繼資料同 Kodi 之類嘅用戶端相容。呢啲設定會套用去所有會儲存 NFO 中繼資料嘅媒體庫。';
+      'NFO metadata is compatible with Kodi and similar clients. Settings apply to all libraries that save NFO metadata.';
 
   @override
-  String get adminLibKodiUser => '喺 NFO 檔案入面儲存觀看紀錄嘅使用者';
+  String get adminLibKodiUser => 'User to store watch data for in NFO files';
 
   @override
-  String get adminLibSaveImagePaths => '喺 NFO 檔案入面儲存圖片路徑';
+  String get adminLibSaveImagePaths => 'Save image paths within NFO files';
 
   @override
-  String get adminLibPathSubstitution => '為 NFO 圖片路徑啟用路徑替換';
+  String get adminLibPathSubstitution =>
+      'Enable path substitution for NFO image paths';
 
   @override
-  String get adminLibExtraThumbs => '將 extrafanart 圖片複製去 extrathumbs 資料夾';
+  String get adminLibExtraThumbs =>
+      'Copy extrafanart images into an extrathumbs folder';
 
   @override
-  String get adminLibNone => '冇';
+  String get adminLibNone => 'None';
 
   @override
   String adminLibRefreshDays(int days) {
-    return '$days 日';
+    return '$days days';
   }
 
   @override
-  String get adminLibEmbeddedTitles => '用內嵌標題';
+  String get adminLibEmbeddedTitles => 'Use embedded titles';
 
   @override
-  String get adminLibEmbeddedExtrasTitles => '特別收錄用內嵌標題';
+  String get adminLibEmbeddedExtrasTitles => 'Use embedded titles for extras';
 
   @override
-  String get adminLibEmbeddedEpisodeInfos => '用內嵌嘅集數資訊';
+  String get adminLibEmbeddedEpisodeInfos => 'Use embedded episode information';
 
   @override
-  String get adminLibAllowEmbeddedSubtitles => '允許內嵌字幕';
+  String get adminLibAllowEmbeddedSubtitles => 'Allow embedded subtitles';
 
   @override
-  String get adminLibEmbeddedAllowAll => '全部允許';
+  String get adminLibEmbeddedAllowAll => 'Allow all';
 
   @override
-  String get adminLibEmbeddedAllowText => '淨係文字';
+  String get adminLibEmbeddedAllowText => 'Text only';
 
   @override
-  String get adminLibEmbeddedAllowImage => '淨係圖片';
+  String get adminLibEmbeddedAllowImage => 'Image only';
 
   @override
-  String get adminLibEmbeddedAllowNone => '冇';
+  String get adminLibEmbeddedAllowNone => 'None';
 
   @override
-  String get adminLibSkipIfEmbeddedSubs => '如果已經有內嵌字幕就唔使下載';
+  String get adminLibSkipIfEmbeddedSubs =>
+      'Skip download if embedded subtitles are present';
 
   @override
-  String get adminLibSkipIfAudioMatches => '如果音軌同下載語言一樣就唔使下載';
+  String get adminLibSkipIfAudioMatches =>
+      'Skip download if the audio track matches the download language';
 
   @override
-  String get adminLibRequirePerfectMatch => '要求字幕完全吻合';
+  String get adminLibRequirePerfectMatch => 'Require a perfect subtitle match';
 
   @override
-  String get adminLibSaveSubtitlesWithMedia => '將字幕存入媒體資料夾';
+  String get adminLibSaveSubtitlesWithMedia =>
+      'Save subtitles into media folders';
 
   @override
-  String get adminLibChapterImageExtraction => '擷取章節圖片';
+  String get adminLibChapterImageExtraction => 'Extract chapter images';
 
   @override
-  String get adminLibChapterImagesDuringScan => '喺媒體庫掃描期間擷取章節圖片';
+  String get adminLibChapterImagesDuringScan =>
+      'Extract chapter images during the library scan';
 
   @override
-  String get adminLibTrickplayExtraction => '啟用 Trickplay 圖片擷取';
+  String get adminLibTrickplayExtraction => 'Enable trickplay image extraction';
 
   @override
-  String get adminLibTrickplayDuringScan => '喺媒體庫掃描期間擷取 Trickplay 圖片';
+  String get adminLibTrickplayDuringScan =>
+      'Extract trickplay images during the library scan';
 
   @override
-  String get adminLibSaveTrickplayWithMedia => '將 Trickplay 圖片存入媒體資料夾';
+  String get adminLibSaveTrickplayWithMedia =>
+      'Save trickplay images into media folders';
 
   @override
-  String get adminLibAutomaticSeriesGrouping => '自動合併分散喺多個資料夾嘅劇集';
+  String get adminLibAutomaticSeriesGrouping =>
+      'Automatically merge series that are spread across multiple folders';
 
   @override
-  String get adminLibSeasonZeroName => '第零季顯示名稱';
+  String get adminLibSeasonZeroName => 'Season zero display name';
 
   @override
-  String get adminLibLufsScan => '啟用 LUFS 掃描嚟做音量正規化';
+  String get adminLibLufsScan => 'Enable LUFS scan for audio normalization';
 
   @override
-  String get adminLibPreferNonstandardArtist => '優先用非標準嘅 artists 標籤';
+  String get adminLibPreferNonstandardArtist =>
+      'Prefer non-standard artists tag';
 
   @override
-  String get adminLibAutoAddToCollection => '自動將電影加入合輯';
+  String get adminLibAutoAddToCollection =>
+      'Automatically add movies to collections';
 
   @override
   String get adminLibraryNameRequired => '庫名稱為必填項';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return '建立唔到媒體庫：$error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4853,27 +4898,27 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '確定要停用 $name？佢就登入唔到喇。';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '確定要啟用 $name？佢就可以再次登入。';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '已停用使用者「$name」';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '已啟用使用者「$name」';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return '更新唔到使用者原則：$error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -4890,7 +4935,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return '建立唔到使用者：$error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -4910,7 +4955,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return '儲存唔到：$error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -4921,7 +4966,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return '失敗：$error';
+    return 'Failed: $error';
   }
 
   @override
@@ -5051,158 +5096,165 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminEnableAllChannels => '允許存取所有頻道';
 
   @override
-  String get adminParentalControl => '家長控制';
+  String get adminParentalControl => 'Parental Control';
 
   @override
-  String get adminMaxParentalRating => '允許嘅最高家長分級';
+  String get adminMaxParentalRating => 'Maximum allowed parental rating';
 
   @override
-  String get adminMaxParentalRatingHint => '分級高過呢個嘅內容會對呢個使用者隱藏。';
+  String get adminMaxParentalRatingHint =>
+      'Content with a higher rating will be hidden from this user.';
 
   @override
-  String get adminParentalRatingNone => '冇';
+  String get adminParentalRatingNone => 'None';
 
   @override
-  String get adminBlockUnratedItems => '封鎖冇分級或者分級認唔到嘅項目';
+  String get adminBlockUnratedItems =>
+      'Block items with no or unrecognized rating information';
 
   @override
-  String get adminUnratedBook => '書籍';
+  String get adminUnratedBook => 'Books';
 
   @override
-  String get adminUnratedChannelContent => '頻道';
+  String get adminUnratedChannelContent => 'Channels';
 
   @override
-  String get adminUnratedLiveTvChannel => '直播電視';
+  String get adminUnratedLiveTvChannel => 'Live TV';
 
   @override
-  String get adminUnratedMovie => '電影';
+  String get adminUnratedMovie => 'Movies';
 
   @override
-  String get adminUnratedMusic => '音樂';
+  String get adminUnratedMusic => 'Music';
 
   @override
-  String get adminUnratedTrailer => '預告片';
+  String get adminUnratedTrailer => 'Trailers';
 
   @override
-  String get adminUnratedSeries => '劇集';
+  String get adminUnratedSeries => 'Shows';
 
   @override
-  String get adminAccessSchedules => '存取時間表';
+  String get adminAccessSchedules => 'Access Schedules';
 
   @override
-  String get adminAccessSchedulesHint => '淨係喺下面排定嘅時間先允許存取。如果冇設定時間表，就全日都可以存取。';
+  String get adminAccessSchedulesHint =>
+      'Allow access only during the scheduled times below. Access is allowed all day when no schedule is set.';
 
   @override
-  String get adminAddSchedule => '加入時間表';
+  String get adminAddSchedule => 'Add Schedule';
 
   @override
-  String get adminScheduleDay => '日子';
+  String get adminScheduleDay => 'Day';
 
   @override
-  String get adminScheduleStart => '開始';
+  String get adminScheduleStart => 'Start';
 
   @override
-  String get adminScheduleEnd => '結束';
+  String get adminScheduleEnd => 'End';
 
   @override
-  String get adminDayEveryday => '每日';
+  String get adminDayEveryday => 'Every day';
 
   @override
-  String get adminDayWeekday => '平日';
+  String get adminDayWeekday => 'Weekday';
 
   @override
-  String get adminDayWeekend => '週末';
+  String get adminDayWeekend => 'Weekend';
 
   @override
-  String get adminDaySunday => '星期日';
+  String get adminDaySunday => 'Sunday';
 
   @override
-  String get adminDayMonday => '星期一';
+  String get adminDayMonday => 'Monday';
 
   @override
-  String get adminDayTuesday => '星期二';
+  String get adminDayTuesday => 'Tuesday';
 
   @override
-  String get adminDayWednesday => '星期三';
+  String get adminDayWednesday => 'Wednesday';
 
   @override
-  String get adminDayThursday => '星期四';
+  String get adminDayThursday => 'Thursday';
 
   @override
-  String get adminDayFriday => '星期五';
+  String get adminDayFriday => 'Friday';
 
   @override
-  String get adminDaySaturday => '星期六';
+  String get adminDaySaturday => 'Saturday';
 
   @override
-  String get adminAllowedTags => '允許嘅標籤';
+  String get adminAllowedTags => 'Allowed tags';
 
   @override
-  String get adminAllowedTagsHint => '淨係顯示有呢啲標籤嘅內容。留空就全部允許。';
+  String get adminAllowedTagsHint =>
+      'Only content with these tags is shown. Leave empty to allow all.';
 
   @override
-  String get adminBlockedTags => '封鎖嘅標籤';
+  String get adminBlockedTags => 'Blocked tags';
 
   @override
-  String get adminBlockedTagsHint => '有呢啲標籤嘅內容會對呢個使用者隱藏。';
+  String get adminBlockedTagsHint =>
+      'Content with these tags is hidden from this user.';
 
   @override
-  String get adminAddTag => '加入標籤';
+  String get adminAddTag => 'Add tag';
 
   @override
-  String get adminEnabledDevices => '已啟用嘅裝置';
+  String get adminEnabledDevices => 'Enabled devices';
 
   @override
-  String get adminEnabledChannels => '已啟用嘅頻道';
+  String get adminEnabledChannels => 'Enabled channels';
 
   @override
-  String get adminAuthProvider => '驗證提供者';
+  String get adminAuthProvider => 'Authentication provider';
 
   @override
-  String get adminPasswordResetProvider => '密碼重設提供者';
+  String get adminPasswordResetProvider => 'Password reset provider';
 
   @override
-  String get adminLoginAttemptsBeforeLockout => '鎖定前允許嘅最多登入失敗次數';
+  String get adminLoginAttemptsBeforeLockout =>
+      'Maximum failed login attempts before lockout';
 
   @override
-  String get adminLoginAttemptsHint => '設做 0 就用預設值，設做 -1 就停用鎖定。';
+  String get adminLoginAttemptsHint =>
+      'Set to 0 for the default, or -1 to disable lockout.';
 
   @override
-  String get adminSyncPlayAccess => 'SyncPlay 存取權';
+  String get adminSyncPlayAccess => 'SyncPlay access';
 
   @override
-  String get adminSyncPlayCreateAndJoin => '允許建立同加入群組';
+  String get adminSyncPlayCreateAndJoin => 'Allow creating and joining groups';
 
   @override
-  String get adminSyncPlayJoin => '允許加入群組';
+  String get adminSyncPlayJoin => 'Allow joining groups';
 
   @override
-  String get adminSyncPlayNone => '冇存取權';
+  String get adminSyncPlayNone => 'No access';
 
   @override
-  String get adminContentDeletionFolders => '允許喺以下位置刪除內容';
+  String get adminContentDeletionFolders => 'Allow content deletion from';
 
   @override
   String get adminResetPasswordWarning => '這將刪除密碼。用戶無需密碼即可登入。';
 
   @override
   String adminServerReturnedHttp(int status) {
-    return '伺服器回傳 HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '你確定要刪除 $name？';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '已刪除使用者「$name」';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return '刪除唔到使用者：$error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -5222,7 +5274,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return '建立唔到金鑰：$error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -5233,7 +5285,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '確定要撤銷 $name 嘅金鑰？';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -5241,7 +5293,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return '撤銷唔到金鑰：$error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -5261,29 +5313,29 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return '權杖：$token\\n建立時間：$created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
-  String get adminBackupOptionsTitle => '建立備份';
+  String get adminBackupOptionsTitle => 'Create Backup';
 
   @override
-  String get adminBackupInclude => '揀吓要備份啲乜。';
+  String get adminBackupInclude => 'Choose what to include in the backup.';
 
   @override
-  String get adminBackupDatabase => '資料庫';
+  String get adminBackupDatabase => 'Database';
 
   @override
-  String get adminBackupDatabaseAlways => '一定會包括';
+  String get adminBackupDatabaseAlways => 'Always included';
 
   @override
-  String get adminBackupMetadata => '中繼資料';
+  String get adminBackupMetadata => 'Metadata';
 
   @override
-  String get adminBackupSubtitles => '字幕';
+  String get adminBackupSubtitles => 'Subtitles';
 
   @override
-  String get adminBackupTrickplay => 'Trickplay 圖片';
+  String get adminBackupTrickplay => 'Trickplay images';
 
   @override
   String get adminCreatingBackup => '正在建立備份...';
@@ -5293,7 +5345,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return '建立唔到備份：$error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -5301,12 +5353,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminBackupManifest(String name) {
-    return '資訊清單：$name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return '載入唔到資訊清單：$error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -5317,7 +5369,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return '還原唔到備份：$error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -5349,17 +5401,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '已儲存去 $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return '儲存唔到檔案：$error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '載入唔到 $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -5370,7 +5422,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return '載入唔到工作：$error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -5381,17 +5433,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return '開始唔到工作：$error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return '停止唔到工作：$error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return '載入唔到工作：$error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -5399,12 +5451,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return '移除唔到觸發條件：$error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return '加入唔到觸發條件：$error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -5430,7 +5482,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours 小時';
+    return '$hours hour(s)';
   }
 
   @override
@@ -5441,7 +5493,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return '切換唔到外掛程式：$error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -5449,27 +5501,27 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '你確定要解除安裝「$name」？';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return '解除安裝唔到外掛程式：$error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return '安裝唔到套件：$error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return '安裝唔到更新：$error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return '載入唔到外掛程式：$error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -5480,12 +5532,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminInstallUpdate(String version) {
-    return '安裝更新（v$version）';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return '載入唔到目錄：$error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -5505,17 +5557,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '伺服器重新啟動之後就會移除「$name」';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return '解除安裝唔到：$error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '更新緊「$name」去 v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -5523,7 +5575,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return '載入唔到外掛程式：$error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -5531,7 +5583,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginVersion(String version) {
-    return '版本 $version';
+    return 'Version $version';
   }
 
   @override
@@ -5551,17 +5603,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '你確定要移除「$name」？';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return '儲存唔到存放庫：$error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return '載入唔到存放庫：$error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5578,12 +5630,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return '載入唔到外掛程式設定：$error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '開唔到 $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5698,10 +5750,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminThrottleBuffering => '油門緩衝';
 
   @override
-  String get adminTrickplaySaved => '已儲存 Trickplay 設定';
+  String get adminTrickplaySaved => '已儲存特技播放設定';
 
   @override
-  String get adminTrickplayLoadFailed => '載入唔到 Trickplay 設定';
+  String get adminTrickplayLoadFailed => '無法載入特技播放設置';
 
   @override
   String get adminEnableHardwareAcceleration => '啟用硬體加速';
@@ -5803,7 +5855,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminBaseUrl => '基本網址';
 
   @override
-  String get adminBaseUrlHint => '例如 /jellyfin';
+  String get adminBaseUrlHint => '例如/果凍';
 
   @override
   String get https => 'HTTPS';
@@ -5843,12 +5895,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return '載入唔到中繼資料：$error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return '儲存唔到中繼資料：$error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -5868,7 +5920,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return '重新整理唔到中繼資料：$error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -5882,7 +5934,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return '遠端搜尋失敗：$error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -5896,7 +5948,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return '更新唔到內容類型：$error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -5910,12 +5962,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '已更新 $imageType 圖片';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return '下載唔到圖片：$error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -5926,27 +5978,27 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '已上載 $imageType 圖片';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return '上載唔到圖片：$error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '刪除 $imageType 圖片';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '已刪除 $imageType 圖片';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return '刪除唔到圖片：$error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -5957,65 +6009,67 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return '搵唔到調諧器：$error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => '新增調音器';
 
   @override
-  String get adminEditTuner => '編輯調諧器';
+  String get adminEditTuner => 'Edit Tuner';
 
   @override
-  String get adminTunerTypeM3u => 'M3U 調諧器';
+  String get adminTunerTypeM3u => 'M3U Tuner';
 
   @override
   String get adminTunerTypeHdHomerun => 'HDHomeRun';
 
   @override
-  String get adminTunerFileOrUrl => '檔案或者 URL';
+  String get adminTunerFileOrUrl => 'File or URL';
 
   @override
-  String get adminTunerIpAddress => '調諧器 IP 位址';
+  String get adminTunerIpAddress => 'Tuner IP address';
 
   @override
-  String get adminTunerFriendlyName => '易記名稱';
+  String get adminTunerFriendlyName => 'Friendly name';
 
   @override
-  String get adminTunerUserAgent => '使用者代理';
+  String get adminTunerUserAgent => 'User agent';
 
   @override
-  String get adminTunerCount => '同時連線上限';
+  String get adminTunerCount => 'Simultaneous connection limit';
 
   @override
-  String get adminTunerCountHelp => '調諧器同一時間最多容許幾多條串流。設做 0 就冇限制。';
+  String get adminTunerCountHelp =>
+      'The maximum number of streams the tuner allows at once. Set to 0 for unlimited.';
 
   @override
-  String get adminTunerFallbackBitrate => '備用嘅最高串流位元率';
+  String get adminTunerFallbackBitrate => 'Fallback max streaming bitrate';
 
   @override
-  String get adminTunerImportFavoritesOnly => '淨係匯入我的最愛頻道';
+  String get adminTunerImportFavoritesOnly => 'Import only favorite channels';
 
   @override
-  String get adminTunerAllowHwTranscoding => '允許硬件轉碼';
+  String get adminTunerAllowHwTranscoding => 'Allow hardware transcoding';
 
   @override
-  String get adminTunerAllowFmp4 => '允許 fMP4 轉碼容器';
+  String get adminTunerAllowFmp4 => 'Allow fMP4 transcoding container';
 
   @override
-  String get adminTunerAllowStreamSharing => '允許共用串流';
+  String get adminTunerAllowStreamSharing => 'Allow stream sharing';
 
   @override
-  String get adminTunerEnableStreamLooping => '啟用串流循環';
+  String get adminTunerEnableStreamLooping => 'Enable stream looping';
 
   @override
-  String get adminTunerIgnoreDts => '忽略 DTS';
+  String get adminTunerIgnoreDts => 'Ignore DTS';
 
   @override
-  String get adminTunerReadAtNativeFramerate => '用原生影格率讀取輸入';
+  String get adminTunerReadAtNativeFramerate =>
+      'Read input at native frame rate';
 
   @override
-  String get adminEditProvider => '編輯提供者';
+  String get adminEditProvider => 'Edit Provider';
 
   @override
   String get adminProviderXmltv => 'XMLTV';
@@ -6024,49 +6078,50 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminProviderSchedulesDirect => 'Schedules Direct';
 
   @override
-  String get adminXmltvPath => '檔案或者 URL';
+  String get adminXmltvPath => 'File or URL';
 
   @override
-  String get adminXmltvMoviePrefix => '電影前置字串';
+  String get adminXmltvMoviePrefix => 'Movie prefix';
 
   @override
-  String get adminXmltvMovieCategories => '電影類別';
+  String get adminXmltvMovieCategories => 'Movie categories';
 
   @override
-  String get adminXmltvCategoriesHelp => '多個類別之間用直線（|）分隔。';
+  String get adminXmltvCategoriesHelp =>
+      'Separate multiple categories with a vertical bar.';
 
   @override
-  String get adminXmltvKidsCategories => '兒童類別';
+  String get adminXmltvKidsCategories => 'Kids categories';
 
   @override
-  String get adminXmltvNewsCategories => '新聞類別';
+  String get adminXmltvNewsCategories => 'News categories';
 
   @override
-  String get adminXmltvSportsCategories => '體育類別';
+  String get adminXmltvSportsCategories => 'Sports categories';
 
   @override
-  String get adminSdUsername => '使用者名稱';
+  String get adminSdUsername => 'Username';
 
   @override
-  String get adminSdPassword => '密碼';
+  String get adminSdPassword => 'Password';
 
   @override
-  String get adminSdCountry => '國家／地區';
+  String get adminSdCountry => 'Country';
 
   @override
-  String get adminSdCountrySelect => '揀一個國家／地區';
+  String get adminSdCountrySelect => 'Select a country';
 
   @override
-  String get adminSdPostalCode => '郵遞區號';
+  String get adminSdPostalCode => 'Postal code';
 
   @override
-  String get adminSdGetListings => '取得節目表';
+  String get adminSdGetListings => 'Get listings';
 
   @override
-  String get adminSdListings => '節目表';
+  String get adminSdListings => 'Listings';
 
   @override
-  String get adminEnableAllTuners => '啟用所有調諧器';
+  String get adminEnableAllTuners => 'Enable all tuners';
 
   @override
   String get adminTunerType => '調音器類型';
@@ -6076,7 +6131,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return '加入唔到調諧器：$error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -6090,12 +6145,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return '加入唔到提供者：$error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return '移除唔到調諧器：$error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -6103,15 +6158,16 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return '重設唔到調諧器：$error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported => '呢種調諧器唔支援重設。';
+  String get adminTunerResetNotSupported =>
+      'This tuner type does not support resetting.';
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return '移除唔到提供者：$error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -6130,43 +6186,43 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminSeriesRecordingPath => '系列錄音路徑';
 
   @override
-  String get adminMovieRecordingPath => '電影錄影路徑';
+  String get adminMovieRecordingPath => 'Movie recording path';
 
   @override
-  String get adminGuideDays => '節目表資料日數';
+  String get adminGuideDays => 'Guide data days';
 
   @override
-  String get adminGuideDaysAuto => '自動';
+  String get adminGuideDaysAuto => 'Automatic';
 
   @override
   String adminGuideDaysValue(int days) {
-    return '$days 日';
+    return '$days days';
   }
 
   @override
-  String get adminRecordingPostProcessor => '後製處理程式路徑';
+  String get adminRecordingPostProcessor => 'Post-processing application path';
 
   @override
-  String get adminRecordingPostProcessorArgs => '後製處理器引數';
+  String get adminRecordingPostProcessorArgs => 'Post-processor arguments';
 
   @override
-  String get adminSaveRecordingNfo => '儲存錄影嘅 NFO 中繼資料';
+  String get adminSaveRecordingNfo => 'Save recording NFO metadata';
 
   @override
-  String get adminSaveRecordingImages => '儲存錄影圖片';
+  String get adminSaveRecordingImages => 'Save recording images';
 
   @override
-  String get adminLiveTvSectionTiming => '時間設定';
+  String get adminLiveTvSectionTiming => 'Timing';
 
   @override
-  String get adminLiveTvSectionPaths => '錄影路徑';
+  String get adminLiveTvSectionPaths => 'Recording paths';
 
   @override
-  String get adminLiveTvSectionPostProcessing => '後製處理';
+  String get adminLiveTvSectionPostProcessing => 'Post-processing';
 
   @override
   String adminGuideDaysDisplay(String value) {
-    return '節目表資料：$value';
+    return 'Guide data: $value';
   }
 
   @override
@@ -6174,7 +6230,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return '儲存唔到設定：$error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -6191,7 +6247,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return '更新唔到對應：$error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -6207,13 +6263,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminGuideProviders => '導遊提供者';
 
   @override
-  String get adminRefreshGuideData => '重新整理節目表資料';
+  String get adminRefreshGuideData => 'Refresh Guide Data';
 
   @override
-  String get adminGuideRefreshStarted => '已開始重新整理節目表資料';
+  String get adminGuideRefreshStarted => 'Guide data refresh started';
 
   @override
-  String get adminGuideRefreshUnavailable => '呢部伺服器冇節目表重新整理工作。';
+  String get adminGuideRefreshUnavailable =>
+      'Guide refresh task is not available on this server.';
 
   @override
   String get adminAddProvider => '新增提供者';
@@ -6223,22 +6280,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return '錄影路徑：$path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return '劇集路徑：$path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return '提早錄影：$minutes 分鐘';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return '延後錄影：$minutes 分鐘';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -6267,7 +6324,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '而家還原備份 $name？';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -6289,13 +6346,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminLiveTvTitle => '直播電視管理';
 
   @override
-  String get adminApply => '套用';
+  String get adminApply => '申請';
 
   @override
   String get adminNotSet => '未設定';
 
   @override
-  String get adminReset => '重設';
+  String get adminReset => '重置';
 
   @override
   String get adminLogsTitle => '伺服器日誌';
@@ -6311,27 +6368,27 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes 分鐘前';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours 小時前';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days 日前';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '載入唔到 $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count 個相符';
+    return '$count matches';
   }
 
   @override
@@ -6341,7 +6398,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminMetadataEditorTitle => '元資料編輯器';
 
   @override
-  String get adminMetadataIdentify => '辨識';
+  String get adminMetadataIdentify => 'Identify';
 
   @override
   String get adminMetadataType => '類型';
@@ -6441,22 +6498,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '已更新 $imageType 圖片';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '已上載 $imageType 圖片';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '已刪除 $imageType 圖片';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return '下載唔到圖片：$error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -6464,12 +6521,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return '上載唔到圖片：$error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '刪除 $imageType 圖片';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -6477,12 +6534,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return '刪除唔到圖片：$error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '揀 $imageType 圖片';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -6514,7 +6571,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return '有更新：v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -6537,7 +6594,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return '安裝更新（v$version）';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -6548,7 +6605,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '安裝緊「$name」...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -6566,7 +6623,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name 設定';
+    return '$name Settings';
   }
 
   @override
@@ -6601,7 +6658,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return '載入唔到存放庫：$error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -6609,15 +6666,15 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '你確定要移除「$name」？';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => '移除';
+  String get adminReposRemove => '消除';
 
   @override
   String adminReposSaveFailed(String error) {
-    return '儲存唔到存放庫：$error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6738,19 +6795,19 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminBrandingEnableSplash => '啟用啟動畫面';
 
   @override
-  String get adminBrandingSplashUpload => '上載圖片';
+  String get adminBrandingSplashUpload => 'Upload image';
 
   @override
-  String get adminBrandingSplashUploaded => '已更新啟動畫面';
+  String get adminBrandingSplashUploaded => 'Splashscreen updated';
 
   @override
-  String get adminBrandingSplashUploadFailed => '上載唔到啟動畫面';
+  String get adminBrandingSplashUploadFailed => 'Failed to upload splashscreen';
 
   @override
-  String get adminBrandingSplashDeleted => '已移除啟動畫面';
+  String get adminBrandingSplashDeleted => 'Splashscreen removed';
 
   @override
-  String get adminBrandingNoSplash => '冇自訂啟動畫面';
+  String get adminBrandingNoSplash => 'No custom splashscreen';
 
   @override
   String get adminPlaybackHwAccel => '硬體加速';
@@ -6765,115 +6822,121 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminPlaybackEnableHwDecoding => '啟用硬體解碼：';
 
   @override
-  String get adminPlaybackQsvDevice => 'QSV 裝置';
+  String get adminPlaybackQsvDevice => 'QSV device';
 
   @override
-  String get adminPlaybackEnhancedNvdec => '啟用增強型 NVDEC 解碼器';
+  String get adminPlaybackEnhancedNvdec => 'Enable enhanced NVDEC decoder';
 
   @override
-  String get adminPlaybackPreferNativeDecoder => '優先用系統原生嘅硬件解碼器';
+  String get adminPlaybackPreferNativeDecoder =>
+      'Prefer system native hardware decoder';
 
   @override
-  String get adminPlaybackColorDepth => '硬件解碼色彩深度';
+  String get adminPlaybackColorDepth => 'Hardware decoding color depth';
 
   @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC 解碼';
+  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC decoding';
 
   @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 解碼';
+  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 decoding';
 
   @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit 解碼';
+  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit decoding';
 
   @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit 解碼';
+  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit decoding';
 
   @override
-  String get adminPlaybackHwEncodingSection => '硬件編碼';
+  String get adminPlaybackHwEncodingSection => 'Hardware encoding';
 
   @override
-  String get adminPlaybackAllowHevcEncoding => '允許 HEVC 編碼';
+  String get adminPlaybackAllowHevcEncoding => 'Allow HEVC encoding';
 
   @override
-  String get adminPlaybackAllowAv1Encoding => '允許 AV1 編碼';
+  String get adminPlaybackAllowAv1Encoding => 'Allow AV1 encoding';
 
   @override
-  String get adminPlaybackIntelLowPowerH264 => '啟用 Intel 低功耗 H.264 編碼器';
+  String get adminPlaybackIntelLowPowerH264 =>
+      'Enable Intel low-power H.264 encoder';
 
   @override
-  String get adminPlaybackIntelLowPowerHevc => '啟用 Intel 低功耗 HEVC 編碼器';
+  String get adminPlaybackIntelLowPowerHevc =>
+      'Enable Intel low-power HEVC encoder';
 
   @override
-  String get adminPlaybackToneMapping => '色調對應';
+  String get adminPlaybackToneMapping => 'Tone Mapping';
 
   @override
-  String get adminPlaybackEnableTonemapping => '啟用色調對應';
+  String get adminPlaybackEnableTonemapping => 'Enable tone mapping';
 
   @override
-  String get adminPlaybackEnableVppTonemapping => '啟用 VPP 色調對應';
+  String get adminPlaybackEnableVppTonemapping => 'Enable VPP tone mapping';
 
   @override
-  String get adminPlaybackEnableVtTonemapping => '啟用 VideoToolbox 色調對應';
+  String get adminPlaybackEnableVtTonemapping =>
+      'Enable VideoToolbox tone mapping';
 
   @override
-  String get adminPlaybackTonemappingAlgorithm => '色調對應演算法';
+  String get adminPlaybackTonemappingAlgorithm => 'Tone mapping algorithm';
 
   @override
-  String get adminPlaybackTonemappingMode => '色調對應模式';
+  String get adminPlaybackTonemappingMode => 'Tone mapping mode';
 
   @override
-  String get adminPlaybackTonemappingRange => '色調對應範圍';
+  String get adminPlaybackTonemappingRange => 'Tone mapping range';
 
   @override
-  String get adminPlaybackTonemappingDesat => '色調對應去飽和度';
+  String get adminPlaybackTonemappingDesat => 'Tone mapping desaturation';
 
   @override
-  String get adminPlaybackTonemappingPeak => '色調對應峰值';
+  String get adminPlaybackTonemappingPeak => 'Tone mapping peak';
 
   @override
-  String get adminPlaybackTonemappingParam => '色調對應參數';
+  String get adminPlaybackTonemappingParam => 'Tone mapping parameter';
 
   @override
-  String get adminPlaybackVppTonemappingBrightness => 'VPP 色調對應亮度';
+  String get adminPlaybackVppTonemappingBrightness =>
+      'VPP tone mapping brightness';
 
   @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP 色調對應對比度';
+  String get adminPlaybackVppTonemappingContrast => 'VPP tone mapping contrast';
 
   @override
-  String get adminPlaybackPresetsQuality => '預設集同品質';
+  String get adminPlaybackPresetsQuality => 'Presets & Quality';
 
   @override
-  String get adminPlaybackEncoderPreset => '編碼器預設集';
+  String get adminPlaybackEncoderPreset => 'Encoder preset';
 
   @override
-  String get adminPlaybackH264Crf => 'H.264 編碼 CRF';
+  String get adminPlaybackH264Crf => 'H.264 encoding CRF';
 
   @override
-  String get adminPlaybackH265Crf => 'H.265（HEVC）編碼 CRF';
+  String get adminPlaybackH265Crf => 'H.265 (HEVC) encoding CRF';
 
   @override
-  String get adminPlaybackDeinterlaceMethod => '去交錯方式';
+  String get adminPlaybackDeinterlaceMethod => 'Deinterlace method';
 
   @override
-  String get adminPlaybackDeinterlaceDoubleRate => '去交錯嗰陣將影格率加倍';
+  String get adminPlaybackDeinterlaceDoubleRate =>
+      'Double the frame rate when deinterlacing';
 
   @override
-  String get adminPlaybackAudioSection => '音訊';
+  String get adminPlaybackAudioSection => 'Audio';
 
   @override
-  String get adminPlaybackEnableAudioVbr => '啟用音訊 VBR 編碼';
+  String get adminPlaybackEnableAudioVbr => 'Enable audio VBR encoding';
 
   @override
-  String get adminPlaybackDownmixBoost => '音訊縮混增益';
+  String get adminPlaybackDownmixBoost => 'Audio downmix boost';
 
   @override
-  String get adminPlaybackDownmixAlgorithm => '立體聲縮混演算法';
+  String get adminPlaybackDownmixAlgorithm => 'Stereo downmix algorithm';
 
   @override
-  String get adminPlaybackMaxMuxingQueue => '最大混流佇列大小';
+  String get adminPlaybackMaxMuxingQueue => 'Max muxing queue size';
 
   @override
-  String get adminPlaybackAutoOption => '自動';
+  String get adminPlaybackAutoOption => 'Auto';
 
   @override
   String get adminPlaybackEncoding => '編碼';
@@ -6987,7 +7050,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminTaskStop => '停止';
 
   @override
-  String get adminRunningTasks => '執行緊嘅工作';
+  String get adminRunningTasks => 'Running Tasks';
 
   @override
   String get adminTaskRun => '跑步';
@@ -7009,17 +7072,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return '每日 $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return '每個$day $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return '每 $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -7057,8 +7120,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 小時',
-      one: '1 小時',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -7086,17 +7149,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days 日前';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours 小時前';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes 分鐘前';
+    return '${minutes}m ago';
   }
 
   @override
@@ -7104,17 +7167,17 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes 分';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours 小時';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days 日';
+    return '${days}d';
   }
 
   @override
@@ -7123,7 +7186,7 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get adminTrickplayDescription => '設定 Trickplay 圖片產生，用嚟做跳轉預覽縮圖。';
+  String get adminTrickplayDescription => '配置搜尋預覽縮圖的特技播放影像生成。';
 
   @override
   String get adminNetworkingPublicHttpsPort => '公共 HTTPS 連接埠';
@@ -7132,49 +7195,49 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminNetworkingBaseUrl => '基本網址';
 
   @override
-  String get adminNetworkingBaseUrlHint => '例如 /jellyfin';
+  String get adminNetworkingBaseUrlHint => '例如/果凍';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
 
   @override
-  String get adminNetworkingPublicHttpPort => '公開 HTTP 連接埠';
+  String get adminNetworkingPublicHttpPort => 'Public HTTP port';
 
   @override
-  String get adminNetworkingRequireHttps => '強制使用 HTTPS';
+  String get adminNetworkingRequireHttps => 'Require HTTPS';
 
   @override
   String get adminNetworkingRequireHttpsHint =>
-      '將所有遠端要求重新導向去 HTTPS。如果伺服器冇有效憑證就唔會生效。';
+      'Redirect all remote requests to HTTPS. Has no effect if the server has no valid certificate.';
 
   @override
-  String get adminNetworkingCertPassword => '憑證密碼';
+  String get adminNetworkingCertPassword => 'Certificate password';
 
   @override
-  String get adminNetworkingIpSettings => 'IP 設定';
+  String get adminNetworkingIpSettings => 'IP Settings';
 
   @override
-  String get adminNetworkingEnableIpv4 => '啟用 IPv4';
+  String get adminNetworkingEnableIpv4 => 'Enable IPv4';
 
   @override
-  String get adminNetworkingEnableIpv6 => '啟用 IPv6';
+  String get adminNetworkingEnableIpv6 => 'Enable IPv6';
 
   @override
-  String get adminNetworkingAutoDiscovery => '啟用自動連接埠對應';
+  String get adminNetworkingAutoDiscovery => 'Enable automatic port mapping';
 
   @override
-  String get adminNetworkingLocalSubnets => '區域網路';
+  String get adminNetworkingLocalSubnets => 'LAN networks';
 
   @override
   String get adminNetworkingLocalSubnetsHint =>
-      '用逗號或者換行分隔嘅 IP 位址或者 CIDR 子網路清單，會當做喺區域網路入面。';
+      'Comma or line separated list of IP addresses or CIDR subnets treated as being on the local network.';
 
   @override
-  String get adminNetworkingPublishedUris => '公開嘅伺服器 URI';
+  String get adminNetworkingPublishedUris => 'Published server URIs';
 
   @override
   String get adminNetworkingPublishedUriHint =>
-      '將子網路或者位址對應去一個公開 URL，例如 all=https://example.com';
+      'Map a subnet or address to a published URL, e.g. all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => '證書路徑';
@@ -7204,10 +7267,11 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => '油門緩衝';
 
   @override
-  String get adminPlaybackThrottleDelay => '節流延遲（秒）';
+  String get adminPlaybackThrottleDelay => 'Throttle delay (seconds)';
 
   @override
-  String get adminPlaybackEnableSubtitleExtraction => '允許即時擷取字幕';
+  String get adminPlaybackEnableSubtitleExtraction =>
+      'Allow subtitle extraction on the fly';
 
   @override
   String get adminResumeMinPct => '最低履歷百分比';
@@ -7253,29 +7317,29 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return '更新唔到內容類型：$error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => '慢響應閾值（毫秒）';
 
   @override
-  String get adminGeneralEnableSlowResponse => '啟用回應緩慢警告';
+  String get adminGeneralEnableSlowResponse => 'Enable slow response warnings';
 
   @override
-  String get adminGeneralQuickConnect => '啟用 Quick Connect';
+  String get adminGeneralQuickConnect => 'Enable Quick Connect';
 
   @override
-  String get adminGeneralSectionServer => '伺服器';
+  String get adminGeneralSectionServer => 'Server';
 
   @override
-  String get adminGeneralSectionMetadata => '中繼資料';
+  String get adminGeneralSectionMetadata => 'Metadata';
 
   @override
-  String get adminGeneralSectionPaths => '路徑';
+  String get adminGeneralSectionPaths => 'Paths';
 
   @override
-  String get adminGeneralSectionPerformance => '效能';
+  String get adminGeneralSectionPerformance => 'Performance';
 
   @override
   String get adminGeneralCachePath => '快取路徑';
@@ -7287,7 +7351,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminGeneralServerName => '伺服器名稱';
 
   @override
-  String get adminGeneralDisplayLanguage => '偏好嘅顯示語言';
+  String get adminGeneralDisplayLanguage => 'Preferred display language';
 
   @override
   String get adminSettingsLoadFailed => '無法載入設定';
@@ -7297,19 +7361,19 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return '更新唔到對應：$error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return '時間限制：$duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => '資料夾';
 
   @override
-  String get libraries => '媒體庫';
+  String get libraries => '圖書館';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -7338,8 +7402,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 位參與者',
-      one: '# 位參與者',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -7379,7 +7443,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return '項目 $index';
+    return 'Item $index';
   }
 
   @override
@@ -7426,12 +7490,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName 加入咗 SyncPlay 群組';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName 離開咗 SyncPlay 群組';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -7443,7 +7507,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '同步緊播放去 $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -7480,8 +7544,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '搵到 # 個列表',
-      one: '搵到 # 個列表',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -7520,19 +7584,20 @@ class AppLocalizationsYue extends AppLocalizations {
   String get offlineSavedMedia => '保存的媒體';
 
   @override
-  String get offlineBannerTitle => '你而家離線';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => '顯示緊你嘅下載';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => '下載';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => '連唔到你個伺服器';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
-  String get serverUnreachableBannerSubtitle => '喺伺服器返嚟之前，會先播下載咗嘅內容';
+  String get serverUnreachableBannerSubtitle =>
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7548,12 +7613,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return '投放控制失敗：$error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind 控制';
+    return '$kind Controls';
   }
 
   @override
@@ -7564,7 +7629,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String castStopKind(String kind) {
-    return '停止 $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -7587,12 +7652,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '輸入 $length 位數字 PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '輸入你嘅 $length 位數字 PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -7611,29 +7676,29 @@ class AppLocalizationsYue extends AppLocalizations {
   String get pinBackspace => '退格鍵';
 
   @override
-  String get quickConnectAuthorized => '已授權 Quick Connect 要求。';
+  String get quickConnectAuthorized => '快速連線請求已獲授權。';
 
   @override
-  String get quickConnectInvalidOrExpired => 'Quick Connect 代碼無效或者已經過期。';
+  String get quickConnectInvalidOrExpired => '快速連線代碼無效或已過期。';
 
   @override
-  String get quickConnectNotSupported => '呢部伺服器唔支援 Quick Connect。';
+  String get quickConnectNotSupported => '此伺服器不支援快速連線。';
 
   @override
-  String get quickConnectAuthorizeFailed => '授權唔到 Quick Connect 代碼。';
+  String get quickConnectAuthorizeFailed => '無法授權快速連線代碼。';
 
   @override
-  String get quickConnectDisabled => '呢部伺服器已經停用咗 Quick Connect。';
+  String get quickConnectDisabled => '此伺服器上禁用了快速連線。';
 
   @override
-  String get quickConnectForbidden => '你個帳戶冇權授權呢個 Quick Connect 要求。';
+  String get quickConnectForbidden => '您的帳戶無法授權此快速連線要求。';
 
   @override
-  String get quickConnectNotFound => '搵唔到呢個 Quick Connect 代碼。試吓攞個新代碼。';
+  String get quickConnectNotFound => '未找到快速連線代碼。嘗試新的程式碼。';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect 失敗：$message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -7644,7 +7709,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return '指令失敗：$error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -7673,7 +7738,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return '開始唔到投放：$error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -7718,7 +7783,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '下載緊 $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -7737,7 +7802,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get shuffleSelectGenre => '選擇類型';
 
   @override
-  String get shuffleLibrary => '媒體庫';
+  String get shuffleLibrary => '圖書館';
 
   @override
   String get shuffleGenre => '類型';
@@ -7804,7 +7869,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return '跳過$segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -7815,12 +7880,12 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '下載緊 $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '下載緊 $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -7857,7 +7922,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get playerTooltipUnlockOrientation => '允許旋轉';
 
   @override
-  String get playerTooltipPrevious => '上一個';
+  String get playerTooltipPrevious => '以前的';
 
   @override
   String get playerTooltipSeekBack => '回頭尋找';
@@ -7881,13 +7946,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get contextMenuGoToSeries => '前往系列';
 
   @override
-  String get contextMenuHideFromContinueWatching => '喺「繼續睇」度隱藏';
+  String get contextMenuHideFromContinueWatching =>
+      'Hide from Continue Watching';
 
   @override
-  String get contextMenuHideFromNextUp => '喺「下一集」度隱藏';
+  String get contextMenuHideFromNextUp => 'Hide from Next Up';
 
   @override
-  String get contextMenuAddToCollection => '加入合輯';
+  String get contextMenuAddToCollection => 'Add to Collection';
 
   @override
   String get settingsAdministrationSubtitle => '存取伺服器管理面板';
@@ -7935,14 +8001,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsAlphabetical => '按字母順序';
 
   @override
-  String get settingsConnectionSection => '連線';
+  String get settingsConnectionSection => 'CONNECTION';
 
   @override
-  String get settingsAllowSelfSignedCerts => '允許自簽憑證';
+  String get settingsAllowSelfSignedCerts => 'Allow self-signed certificates';
 
   @override
   String get settingsAllowSelfSignedCertsSubtitle =>
-      '信任使用自簽或者私人 CA TLS 憑證嘅伺服器。淨係喺你自己控制嘅伺服器先好開。呢個會停用所有連線嘅憑證驗證。';
+      'Trust servers using self-signed or private-CA TLS certificates. Only enable for servers you control. This disables certificate validation for all connections.';
 
   @override
   String get settingsPrivacyAndSafetySection => '隱私與安全';
@@ -7957,10 +8023,11 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsGeneralStyleSubtitle => '主題口音、背景、觀看指示器和主題音樂';
 
   @override
-  String get settingsDetailsScreen => '詳細資料頁';
+  String get settingsDetailsScreen => 'Details Screen';
 
   @override
-  String get settingsDetailsScreenSubtitle => '樣式、背景模糊同分頁行為';
+  String get settingsDetailsScreenSubtitle =>
+      'Style, background blur, and tab behavior';
 
   @override
   String get settingsHomePage => '首頁';
@@ -7990,10 +8057,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsShowLibrariesButtonInNavigation => '在導覽列中顯示庫按鈕';
 
   @override
-  String get settingsShowSeerrButtonInNavigation => '喺導覽列顯示 Seerr 按鈕';
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
 
   @override
-  String get settingsAlwaysExpandNavbarLabels => '喺頂部導覽列永遠顯示文字標籤';
+  String get settingsAlwaysExpandNavbarLabels =>
+      'Always show text labels in the top navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -8058,7 +8127,8 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsSupportMoonfin => '支援Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => '請開發者飲杯咖啡';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => '合法的';
@@ -8089,8 +8159,8 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 則授權聲明',
-      one: '# 則授權聲明',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -8133,16 +8203,16 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '跳過片頭和片尾？';
 
   @override
-  String get settingsMediaSegmentCountdown => '媒體片段倒數';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => '進度列';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => '計時器';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => '冇';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => '提示用戶';
@@ -8174,13 +8244,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3（建議）';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3（舊版）';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv（舊版）';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv（建議）';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision 後備';
@@ -8265,7 +8335,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value 毫秒';
+    return '$value ms';
   }
 
   @override
@@ -8342,7 +8412,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String libraryNameWithServer(String libraryName, String serverName) {
-    return '$libraryName（$serverName）';
+    return '$libraryName ($serverName)';
   }
 
   @override
@@ -8352,705 +8422,749 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '最近上架嘅$libraryName';
+    return 'Recently Released $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => '自動播放下一集';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
-  String get autoplayNextEpisodeSubtitle => '如果有下一集就自動播。';
+  String get autoplayNextEpisodeSubtitle =>
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => '跳過靜音';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
-  String get skipSilenceSubtitle => '如果串流支援，就自動跳過靜音片段。';
+  String get skipSilenceSubtitle =>
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle => '允許外部音效';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      '允許等化器同音效應用程式（例如 Wavelet）接駁 Media3 播放工作階段。';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => '停用穿隧';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
-  String get disableTunnelingSubtitle => '強制唔用穿隧播放。喺啲穿隧會令音訊／視訊唔連貫嘅裝置度好有用。';
+  String get disableTunnelingSubtitle =>
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => '啟用穿隧';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      '進階功能。將音訊同視訊經由耦合嘅硬件路徑傳送。預設係閂咗，因為喺部分裝置會令音訊／視訊斷斷續續。';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title => '將 Dolby Vision profile 7 對應做 HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      '喺唔支援 Dolby Vision 嘅裝置度，將 Dolby Vision profile 7 串流當做 HDR10 相容嘅 HEVC 嚟播。';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => '用內嵌嘅字幕樣式';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      '套用字幕軌入面內嵌嘅顏色、字體同位置。閂咗就會改用你嘅字幕樣式偏好設定。';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
-  String get subtitlesUseEmbeddedFontSizes => '用內嵌嘅字幕字型大細';
+  String get subtitlesUseEmbeddedFontSizes =>
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      '套用字幕軌入面內嵌嘅字型大細提示。閂咗就會用你樣式偏好設定入面嘅字幕大細。';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => '顯示媒體詳情';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
-  String get showMediaDetailsOnLibraryPageDescription => '喺媒體庫頁面頂部顯示已揀項目嘅詳情。';
+  String get showMediaDetailsOnLibraryPageDescription =>
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => '瀏覽嗰陣隱藏背景圖？';
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
-  String get useDetailedSubHeadings => '用詳細副標題';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
-  String get useDetailedSubHeadingsDescription => '喺媒體庫頁面顯示詳細定簡潔嘅副列。';
+  String get useDetailedSubHeadingsDescription =>
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => '確定要刪除已儲存嘅主題？';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '確定要喺呢部裝置嘅快取度移除「$themeName」？';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
-  String get themeStore => '主題商店';
+  String get themeStore => 'Theme Store';
 
   @override
-  String get themeStoreSubtitle => '瀏覽同儲存社群主題';
+  String get themeStoreSubtitle => 'Browse and save community themes';
 
   @override
-  String get themeStoreDescription => '儲存咗主題之後，就可以好似其他已儲存嘅主題咁用。';
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
 
   @override
-  String get themeStoreEmpty => '而家冇主題可以用。';
+  String get themeStoreEmpty => 'No themes are available right now.';
 
   @override
-  String get themeStoreLoadFailed => '載入唔到主題商店。檢查吓你嘅連線再試過。';
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
 
   @override
-  String get themeStoreSave => '儲存';
+  String get themeStoreSave => 'Save';
 
   @override
-  String get themeStoreSaveAndApply => '儲存並套用';
+  String get themeStoreSaveAndApply => 'Save & apply';
 
   @override
-  String get themeStoreSaved => '已儲存';
+  String get themeStoreSaved => 'Saved';
 
   @override
-  String get themeStoreInvalidMessage => '載入唔到呢個主題。';
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
 
   @override
   String themeStoreSavedMessage(String themeName) {
-    return '已儲存「$themeName」。';
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '已喺呢部裝置度刪除「$themeName」。';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '刪除唔到「$themeName」。';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => '已儲存嘅主題';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      '呢啲係為目前伺服器由 Moonfin 外掛程式下載返嚟嘅主題。刪除淨係會移除呢個本機副本。';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => '搵唔到呢部伺服器嘅已儲存主題。';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • 使用緊';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => '刪除已儲存嘅主題';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
-  String get savedThemesManageSubtitle => '管理呢部裝置度已下載嘅外掛程式主題';
+  String get savedThemesManageSubtitle =>
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => '主題編輯器';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => '喺你嘅瀏覽器度開 Moonfin 主題編輯器';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => '主畫面';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => '底部列';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => '經典';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => '現代';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => '主畫面列表';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => '主畫面列表顯示';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => '主畫面列表區段';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => '主畫面列表開關';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
-  String get homeRowTogglesSubtitle => '啟用或者停用以媒體庫為基礎嘅主畫面列表類別';
+  String get homeRowTogglesSubtitle =>
+      'Enable or disable library-based home row categories';
 
   @override
-  String get homeRowTogglesDescription => '開以下嘅開關，就會喺主畫面區段度顯示對應嘅列表。';
+  String get homeRowTogglesDescription =>
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
-  String get rowsTypeDescription => '「經典」保留逐行嘅圖片類型同資訊覆蓋層。「現代」用直度轉背景圖嘅列表。';
+  String get rowsTypeDescription =>
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => '顯示我的最愛列表';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
-  String get displayFavoritesRowsSubtitle => '喺主畫面區段顯示最愛電影、劇集同其他最愛列表。';
+  String get displayFavoritesRowsSubtitle =>
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => '我的最愛列表排序';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
-  String get favoritesRowSortingDescription => '用加入日期、上映日期、字母順序等等嚟排序我的最愛列表。';
+  String get favoritesRowSortingDescription =>
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => '顯示合輯列表';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
-  String get displayCollectionsRowsSubtitle => '喺主畫面區段顯示合輯列表。';
+  String get displayCollectionsRowsSubtitle =>
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => '合輯列表排序';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
-  String get collectionsRowSortingDescription => '用加入日期、上映日期、字母順序等等嚟排序合輯列表。';
+  String get collectionsRowSortingDescription =>
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => '顯示類型列表';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => '喺主畫面區段顯示類型列表。';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => '類型列表排序';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
-  String get genresRowSortingDescription => '用加入日期、上映日期、字母順序等等嚟排序類型列表。';
+  String get genresRowSortingDescription =>
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => '類型列表項目';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
-  String get genresRowItemsDescription => '喺類型列表度顯示電影、劇集，或者兩樣都顯示。';
+  String get genresRowItemsDescription =>
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => '顯示播放清單列表';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
-  String get displayPlaylistsRowsSubtitle => '喺主畫面區段顯示播放清單列表。';
+  String get displayPlaylistsRowsSubtitle =>
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => '播放清單列表排序';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
-  String get playlistsRowSortingDescription => '用加入日期、上映日期、字母順序等等嚟排序播放清單列表。';
+  String get playlistsRowSortingDescription =>
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => '顯示音訊列表';
+  String get displayAudioRows => 'Display Audio Rows';
 
   @override
-  String get displayAudioRowsSubtitle => '喺主畫面區段顯示音訊列表。';
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
 
   @override
-  String get audioRowsSorting => '音訊列表排序';
+  String get audioRowsSorting => 'Audio Rows sorting';
 
   @override
-  String get audioRowsSortingDescription => '用加入日期、上映日期、字母順序等等嚟排序音訊列表。';
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get audioPlaylists => '音訊播放清單';
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get appearance => '外觀';
+  String get appearance => 'Appearance';
 
   @override
-  String get layout => '版面配置';
+  String get layout => 'Layout';
 
   @override
-  String get theme => '主題';
+  String get theme => 'Theme';
 
   @override
-  String get keyboard => '鍵盤';
+  String get keyboard => 'Keyboard';
 
   @override
-  String get navButtons => '按鈕';
+  String get navButtons => 'Buttons';
 
   @override
-  String get rendering => '算圖';
+  String get rendering => 'Rendering';
 
   @override
-  String get mpvConfiguration => 'MPV 設定';
+  String get mpvConfiguration => 'MPV configuration';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => '外部播放器應用程式';
+  String get externalPlayerApp => 'External player app';
 
   @override
-  String get externalPlayerAppDescription => '設定咗外部播放器就可以用長按播放選項';
+  String get externalPlayerAppDescription =>
+      'Set external player to enable long-press play option';
 
   @override
-  String get externalPlayerAskEachTimeSubtitle => '開始播放嗰陣顯示應用程式選擇器。';
+  String get externalPlayerAskEachTimeSubtitle =>
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => '載入緊已安裝嘅播放器...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => '連線';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => '音訊轉碼目標';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => '直通';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => '呢部裝置支援';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => '呢部裝置唔支援';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X（DTS UHD）直通';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      '將 DTS:X（DTS UHD）位元流送去外部解碼器。';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
-  String get settingsAudioTrueHdJocPassthrough => '帶 Atmos（JOC）嘅 TrueHD 直通';
+  String get settingsAudioTrueHdJocPassthrough =>
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => '媒體播放器行為';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => '播放增強功能';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => '永遠開啟。';
+  String get alwaysOn => 'Always on.';
 
   @override
-  String get replaceSkipOutroWithNextUpDisplay => '用「下一集」顯示取代「跳過片尾」';
+  String get replaceSkipOutroWithNextUpDisplay =>
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '顯示「下一集」覆蓋層，唔顯示「跳過片尾」按鈕。';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => '播放器路由';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => '優先用軟件解碼器';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      '喺硬件解碼器之前先用 FFmpeg（音訊）同 libgav1（AV1）。如果 HDMI 音訊直通有問題就閂咗佢。';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
-  String get useExternalPlayerSubtitle => '喺 Android TV 度用你揀咗嘅外部應用程式播片。';
+  String get useExternalPlayerSubtitle =>
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => '自動排隊';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => '優先用 SDH 字幕';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
-  String get preferSdhSubtitlesSubtitle => '自動揀字幕嗰陣優先揀 SDH/CC 字幕軌。';
+  String get preferSdhSubtitlesSubtitle =>
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => '網頁診斷';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin 網頁診斷';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
-  String get webDiagnosticsIntro => '用呢版嚟診斷瀏覽器嘅連線問題（CORS、混合內容同探索設定）。';
+  String get webDiagnosticsIntro =>
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
-  String get webDiagnosticsDetectedMixedContentFailure => '偵測到混合內容失敗';
+  String get webDiagnosticsDetectedMixedContentFailure =>
+      'Detected Mixed-Content Failure';
 
   @override
-  String get webDiagnosticsDetectedCorsPreflightFailure => '偵測到 CORS／預檢失敗';
+  String get webDiagnosticsDetectedCorsPreflightFailure =>
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin 偵測到有 HTTPS 網頁想呼叫 HTTP 嘅伺服器 URL。瀏覽器會喺要求去到你部伺服器之前就封鎖咗佢。';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin 偵測到瀏覽器層面嘅要求失敗，通常係因為媒體伺服器度缺少咗 CORS 或者預檢標頭。';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return '目標 URL：$url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return '詳情：$detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => '目前嘅執行階段內容';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => '來源';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => '通訊協定';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => '外掛程式模式';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC 掃描';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => '強制指定嘅伺服器 URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => '預設伺服器 URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => '探索代理 URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => '未設定';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => '混合內容';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      '呢版係經 HTTPS 載入，但係有一個或者多個設定咗嘅 URL 係 HTTP。瀏覽器會封鎖 HTTPS 網頁呼叫 HTTP API。';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      '解決方法：用 HTTPS 提供你嘅媒體伺服器或者代理端點，又或者淨係喺可信嘅本地網路度用 HTTP 載入 Moonfin。';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      '喺目前嘅執行階段設定度，冇偵測到明顯嘅混合內容問題。';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS 檢查清單';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• 喺 Access-Control-Allow-Origin 度允許瀏覽器嘅來源。';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• 喺 Access-Control-Allow-Headers 度包含 Authorization、X-Emby-Authorization 同 X-Emby-Token。';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• 為串流同跳轉行為公開 Content-Range 同 Accept-Ranges。';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
-  String get webDiagnosticsCorsChecklistItem4 => '• 對 OPTIONS 預檢要求回傳 204。';
+  String get webDiagnosticsCorsChecklistItem4 =>
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
-  String get webDiagnosticsHeaderSnippetTitle => '標頭範例片段（nginx 風格）';
+  String get webDiagnosticsHeaderSnippetTitle =>
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => '注意';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      '呢個診斷路由係為網頁版而設。如果你喺其他平台睇到呢版，呢啲檢查可能唔適用。';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => '返去揀伺服器';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => '登出所有使用者';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      '麥克風權限已經永久拒絕咗。要喺系統設定度開返佢。';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
-  String get voiceSearchPermissionRequired => '語音搜尋需要麥克風權限。';
+  String get voiceSearchPermissionRequired =>
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => '聽唔清楚。再試過啦。';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => '冇偵測到聲音。';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => '麥克風錯誤。';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => '語音搜尋需要連上網。';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => '語音服務忙緊。再試過啦。';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
-  String get microphonePermissionPermanentlyDenied => '麥克風權限已經永久拒絕咗。';
+  String get microphonePermissionPermanentlyDenied =>
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => '麥克風權限已經拒絕咗。';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
-  String get speechRecognitionUnavailable => '呢部裝置冇語音辨識功能。';
+  String get speechRecognitionUnavailable =>
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => '開 iOS 路由選擇器';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
-  String get airPlayRoutePickerUnavailable => '呢部裝置冇 AirPlay 路由選擇器。';
+  String get airPlayRoutePickerUnavailable =>
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => '影片';
+  String get videos => 'Videos';
 
   @override
-  String get programs => '節目';
+  String get programs => 'Programs';
 
   @override
-  String get songs => '歌曲';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => '相簿';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => '相片';
+  String get photos => 'Photos';
 
   @override
-  String get people => '人物';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => '最近上架嘅集數';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => '再睇一次';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => '客串演出';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => '演出（Seerr）';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => '幕後參與（Seerr）';
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
 
   @override
-  String get watchWithGroup => '同群組一齊睇';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => '錯誤';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => '警告';
+  String get warnings => 'Warnings';
 
   @override
-  String get disk => '磁碟';
+  String get disk => 'Disk';
 
   @override
-  String get openInBrowser => '喺瀏覽器度開';
+  String get openInBrowser => 'Open in Browser';
 
   @override
-  String get embeddedBrowserNotAvailable => '呢個平台冇內嵌瀏覽器。';
+  String get embeddedBrowserNotAvailable =>
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get adminRestartServerConfirmation => '你確定要重新啟動伺服器？';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
-  String get adminShutdownServerConfirmation => '你確定要關閉伺服器？之後你要自己手動開返佢。';
+  String get adminShutdownServerConfirmation =>
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => '內部';
+  String get internal => 'Internal';
 
   @override
-  String get idle => '閒置';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => '搵唔到使用者';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => '冇使用者符合你嘅搜尋';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => '搵唔到裝置';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
-  String get adminNoDevicesMatchCurrentFilters => '冇裝置符合目前嘅篩選條件';
+  String get adminNoDevicesMatchCurrentFilters =>
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => '已設定密碼';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => '未設定密碼';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => '遠端存取';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => '淨係限本機';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => '載入唔到媒體分析';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
-  String get analyticsCombinedAcrossLibraries => '綜合所有媒體庫嘅分析數據。';
+  String get analyticsCombinedAcrossLibraries =>
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => '熱門演出者';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => '熱門作者';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => '熱門貢獻者';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 個媒體庫',
-      one: '1 個媒體庫',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
-  String get analyticsNoIndexedMediaTotals => '呢個選擇暫時仲未有已建立索引嘅媒體總數。';
+  String get analyticsNoIndexedMediaTotals =>
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => '媒體庫詳情';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => '媒體庫細分';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => '冇媒體庫可以用。';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => '伺服器管理';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => '資料';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => '圖片快取';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => '快取';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => '紀錄';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => '中繼資料';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => '轉碼';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => '呢部伺服器冇回傳任何伺服器路徑。';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '已用 $percent%';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => '使用者活動';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => '系統事件';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => '需要處理';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => '伺服器';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => '播放';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => '裝置';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => '進階';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => '外掛程式';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => '直播電視';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => '家庭影片';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => '混合內容';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => '家庭影片同相片';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => '電影同劇集混合';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -9062,292 +9176,299 @@ class AppLocalizationsYue extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => '搵唔到錄影';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '喺 .$extension 壓縮檔入面搵唔到圖片頁。';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return '內嵌算圖器失敗（$code）：$description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB 算圖器失敗（$code）：$description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return '閱讀器搵唔到本機檔案：$uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '由 $uri 開啟書籍資料嗰陣出現 HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => '冇可以讀取嘅書籍端點';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return '唔支援嘅漫畫壓縮檔格式：.$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
-  String get cbrExtractionPluginUnavailable => '呢個平台冇 CBR 解壓縮外掛程式。';
+  String get cbrExtractionPluginUnavailable =>
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '解壓縮唔到 .cbr 檔案。';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => '呢個平台唔支援 CB7 解壓縮。';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
-  String get cb7ExtractionPluginUnavailable => '呢個平台冇 CB7 解壓縮外掛程式。';
+  String get cb7ExtractionPluginUnavailable =>
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => '關閉類型面板';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => '載入緊隨機播放...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => '媒體庫隨機播放';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => '隨機播放';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => '類型隨機播放';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => '自動切換 HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
-  String get autoHdrSwitchingDescription => '播放 HDR 影片嗰陣自動開 HDR，退出嗰陣還原顯示模式。';
+  String get autoHdrSwitchingDescription =>
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => '全螢幕嗰陣';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => '更改封面圖';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => '缺少';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => '轉碼限制';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => '確定要清除所有封面圖？';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
-  String get clearAllArtworkWarning => '你確定要清除所有已下載嘅封面圖？';
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => '確認清除';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return '你確定要清除呢個$itemType？';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => '要上載？';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => '解像度： ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
-  String get onlyShowInterfaceLanguage => '淨係顯示介面語言嘅封面圖';
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => '確認全部清除';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => '圖片已成功上載！';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return '上載唔到圖片：$error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return '設定唔到圖片：$error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return '刪除唔到圖片：$error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return '清除唔到所有封面圖：$error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => '係';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => '海報';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => '背景圖';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => '橫幅';
+  String get bannerCategory => 'Banner';
 
   @override
-  String get logoCategory => '標誌';
+  String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => '縮圖';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => '美術圖';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => '碟面圖';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => '螢幕截圖';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => '盒面封面';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => '盒背封面';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => '選單美術圖';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => '海報';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => '背景圖';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => '橫幅';
+  String get confirmItemBanner => 'banner';
 
   @override
-  String get confirmItemLogo => '標誌';
+  String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => '縮圖';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => '美術圖';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => '碟面圖';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => '螢幕截圖';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => '盒面封面';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => '盒背封面';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => '選單美術圖';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => '全部';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => '高（1080p+）';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => '中（720p）';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => '低（<720p）';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => '來源';
+  String get sources => 'Sources';
 
   @override
-  String get audiobookChapters => '章節';
+  String get audiobookChapters => 'Chapters';
 
   @override
-  String get audiobookBookmarks => '書籤';
+  String get audiobookBookmarks => 'Bookmarks';
 
   @override
-  String get audiobookNotes => '筆記';
+  String get audiobookNotes => 'Notes';
 
   @override
-  String get audiobookQueue => '佇列';
+  String get audiobookQueue => 'Queue';
 
   @override
-  String get audiobookTimeline => '時間軸';
+  String get audiobookTimeline => 'Timeline';
 
   @override
-  String get audiobookTimelineEmpty => '時間軸係空嘅';
+  String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => '成本書';
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
-  String get audiobookFocusedTimeline => '聚焦時間軸';
+  String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
-  String get audiobookExportBookmarks => '匯出書籤';
+  String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override
-  String get audiobookExportNotes => '匯出筆記';
+  String get audiobookExportNotes => 'Export Notes';
 
   @override
-  String get audiobookExportAll => '全部匯出';
+  String get audiobookExportAll => 'Export All';
 
   @override
   String audiobookExportSuccess(String path) {
-    return '已匯出去 $path';
+    return 'Exported to $path';
   }
 
   @override
   String audiobookExportFailed(String error) {
-    return '匯出失敗：$error';
+    return 'Export failed: $error';
   }
 
   @override
-  String get audiobookLyrics => '歌詞';
+  String get audiobookLyrics => 'Lyrics';
 
   @override
-  String get audiobookAddBookmark => '加書籤';
+  String get audiobookAddBookmark => 'Add bookmark';
 
   @override
-  String get audiobookAddNote => '加筆記';
+  String get audiobookAddNote => 'Add note';
 
   @override
-  String get audiobookEditNote => '編輯筆記';
+  String get audiobookEditNote => 'Edit note';
 
   @override
-  String get audiobookNoteHint => '為呢一刻寫個筆記';
+  String get audiobookNoteHint => 'Write a note for this moment';
 
   @override
-  String get audiobookSleepTimer => '睡眠計時器';
+  String get audiobookSleepTimer => 'Sleep timer';
 
   @override
-  String get audiobookSleepOff => '關';
+  String get audiobookSleepOff => 'Off';
 
   @override
-  String get audiobookSleepEndOfChapter => '章節結尾';
+  String get audiobookSleepEndOfChapter => 'End of chapter';
 
   @override
-  String get audiobookSleepCustom => '自訂';
+  String get audiobookSleepCustom => 'Custom';
 
   @override
   String audiobookSleepRemaining(String remaining) {
-    return '仲有 $remaining';
+    return '$remaining left';
   }
 
   @override
@@ -9355,58 +9476,58 @@ class AppLocalizationsYue extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 分鐘',
-      one: '1 分鐘',
+      other: '$count min',
+      one: '1 min',
     );
     return '$_temp0';
   }
 
   @override
-  String get audiobookPlaybackSpeed => '播放速度';
+  String get audiobookPlaybackSpeed => 'Playback speed';
 
   @override
-  String get audiobookRemainingTime => '剩餘';
+  String get audiobookRemainingTime => 'Remaining';
 
   @override
-  String get audiobookElapsedTime => '已播';
+  String get audiobookElapsedTime => 'Elapsed';
 
   @override
   String audiobookSkipBackSeconds(int seconds) {
-    return '倒返 $seconds 秒';
+    return 'Back ${seconds}s';
   }
 
   @override
   String audiobookSkipForwardSeconds(int seconds) {
-    return '快進 $seconds 秒';
+    return 'Forward ${seconds}s';
   }
 
   @override
-  String get audiobookPreviousChapter => '上一章';
+  String get audiobookPreviousChapter => 'Previous chapter';
 
   @override
-  String get audiobookNextChapter => '下一章';
+  String get audiobookNextChapter => 'Next chapter';
 
   @override
   String audiobookChapterIndicator(int current, int total) {
-    return '第 $current 章，共 $total 章';
+    return 'Chapter $current of $total';
   }
 
   @override
-  String get audiobookNoChapters => '冇章節';
+  String get audiobookNoChapters => 'No chapters';
 
   @override
-  String get audiobookNoBookmarks => '仲未有書籤';
+  String get audiobookNoBookmarks => 'No bookmarks yet';
 
   @override
-  String get audiobookNoNotes => '仲未有筆記';
+  String get audiobookNoNotes => 'No notes yet';
 
   @override
   String audiobookBookmarkAdded(String position) {
-    return '已喺 $position 加咗書籤';
+    return 'Bookmark added at $position';
   }
 
   @override
-  String get audiobookSpeedReset => '重設做 1.0x';
+  String get audiobookSpeedReset => 'Reset to 1.0x';
 
   @override
   String audiobookSpeedCustomLabel(String value) {
@@ -9414,239 +9535,251 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get audiobookSave => '儲存';
+  String get audiobookSave => 'Save';
 
   @override
-  String get audiobookCancel => '取消';
+  String get audiobookCancel => 'Cancel';
 
   @override
-  String get audiobookDelete => '刪除';
+  String get audiobookDelete => 'Delete';
 
   @override
-  String get subtitlePreferences => '字幕偏好設定';
+  String get subtitlePreferences => 'Subtitle Preferences';
 
   @override
-  String get subtitlePreferencesDescription => '更改字幕模式、預設語言、外觀同算圖選項。';
+  String get subtitlePreferencesDescription =>
+      'Change subtitle modes, default languages, appearance, and rendering options.';
 
   @override
-  String get subtitleRendering => '字幕算圖';
+  String get subtitleRendering => 'Subtitle Rendering';
 
   @override
-  String get displayOptions => '顯示選項';
+  String get displayOptions => 'Display Options';
 
   @override
-  String get releaseDateAscending => '上映日期（由舊到新）';
+  String get releaseDateAscending => 'Release Date (Ascending)';
 
   @override
-  String get releaseDateDescending => '上映日期（由新到舊）';
+  String get releaseDateDescending => 'Release Date (Descending)';
 
   @override
-  String get groupContributions => '參與作品分組';
+  String get groupContributions => 'Group Contributions';
 
   @override
-  String get groupMultipleRoles => '將多個角色合併';
+  String get groupMultipleRoles => 'Group multiple roles';
 
   @override
-  String get libraryWriteAccessWarningTitle => '媒體庫寫入權限警告';
+  String get libraryWriteAccessWarningTitle => 'Library Write Access Warning';
 
   @override
-  String get libraryWriteAccessHowToFix => '點樣解決：';
+  String get libraryWriteAccessHowToFix => 'How to fix this:';
 
   @override
   String get libraryWriteAccessFixSteps =>
-      '1. 喺伺服器度，為你嘅媒體庫資料夾俾寫入權限畀 Jellyfin 服務使用者（例如 jellyfin 或者 Docker PUID/PGID）。\n\n2. 又或者去你嘅 Jellyfin 儀表板 -> 媒體庫，編輯呢個媒體庫，然後閂咗「Save artwork into media folders」，咁封面圖就會存喺 Jellyfin 嘅內部資料庫入面。';
+      '1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable \'Save artwork into media folders\' to store artwork in Jellyfin\'s internal database.';
 
   @override
-  String get dismiss => '知道喇';
+  String get dismiss => 'Dismiss';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '你嘅「$libraryName」媒體庫設定咗將封面圖直接存入媒體資料夾（「Save artwork into media folders」已經啟用）。不過 Jellyfin 測試過寫入權限，發現冇權限將檔案寫入呢個目錄：\n\n$failedPath';
+    return 'Your \'$libraryName\' library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$failedPath';
   }
 
   @override
   String get libraryWriteAccessReactiveBody =>
-      '睇嚟 Jellyfin 更新唔到封面圖。你個媒體庫設定咗將封面圖直接存入媒體資料夾（「Save artwork into media folders」已經啟用）。呢個錯誤通常係因為 Jellyfin 伺服器程序冇權限將檔案寫入你嘅媒體目錄。';
+      'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => '外部清單';
+  String get externalLists => 'External Lists';
 
   @override
-  String get replay => '重播';
+  String get replay => 'Replay';
 
   @override
-  String get fileInformation => '檔案資訊';
+  String get fileInformation => 'File Information';
 
   @override
   String fileSizeFormat(Object size, Object format) {
-    return '大細：$size  •  格式：$format';
+    return 'Size: $size  •  Format: $format';
   }
 
   @override
   String showAllAudioTracks(int count) {
-    return '顯示全部（$count）音軌';
+    return 'Show All ($count) Audio Tracks';
   }
 
   @override
   String showAllSubtitleTracks(int count) {
-    return '顯示全部（$count）字幕軌';
+    return 'Show All ($count) Subtitle Tracks';
   }
 
   @override
-  String get checkingDirectPlay => '檢查緊直接播放能力...';
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
 
   @override
-  String get directPlayCapabilityLabel => '直接播放能力： ';
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
 
   @override
-  String get forced => '強制';
+  String get forced => 'Forced';
 
   @override
-  String get transcodeContainerNotSupported => '播放器唔支援呢個容器格式。';
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
 
   @override
-  String get transcodeVideoCodecNotSupported => '唔支援呢個視訊編解碼器。';
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
 
   @override
-  String get transcodeAudioCodecNotSupported => '唔支援呢個音訊編解碼器。';
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
 
   @override
-  String get transcodeSubtitleCodecNotSupported => '唔支援呢個字幕格式（需要燒錄）。';
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
 
   @override
-  String get transcodeAudioProfileNotSupported => '唔支援呢個音訊設定檔。';
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
 
   @override
-  String get transcodeVideoProfileNotSupported => '唔支援呢個視訊設定檔。';
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
 
   @override
-  String get transcodeVideoLevelNotSupported => '唔支援呢個視訊等級。';
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
 
   @override
-  String get transcodeVideoResolutionNotSupported => '呢部裝置唔支援呢個視訊解像度。';
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
 
   @override
-  String get transcodeVideoBitDepthNotSupported => '唔支援呢個視訊位元深度。';
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
 
   @override
-  String get transcodeVideoFramerateNotSupported => '唔支援呢個視訊幀率。';
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
 
   @override
-  String get transcodeContainerBitrateExceedsLimit => '檔案位元率超出咗播放器嘅串流上限。';
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
 
   @override
-  String get transcodeVideoBitrateExceedsLimit => '視訊位元率超出咗串流上限。';
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioBitrateExceedsLimit => '音訊位元率超出咗串流上限。';
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
 
   @override
-  String get transcodeAudioChannelsNotSupported => '唔支援呢個音訊聲道數。';
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
 
   @override
-  String get sortAlphabetical => '按字母順序';
+  String get sortAlphabetical => 'Alphabetical';
 
   @override
-  String get sortReleaseAscending => '上映順序（由舊到新）';
+  String get sortReleaseAscending => 'Release Order (Ascending)';
 
   @override
-  String get sortReleaseDescending => '上映順序（由新到舊）';
+  String get sortReleaseDescending => 'Release Order (Descending)';
 
   @override
-  String get sortCustomDragDrop => '自訂（拖放）';
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
 
   @override
-  String get playlistSortOptions => '播放清單排序選項';
+  String get playlistSortOptions => 'Playlist Sort Options';
 
   @override
-  String get resetSort => '重設排序';
+  String get resetSort => 'Reset Sort';
 
   @override
   String rewatchSeasonEpisode(int season, int episode) {
-    return '重睇第$season季第$episode集';
+    return 'Rewatch S$season:E$episode';
   }
 
   @override
-  String get rewatchPlaylist => '重睇播放清單';
+  String get rewatchPlaylist => 'Rewatch Playlist';
 
   @override
-  String get noSubtitlesFound => '搵唔到字幕。';
+  String get noSubtitlesFound => 'No subtitles found.';
 
   @override
-  String get adminControls => '管理員控制';
+  String get adminControls => 'Admin Controls';
 
   @override
-  String get impellerRendering => '算圖引擎（Impeller）';
+  String get impellerRendering => 'Rendering engine (Impeller)';
 
   @override
   String get impellerRenderingSubtitle =>
-      'Impeller 係 Flutter 新一代嘅 GPU 算圖器，動畫會順啲、少啲窒。喺部分電視盒同舊 GPU 上面可能會有花屏或者黑畫面；如果你見到咁就閂咗佢。「自動」會為你部裝置揀最啱嘅預設值。要重新啟動 Moonfin 先生效。';
+      'Impeller is Flutter\'s modern GPU renderer for smoother animations and less stutter. On some TV boxes and older GPUs it can cause glitches or black video; switch it Off if you see those. Automatic picks the best default for your device. Restart Moonfin to apply.';
 
   @override
-  String get impellerAuto => '自動';
+  String get impellerAuto => 'Automatic';
 
   @override
-  String get impellerOn => '開';
+  String get impellerOn => 'On';
 
   @override
-  String get impellerOff => '關';
+  String get impellerOff => 'Off';
 
   @override
-  String get impellerRestartTitle => '需要重新啟動';
+  String get impellerRestartTitle => 'Restart required';
 
   @override
   String get impellerRestartMessage =>
-      'Moonfin 要重新啟動先可以更改算圖引擎。而家閂咗個應用程式，再開返就會生效。';
+      'Moonfin needs to restart to change the rendering engine. Close the app now, then reopen it to apply.';
 
   @override
-  String get impellerCloseNow => '而家閂咗應用程式';
+  String get impellerCloseNow => 'Close app now';
 
   @override
-  String get adminRefreshLibrary => '重新整理媒體庫';
+  String get adminRefreshLibrary => 'Refresh Library';
 
   @override
-  String get adminRefreshAllLibraries => '重新整理所有媒體庫';
+  String get adminRefreshAllLibraries => 'Refresh All Libraries';
 
   @override
-  String get adminRepoSortDateOldest => '加入日期（由舊到新）';
+  String get adminRepoSortDateOldest => 'Date Added (Oldest First)';
 
   @override
-  String get adminRepoSortDateNewest => '加入日期（由新到舊）';
+  String get adminRepoSortDateNewest => 'Date Added (Newest First)';
 
   @override
-  String get adminRepoSortNameAsc => '按字母順序（A 到 Z）';
+  String get adminRepoSortNameAsc => 'Alphabetical (A to Z)';
 
   @override
-  String get adminRepoSortNameDesc => '按字母順序（Z 到 A）';
+  String get adminRepoSortNameDesc => 'Alphabetical (Z to A)';
 
   @override
   String adminAnalyticsLoadingProgress(int percentage) {
-    return '載入緊伺服器分析... $percentage%';
+    return 'Loading Server Analytics... $percentage%';
   }
 
   @override
-  String get adminLibChapterImageResolutionMatchSource => '同來源一樣';
+  String get adminLibChapterImageResolutionMatchSource => 'Match source';
 
   @override
-  String get imdbTop250Movies => 'IMDb 250 大電影';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 250 大電視劇';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb 最受歡迎電影';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb 最受歡迎電視劇';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb 評分最低電影';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb 評分最高英語電影';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).
@@ -9663,6 +9796,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String connectingToServer(String serverName) {
     return '连接到$serverName';
   }
+
+  @override
+  String get quickConnect => '快速连接';
 
   @override
   String get password => '密码';
@@ -10259,6 +10395,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get librivoxPage => 'LibriVox 页';
+
+  @override
+  String get internetArchive => '互联网档案馆';
 
   @override
   String get rssFeed => 'RSS 源';
@@ -11274,6 +11413,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => '西尔账户类型';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -12564,7 +12706,34 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get displayClockDuringScreensaver => '屏幕保护期间显示时钟';
 
   @override
+  String get rottenTomatoesCritics => '烂番茄（评论家）';
+
+  @override
+  String get rottenTomatoesAudience => '烂番茄（观众）';
+
+  @override
+  String get imdb => '互联网医学数据库';
+
+  @override
+  String get tmdb => 'TM数据库';
+
+  @override
+  String get metacritic => '元评论家';
+
+  @override
+  String get metacriticUser => '元评论家（用户）';
+
+  @override
+  String get trakt => '特拉克特';
+
+  @override
   String get letterboxd => '信箱';
+
+  @override
+  String get myAnimeList => '我的动漫列表';
+
+  @override
+  String get aniList => '动画列表';
 
   @override
   String get communityRating => '社区评级';
@@ -12601,6 +12770,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get ratingSourcesDescription => '启用并重新排序整个应用程序中显示的评级来源';
+
+  @override
+  String get pluginLabel => '插件';
 
   @override
   String get pluginDetected => '检测到插件';
@@ -12672,6 +12844,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get resetRowsToDefaults => '将行重置为默认值';
 
   @override
+  String get enableSeerr => '启用搜索器';
+
+  @override
   String get showSeerrInNavigation => '在导航中显示 Seerr（需要服务器插件）';
 
   @override
@@ -12687,6 +12862,16 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String loggedInAs(String username) {
     return 'Logged in as: $username';
   }
+
+  @override
+  String get discoverRows => '发现行';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      '拖动以重新排序。启用或禁用行。启用与 Moonfin 插件的行顺序同步。';
+
+  @override
+  String get discoverRowsDescription => '拖动以重新排序。启用或禁用行。';
 
   @override
   String get enabled => '启用';
@@ -12817,6 +13002,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String itemsCount(int count) {
     return '$count Items';
   }
+
+  @override
+  String get seerrSettings => '搜索者设置';
 
   @override
   String get requestMore => '请求更多';
@@ -13108,6 +13296,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get time => '时间';
 
   @override
+  String get trickplay => '特技游戏';
+
+  @override
   String get uninstall => '卸载';
 
   @override
@@ -13154,6 +13345,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get adminDrawerStreaming => '流媒体';
+
+  @override
+  String get adminDrawerTrickplay => '特技游戏';
 
   @override
   String get adminDrawerDevices => '设备';
@@ -14232,6 +14426,12 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get adminThrottleBuffering => '油门缓冲';
 
   @override
+  String get adminTrickplaySaved => '已保存特技播放设置';
+
+  @override
+  String get adminTrickplayLoadFailed => '无法加载特技播放设置';
+
+  @override
   String get adminEnableHardwareAcceleration => '启用硬件加速';
 
   @override
@@ -14329,6 +14529,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get adminBaseUrl => '基本网址';
+
+  @override
+  String get adminBaseUrlHint => '例如/果冻';
 
   @override
   String get https => 'HTTPS';
@@ -15359,10 +15562,16 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   }
 
   @override
+  String get adminTrickplayDescription => '配置搜索预览缩略图的特技播放图像生成。';
+
+  @override
   String get adminNetworkingPublicHttpsPort => '公共 HTTPS 端口';
 
   @override
   String get adminNetworkingBaseUrl => '基本网址';
+
+  @override
+  String get adminNetworkingBaseUrlHint => '例如/果冻';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -15758,6 +15967,27 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get pinBackspace => '退格键';
+
+  @override
+  String get quickConnectAuthorized => '快速连接请求已获授权。';
+
+  @override
+  String get quickConnectInvalidOrExpired => '快速连接代码无效或已过期。';
+
+  @override
+  String get quickConnectNotSupported => '此服务器不支持快速连接。';
+
+  @override
+  String get quickConnectAuthorizeFailed => '无法授权快速连接代码。';
+
+  @override
+  String get quickConnectDisabled => '此服务器上禁用了快速连接。';
+
+  @override
+  String get quickConnectForbidden => '您的帐户无法授权此快速连接请求。';
+
+  @override
+  String get quickConnectNotFound => '未找到快速连接代码。尝试新的代码。';
 
   @override
   String quickConnectFailedWithMessage(String message) {
@@ -17161,6 +17391,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
+  String get quickConnect => '快速連接';
+
+  @override
   String get password => '密碼';
 
   @override
@@ -17756,6 +17989,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get librivoxPage => 'LibriVox 頁';
+
+  @override
+  String get internetArchive => '互聯網檔案館';
 
   @override
   String get rssFeed => 'RSS 來源';
@@ -18771,6 +19007,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get seerr => 'Seerr';
+
+  @override
+  String get seerrAccountType => '西爾帳戶類型';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -20061,7 +20300,34 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String get displayClockDuringScreensaver => '螢幕保護期間顯示時鐘';
 
   @override
+  String get rottenTomatoesCritics => '爛番茄（評論家）';
+
+  @override
+  String get rottenTomatoesAudience => '爛番茄（觀眾）';
+
+  @override
+  String get imdb => '網路醫學資料庫';
+
+  @override
+  String get tmdb => 'TM資料庫';
+
+  @override
+  String get metacritic => '元評論家';
+
+  @override
+  String get metacriticUser => '元評論家（使用者）';
+
+  @override
+  String get trakt => '特拉克特';
+
+  @override
   String get letterboxd => '信箱';
+
+  @override
+  String get myAnimeList => '我的動漫列表';
+
+  @override
+  String get aniList => '動畫列表';
 
   @override
   String get communityRating => '社區評級';
@@ -20098,6 +20364,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get ratingSourcesDescription => '啟用並重新排序整個應用程式中顯示的評級來源';
+
+  @override
+  String get pluginLabel => '外掛';
 
   @override
   String get pluginDetected => '偵測到插件';
@@ -20169,6 +20438,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String get resetRowsToDefaults => '將行重設為預設值';
 
   @override
+  String get enableSeerr => '啟用搜尋器';
+
+  @override
   String get showSeerrInNavigation => '在導航中顯示 Seerr（需要伺服器插件）';
 
   @override
@@ -20184,6 +20456,16 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String loggedInAs(String username) {
     return 'Logged in as: $username';
   }
+
+  @override
+  String get discoverRows => '發現行';
+
+  @override
+  String get discoverRowsDescriptionPlugin =>
+      '拖曳以重新排序。啟用或停用行。啟用與 Moonfin 插件的行順序同步。';
+
+  @override
+  String get discoverRowsDescription => '拖曳以重新排序。啟用或停用行。';
 
   @override
   String get enabled => '啟用';
@@ -20314,6 +20596,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String itemsCount(int count) {
     return '$count Items';
   }
+
+  @override
+  String get seerrSettings => '搜尋者設定';
 
   @override
   String get requestMore => '請求更多';
@@ -20605,6 +20890,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String get time => '時間';
 
   @override
+  String get trickplay => '特技遊戲';
+
+  @override
   String get uninstall => '解除安裝';
 
   @override
@@ -20651,6 +20939,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get adminDrawerStreaming => '串流媒體';
+
+  @override
+  String get adminDrawerTrickplay => '特技遊戲';
 
   @override
   String get adminDrawerDevices => '裝置';
@@ -21729,6 +22020,12 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String get adminThrottleBuffering => '油門緩衝';
 
   @override
+  String get adminTrickplaySaved => '已儲存特技播放設定';
+
+  @override
+  String get adminTrickplayLoadFailed => '無法載入特技播放設置';
+
+  @override
   String get adminEnableHardwareAcceleration => '啟用硬體加速';
 
   @override
@@ -21826,6 +22123,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get adminBaseUrl => '基本網址';
+
+  @override
+  String get adminBaseUrlHint => '例如/果凍';
 
   @override
   String get https => 'HTTPS';
@@ -22856,10 +23156,16 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
+  String get adminTrickplayDescription => '配置搜尋預覽縮圖的特技播放影像生成。';
+
+  @override
   String get adminNetworkingPublicHttpsPort => '公共 HTTPS 連接埠';
 
   @override
   String get adminNetworkingBaseUrl => '基本網址';
+
+  @override
+  String get adminNetworkingBaseUrlHint => '例如/果凍';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
@@ -23255,6 +23561,27 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get pinBackspace => '退格鍵';
+
+  @override
+  String get quickConnectAuthorized => '快速連線請求已獲授權。';
+
+  @override
+  String get quickConnectInvalidOrExpired => '快速連線代碼無效或已過期。';
+
+  @override
+  String get quickConnectNotSupported => '此伺服器不支援快速連線。';
+
+  @override
+  String get quickConnectAuthorizeFailed => '無法授權快速連線代碼。';
+
+  @override
+  String get quickConnectDisabled => '此伺服器上禁用了快速連線。';
+
+  @override
+  String get quickConnectForbidden => '您的帳戶無法授權此快速連線要求。';
+
+  @override
+  String get quickConnectNotFound => '未找到快速連線代碼。嘗試新的程式碼。';
 
   @override
   String quickConnectFailedWithMessage(String message) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -32,7 +32,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => '快速连接';
 
   @override
   String get password => '密码';
@@ -60,12 +60,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect 不可用：$detail';
+    return '快速连接不可用：$detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect 不可用（$status）：$detail';
+    return '快速连接不可用（$status）：$detail';
   }
 
   @override
@@ -152,16 +152,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get detailScreenStyleModern => '现代';
 
   @override
-  String get expandedTabs => '展开标签页';
+  String get expandedTabs => '自动展开标签页';
 
   @override
-  String get expandedTabsSubtitle => '浏览标签页时自动显示其内容。关闭后需手动展开和收起每个标签页。';
+  String get expandedTabsSubtitle => '浏览时自动加载标签内容；关闭后需手动展开/收起标签。';
 
   @override
-  String get showTechnicalDetails => '显示技术详情？';
+  String get showTechnicalDetails => '显示媒体技术参数？';
 
   @override
-  String get showTechnicalDetailsSubtitle => '在横幅摘要中显示编解码器、分辨率和串流信息';
+  String get showTechnicalDetailsSubtitle => '在顶部概览栏显示编码、分辨率及音视频流信息';
 
   @override
   String get recommendationSystem => '推荐系统';
@@ -351,7 +351,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get guide => '节目指南';
 
   @override
-  String get recordings => '录制内容';
+  String get recordings => '录制';
 
   @override
   String get schedule => '日程';
@@ -1447,7 +1447,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get longPressToUnlock => '长按解锁';
 
   @override
-  String get off => '关';
+  String get off => '关闭';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1533,7 +1533,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoBitrate => '视频码率';
 
   @override
-  String get track => '音轨';
+  String get track => '轨道';
 
   @override
   String get channels => '声道';
@@ -1833,7 +1833,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get no => '否';
+  String get no => '不';
 
   @override
   String get yesCancel => '是，取消';
@@ -2223,7 +2223,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get themeMusicVolume => '主题音乐音量';
 
   @override
-  String get themeMusicSettingsSubtitle => '详情页、首页行和音量';
+  String get themeMusicSettingsSubtitle => '详情页、首页分类栏及音量控制';
 
   @override
   String percentValue(int value) {
@@ -2240,7 +2240,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loopThemeMusic => '循环播放主题音乐';
 
   @override
-  String get loopThemeMusicSubtitle => '重复播放该曲目，而不是只播放一次';
+  String get loopThemeMusicSubtitle => '单曲循环，而非仅播放一次';
 
   @override
   String get detailsBackgroundBlur => '详情页背景模糊';
@@ -2269,7 +2269,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsScrollWheelActionDescription => '选择播放时在视频上滚动鼠标滚轮会触发什么操作。';
 
   @override
-  String get scrollWheelActionOff => '关';
+  String get scrollWheelActionOff => '关闭';
 
   @override
   String get scrollWheelActionSeek => '快进/快退';
@@ -2347,16 +2347,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get transcodingAudio => '转码（仅音频）';
 
   @override
-  String get directStreamRemux => '直接串流（重新封装）';
+  String get directStreamRemux => '直流（封装转码）';
 
   @override
-  String get transcodingBitrateOrResolution => '转码（比特率或分辨率）';
+  String get transcodingBitrateOrResolution => '转码（码率/分辨率适配）';
 
   @override
-  String get transcodingVideoAndAudio => '转码（视频和音频）';
+  String get transcodingVideoAndAudio => '转码（视频+音频）';
 
   @override
-  String get transcodingVideo => '转码（视频）';
+  String get transcodingVideo => '转码（仅视频）';
 
   @override
   String get autoServerDefault => '自动（服务器默认）';
@@ -3131,7 +3131,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => '关';
+  String get mediaBarModeOff => '关闭';
 
   @override
   String get enableMediaBar => '启用媒体栏';
@@ -3179,7 +3179,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trailerAudio => '预告片音频';
 
   @override
-  String get enableTrailerAudio => '为媒体栏中的预告片启用音频';
+  String get enableTrailerAudio => '媒体栏预告片开启音效';
 
   @override
   String get episodePreview => '剧集预览';
@@ -3546,10 +3546,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seerrNotifyLibraryAddedSubtitle => '已批准、已拒绝和已添加到媒体库';
 
   @override
-  String get seerrNotifyIssuesTitle => '问题更新';
+  String get seerrNotifyIssuesTitle => '媒体问题通知';
 
   @override
-  String get seerrNotifyIssuesSubtitle => '新问题、回复和解决情况';
+  String get seerrNotifyIssuesSubtitle => '新增问题、回复及问题解决通知';
 
   @override
   String loggedInAs(String username) {
@@ -3561,11 +3561,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      '启用要在 Seerr 首页显示的栏目，拖动可调整排序。自定义顺序将与 Moonbase 同步。';
+      '启用首页展示栏目，拖动调整排序，自定义顺序将同步至 Moonfin 服务端。';
 
   @override
   String get discoverRowsDescription =>
-      '启用要在 Seerr 首页显示的栏目，拖动可调整排序。自定义顺序将与 Moonbase 同步。';
+      '启用首页展示栏目，拖动调整排序，自定义顺序将同步至 Moonfin 服务端。';
 
   @override
   String get enabled => '已启用';
@@ -3708,11 +3708,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return '正在下载 · $percent%';
+    return '下载中 · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => '正在导入';
+  String get seerrImportingStatus => '入库中';
 
   @override
   String itemsCount(int count) {
@@ -3853,146 +3853,146 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deletedStatus => '已删除';
 
   @override
-  String get failedStatus => '失败';
+  String get failedStatus => '请求失败';
 
   @override
   String get processingStatus => '处理中';
 
   @override
   String modifiedByName(String name) {
-    return '由 $name 修改';
+    return '操作人：$name';
   }
 
   @override
   String get completedStatus => '已完成';
 
   @override
-  String get requestErrorDuplicate => '该内容已被请求过';
+  String get requestErrorDuplicate => '该影片已提交过请求';
 
   @override
-  String get requestErrorQuota => '已达请求上限';
+  String get requestErrorQuota => '已达最大请求额度';
 
   @override
-  String get requestErrorBlocklisted => '该内容已被列入屏蔽名单';
+  String get requestErrorBlocklisted => '该影片已被屏蔽，无法请求';
 
   @override
-  String get requestErrorNoSeasons => '没有可请求的季';
+  String get requestErrorNoSeasons => '全季资源已拥有或已提交请求';
 
   @override
-  String get requestErrorPermission => '你没有权限发起此请求';
+  String get requestErrorPermission => '你无权限提交媒体请求';
 
   @override
-  String get seerrRequestsTitle => '请求';
+  String get seerrRequestsTitle => '媒体请求';
 
   @override
-  String get seerrIssuesTitle => '问题';
+  String get seerrIssuesTitle => '媒体问题反馈';
 
   @override
-  String get sortNewest => '最新';
+  String get sortNewest => '最新提交';
 
   @override
-  String get sortLastModified => '最近修改';
+  String get sortLastModified => '最近更新';
 
   @override
-  String get noIssues => '暂无问题';
+  String get noIssues => '暂无反馈问题';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '电影请求剩余 $remaining/$limit 次';
+    return '电影剩余请求额度：$remaining/$limit';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '剧季请求剩余 $remaining/$limit 次';
+    return '剧集剩余请求额度：$remaining/$limit';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '属于 $name';
+    return '合集：$name';
   }
 
   @override
-  String get viewCollection => '查看合集';
+  String get viewCollection => '查看完整合集';
 
   @override
-  String get requestCollection => '请求合集';
+  String get requestCollection => '请求整套合集';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total 部电影 · $available 部可用';
+    return '共$total部影片 · 已有$available部';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '请求 $count 部电影';
+    return '请求$count部影片';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return '正在请求第 $current/$total 部...';
+    return '正在提交 $current/$total……';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '已请求 $count 部电影';
+    return '已提交$count部影片请求';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return '已请求 $total 部电影中的 $ok 部';
+    return '成功$ok部，总计$total部';
   }
 
   @override
-  String get collectionAllRequested => '所有电影均已可用或已请求';
+  String get collectionAllRequested => '合集全部影片已拥有或已提交请求';
 
   @override
-  String get reportIssue => '报告问题';
+  String get reportIssue => '反馈媒体问题';
 
   @override
-  String get issueTypeVideo => '视频';
+  String get issueTypeVideo => '视频画面';
 
   @override
-  String get issueTypeAudio => '音频';
+  String get issueTypeAudio => '音频音效';
 
   @override
-  String get whatsWrong => '遇到了什么问题？';
+  String get whatsWrong => '问题描述？';
 
   @override
-  String get allEpisodes => '所有剧集';
+  String get allEpisodes => '全季所有集数';
 
   @override
-  String get episode => '剧集';
+  String get episode => '单集';
 
   @override
-  String get openStatus => '未解决';
+  String get openStatus => '待处理';
 
   @override
   String get resolvedStatus => '已解决';
 
   @override
-  String get resolveAction => '解决';
+  String get resolveAction => '标记已解决';
 
   @override
-  String get reopenAction => '重新打开';
+  String get reopenAction => '重新开启反馈';
 
   @override
   String reportedByName(String name) {
-    return '由 $name 报告';
+    return '反馈人：$name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count 条评论';
+    return '$count条评论';
   }
 
   @override
   String get addComment => '添加评论';
 
   @override
-  String get deleteIssueConfirm => '删除此问题？';
+  String get deleteIssueConfirm => '确定删除这条反馈？';
 
   @override
-  String get submitReport => '提交报告';
+  String get submitReport => '提交反馈';
 
   @override
   String get tmdbScore => 'TMDB 评分';
@@ -4016,7 +4016,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get originalLanguageLabel => '原始语言';
 
   @override
-  String get seasonsLabel => '季数';
+  String get seasonsLabel => '季';
 
   @override
   String get episodesLabel => '集';
@@ -4085,7 +4085,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get networking => '网络';
 
   @override
-  String get next => '下一个';
+  String get next => '下一项';
 
   @override
   String get path => '路径';
@@ -4109,7 +4109,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get refresh => '刷新';
 
   @override
-  String get remote => '遥控';
+  String get remote => '远程';
 
   @override
   String get rename => '重命名';
@@ -4208,7 +4208,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminDrawerTranscoding => '转码';
 
   @override
-  String get adminDrawerResume => '继续播放';
+  String get adminDrawerResume => '播放进度';
 
   @override
   String get adminDrawerStreaming => '串流';
@@ -4385,7 +4385,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sessionForward => '快进';
 
   @override
-  String get sessionNext => '下一个';
+  String get sessionNext => '下一项';
 
   @override
   String get sessionVolumeDown => '音量 -';
@@ -5964,85 +5964,85 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminEditTuner => '编辑调谐器';
 
   @override
-  String get adminTunerTypeM3u => 'M3U 调谐器';
+  String get adminTunerTypeM3u => 'M3U 直播源调谐器';
 
   @override
-  String get adminTunerTypeHdHomerun => 'HDHomeRun';
+  String get adminTunerTypeHdHomerun => 'HDHomeRun 硬件调谐器';
 
   @override
-  String get adminTunerFileOrUrl => '文件或 URL';
+  String get adminTunerFileOrUrl => '文件/网络地址';
 
   @override
   String get adminTunerIpAddress => '调谐器 IP 地址';
 
   @override
-  String get adminTunerFriendlyName => '友好名称';
+  String get adminTunerFriendlyName => '自定义名称';
 
   @override
-  String get adminTunerUserAgent => '用户代理';
+  String get adminTunerUserAgent => 'UA 客户端标识';
 
   @override
-  String get adminTunerCount => '同时连接数上限';
+  String get adminTunerCount => '最大并发流数量';
 
   @override
-  String get adminTunerCountHelp => '调谐器同时允许的最大串流数量。设为 0 表示不限制。';
+  String get adminTunerCountHelp => '调谐器同时允许的最大播放流，填 0 代表无限制。';
 
   @override
   String get adminTunerFallbackBitrate => '备用最大串流码率';
 
   @override
-  String get adminTunerImportFavoritesOnly => '仅导入收藏的频道';
+  String get adminTunerImportFavoritesOnly => '仅导入收藏频道';
 
   @override
-  String get adminTunerAllowHwTranscoding => '允许硬件转码';
+  String get adminTunerAllowHwTranscoding => '启用硬件转码';
 
   @override
-  String get adminTunerAllowFmp4 => '允许 fMP4 转码容器';
+  String get adminTunerAllowFmp4 => '允许 fMP4 封装转码';
 
   @override
-  String get adminTunerAllowStreamSharing => '允许共享串流';
+  String get adminTunerAllowStreamSharing => '开启播放流共享';
 
   @override
-  String get adminTunerEnableStreamLooping => '启用串流循环';
+  String get adminTunerEnableStreamLooping => '启用直播循环播放';
 
   @override
-  String get adminTunerIgnoreDts => '忽略 DTS';
+  String get adminTunerIgnoreDts => '忽略 DTS 音轨';
 
   @override
-  String get adminTunerReadAtNativeFramerate => '以原始帧率读取输入';
+  String get adminTunerReadAtNativeFramerate => '按原始帧率读取源文件';
 
   @override
-  String get adminEditProvider => '编辑提供程序';
+  String get adminEditProvider => '编辑节目源';
 
   @override
-  String get adminProviderXmltv => 'XMLTV';
+  String get adminProviderXmltv => 'XMLTV 节目单';
 
   @override
-  String get adminProviderSchedulesDirect => 'Schedules Direct';
+  String get adminProviderSchedulesDirect => 'Schedules Direct 节目源';
 
   @override
-  String get adminXmltvPath => '文件或 URL';
+  String get adminXmltvPath => '文件/节目单链接';
 
   @override
-  String get adminXmltvMoviePrefix => '电影前缀';
+  String get adminXmltvMoviePrefix => '电影分类前缀';
 
   @override
-  String get adminXmltvMovieCategories => '电影类别';
+  String get adminXmltvMovieCategories => '电影分类标签';
 
   @override
-  String get adminXmltvCategoriesHelp => '多个类别之间请用竖线分隔。';
+  String get adminXmltvCategoriesHelp => '多分类使用竖线 | 分隔。';
 
   @override
-  String get adminXmltvKidsCategories => '儿童类别';
+  String get adminXmltvKidsCategories => '少儿分类标签';
 
   @override
-  String get adminXmltvNewsCategories => '新闻类别';
+  String get adminXmltvNewsCategories => '新闻分类标签';
 
   @override
-  String get adminXmltvSportsCategories => '体育类别';
+  String get adminXmltvSportsCategories => '体育分类标签';
 
   @override
-  String get adminSdUsername => '用户名';
+  String get adminSdUsername => '账号';
 
   @override
   String get adminSdPassword => '密码';
@@ -6051,19 +6051,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminSdCountry => '国家/地区';
 
   @override
-  String get adminSdCountrySelect => '选择国家/地区';
+  String get adminSdCountrySelect => '选择地区';
 
   @override
   String get adminSdPostalCode => '邮政编码';
 
   @override
-  String get adminSdGetListings => '获取节目单';
+  String get adminSdGetListings => '拉取节目单';
 
   @override
-  String get adminSdListings => '节目单';
+  String get adminSdListings => '电视节目单';
 
   @override
-  String get adminEnableAllTuners => '启用所有调谐器';
+  String get adminEnableAllTuners => '启用全部调谐器';
 
   @override
   String get adminTunerType => '调谐器类型';
@@ -6852,7 +6852,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPlaybackDeinterlaceMethod => '去隔行方法';
 
   @override
-  String get adminPlaybackDeinterlaceDoubleRate => '去隔行时将帧率加倍';
+  String get adminPlaybackDeinterlaceDoubleRate => '去隔行时倍帧输出';
 
   @override
   String get adminPlaybackAudioSection => '音频';
@@ -7201,10 +7201,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPlaybackThrottleBuffering => '启用缓冲节流';
 
   @override
-  String get adminPlaybackThrottleDelay => '节流延迟（秒）';
+  String get adminPlaybackThrottleDelay => '播放节流延迟（秒）';
 
   @override
-  String get adminPlaybackEnableSubtitleExtraction => '允许实时提取字幕';
+  String get adminPlaybackEnableSubtitleExtraction => '实时提取内嵌字幕';
 
   @override
   String get adminResumeMinPct => '保存进度的最低百分比';
@@ -7260,7 +7260,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminGeneralEnableSlowResponse => '启用慢速响应警告';
 
   @override
-  String get adminGeneralQuickConnect => '启用 Quick Connect';
+  String get adminGeneralQuickConnect => '启用快速连接';
 
   @override
   String get adminGeneralSectionServer => '服务器';
@@ -7284,7 +7284,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminGeneralServerName => '服务器名称';
 
   @override
-  String get adminGeneralDisplayLanguage => '首选显示语言';
+  String get adminGeneralDisplayLanguage => '界面首选语言';
 
   @override
   String get adminSettingsLoadFailed => '无法加载设置';
@@ -7517,19 +7517,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get offlineSavedMedia => '已保存媒体';
 
   @override
-  String get offlineBannerTitle => '你已离线';
+  String get offlineBannerTitle => '当前离线状态';
 
   @override
-  String get offlineBannerSubtitle => '正在显示已下载内容';
+  String get offlineBannerSubtitle => '仅展示本地离线下载内容';
 
   @override
-  String get offlineBannerAction => '下载';
+  String get offlineBannerAction => '离线下载';
 
   @override
-  String get serverUnreachableBannerTitle => '无法连接到服务器';
+  String get serverUnreachableBannerTitle => '无法连接媒体服务器';
 
   @override
-  String get serverUnreachableBannerSubtitle => '恢复前将播放已下载内容';
+  String get serverUnreachableBannerSubtitle => '服务器恢复前仅播放本地缓存影片';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -7608,29 +7608,29 @@ class AppLocalizationsZh extends AppLocalizations {
   String get pinBackspace => '退格键';
 
   @override
-  String get quickConnectAuthorized => 'Quick Connect 请求已获授权。';
+  String get quickConnectAuthorized => '快速连接请求已获授权。';
 
   @override
-  String get quickConnectInvalidOrExpired => 'Quick Connect 代码无效或已过期。';
+  String get quickConnectInvalidOrExpired => '快速连接代码无效或已过期。';
 
   @override
-  String get quickConnectNotSupported => '此服务器不支持 Quick Connect。';
+  String get quickConnectNotSupported => '此服务器不支持快速连接。';
 
   @override
-  String get quickConnectAuthorizeFailed => '无法授权 Quick Connect 代码。';
+  String get quickConnectAuthorizeFailed => '无法授权快速连接代码。';
 
   @override
-  String get quickConnectDisabled => '此服务器上禁用了 Quick Connect。';
+  String get quickConnectDisabled => '此服务器上禁用了快速连接。';
 
   @override
-  String get quickConnectForbidden => '你的账号无法授权此 Quick Connect 请求。';
+  String get quickConnectForbidden => '你的账号无法授权此快速连接请求。';
 
   @override
-  String get quickConnectNotFound => '未找到 Quick Connect 代码。请尝试新的代码。';
+  String get quickConnectNotFound => '未找到快速连接代码。请尝试新的代码。';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect 失败：$message';
+    return '快速连接失败：$message';
   }
 
   @override
@@ -7854,7 +7854,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get playerTooltipUnlockOrientation => '允许旋转';
 
   @override
-  String get playerTooltipPrevious => '上一个';
+  String get playerTooltipPrevious => '上一项';
 
   @override
   String get playerTooltipSeekBack => '快退';
@@ -7878,13 +7878,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get contextMenuGoToSeries => '前往剧集';
 
   @override
-  String get contextMenuHideFromContinueWatching => '从“继续观看”中隐藏';
+  String get contextMenuHideFromContinueWatching => '从继续观看列表隐藏';
 
   @override
-  String get contextMenuHideFromNextUp => '从“接下来播放”中隐藏';
+  String get contextMenuHideFromNextUp => '从待播剧集列表隐藏';
 
   @override
-  String get contextMenuAddToCollection => '添加到合集';
+  String get contextMenuAddToCollection => '添加至影片合集';
 
   @override
   String get settingsAdministrationSubtitle => '访问服务器管理面板';
@@ -7954,10 +7954,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsGeneralStyleSubtitle => '主题强调色、背景图、已观看标记和主题音乐';
 
   @override
-  String get settingsDetailsScreen => '详情界面';
+  String get settingsDetailsScreen => '媒体详情页设置';
 
   @override
-  String get settingsDetailsScreenSubtitle => '样式、背景模糊和标签页行为';
+  String get settingsDetailsScreenSubtitle => '页面样式、背景模糊、标签交互逻辑';
 
   @override
   String get settingsHomePage => '主页';
@@ -8412,7 +8412,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showMediaDetailsOnLibraryPageDescription => '在媒体库页面顶部显示所选媒体项的详情。';
 
   @override
-  String get hideBackdropsInLibraries => '浏览时隐藏背景图？';
+  String get hideBackdropsInLibraries => '浏览库时隐藏背景海报？';
 
   @override
   String get useDetailedSubHeadings => '使用详细的副标题';
@@ -8606,22 +8606,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get appearance => '外观';
 
   @override
-  String get layout => '布局';
+  String get layout => '界面布局';
 
   @override
-  String get theme => '主题';
+  String get theme => '主题外观';
 
   @override
-  String get keyboard => '键盘';
+  String get keyboard => '键盘快捷键';
 
   @override
-  String get navButtons => '按钮';
+  String get navButtons => '导航按钮';
 
   @override
-  String get rendering => '渲染';
+  String get rendering => '渲染设置';
 
   @override
-  String get mpvConfiguration => 'MPV 配置';
+  String get mpvConfiguration => 'MPV 播放器参数';
 
   @override
   String get cardSize => '首页行卡片尺寸';
@@ -9333,7 +9333,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audiobookSleepTimer => '睡眠定时';
 
   @override
-  String get audiobookSleepOff => '关';
+  String get audiobookSleepOff => '关闭';
 
   @override
   String get audiobookSleepEndOfChapter => '章节结束';
@@ -9468,7 +9468,7 @@ class AppLocalizationsZh extends AppLocalizations {
       'Jellyfin 封面更新失败。当前媒体库设置为直接将封面存入媒体文件夹，该报错通常是 Jellyfin 服务进程缺少媒体目录写入权限导致。';
 
   @override
-  String get externalLists => '外部首页栏目列表';
+  String get externalLists => '外部榜单';
 
   @override
   String get replay => '重播';
@@ -9585,10 +9585,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get impellerAuto => '自动';
 
   @override
-  String get impellerOn => '开';
+  String get impellerOn => '开启';
 
   @override
-  String get impellerOff => '关';
+  String get impellerOff => '关闭';
 
   @override
   String get impellerRestartTitle => '需要重启';
@@ -9627,22 +9627,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminLibChapterImageResolutionMatchSource => '匹配源';
 
   @override
-  String get imdbTop250Movies => 'IMDb 250 佳片';
+  String get imdbTop250Movies => 'IMDb Top250 电影';
 
   @override
-  String get imdbTop250TvShows => 'IMDb 剧集 250 佳作';
+  String get imdbTop250TvShows => 'IMDb Top250 电视剧';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb 最热门电影';
+  String get imdbMostPopularMovies => 'IMDb 热门电影榜单';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb 最热门剧集';
+  String get imdbMostPopularTvShows => 'IMDb 热门电视剧榜单';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb 评分最低电影';
+  String get imdbLowestRatedMovies => 'IMDb 低分电影榜单';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb 英语片高分榜';
+  String get imdbTopEnglishMovies => 'IMDb 高分英语电影';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -9653,27 +9653,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => '帳戶偏好設定';
-
-  @override
-  String get interfaceLanguage => '介面語言';
-
-  @override
-  String get systemLanguageDefault => '系統預設';
-
-  @override
   String get signIn => '登入';
 
   @override
-  String get empty => '空';
-
-  @override
   String connectingToServer(String serverName) {
-    return '正在連線到 $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => '快速連接';
 
   @override
   String get password => '密碼';
@@ -9691,7 +9679,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get waitingForAuthorization => '等待授權...';
 
   @override
-  String get back => '返回';
+  String get back => '後退';
 
   @override
   String get serverUnavailable => '伺服器不可用';
@@ -9701,12 +9689,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect 無法使用：$detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect 無法使用（$status）：$detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -9720,7 +9708,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin 版本 $version';
+    return 'Moonfin version $version';
   }
 
   @override
@@ -9746,14 +9734,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String removeServerConfirmation(String serverName) {
-    return '要將「$serverName」從您的伺服器清單中移除嗎？';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
   String get cancel => '取消';
 
   @override
-  String get remove => '移除';
+  String get remove => '消除';
 
   @override
   String get connectToServer => '連接到伺服器';
@@ -9781,97 +9769,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsAppearanceTheme => '應用主題';
 
   @override
-  String get detailScreenStyle => '詳細資料頁樣式';
-
-  @override
-  String get detailScreenStyleSubtitle =>
-      '「經典」是 Moonfin 原本的置中版面；「現代」是自適應的電影感版面。';
-
-  @override
-  String get detailScreenStyleMoonfin => '經典';
-
-  @override
-  String get detailScreenStyleModern => '現代';
-
-  @override
-  String get expandedTabs => '展開分頁';
-
-  @override
-  String get expandedTabsSubtitle => '瀏覽分頁時自動顯示內容。關閉後需手動開合每個分頁。';
-
-  @override
-  String get showTechnicalDetails => '顯示技術詳細資料？';
-
-  @override
-  String get showTechnicalDetailsSubtitle => '在橫幅摘要中顯示編解碼器、解析度與串流資訊';
-
-  @override
-  String get recommendationSystem => '推薦系統';
-
-  @override
-  String get recommendationSystemSubtitle =>
-      '使用 Moonfin Recommends 的本機媒體庫演算法，或線上 TMDb 的相似度指標。注意：線上推薦需要整合 Seerr。';
-
-  @override
-  String get recommendationSystemMoonfin => 'Moonfin Recommends';
-
-  @override
-  String get recommendationSystemTmdb => 'TMDb 相似度';
-
-  @override
-  String get recommendationsApplyParentalRatingCap => '套用家長分級上限？';
-
-  @override
-  String get recommendationsApplyParentalRatingCapSubtitle =>
-      '依目標媒體的家長分級限制 Moonfin Recommends 的建議';
-
-  @override
-  String get interfaceStyle => '介面風格';
-
-  @override
-  String get interfaceStyleSubtitle =>
-      '「自動」會依您的裝置調整。選擇「Apple」或「Material」可指定外觀。';
-
-  @override
-  String get interfaceStyleAutomatic => '自動';
-
-  @override
-  String get interfaceStyleApple => 'Apple';
-
-  @override
-  String get interfaceStyleMaterial => 'Material';
-
-  @override
-  String get glassQuality => '玻璃效果品質';
-
-  @override
-  String get glassQualitySubtitle =>
-      '「自動」會為此裝置選擇最合適的玻璃效果。「完整」會強制使用真實模糊；「精簡」使用輕量玻璃，可節省 GPU 電力。';
-
-  @override
-  String get glassQualityAuto => '自動';
-
-  @override
-  String get glassQualityFull => '完整';
-
-  @override
-  String get glassQualityReduced => '精簡';
-
-  @override
   String get settingsAppearanceThemeSubtitle =>
       '在 Moonfin 和 Neon Pulse 之間切換，無需重新啟動應用程式';
 
   @override
-  String get customThemeTitle => '自訂主題';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
-  String get customThemeSubtitle => '自訂主題會改變整個 Moonfin 的視覺元素。請選擇一個符合您風格的選項。';
-
-  @override
-  String get keyboardPreferSystemIme => '優先使用系統鍵盤';
-
-  @override
-  String get keyboardPreferSystemImeDescription => '預設使用您裝置的輸入法輸入文字';
+  String get keyboardPreferSystemImeDescription =>
+      'Use your device input method by default for text entry';
 
   @override
   String get themeMoonfin => 'Moonfin';
@@ -9880,22 +9786,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get themeMoonfinSubtitle => '目前的 Moonfin 外觀你們都喜歡';
 
   @override
-  String get themeNeonPulse => '霓虹脈動';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle => 'Synthwave 風格具有洋紅色發光、青色文字和更強的鍍鉻對比度';
-
-  @override
-  String get themeGlass => '玻璃';
-
-  @override
-  String get themeGlassSubtitle => '液態玻璃風格，搭配流動漸層背景、霧面表面與 Apple 藍點綴';
-
-  @override
-  String get theme8BitHero => '8-bit 英雄';
-
-  @override
-  String get theme8BitHeroSubtitle => '復古像素風格，搭配粗獷色盤、方塊邊框、硬陰影與像素字體';
 
   @override
   String get embyConnectSignInSubtitle => '使用您的 Emby Connect 帳戶登入';
@@ -9938,7 +9832,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String unableToConnectTo(String target) {
-    return '無法連線到 $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -9949,36 +9843,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get exit => '出口';
-
-  @override
-  String get gameMenu => '選單';
-
-  @override
-  String get gamePaused => '已暫停';
-
-  @override
-  String get gameSaveState => '即時存檔';
-
-  @override
-  String get games => '遊戲';
-
-  @override
-  String get gameLoadState => '讀取存檔';
-
-  @override
-  String get gameFastForward => '快轉';
-
-  @override
-  String get gameEmulatorSettings => '模擬器設定';
-
-  @override
-  String get gameNoCoreOptions => '此核心沒有可調整的選項。';
-
-  @override
-  String get gameHoldToOpenMenu => '按住以開啟選單';
-
-  @override
-  String get gamePlaybackUnsupported => '此裝置尚未支援遊玩遊戲。';
 
   @override
   String get noHomeRowsLoaded => '無法載入主行';
@@ -9993,19 +9857,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get guide => '指導';
 
   @override
-  String get recordings => '錄影內容';
+  String get recordings => '錄音';
 
   @override
   String get schedule => '行程';
 
   @override
-  String get series => '影集';
+  String get series => '系列';
 
   @override
   String get noItemsFound => '沒有找到物品';
 
   @override
-  String get home => '首頁';
+  String get home => '家';
 
   @override
   String get browseAll => '瀏覽全部';
@@ -10035,7 +9899,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get noLibrariesFound => '沒有找到庫';
 
   @override
-  String get library => '媒體庫';
+  String get library => '圖書館';
 
   @override
   String get displaySettings => '顯示設定';
@@ -10048,7 +9912,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String failedToLoadFolderError(String error) {
-    return '無法載入資料夾：$error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -10056,7 +9920,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String itemCountLabel(int count) {
-    return '$count 個項目';
+    return '$count items';
   }
 
   @override
@@ -10073,7 +9937,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String totalCountItems(int count) {
-    return '$count 個項目';
+    return '$count Items';
   }
 
   @override
@@ -10114,7 +9978,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — 類型';
+    return '$name — Genres';
   }
 
   @override
@@ -10127,7 +9991,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get albumArtists => '專輯藝人';
 
   @override
-  String get artists => '藝人';
+  String get artists => '藝術家';
 
   @override
   String get bookmarks => '書籤';
@@ -10152,17 +10016,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String minutesAgo(int count) {
-    return '$count 分鐘前';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '$count 小時前';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '$count 天前';
+    return '${count}d ago';
   }
 
   @override
@@ -10172,7 +10036,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get pickDiscoverySubjects => '選擇要在「發現」中顯示的主題來源。';
 
   @override
-  String get apply => '套用';
+  String get apply => '申請';
 
   @override
   String get openLink => '打開連結';
@@ -10194,7 +10058,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String titlesCount(int count) {
-    return '$count 部作品';
+    return '$count titles';
   }
 
   @override
@@ -10219,7 +10083,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get listen => '聽';
 
   @override
-  String get resume => '繼續';
+  String get resume => '恢復';
 
   @override
   String get failedToLoadLibrary => '載入庫失敗';
@@ -10274,17 +10138,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String authorsCount(int count) {
-    return '$count 位作者';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count 種類型';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '已完成 $percent%';
+    return '$percent% completed';
   }
 
   @override
@@ -10301,11 +10165,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count 部作品，以閱讀優先的方式編排。';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
-  String get titles => '作品';
+  String get titles => '標題';
 
   @override
   String get allTitles => '所有標題';
@@ -10336,7 +10200,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String noLabelFound(String label) {
-    return '找不到$label';
+    return 'No $label found';
   }
 
   @override
@@ -10355,13 +10219,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get readStatus => '讀';
 
   @override
-  String get watched => '已觀看';
+  String get watched => '看過';
 
   @override
   String get unread => '未讀';
 
   @override
-  String get unwatched => '未觀看';
+  String get unwatched => '無人看管';
 
   @override
   String get seriesStatus => '系列狀態';
@@ -10371,45 +10235,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get books => '圖書';
-
-  @override
-  String get latestBooks => '最新書籍';
-
-  @override
-  String get latestAudiobooks => '最新有聲書';
-
-  @override
-  String bookSeriesItemCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count 本書',
-      one: '1 本書',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get bookFormatBook => '書籍';
-
-  @override
-  String get bookFormatAudiobook => '有聲書';
-
-  @override
-  String bookPercentRead(int percent) {
-    return '已讀 $percent%';
-  }
-
-  @override
-  String bookTimeLeft(String time) {
-    return '還剩 $time';
-  }
-
-  @override
-  String get bookHeroRead => '閱讀';
-
-  @override
-  String get bookHeroListen => '聆聽';
 
   @override
   String get author => '作者';
@@ -10446,12 +10271,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count 個章節';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return '首次出版於 $year';
+    return 'First published $year';
   }
 
   @override
@@ -10465,7 +10290,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String booksCount(int count) {
-    return '$count 本書';
+    return '$count books';
   }
 
   @override
@@ -10476,7 +10301,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count 位作者';
+    return '$count Authors';
   }
 
   @override
@@ -10484,8 +10309,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 本有聲書',
-      one: '1 本有聲書',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -10503,7 +10328,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get delete => '刪除';
 
   @override
-  String get save => '儲存';
+  String get save => '節省';
 
   @override
   String get moreLikeThis => '更多類似的';
@@ -10521,7 +10346,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get nextUp => '下一步';
 
   @override
-  String get seasons => '季';
+  String get seasons => '季節';
 
   @override
   String get chapters => '章節';
@@ -10533,7 +10358,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get movies => '電影';
 
   @override
-  String get musicVideos => '音樂影片';
+  String get musicVideos => 'Music Videos';
 
   @override
   String get other => '其他';
@@ -10552,7 +10377,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String discNumber(int number) {
-    return '第 $number 片';
+    return 'Disc $number';
   }
 
   @override
@@ -10575,7 +10400,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String published(int year) {
-    return '$year 年出版';
+    return 'Published $year';
   }
 
   @override
@@ -10586,53 +10411,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 季',
-      one: '1 季',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return '$time 結束';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => '項目';
-
-  @override
-  String get extras => '特別收錄';
-
-  @override
-  String get behindTheScenes => '幕後花絮';
-
-  @override
-  String get deletedScenes => '刪除片段';
-
-  @override
-  String get featurettes => '特輯';
-
-  @override
-  String get interviews => '訪談';
-
-  @override
-  String get scenes => '片段';
-
-  @override
-  String get shorts => '短片';
-
-  @override
-  String get trailers => '預告片';
-
-  @override
-  String timeRemaining(String time) {
-    return '還剩 $time';
-  }
-
-  @override
-  String endsIn(String time) {
-    return '$time 後結束';
-  }
+  String get trailers => 'Trailers';
 
   @override
   String get view => '看法';
@@ -10645,11 +10436,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String resumeFrom(String position) {
-    return '從 $position 繼續播放';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => '播放';
+  String get play => '玩';
 
   @override
   String get startOver => '重新開始';
@@ -10673,10 +10464,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get version => '版本';
 
   @override
-  String get cast => '投放';
+  String get cast => '投擲';
 
   @override
-  String get trailer => '預告片';
+  String get trailer => '拖車';
 
   @override
   String get finished => '完成的';
@@ -10743,7 +10534,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return '要刪除「$title」已下載的曲目嗎？';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -10757,17 +10548,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return '未載入任何$itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '正在下載 $title（$count 個項目）...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return '您確定要從伺服器刪除「$name」嗎？此動作無法復原。';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
@@ -10778,7 +10569,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String unsupportedBookFormat(String extension) {
-    return '不支援的書籍格式：.$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -10788,7 +10579,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get subtitleTrack => '字幕軌道';
 
   @override
-  String get none => '無';
+  String get none => '沒有任何';
 
   @override
   String get downloadSubtitlesLabel => '下載字幕...';
@@ -10804,7 +10595,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return '字幕已下載並選用：$name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -10813,7 +10604,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return '找不到 $language 的遠端字幕。';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
@@ -10821,7 +10612,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String versionNumber(int number) {
-    return '版本 $number';
+    return 'Version $number';
   }
 
   @override
@@ -10841,7 +10632,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String downloadingItem(String name, String quality) {
-    return '正在下載 $name（$quality）...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -10849,7 +10640,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return '要刪除$typeLabel的本機檔案嗎？\n\n這將釋出儲存空間。您之後可以重新下載。';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -10865,25 +10656,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get director => '導演';
 
   @override
-  String get directors => '導演';
-
-  @override
-  String get writer => '編劇';
-
-  @override
-  String get writers => '編劇';
+  String get writers => '作家';
 
   @override
   String get studio => '工作室';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count 個';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count 集';
+    return '$count Episodes';
   }
 
   @override
@@ -10893,12 +10678,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String episodeLabel(int number) {
-    return '第 $number 集';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return '第 $number 章';
+    return 'Chapter $number';
   }
 
   @override
@@ -10906,8 +10691,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 首曲目',
-      one: '1 首曲目',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -10917,25 +10702,25 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 個章節',
-      one: '1 個章節',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return '$date 出生';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return '$date 逝世';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return '$age 歲';
+    return 'Age $age';
   }
 
   @override
@@ -10948,17 +10733,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get shuffle => '隨機播放';
 
   @override
-  String get shuffleAllMusic => '隨機播放所有音樂';
-
-  @override
-  String get carSignInPrompt => '請在您的手機上登入 Moonfin';
-
-  @override
-  String get carServerUnreachable => '無法連線到您的伺服器';
-
-  @override
   String downloadsCount(int count) {
-    return '$count 次下載';
+    return '$count downloads';
   }
 
   @override
@@ -10966,43 +10742,43 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String channelsCount(int count) {
-    return '$count 聲道';
+    return '${count}ch';
   }
 
   @override
-  String get mono => '單聲道';
+  String get mono => '單核白血球增多症';
 
   @override
   String get stereo => '立體聲';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return '遠端字幕$action需要此使用者具備 Jellyfin 的字幕管理權限。';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return '在伺服器上找不到此項目，無法$action遠端字幕。';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return '遠端字幕$action失敗：$detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return '遠端字幕$action失敗（HTTP $status）。';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return '無法$action遠端字幕。';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return '「$name」所有已下載的集數';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -11030,17 +10806,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label 動作失敗：$error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return '無法設定投放音量：$error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label 控制';
+    return '$label Controls';
   }
 
   @override
@@ -11057,7 +10833,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String stopCast(String label) {
-    return '停止 $label';
+    return 'Stop $label';
   }
 
   @override
@@ -11065,7 +10841,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String trackNumber(int number) {
-    return '曲目 $number';
+    return 'Track $number';
   }
 
   @override
@@ -11082,14 +10858,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds 秒';
+    return '$seconds seconds';
   }
 
   @override
   String get longPressToUnlock => '長按解鎖';
 
   @override
-  String get off => '關閉';
+  String get off => '離開';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -11124,7 +10900,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get subtitleDelay => '字幕延遲';
 
   @override
-  String get reset => '重設';
+  String get reset => '重置';
 
   @override
   String get unknown => '未知';
@@ -11151,7 +10927,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get transcodeReasons => '轉碼原因';
 
   @override
-  String get player => '播放器';
+  String get player => '玩家';
 
   @override
   String get container => '容器';
@@ -11175,7 +10951,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get videoBitrate => '視訊比特率';
 
   @override
-  String get track => '音軌';
+  String get track => '追蹤';
 
   @override
   String get channels => '頻道';
@@ -11197,12 +10973,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol 工作階段錯誤';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return '無法載入書籍詳細資料：$error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -11210,7 +10986,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return '此格式（.$extension）尚無法在應用程式內顯示。';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -11221,17 +10997,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return '無法開啟應用程式內閱讀器：$error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return '$label 已有書籤。';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return '已加入書籤：$label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -11242,7 +11018,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String pageLabel(int number) {
-    return '第 $number 頁';
+    return 'Page $number';
   }
 
   @override
@@ -11253,12 +11029,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String formatExtension(String extension) {
-    return '格式：.$extension';
+    return 'Format: .$extension';
   }
 
   @override
   String percentRead(String percent) {
-    return '已讀 $percent%';
+    return '$percent% read';
   }
 
   @override
@@ -11281,7 +11057,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String resetZoom(String zoom) {
-    return '重設縮放（${zoom}x）';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
@@ -11304,7 +11080,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String failedToUpdateReadState(String error) {
-    return '無法更新閱讀狀態：$error';
+    return 'Failed to update read state: $error';
   }
 
   @override
@@ -11336,7 +11112,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return '此平台無法載入 $extension 檔案的內嵌文件引擎。';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -11375,7 +11151,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String failedToLoadGuide(String error) {
-    return '無法載入節目表：$error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -11383,26 +11159,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get liveBadge => '居住';
-
-  @override
-  String guideNextProgram(String time, String title) {
-    return '下一個：$time  $title';
-  }
-
-  @override
-  String guideMinutesLeft(int minutes) {
-    return '還剩 $minutes 分鐘';
-  }
-
-  @override
-  String guideHoursLeft(int hours) {
-    return '還剩 $hours 小時';
-  }
-
-  @override
-  String guideHoursMinutesLeft(int hours, int minutes) {
-    return '還剩 $hours 小時 $minutes 分鐘';
-  }
 
   @override
   String get movie => '電影';
@@ -11423,29 +11179,29 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get favoriteChannel => '最喜歡的頻道';
 
   @override
-  String get record => '錄影';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => '取消錄影';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => '已排定錄影';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => '已取消錄影';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => '無法建立錄影';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => '觀看';
+  String get watch => '手錶';
 
   @override
   String get close => '關閉';
 
   @override
   String failedToPlayChannel(String name) {
-    return '無法播放 $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -11471,11 +11227,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return '要取消「$name」的排定錄影嗎？';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
-  String get no => '否';
+  String get no => '不';
 
   @override
   String get yesCancel => '是，取消';
@@ -11497,7 +11253,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String stopRecordingName(String name) {
-    return '要停止錄影「$name」嗎？';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -11511,19 +11267,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String noResultsForQuery(String query) {
-    return '找不到「$query」的結果';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return '搜尋失敗：$error';
+    return 'Search failed: $error';
   }
 
   @override
   String get seerr => 'Seerr';
 
   @override
-  String get seerrAccountType => 'Seerr 帳戶類型';
+  String get seerrAccountType => '西爾帳戶類型';
 
   @override
   String get jellyfinAccount => 'Jellyfin';
@@ -11557,12 +11313,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String removeItemAndFiles(String name) {
-    return '要移除「$name」及其檔案嗎？';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count 首曲目';
+    return '$count tracks';
   }
 
   @override
@@ -11573,16 +11329,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String failedToLoadAlbum(String error) {
-    return '無法載入專輯：$error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return '找不到 $name 已下載的曲目。';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
-  String get season => '季';
+  String get season => '季節';
 
   @override
   String get errorLoadingEpisodes => '載入劇集時出錯';
@@ -11595,22 +11351,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String removeName(String name) {
-    return '要移除「$name」嗎？';
+    return 'Remove \"$name\"?';
   }
 
   @override
   String durationMinutes(int minutes) {
-    return '$minutes 分鐘';
+    return '$minutes min';
   }
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return '第$season季 第$episode集';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return '第 $number 集';
+    return 'Episode $number';
   }
 
   @override
@@ -11624,12 +11380,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String seasonNumber(int number) {
-    return '第 $number 季';
+    return 'Season $number';
   }
 
   @override
   String seasonChip(int number) {
-    return '第$number季';
+    return 'S$number';
   }
 
   @override
@@ -11640,7 +11396,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return '要刪除 $season 中所有已下載的集數嗎？';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -11648,8 +11404,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 集',
-      one: '1 集',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -11683,7 +11439,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String deleteSelectedCount(int count) {
-    return '要刪除 $count 個已下載的項目嗎？';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -11697,7 +11453,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String ofStorageLimit(String limit) {
-    return '上限 $limit';
+    return 'of $limit limit';
   }
 
   @override
@@ -11777,7 +11533,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String optionsCount(int count) {
-    return '$count 個選項';
+    return '$count options';
   }
 
   @override
@@ -11865,9 +11621,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get themeMusicVolume => '主題音樂音量';
 
   @override
-  String get themeMusicSettingsSubtitle => '詳細資料頁、主畫面列與音量';
-
-  @override
   String percentValue(int value) {
     return '$value%';
   }
@@ -11877,12 +11630,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get playWhenBrowsingHomeScreen => '瀏覽主畫面時播放';
-
-  @override
-  String get loopThemeMusic => '循環播放主題音樂';
-
-  @override
-  String get loopThemeMusicSubtitle => '重複播放此曲目，而非只播放一次';
 
   @override
   String get detailsBackgroundBlur => '細節背景模糊';
@@ -11905,24 +11652,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get playerZoomMode => '播放器縮放模式';
 
   @override
-  String get settingsScrollWheelAction => '滑鼠滾輪';
-
-  @override
-  String get settingsScrollWheelActionDescription => '選擇播放時在影片上捲動滑鼠滾輪的行為。';
-
-  @override
-  String get scrollWheelActionOff => '關閉';
-
-  @override
-  String get scrollWheelActionSeek => '跳轉（前 / 後）';
-
-  @override
-  String get scrollWheelActionVolume => '音量';
-
-  @override
-  String get playerTooltipVolume => '音量';
-
-  @override
   String get fit => '合身';
 
   @override
@@ -11935,7 +11664,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get refreshRateSwitching => '刷新率切換';
 
   @override
-  String get disabled => '已停用';
+  String get disabled => '殘障人士';
 
   @override
   String get scaleOnTv => '在電視上縮放';
@@ -11969,36 +11698,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get defaultAudioLanguage => '預設音訊語言';
-
-  @override
-  String get fallbackAudioLanguage => '備用音訊語言';
-
-  @override
-  String get preferDefaultAudioTrack => '優先使用預設音軌';
-
-  @override
-  String get preferDefaultAudioTrackDescription => '優先使用原始音軌，而非本地化配音。';
-
-  @override
-  String get preferAudioDescription => '優先使用口述影像音軌';
-
-  @override
-  String get preferAudioDescriptionDescription => '優先使用口述影像音軌，而非一般音軌。';
-
-  @override
-  String get transcodingAudio => '轉碼（音訊）';
-
-  @override
-  String get directStreamRemux => '直接串流（重新封裝）';
-
-  @override
-  String get transcodingBitrateOrResolution => '轉碼（位元率或解析度）';
-
-  @override
-  String get transcodingVideoAndAudio => '轉碼（視訊與音訊）';
-
-  @override
-  String get transcodingVideo => '轉碼（視訊）';
 
   @override
   String get autoServerDefault => '自動（伺服器預設）';
@@ -12073,141 +11772,76 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get enableTrueHdAudio => '啟用 TrueHD 音訊（可能不適用於所有平台）';
 
   @override
-  String get settingsAudioOutputMode => '音訊輸出模式';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
-  String get settingsAudioOutputModeDescription =>
-      '選擇音訊的解碼方式。「AVR 直通」會將原始的 Dolby/DTS 串流傳送至您的擴大機；「自動」或「縮混」則會在本機解碼。';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR 直通';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
-  String get settingsAudioFallbackCodec => '備用音訊編解碼器';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioFallbackCodecDescription =>
-      '選擇當來源串流無法直接播放或直通時，多聲道音訊要轉碼成的目標格式。';
-
-  @override
-  String get settingsAudioFallbackCodecAuto => '自動偵測\n（建議）';
-
-  @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n（預設）';
-
-  @override
-  String get settingsAudioFallbackCodecAc3 => 'AC3\n（Dolby Digital）';
-
-  @override
-  String get settingsAudioFallbackCodecEac3 => 'EAC3\n（Dolby Digital Plus）';
-
-  @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n（無損）';
-
-  @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n（僅支援立體聲）';
-
-  @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n（高效率）';
-
-  @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n（無損）';
-
-  @override
-  String get settingsMaxAudioChannels => '最大音訊聲道數';
-
-  @override
-  String get settingsMaxAudioChannelsDescription =>
-      '設定您音響系統的最大聲道數。超過此上限的多聲道串流將會縮混或轉碼。';
-
-  @override
-  String get settingsMaxAudioChannelsAuto => '自動偵測\n（硬體預設）';
-
-  @override
-  String get settingsMaxAudioChannelsMono => '1.0 單聲道';
-
-  @override
-  String get settingsMaxAudioChannelsStereo => '2.0 立體聲';
-
-  @override
-  String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 環繞聲';
-
-  @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 四聲道';
-
-  @override
-  String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 環繞聲';
-
-  @override
-  String get settingsMaxAudioChannels5_1 => '5.1 環繞聲';
-
-  @override
-  String get settingsMaxAudioChannels6_1 => '6.1 環繞聲';
-
-  @override
-  String get settingsMaxAudioChannels7_1 => '7.1 環繞聲';
-
-  @override
-  String get settingsAudioPassthroughAdvanced => '直通（進階）';
-
-  @override
-  String get settingsAudioCodecPassthrough => '編解碼器直通';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      '僅啟用您的 AVR 或 HDMI 接收裝置支援的格式。';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 直通';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC（Atmos）直通';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core 直通';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA 直通';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD 直通';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos 直通';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      '將 Dolby Digital Plus（EAC3）位元流傳送至外部解碼器。';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      '將以 EAC3（JOC）承載的 Dolby Atmos 位元流傳送至外部解碼器。';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      '將 DTS-HD MA（含 DTS core）位元流傳送至外部解碼器。';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      '將含 Atmos 中繼資料的 Dolby TrueHD 位元流傳送至外部解碼器。';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => '偵測到的音訊能力';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
-  String get settingsDetectedAudioCapabilitiesUnavailable => '尚無可用的執行階段能力快照。';
+  String get settingsDetectedAudioCapabilitiesUnavailable =>
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => '路由';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => '解碼';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => '直通';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD 音訊路由';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -12222,46 +11856,47 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => '喇叭';
-
-  @override
-  String get settingsAudioRouteHeadphones => '耳機';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count 聲道 PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => '診斷';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => '視訊等級';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => '視訊範圍';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => '字幕編解碼器';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
-  String get settingsAudioDiagnosticsAllowedAudioCodecs => '允許的音訊編解碼器';
+  String get settingsAudioDiagnosticsAllowedAudioCodecs =>
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS 音訊編解碼器';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs => 'HLS fMP4 音訊編解碼器';
+  String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
+      'HLS fMP4 Audio Codecs';
 
   @override
-  String get settingsAudioDiagnosticsAudioSpdifPassthrough => 'audio-spdif 直通';
+  String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => '使用中的音訊路由';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
-  String get settingsAudioDiagnosticsRouteHdAudioSupport => '路由 HD 音訊支援';
+  String get settingsAudioDiagnosticsRouteHdAudioSupport =>
+      'Route HD Audio Support';
 
   @override
   String get nightMode => '夜間模式';
@@ -12307,7 +11942,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String secondsValue(int value) {
-    return '$value 秒';
+    return '${value}s';
   }
 
   @override
@@ -12321,7 +11956,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '在 $episodes 集 / $hours 小時之後';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -12395,43 +12030,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get subtitleCustomizationDescription => '自訂字幕外觀';
 
   @override
-  String get subtitleMode => '字幕模式';
-
-  @override
-  String get subtitleModeFlagged => '已標記';
-
-  @override
-  String get subtitleModeAlways => '一律顯示';
-
-  @override
-  String get subtitleModeForeign => '外語';
-
-  @override
-  String get subtitleModeForced => '強制';
-
-  @override
-  String get subtitleModeFlaggedDescription =>
-      '播放在媒體檔案中繼資料中標示為「default」或「forced」的字幕軌。';
-
-  @override
-  String get subtitleModeAlwaysDescription => '每次開始播放影片時自動載入並顯示字幕。';
-
-  @override
-  String get subtitleModeForeignDescription => '若預設音軌為外語，則自動開啟字幕。';
-
-  @override
-  String get subtitleModeForcedDescription => '僅載入明確標示 forced 中繼資料旗標的字幕。';
-
-  @override
-  String get subtitleModeNoneDescription => '完全停用自動載入字幕。';
-
-  @override
-  String get fallbackSubtitleLanguage => '備用字幕語言';
-
-  @override
-  String get subtitleStream => '字幕串流';
-
-  @override
   String get subtitlePreviewText => '敏捷的棕色狐狸跳過了懶狗';
 
   @override
@@ -12487,17 +12085,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '已載入 $profile 設定檔的設定。';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '無法載入 $profile 設定檔的設定。';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return '已將本機設定同步至 $profile 設定檔。';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -12627,12 +12225,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get showLibrariesInToolbar => '在工具列中顯示庫';
 
   @override
-  String get navbarAlwaysExpanded => '一律展開導覽列標籤';
-
-  @override
-  String get showSeerrButton => '顯示 Seerr 按鈕';
-
-  @override
   String get navbarOpacity => '導覽列不透明度';
 
   @override
@@ -12702,19 +12294,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get showFolderBrowsingOption => '顯示資料夾瀏覽選項';
 
   @override
-  String get groupItemsIntoCollections => '將項目歸入合輯';
-
-  @override
-  String get hideCollectionAssociatedItems => '瀏覽媒體庫時隱藏已歸入合輯的項目';
-
-  @override
-  String get groupItemsIntoCollectionsDialogTitle => '媒體庫分組須知';
-
-  @override
-  String get groupItemsIntoCollectionsDialogMessage =>
-      '若要使用此設定，請確認您的 Jellyfin 或 Emby 伺服器中，該媒體庫的「顯示」設定已啟用「Group movies into collections」及／或「Group shows into collections」。';
-
-  @override
   String get libraryVisibility => '圖書館可見性';
 
   @override
@@ -12740,7 +12319,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String itemsSelected(int count) {
-    return '已選取 $count 個';
+    return '$count selected';
   }
 
   @override
@@ -12774,7 +12353,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get mediaBarModeMakd => '馬克D';
 
   @override
-  String get mediaBarModeOff => '關閉';
+  String get mediaBarModeOff => '離開';
 
   @override
   String get enableMediaBar => '啟用媒體欄';
@@ -12817,12 +12396,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get autoPlayTrailers => '3 秒後在媒體列中自動播放預告片';
-
-  @override
-  String get trailerAudio => '預告片音訊';
-
-  @override
-  String get enableTrailerAudio => '為媒體列中的預告片啟用音訊';
 
   @override
   String get episodePreview => '劇集預覽';
@@ -12894,12 +12467,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get combineBothRows => '將兩行合併為一個主頁部分';
 
   @override
-  String get fullScreenRows => '展開主畫面列';
-
-  @override
-  String get fullScreenRowsDescription => '每個畫面僅顯示一列主畫面列';
-
-  @override
   String get perRowImageType => '每行圖像類型';
 
   @override
@@ -12910,9 +12477,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get lastUser => '最後一個用戶';
-
-  @override
-  String get currentUser => '目前使用者';
 
   @override
   String get alwaysAuthenticate => '始終進行身份驗證';
@@ -12982,7 +12546,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String minutesShort(int minutes) {
-    return '$minutes 分鐘';
+    return '$minutes min';
   }
 
   @override
@@ -13012,22 +12576,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get displayClockDuringScreensaver => '螢幕保護期間顯示時鐘';
 
   @override
-  String get clockModeStatic => '固定';
-
-  @override
-  String get clockModeBouncing => '彈跳';
-
-  @override
   String get rottenTomatoesCritics => '爛番茄（評論家）';
 
   @override
   String get rottenTomatoesAudience => '爛番茄（觀眾）';
 
   @override
-  String get imdb => 'IMDb';
+  String get imdb => '網路醫學資料庫';
 
   @override
-  String get tmdb => 'TMDB';
+  String get tmdb => 'TM資料庫';
 
   @override
   String get metacritic => '元評論家';
@@ -13036,7 +12594,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get metacriticUser => '元評論家（使用者）';
 
   @override
-  String get trakt => 'Trakt';
+  String get trakt => '特拉克特';
 
   @override
   String get letterboxd => '信箱';
@@ -13084,7 +12642,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get ratingSourcesDescription => '啟用並重新排序整個應用程式中顯示的評級來源';
 
   @override
-  String get pluginLabel => 'Moonbase 外掛程式';
+  String get pluginLabel => '外掛';
 
   @override
   String get pluginDetected => '偵測到插件';
@@ -13100,7 +12658,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String pluginStatusVersion(String status, String version) {
-    return '$status\n版本：$version';
+    return '$status\nVersion: $version';
   }
 
   @override
@@ -13153,13 +12711,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get networks => '網路';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr 探索列';
-
-  @override
   String get resetRowsToDefaults => '將行重設為預設值';
 
   @override
-  String get enableSeerr => '啟用 Seerr';
+  String get enableSeerr => '啟用搜尋器';
 
   @override
   String get showSeerrInNavigation => '在導航中顯示 Seerr（需要伺服器插件）';
@@ -13174,44 +12729,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get hideAdultContent => '在結果中隱藏成人內容';
 
   @override
-  String get seerrNotificationsSection => '通知';
-
-  @override
-  String get seerrNotifyNewRequestsTitle => '新請求通知';
-
-  @override
-  String get seerrNotifyNewRequestsSubtitle => '有人提交請求時通知我';
-
-  @override
-  String get seerrNotifyLibraryAddedTitle => '請求進度更新';
-
-  @override
-  String get seerrNotifyLibraryAddedSubtitle => '已核准、已拒絕，以及已加入您的媒體庫';
-
-  @override
-  String get seerrNotifyIssuesTitle => '問題更新';
-
-  @override
-  String get seerrNotifyIssuesSubtitle => '新問題、回覆與解決結果';
-
-  @override
   String loggedInAs(String username) {
-    return '登入身分：$username';
+    return 'Logged in as: $username';
   }
 
   @override
-  String get discoverRows => 'Seerr 探索頁';
+  String get discoverRows => '發現行';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      '啟用要在 Seerr 主頁顯示的列。拖曳可重新排序。自訂順序會與 Moonbase 同步。';
+      '拖曳以重新排序。啟用或停用行。啟用與 Moonfin 插件的行順序同步。';
 
   @override
-  String get discoverRowsDescription =>
-      '啟用要在 Seerr 主頁顯示的列。拖曳可重新排序。自訂順序會與 Moonbase 同步。';
+  String get discoverRowsDescription => '拖曳以重新排序。啟用或停用行。';
 
   @override
-  String get enabled => '已啟用';
+  String get enabled => '啟用';
 
   @override
   String get hidden => '隱';
@@ -13221,7 +12754,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String versionValue(String version) {
-    return '版本 $version';
+    return 'Version $version';
   }
 
   @override
@@ -13265,7 +12798,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String updateAvailableVersion(String version) {
-    return '有可用更新：v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -13276,7 +12809,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version 已推出';
+    return 'v$version Available';
   }
 
   @override
@@ -13350,20 +12883,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get seerrRequestedStatus => '已請求';
 
   @override
-  String seerrDownloadingPercent(int percent) {
-    return '下載中 · $percent%';
-  }
-
-  @override
-  String get seerrImportingStatus => '匯入中';
-
-  @override
   String itemsCount(int count) {
-    return '$count 個項目';
+    return '$count Items';
   }
 
   @override
-  String get seerrSettings => 'Seerr 設定';
+  String get seerrSettings => '搜尋者設定';
 
   @override
   String get requestMore => '請求更多';
@@ -13379,7 +12904,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String requestedByName(String name) {
-    return '由 $name 請求';
+    return 'Requested by $name';
   }
 
   @override
@@ -13396,12 +12921,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '要取消「$title」的請求嗎？';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '要取消「$title」的 $count 個請求嗎？';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -13415,12 +12940,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String budgetAmount(String amount) {
-    return '預算：\$$amount';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return '票房：\$$amount';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -13430,7 +12955,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return '請求$type';
+    return 'Request $type';
   }
 
   @override
@@ -13458,14 +12983,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get showMore => '顯示更多';
 
   @override
-  String get appearances => '參演作品';
+  String get appearances => '出場次數';
 
   @override
   String get crewSection => '全體人員';
 
   @override
   String ageValue(int age) {
-    return '$age 歲';
+    return 'age $age';
   }
 
   @override
@@ -13496,148 +13021,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get deletedStatus => '已刪除';
 
   @override
-  String get failedStatus => '失敗';
-
-  @override
-  String get processingStatus => '處理中';
-
-  @override
-  String modifiedByName(String name) {
-    return '由 $name 修改';
-  }
-
-  @override
-  String get completedStatus => '已完成';
-
-  @override
-  String get requestErrorDuplicate => '此作品已經請求過';
-
-  @override
-  String get requestErrorQuota => '已達請求上限';
-
-  @override
-  String get requestErrorBlocklisted => '此作品已列入封鎖名單';
-
-  @override
-  String get requestErrorNoSeasons => '沒有可請求的季數';
-
-  @override
-  String get requestErrorPermission => '您沒有權限提出此請求';
-
-  @override
-  String get seerrRequestsTitle => '請求';
-
-  @override
-  String get seerrIssuesTitle => '問題';
-
-  @override
-  String get sortNewest => '最新';
-
-  @override
-  String get sortLastModified => '最後修改';
-
-  @override
-  String get noIssues => '沒有問題';
-
-  @override
-  String movieQuotaRemaining(int remaining, int limit) {
-    return '電影請求還剩 $remaining / $limit 個';
-  }
-
-  @override
-  String seasonQuotaRemaining(int remaining, int limit) {
-    return '季數請求還剩 $remaining / $limit 個';
-  }
-
-  @override
-  String partOfCollectionName(String name) {
-    return '屬於 $name';
-  }
-
-  @override
-  String get viewCollection => '查看合輯';
-
-  @override
-  String get requestCollection => '請求整個合輯';
-
-  @override
-  String collectionMoviesSummary(int total, int available) {
-    return '$total 部電影 · $available 部可觀看';
-  }
-
-  @override
-  String requestMoviesCount(int count) {
-    return '請求 $count 部電影';
-  }
-
-  @override
-  String requestingProgress(int current, int total) {
-    return '正在請求第 $current / $total 個...';
-  }
-
-  @override
-  String requestedMoviesCount(int count) {
-    return '已請求 $count 部電影';
-  }
-
-  @override
-  String requestedMoviesPartial(int ok, int total) {
-    return '$total 部電影中已請求 $ok 部';
-  }
-
-  @override
-  String get collectionAllRequested => '所有電影皆已可觀看或已請求';
-
-  @override
-  String get reportIssue => '回報問題';
-
-  @override
-  String get issueTypeVideo => '畫面';
-
-  @override
-  String get issueTypeAudio => '聲音';
-
-  @override
-  String get whatsWrong => '發生什麼問題？';
-
-  @override
-  String get allEpisodes => '所有集數';
-
-  @override
-  String get episode => '集數';
-
-  @override
-  String get openStatus => '未解決';
-
-  @override
-  String get resolvedStatus => '已解決';
-
-  @override
-  String get resolveAction => '標為已解決';
-
-  @override
-  String get reopenAction => '重新開啟';
-
-  @override
-  String reportedByName(String name) {
-    return '由 $name 回報';
-  }
-
-  @override
-  String commentsCount(int count) {
-    return '$count 則留言';
-  }
-
-  @override
-  String get addComment => '新增留言';
-
-  @override
-  String get deleteIssueConfirm => '要刪除此問題嗎？';
-
-  @override
-  String get submitReport => '提交回報';
-
-  @override
   String get tmdbScore => 'TMDB分數';
 
   @override
@@ -13659,7 +13042,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get originalLanguageLabel => '原始語言';
 
   @override
-  String get seasonsLabel => '季數';
+  String get seasonsLabel => '季節';
 
   @override
   String get episodesLabel => '劇集數';
@@ -13668,7 +13051,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get access => '使用權';
 
   @override
-  String get add => '新增';
+  String get add => '添加';
 
   @override
   String get address => '地址';
@@ -13692,7 +13075,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get disable => '停用';
 
   @override
-  String get done => '完成';
+  String get done => '完畢';
 
   @override
   String get edit => '編輯';
@@ -13704,10 +13087,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get error => '錯誤';
 
   @override
-  String get forward => '快轉';
+  String get forward => '向前';
 
   @override
-  String get general => '一般';
+  String get general => '一般的';
 
   @override
   String get go => '去';
@@ -13752,7 +13135,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get refresh => '重新整理';
 
   @override
-  String get remote => '遙控';
+  String get remote => '偏僻的';
 
   @override
   String get rename => '重新命名';
@@ -13797,7 +13180,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get time => '時間';
 
   @override
-  String get trickplay => 'Trickplay';
+  String get trickplay => '特技遊戲';
 
   @override
   String get uninstall => '解除安裝';
@@ -13815,7 +13198,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get unmute => '取消靜音';
 
   @override
-  String get mute => '靜音';
+  String get mute => '沉默的';
 
   @override
   String get branding => '品牌推廣';
@@ -13836,28 +13219,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminDrawerUsers => '使用者';
 
   @override
-  String get adminDrawerLibraries => '媒體庫';
-
-  @override
-  String get adminDrawerDisplay => '顯示';
-
-  @override
-  String get adminDrawerMetadata => '中繼資料';
-
-  @override
-  String get adminDrawerNfo => 'NFO 設定';
+  String get adminDrawerLibraries => '圖書館';
 
   @override
   String get adminDrawerTranscoding => '轉碼';
 
   @override
-  String get adminDrawerResume => '繼續播放';
+  String get adminDrawerResume => '恢復';
 
   @override
   String get adminDrawerStreaming => '串流媒體';
 
   @override
-  String get adminDrawerTrickplay => 'Trickplay';
+  String get adminDrawerTrickplay => '特技遊戲';
 
   @override
   String get adminDrawerDevices => '裝置';
@@ -13906,22 +13280,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return '有可用的外掛程式更新：$count 個';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return '需要重新啟動的外掛程式：$count 個';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return '失敗的排程工作：$count 個';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return '最近的警告／錯誤紀錄：$count 項';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -13980,7 +13354,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String errorGeneric(String error) {
-    return '錯誤：$error';
+    return 'Error: $error';
   }
 
   @override
@@ -14006,7 +13380,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminCommandFailed(String error) {
-    return '指令失敗：$error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -14025,7 +13399,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get sessionRewind => '倒帶';
 
   @override
-  String get sessionForward => '快轉';
+  String get sessionForward => '向前';
 
   @override
   String get sessionNext => '下一個';
@@ -14043,7 +13417,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get nowPlaying => '正在播放';
 
   @override
-  String get volume => '音量';
+  String get volume => '體積';
 
   @override
   String get actions => '行動';
@@ -14070,14 +13444,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminClearDates => '明確日期';
 
   @override
-  String get adminActivitySeverityAll => '所有嚴重程度';
-
-  @override
-  String get adminActivityDateRange => '日期範圍';
-
-  @override
   String adminActivityLoadFailed(String error) {
-    return '無法載入活動紀錄：$error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -14094,7 +13462,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return '無法更新裝置：$error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -14105,28 +13473,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return '無法刪除裝置：$error';
-  }
-
-  @override
-  String adminRemoveDeviceConfirm(String name) {
-    return '要移除裝置「$name」嗎？該使用者需要在此裝置上重新登入。';
-  }
-
-  @override
-  String get adminDeleteAllDevices => '刪除所有裝置';
-
-  @override
-  String adminDeleteAllDevicesConfirm(int count) {
-    return '要移除 $count 部裝置嗎？受影響的使用者需要重新登入。您目前使用的裝置不受影響。';
-  }
-
-  @override
-  String get adminDevicesDeletedAll => '已移除裝置';
-
-  @override
-  String adminDevicesDeletedPartial(int count) {
-    return '已移除部分裝置；有 $count 部無法移除。';
+    return 'Failed to delete device: $error';
   }
 
   @override
@@ -14155,7 +13502,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminScanFailed(String error) {
-    return '無法開始掃描：$error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -14166,12 +13513,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminLibraryRenamed(String name) {
-    return '媒體庫已重新命名為「$name」';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return '無法重新命名：$error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -14179,17 +13526,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '已刪除媒體庫「$name」';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return '無法刪除媒體庫：$error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return '無法新增路徑：$error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -14197,12 +13544,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '要從此媒體庫移除「$path」嗎？';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return '無法移除路徑：$error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -14210,7 +13557,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return '無法儲存選項：$error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -14241,234 +13588,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminMetadataCountryHint => '例如美國、德國、法國';
 
   @override
-  String get adminLibraryTabPaths => '路徑';
-
-  @override
-  String get adminLibraryTabOptions => '選項';
-
-  @override
-  String get adminLibraryTabDownloaders => '下載器';
-
-  @override
-  String get adminLibMetadataSavers => '中繼資料儲存器';
-
-  @override
-  String get adminLibSubtitleDownloaders => '字幕下載器';
-
-  @override
-  String get adminLibLyricDownloaders => '歌詞下載器';
-
-  @override
-  String adminLibMetadataDownloadersFor(String type) {
-    return '中繼資料下載器：$type';
-  }
-
-  @override
-  String adminLibImageFetchersFor(String type) {
-    return '圖片擷取器：$type';
-  }
-
-  @override
-  String get adminLibNoDownloaders => '此伺服器並未為這種媒體庫類型提供任何下載器。';
-
-  @override
-  String get adminLibrarySectionGeneral => '一般';
-
-  @override
-  String get adminLibrarySectionMetadata => '中繼資料';
-
-  @override
-  String get adminLibrarySectionEmbedded => '內嵌資訊';
-
-  @override
-  String get adminLibrarySectionSubtitles => '字幕';
-
-  @override
-  String get adminLibrarySectionImages => '圖片';
-
-  @override
-  String get adminLibrarySectionSeries => '影集';
-
-  @override
-  String get adminLibrarySectionMusic => '音樂';
-
-  @override
-  String get adminLibrarySectionMovies => '電影';
-
-  @override
-  String get adminLibRealtimeMonitor => '啟用即時監控';
-
-  @override
-  String get adminLibRealtimeMonitorHint => '偵測檔案變更並自動處理。';
-
-  @override
-  String get adminLibArchiveMediaFiles => '將封存檔視為媒體檔案';
-
-  @override
-  String get adminLibEnablePhotos => '顯示相片';
-
-  @override
-  String get adminLibSaveLocalMetadata => '將封面圖儲存至媒體資料夾';
-
-  @override
-  String get adminLibRefreshInterval => '自動重新整理中繼資料';
-
-  @override
-  String get adminLibRefreshNever => '永不';
-
-  @override
-  String get adminLibDefault => '預設';
-
-  @override
-  String get adminLibDisplayTitle => '顯示';
-
-  @override
-  String get adminLibDisplaySection => '媒體庫顯示';
-
-  @override
-  String get adminLibFolderView => '顯示資料夾檢視以呈現原始媒體資料夾';
-
-  @override
-  String get adminLibSpecialsInSeasons => '將特別篇顯示於其首播的季別中';
-
-  @override
-  String get adminLibGroupMovies => '將電影歸入合輯';
-
-  @override
-  String get adminLibGroupShows => '將影集歸入合輯';
-
-  @override
-  String get adminLibExternalSuggestions => '在建議中顯示外部內容';
-
-  @override
-  String get adminLibDateAddedSection => '加入日期行為';
-
-  @override
-  String get adminLibDateAddedLabel => '加入日期的依據';
-
-  @override
-  String get adminLibDateAddedImport => '掃描進媒體庫的日期';
-
-  @override
-  String get adminLibDateAddedFile => '檔案建立的日期';
-
-  @override
-  String get adminLibMetadataTitle => '中繼資料與圖片';
-
-  @override
-  String get adminLibMetadataLangSection => '偏好的中繼資料語言';
-
-  @override
-  String get adminLibChaptersSection => '章節';
-
-  @override
-  String get adminLibDummyChapterDuration => '虛擬章節長度（秒）';
-
-  @override
-  String get adminLibDummyChapterDurationHint => '為沒有章節的媒體所產生的章節長度。設為 0 即可停用。';
-
-  @override
-  String get adminLibChapterImageResolution => '章節圖片解析度';
-
-  @override
-  String get adminLibNfoTitle => 'NFO 設定';
-
-  @override
-  String get adminLibNfoHelp =>
-      'NFO 中繼資料與 Kodi 及類似的用戶端相容。這些設定會套用至所有會儲存 NFO 中繼資料的媒體庫。';
-
-  @override
-  String get adminLibKodiUser => '在 NFO 檔案中儲存觀看紀錄的使用者';
-
-  @override
-  String get adminLibSaveImagePaths => '在 NFO 檔案中儲存圖片路徑';
-
-  @override
-  String get adminLibPathSubstitution => '為 NFO 圖片路徑啟用路徑替換';
-
-  @override
-  String get adminLibExtraThumbs => '將 extrafanart 圖片複製到 extrathumbs 資料夾';
-
-  @override
-  String get adminLibNone => '無';
-
-  @override
-  String adminLibRefreshDays(int days) {
-    return '$days 天';
-  }
-
-  @override
-  String get adminLibEmbeddedTitles => '使用內嵌標題';
-
-  @override
-  String get adminLibEmbeddedExtrasTitles => '特別收錄使用內嵌標題';
-
-  @override
-  String get adminLibEmbeddedEpisodeInfos => '使用內嵌的集數資訊';
-
-  @override
-  String get adminLibAllowEmbeddedSubtitles => '允許內嵌字幕';
-
-  @override
-  String get adminLibEmbeddedAllowAll => '全部允許';
-
-  @override
-  String get adminLibEmbeddedAllowText => '僅文字';
-
-  @override
-  String get adminLibEmbeddedAllowImage => '僅圖片';
-
-  @override
-  String get adminLibEmbeddedAllowNone => '無';
-
-  @override
-  String get adminLibSkipIfEmbeddedSubs => '若已有內嵌字幕則略過下載';
-
-  @override
-  String get adminLibSkipIfAudioMatches => '若音軌與下載語言相符則略過下載';
-
-  @override
-  String get adminLibRequirePerfectMatch => '要求字幕完全相符';
-
-  @override
-  String get adminLibSaveSubtitlesWithMedia => '將字幕儲存至媒體資料夾';
-
-  @override
-  String get adminLibChapterImageExtraction => '擷取章節圖片';
-
-  @override
-  String get adminLibChapterImagesDuringScan => '在媒體庫掃描期間擷取章節圖片';
-
-  @override
-  String get adminLibTrickplayExtraction => '啟用 Trickplay 圖片擷取';
-
-  @override
-  String get adminLibTrickplayDuringScan => '在媒體庫掃描期間擷取 Trickplay 圖片';
-
-  @override
-  String get adminLibSaveTrickplayWithMedia => '將 Trickplay 圖片儲存至媒體資料夾';
-
-  @override
-  String get adminLibAutomaticSeriesGrouping => '自動合併散落於多個資料夾的影集';
-
-  @override
-  String get adminLibSeasonZeroName => '第零季顯示名稱';
-
-  @override
-  String get adminLibLufsScan => '啟用 LUFS 掃描以進行音量正規化';
-
-  @override
-  String get adminLibPreferNonstandardArtist => '優先使用非標準的 artists 標籤';
-
-  @override
-  String get adminLibAutoAddToCollection => '自動將電影加入合輯';
-
-  @override
   String get adminLibraryNameRequired => '庫名稱為必填項';
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return '無法建立媒體庫：$error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -14494,27 +13618,27 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '要停用 $name 嗎？該使用者將無法登入。';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '要啟用 $name 嗎？該使用者將可以再次登入。';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '已停用使用者「$name」';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '已啟用使用者「$name」';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return '無法更新使用者原則：$error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -14531,7 +13655,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminUserCreateFailed(String error) {
-    return '無法建立使用者：$error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -14551,7 +13675,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminSaveFailed(String error) {
-    return '無法儲存：$error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -14562,7 +13686,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminFailed(String error) {
-    return '失敗：$error';
+    return 'Failed: $error';
   }
 
   @override
@@ -14692,158 +13816,26 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminEnableAllChannels => '允許存取所有頻道';
 
   @override
-  String get adminParentalControl => '家長控制';
-
-  @override
-  String get adminMaxParentalRating => '允許的最高家長分級';
-
-  @override
-  String get adminMaxParentalRatingHint => '分級高於此設定的內容將對此使用者隱藏。';
-
-  @override
-  String get adminParentalRatingNone => '無';
-
-  @override
-  String get adminBlockUnratedItems => '封鎖沒有分級或分級無法辨識的項目';
-
-  @override
-  String get adminUnratedBook => '書籍';
-
-  @override
-  String get adminUnratedChannelContent => '頻道';
-
-  @override
-  String get adminUnratedLiveTvChannel => '直播電視';
-
-  @override
-  String get adminUnratedMovie => '電影';
-
-  @override
-  String get adminUnratedMusic => '音樂';
-
-  @override
-  String get adminUnratedTrailer => '預告片';
-
-  @override
-  String get adminUnratedSeries => '影集';
-
-  @override
-  String get adminAccessSchedules => '存取時間表';
-
-  @override
-  String get adminAccessSchedulesHint => '僅允許在下方排定的時段內存取。未設定時間表時，全天皆可存取。';
-
-  @override
-  String get adminAddSchedule => '新增時間表';
-
-  @override
-  String get adminScheduleDay => '日期';
-
-  @override
-  String get adminScheduleStart => '開始';
-
-  @override
-  String get adminScheduleEnd => '結束';
-
-  @override
-  String get adminDayEveryday => '每天';
-
-  @override
-  String get adminDayWeekday => '平日';
-
-  @override
-  String get adminDayWeekend => '週末';
-
-  @override
-  String get adminDaySunday => '星期日';
-
-  @override
-  String get adminDayMonday => '星期一';
-
-  @override
-  String get adminDayTuesday => '星期二';
-
-  @override
-  String get adminDayWednesday => '星期三';
-
-  @override
-  String get adminDayThursday => '星期四';
-
-  @override
-  String get adminDayFriday => '星期五';
-
-  @override
-  String get adminDaySaturday => '星期六';
-
-  @override
-  String get adminAllowedTags => '允許的標籤';
-
-  @override
-  String get adminAllowedTagsHint => '僅顯示具有這些標籤的內容。留空則允許全部。';
-
-  @override
-  String get adminBlockedTags => '封鎖的標籤';
-
-  @override
-  String get adminBlockedTagsHint => '具有這些標籤的內容將對此使用者隱藏。';
-
-  @override
-  String get adminAddTag => '新增標籤';
-
-  @override
-  String get adminEnabledDevices => '已啟用的裝置';
-
-  @override
-  String get adminEnabledChannels => '已啟用的頻道';
-
-  @override
-  String get adminAuthProvider => '驗證提供者';
-
-  @override
-  String get adminPasswordResetProvider => '密碼重設提供者';
-
-  @override
-  String get adminLoginAttemptsBeforeLockout => '鎖定前允許的最多登入失敗次數';
-
-  @override
-  String get adminLoginAttemptsHint => '設為 0 使用預設值，或設為 -1 停用鎖定。';
-
-  @override
-  String get adminSyncPlayAccess => 'SyncPlay 存取權';
-
-  @override
-  String get adminSyncPlayCreateAndJoin => '允許建立及加入群組';
-
-  @override
-  String get adminSyncPlayJoin => '允許加入群組';
-
-  @override
-  String get adminSyncPlayNone => '無存取權';
-
-  @override
-  String get adminContentDeletionFolders => '允許從下列位置刪除內容';
-
-  @override
   String get adminResetPasswordWarning => '這將刪除密碼。用戶無需密碼即可登入。';
 
   @override
   String adminServerReturnedHttp(int status) {
-    return '伺服器回傳 HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '您確定要刪除 $name 嗎？';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '已刪除使用者「$name」';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return '無法刪除使用者：$error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -14863,7 +13855,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return '無法建立金鑰：$error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -14874,7 +13866,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '要撤銷 $name 的金鑰嗎？';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -14882,7 +13874,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return '無法撤銷金鑰：$error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -14902,29 +13894,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return '權杖：$token\\n建立時間：$created';
+    return 'Token: $token\\nCreated: $created';
   }
-
-  @override
-  String get adminBackupOptionsTitle => '建立備份';
-
-  @override
-  String get adminBackupInclude => '選擇要納入備份的項目。';
-
-  @override
-  String get adminBackupDatabase => '資料庫';
-
-  @override
-  String get adminBackupDatabaseAlways => '一律納入';
-
-  @override
-  String get adminBackupMetadata => '中繼資料';
-
-  @override
-  String get adminBackupSubtitles => '字幕';
-
-  @override
-  String get adminBackupTrickplay => 'Trickplay 圖片';
 
   @override
   String get adminCreatingBackup => '正在建立備份...';
@@ -14934,7 +13905,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return '無法建立備份：$error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -14942,12 +13913,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminBackupManifest(String name) {
-    return '資訊清單：$name';
+    return 'Manifest: $name';
   }
 
   @override
   String adminManifestLoadFailed(String error) {
-    return '無法載入資訊清單：$error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -14958,7 +13929,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRestoreFailed(String error) {
-    return '無法還原備份：$error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -14990,17 +13961,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminSavedTo(String path) {
-    return '已儲存至 $path';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return '無法儲存檔案：$error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return '無法載入 $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -15011,7 +13982,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return '無法載入工作：$error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -15022,17 +13993,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTaskStartFailed(String error) {
-    return '無法開始工作：$error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return '無法停止工作：$error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return '無法載入工作：$error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -15040,12 +14011,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return '無法移除觸發條件：$error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return '無法新增觸發條件：$error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -15071,7 +14042,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminHours(String hours) {
-    return '$hours 小時';
+    return '$hours hour(s)';
   }
 
   @override
@@ -15082,7 +14053,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return '無法切換外掛程式：$error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -15090,27 +14061,27 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '您確定要解除安裝「$name」嗎？';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return '無法解除安裝外掛程式：$error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return '無法安裝套件：$error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return '無法安裝更新：$error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return '無法載入外掛程式：$error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -15121,12 +14092,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminInstallUpdate(String version) {
-    return '安裝更新（v$version）';
+    return 'Install update (v$version)';
   }
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return '無法載入目錄：$error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -15146,17 +14117,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '伺服器重新啟動後將會移除「$name」';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return '無法解除安裝：$error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '正在將「$name」更新至 v$version...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -15164,7 +14135,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return '無法載入外掛程式：$error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -15172,7 +14143,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginVersion(String version) {
-    return '版本 $version';
+    return 'Version $version';
   }
 
   @override
@@ -15192,17 +14163,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '您確定要移除「$name」嗎？';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return '無法儲存存放庫：$error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return '無法載入存放庫：$error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -15219,12 +14190,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return '無法載入外掛程式設定：$error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '無法開啟 $uri';
+    return 'Could not open $uri';
   }
 
   @override
@@ -15339,10 +14310,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminThrottleBuffering => '油門緩衝';
 
   @override
-  String get adminTrickplaySaved => '已儲存 Trickplay 設定';
+  String get adminTrickplaySaved => '已儲存特技播放設定';
 
   @override
-  String get adminTrickplayLoadFailed => '無法載入 Trickplay 設定';
+  String get adminTrickplayLoadFailed => '無法載入特技播放設置';
 
   @override
   String get adminEnableHardwareAcceleration => '啟用硬體加速';
@@ -15444,7 +14415,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminBaseUrl => '基本網址';
 
   @override
-  String get adminBaseUrlHint => '例如 /jellyfin';
+  String get adminBaseUrlHint => '例如/果凍';
 
   @override
   String get https => 'HTTPS';
@@ -15484,12 +14455,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return '無法載入中繼資料：$error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return '無法儲存中繼資料：$error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -15509,7 +14480,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return '無法重新整理中繼資料：$error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -15523,7 +14494,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return '遠端搜尋失敗：$error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -15537,7 +14508,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return '無法更新內容類型：$error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -15551,12 +14522,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '已更新 $imageType 圖片';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return '無法下載圖片：$error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -15567,27 +14538,27 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '已上傳 $imageType 圖片';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return '無法上傳圖片：$error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminDeleteImage(String imageType) {
-    return '刪除 $imageType 圖片';
+    return 'Delete $imageType image';
   }
 
   @override
   String adminImageDeleted(String imageType) {
-    return '已刪除 $imageType 圖片';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return '無法刪除圖片：$error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -15598,116 +14569,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return '調諧器探索失敗：$error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
   String get adminAddTuner => '新增調音器';
-
-  @override
-  String get adminEditTuner => '編輯調諧器';
-
-  @override
-  String get adminTunerTypeM3u => 'M3U 調諧器';
-
-  @override
-  String get adminTunerTypeHdHomerun => 'HDHomeRun';
-
-  @override
-  String get adminTunerFileOrUrl => '檔案或 URL';
-
-  @override
-  String get adminTunerIpAddress => '調諧器 IP 位址';
-
-  @override
-  String get adminTunerFriendlyName => '易記名稱';
-
-  @override
-  String get adminTunerUserAgent => '使用者代理';
-
-  @override
-  String get adminTunerCount => '同時連線上限';
-
-  @override
-  String get adminTunerCountHelp => '此調諧器同時允許的最大串流數量。設為 0 表示不限制。';
-
-  @override
-  String get adminTunerFallbackBitrate => '備用的最高串流位元率';
-
-  @override
-  String get adminTunerImportFavoritesOnly => '僅匯入我的最愛頻道';
-
-  @override
-  String get adminTunerAllowHwTranscoding => '允許硬體轉碼';
-
-  @override
-  String get adminTunerAllowFmp4 => '允許 fMP4 轉碼容器';
-
-  @override
-  String get adminTunerAllowStreamSharing => '允許共用串流';
-
-  @override
-  String get adminTunerEnableStreamLooping => '啟用串流循環';
-
-  @override
-  String get adminTunerIgnoreDts => '忽略 DTS';
-
-  @override
-  String get adminTunerReadAtNativeFramerate => '以原生影格率讀取輸入';
-
-  @override
-  String get adminEditProvider => '編輯提供者';
-
-  @override
-  String get adminProviderXmltv => 'XMLTV';
-
-  @override
-  String get adminProviderSchedulesDirect => 'Schedules Direct';
-
-  @override
-  String get adminXmltvPath => '檔案或 URL';
-
-  @override
-  String get adminXmltvMoviePrefix => '電影前置字串';
-
-  @override
-  String get adminXmltvMovieCategories => '電影類別';
-
-  @override
-  String get adminXmltvCategoriesHelp => '多個類別之間請以直線（|）分隔。';
-
-  @override
-  String get adminXmltvKidsCategories => '兒童類別';
-
-  @override
-  String get adminXmltvNewsCategories => '新聞類別';
-
-  @override
-  String get adminXmltvSportsCategories => '體育類別';
-
-  @override
-  String get adminSdUsername => '使用者名稱';
-
-  @override
-  String get adminSdPassword => '密碼';
-
-  @override
-  String get adminSdCountry => '國家／地區';
-
-  @override
-  String get adminSdCountrySelect => '請選擇國家／地區';
-
-  @override
-  String get adminSdPostalCode => '郵遞區號';
-
-  @override
-  String get adminSdGetListings => '取得節目表';
-
-  @override
-  String get adminSdListings => '節目表';
-
-  @override
-  String get adminEnableAllTuners => '啟用所有調諧器';
 
   @override
   String get adminTunerType => '調音器類型';
@@ -15717,7 +14583,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTunerAddFailed(String error) {
-    return '無法新增調諧器：$error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -15731,12 +14597,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminProviderAddFailed(String error) {
-    return '無法新增提供者：$error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return '無法移除調諧器：$error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -15744,15 +14610,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTunerResetFailed(String error) {
-    return '無法重設調諧器：$error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
-  String get adminTunerResetNotSupported => '此類型的調諧器不支援重設。';
-
-  @override
   String adminProviderRemoveFailed(String error) {
-    return '無法移除提供者：$error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -15771,51 +14634,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminSeriesRecordingPath => '系列錄音路徑';
 
   @override
-  String get adminMovieRecordingPath => '電影錄影路徑';
-
-  @override
-  String get adminGuideDays => '節目表資料天數';
-
-  @override
-  String get adminGuideDaysAuto => '自動';
-
-  @override
-  String adminGuideDaysValue(int days) {
-    return '$days 天';
-  }
-
-  @override
-  String get adminRecordingPostProcessor => '後製處理程式路徑';
-
-  @override
-  String get adminRecordingPostProcessorArgs => '後製處理器引數';
-
-  @override
-  String get adminSaveRecordingNfo => '儲存錄影的 NFO 中繼資料';
-
-  @override
-  String get adminSaveRecordingImages => '儲存錄影圖片';
-
-  @override
-  String get adminLiveTvSectionTiming => '時間設定';
-
-  @override
-  String get adminLiveTvSectionPaths => '錄影路徑';
-
-  @override
-  String get adminLiveTvSectionPostProcessing => '後製處理';
-
-  @override
-  String adminGuideDaysDisplay(String value) {
-    return '節目表資料：$value';
-  }
-
-  @override
   String get adminRecordingSettingsSaved => '已儲存錄音設定';
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return '無法儲存設定：$error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -15832,7 +14655,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return '無法更新對應：$error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -15848,15 +14671,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminGuideProviders => '導遊提供者';
 
   @override
-  String get adminRefreshGuideData => '重新整理節目表資料';
-
-  @override
-  String get adminGuideRefreshStarted => '已開始重新整理節目表資料';
-
-  @override
-  String get adminGuideRefreshUnavailable => '此伺服器沒有節目表重新整理工作。';
-
-  @override
   String get adminAddProvider => '新增提供者';
 
   @override
@@ -15864,22 +14678,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return '錄影路徑：$path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return '影集路徑：$path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return '提前錄影：$minutes 分鐘';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return '延後錄影：$minutes 分鐘';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -15908,7 +14722,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '要立即還原備份 $name 嗎？';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -15930,13 +14744,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminLiveTvTitle => '直播電視管理';
 
   @override
-  String get adminApply => '套用';
+  String get adminApply => '申請';
 
   @override
   String get adminNotSet => '未設定';
 
   @override
-  String get adminReset => '重設';
+  String get adminReset => '重置';
 
   @override
   String get adminLogsTitle => '伺服器日誌';
@@ -15952,27 +14766,27 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes 分鐘前';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours 小時前';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '$days 天前';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '無法載入 $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count 個相符項目';
+    return '$count matches';
   }
 
   @override
@@ -15980,9 +14794,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get adminMetadataEditorTitle => '元資料編輯器';
-
-  @override
-  String get adminMetadataIdentify => '辨識';
 
   @override
   String get adminMetadataType => '類型';
@@ -16082,22 +14893,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '已更新 $imageType 圖片';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '已上傳 $imageType 圖片';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '已刪除 $imageType 圖片';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return '無法下載圖片：$error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -16105,12 +14916,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return '無法上傳圖片：$error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String adminMetadataDeleteImageTitle(String imageType) {
-    return '刪除 $imageType 圖片';
+    return 'Delete $imageType image';
   }
 
   @override
@@ -16118,12 +14929,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return '無法刪除圖片：$error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '選擇 $imageType 圖片';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -16155,7 +14966,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return '有可用更新：v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -16178,7 +14989,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginsInstallUpdateVersioned(String version) {
-    return '安裝更新（v$version）';
+    return 'Install update (v$version)';
   }
 
   @override
@@ -16189,7 +15000,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '正在安裝「$name」...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -16207,7 +15018,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name 設定';
+    return '$name Settings';
   }
 
   @override
@@ -16242,7 +15053,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminReposLoadFailed(String error) {
-    return '無法載入存放庫：$error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -16250,15 +15061,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '您確定要移除「$name」嗎？';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
-  String get adminReposRemove => '移除';
+  String get adminReposRemove => '消除';
 
   @override
   String adminReposSaveFailed(String error) {
-    return '無法儲存存放庫：$error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -16379,21 +15190,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminBrandingEnableSplash => '啟用啟動畫面';
 
   @override
-  String get adminBrandingSplashUpload => '上傳圖片';
-
-  @override
-  String get adminBrandingSplashUploaded => '已更新啟動畫面';
-
-  @override
-  String get adminBrandingSplashUploadFailed => '無法上傳啟動畫面';
-
-  @override
-  String get adminBrandingSplashDeleted => '已移除啟動畫面';
-
-  @override
-  String get adminBrandingNoSplash => '沒有自訂啟動畫面';
-
-  @override
   String get adminPlaybackHwAccel => '硬體加速';
 
   @override
@@ -16404,117 +15200,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get adminPlaybackEnableHwDecoding => '啟用硬體解碼：';
-
-  @override
-  String get adminPlaybackQsvDevice => 'QSV 裝置';
-
-  @override
-  String get adminPlaybackEnhancedNvdec => '啟用增強型 NVDEC 解碼器';
-
-  @override
-  String get adminPlaybackPreferNativeDecoder => '優先使用系統原生的硬體解碼器';
-
-  @override
-  String get adminPlaybackColorDepth => '硬體解碼色彩深度';
-
-  @override
-  String get adminPlaybackColorDepth10Hevc => '10-bit HEVC 解碼';
-
-  @override
-  String get adminPlaybackColorDepth10Vp9 => '10-bit VP9 解碼';
-
-  @override
-  String get adminPlaybackColorDepth10HevcRext => 'HEVC RExt 8/10-bit 解碼';
-
-  @override
-  String get adminPlaybackColorDepth12HevcRext => 'HEVC RExt 12-bit 解碼';
-
-  @override
-  String get adminPlaybackHwEncodingSection => '硬體編碼';
-
-  @override
-  String get adminPlaybackAllowHevcEncoding => '允許 HEVC 編碼';
-
-  @override
-  String get adminPlaybackAllowAv1Encoding => '允許 AV1 編碼';
-
-  @override
-  String get adminPlaybackIntelLowPowerH264 => '啟用 Intel 低功耗 H.264 編碼器';
-
-  @override
-  String get adminPlaybackIntelLowPowerHevc => '啟用 Intel 低功耗 HEVC 編碼器';
-
-  @override
-  String get adminPlaybackToneMapping => '色調對應';
-
-  @override
-  String get adminPlaybackEnableTonemapping => '啟用色調對應';
-
-  @override
-  String get adminPlaybackEnableVppTonemapping => '啟用 VPP 色調對應';
-
-  @override
-  String get adminPlaybackEnableVtTonemapping => '啟用 VideoToolbox 色調對應';
-
-  @override
-  String get adminPlaybackTonemappingAlgorithm => '色調對應演算法';
-
-  @override
-  String get adminPlaybackTonemappingMode => '色調對應模式';
-
-  @override
-  String get adminPlaybackTonemappingRange => '色調對應範圍';
-
-  @override
-  String get adminPlaybackTonemappingDesat => '色調對應去飽和度';
-
-  @override
-  String get adminPlaybackTonemappingPeak => '色調對應峰值';
-
-  @override
-  String get adminPlaybackTonemappingParam => '色調對應參數';
-
-  @override
-  String get adminPlaybackVppTonemappingBrightness => 'VPP 色調對應亮度';
-
-  @override
-  String get adminPlaybackVppTonemappingContrast => 'VPP 色調對應對比度';
-
-  @override
-  String get adminPlaybackPresetsQuality => '預設集與品質';
-
-  @override
-  String get adminPlaybackEncoderPreset => '編碼器預設集';
-
-  @override
-  String get adminPlaybackH264Crf => 'H.264 編碼 CRF';
-
-  @override
-  String get adminPlaybackH265Crf => 'H.265（HEVC）編碼 CRF';
-
-  @override
-  String get adminPlaybackDeinterlaceMethod => '去交錯方式';
-
-  @override
-  String get adminPlaybackDeinterlaceDoubleRate => '去交錯時將影格率加倍';
-
-  @override
-  String get adminPlaybackAudioSection => '音訊';
-
-  @override
-  String get adminPlaybackEnableAudioVbr => '啟用音訊 VBR 編碼';
-
-  @override
-  String get adminPlaybackDownmixBoost => '音訊縮混增益';
-
-  @override
-  String get adminPlaybackDownmixAlgorithm => '立體聲縮混演算法';
-
-  @override
-  String get adminPlaybackMaxMuxingQueue => '最大混流佇列大小';
-
-  @override
-  String get adminPlaybackAutoOption => '自動';
 
   @override
   String get adminPlaybackEncoding => '編碼';
@@ -16628,9 +15313,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminTaskStop => '停止';
 
   @override
-  String get adminRunningTasks => '執行中的工作';
-
-  @override
   String get adminTaskRun => '跑步';
 
   @override
@@ -16650,17 +15332,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return '每天 $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return '每個$day $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return '每 $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -16698,8 +15380,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 小時',
-      one: '1 小時',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -16727,17 +15409,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days 天前';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours 小時前';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes 分鐘前';
+    return '${minutes}m ago';
   }
 
   @override
@@ -16745,17 +15427,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminActivityMinutesShort(int minutes) {
-    return '$minutes 分';
+    return '${minutes}m';
   }
 
   @override
   String adminActivityHoursShort(int hours) {
-    return '$hours 小時';
+    return '${hours}h';
   }
 
   @override
   String adminActivityDaysShort(int days) {
-    return '$days 天';
+    return '${days}d';
   }
 
   @override
@@ -16764,7 +15446,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get adminTrickplayDescription => '設定 Trickplay 圖片產生方式，用於跳轉預覽縮圖。';
+  String get adminTrickplayDescription => '配置搜尋預覽縮圖的特技播放影像生成。';
 
   @override
   String get adminNetworkingPublicHttpsPort => '公共 HTTPS 連接埠';
@@ -16773,49 +15455,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminNetworkingBaseUrl => '基本網址';
 
   @override
-  String get adminNetworkingBaseUrlHint => '例如 /jellyfin';
+  String get adminNetworkingBaseUrlHint => '例如/果凍';
 
   @override
   String get adminNetworkingHttps => 'HTTPS';
-
-  @override
-  String get adminNetworkingPublicHttpPort => '公開 HTTP 連接埠';
-
-  @override
-  String get adminNetworkingRequireHttps => '強制使用 HTTPS';
-
-  @override
-  String get adminNetworkingRequireHttpsHint =>
-      '將所有遠端要求重新導向至 HTTPS。若伺服器沒有有效憑證則不會生效。';
-
-  @override
-  String get adminNetworkingCertPassword => '憑證密碼';
-
-  @override
-  String get adminNetworkingIpSettings => 'IP 設定';
-
-  @override
-  String get adminNetworkingEnableIpv4 => '啟用 IPv4';
-
-  @override
-  String get adminNetworkingEnableIpv6 => '啟用 IPv6';
-
-  @override
-  String get adminNetworkingAutoDiscovery => '啟用自動連接埠對應';
-
-  @override
-  String get adminNetworkingLocalSubnets => '區域網路';
-
-  @override
-  String get adminNetworkingLocalSubnetsHint =>
-      '以逗號或換行分隔的 IP 位址或 CIDR 子網路清單，這些將被視為位於區域網路內。';
-
-  @override
-  String get adminNetworkingPublishedUris => '公開的伺服器 URI';
-
-  @override
-  String get adminNetworkingPublishedUriHint =>
-      '將子網路或位址對應至公開 URL，例如 all=https://example.com';
 
   @override
   String get adminNetworkingCertPath => '證書路徑';
@@ -16843,12 +15486,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get adminPlaybackThrottleBuffering => '油門緩衝';
-
-  @override
-  String get adminPlaybackThrottleDelay => '節流延遲（秒）';
-
-  @override
-  String get adminPlaybackEnableSubtitleExtraction => '允許即時擷取字幕';
 
   @override
   String get adminResumeMinPct => '最低履歷百分比';
@@ -16894,29 +15531,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return '無法更新內容類型：$error';
+    return 'Failed to update content type: $error';
   }
 
   @override
   String get adminGeneralSlowResponseThreshold => '慢響應閾值（毫秒）';
-
-  @override
-  String get adminGeneralEnableSlowResponse => '啟用回應緩慢警告';
-
-  @override
-  String get adminGeneralQuickConnect => '啟用 Quick Connect';
-
-  @override
-  String get adminGeneralSectionServer => '伺服器';
-
-  @override
-  String get adminGeneralSectionMetadata => '中繼資料';
-
-  @override
-  String get adminGeneralSectionPaths => '路徑';
-
-  @override
-  String get adminGeneralSectionPerformance => '效能';
 
   @override
   String get adminGeneralCachePath => '快取路徑';
@@ -16928,9 +15547,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get adminGeneralServerName => '伺服器名稱';
 
   @override
-  String get adminGeneralDisplayLanguage => '偏好的顯示語言';
-
-  @override
   String get adminSettingsLoadFailed => '無法載入設定';
 
   @override
@@ -16938,19 +15554,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return '無法更新對應：$error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return '時間限制：$duration';
+    return 'Time limit: $duration';
   }
 
   @override
   String get folders => '資料夾';
 
   @override
-  String get libraries => '媒體庫';
+  String get libraries => '圖書館';
 
   @override
   String get syncPlay => 'SyncPlay';
@@ -16979,8 +15595,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 位參與者',
-      one: '# 位參與者',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -17020,7 +15636,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String syncPlayQueueItemFallback(int index) {
-    return '項目 $index';
+    return 'Item $index';
   }
 
   @override
@@ -17067,12 +15683,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName 已加入 SyncPlay 群組';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName 已離開 SyncPlay 群組';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -17084,7 +15700,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return '正在將播放同步至 $groupName';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -17121,8 +15737,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '已找到 # 個列',
-      one: '已找到 # 個列',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
@@ -17161,21 +15777,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get offlineSavedMedia => '保存的媒體';
 
   @override
-  String get offlineBannerTitle => '您目前離線';
-
-  @override
-  String get offlineBannerSubtitle => '正在顯示您的下載內容';
-
-  @override
-  String get offlineBannerAction => '下載';
-
-  @override
-  String get serverUnreachableBannerTitle => '無法連線到您的伺服器';
-
-  @override
-  String get serverUnreachableBannerSubtitle => '在伺服器恢復前將播放下載的內容';
-
-  @override
   String get castGoogleCast => 'Google Cast';
 
   @override
@@ -17189,12 +15790,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String castControlFailed(String error) {
-    return '投放控制失敗：$error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind 控制';
+    return '$kind Controls';
   }
 
   @override
@@ -17205,7 +15806,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String castStopKind(String kind) {
-    return '停止 $kind';
+    return 'Stop $kind';
   }
 
   @override
@@ -17228,12 +15829,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String pinEnterNDigit(int length) {
-    return '請輸入 $length 位數 PIN';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '請輸入您的 $length 位數 PIN';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -17252,29 +15853,29 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get pinBackspace => '退格鍵';
 
   @override
-  String get quickConnectAuthorized => '已授權 Quick Connect 要求。';
+  String get quickConnectAuthorized => '快速連線請求已獲授權。';
 
   @override
-  String get quickConnectInvalidOrExpired => 'Quick Connect 代碼無效或已過期。';
+  String get quickConnectInvalidOrExpired => '快速連線代碼無效或已過期。';
 
   @override
-  String get quickConnectNotSupported => '此伺服器不支援 Quick Connect。';
+  String get quickConnectNotSupported => '此伺服器不支援快速連線。';
 
   @override
-  String get quickConnectAuthorizeFailed => '無法授權 Quick Connect 代碼。';
+  String get quickConnectAuthorizeFailed => '無法授權快速連線代碼。';
 
   @override
-  String get quickConnectDisabled => '此伺服器已停用 Quick Connect。';
+  String get quickConnectDisabled => '此伺服器上禁用了快速連線。';
 
   @override
-  String get quickConnectForbidden => '您的帳戶無法授權此 Quick Connect 要求。';
+  String get quickConnectForbidden => '您的帳戶無法授權此快速連線要求。';
 
   @override
-  String get quickConnectNotFound => '找不到此 Quick Connect 代碼。請嘗試取得新的代碼。';
+  String get quickConnectNotFound => '未找到快速連線代碼。嘗試新的程式碼。';
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect 失敗：$message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -17285,7 +15886,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String remoteCommandFailed(String error) {
-    return '指令失敗：$error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -17314,7 +15915,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String castingFailed(String error) {
-    return '無法開始投放：$error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -17359,7 +15960,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String trackActionDownloading(String name) {
-    return '正在下載 $name...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -17378,7 +15979,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get shuffleSelectGenre => '選擇類型';
 
   @override
-  String get shuffleLibrary => '媒體庫';
+  String get shuffleLibrary => '圖書館';
 
   @override
   String get shuffleGenre => '類型';
@@ -17445,7 +16046,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String skipSegment(String segment) {
-    return '跳過$segment';
+    return 'Skip $segment';
   }
 
   @override
@@ -17456,12 +16057,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return '正在下載 $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '正在下載 $fileName';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -17498,7 +16099,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get playerTooltipUnlockOrientation => '允許旋轉';
 
   @override
-  String get playerTooltipPrevious => '上一個';
+  String get playerTooltipPrevious => '以前的';
 
   @override
   String get playerTooltipSeekBack => '回頭尋找';
@@ -17520,15 +16121,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get contextMenuGoToSeries => '前往系列';
-
-  @override
-  String get contextMenuHideFromContinueWatching => '從「繼續觀看」中隱藏';
-
-  @override
-  String get contextMenuHideFromNextUp => '從「下一集」中隱藏';
-
-  @override
-  String get contextMenuAddToCollection => '加入合輯';
 
   @override
   String get settingsAdministrationSubtitle => '存取伺服器管理面板';
@@ -17576,16 +16168,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsAlphabetical => '按字母順序';
 
   @override
-  String get settingsConnectionSection => '連線';
-
-  @override
-  String get settingsAllowSelfSignedCerts => '允許自我簽署憑證';
-
-  @override
-  String get settingsAllowSelfSignedCertsSubtitle =>
-      '信任使用自我簽署或私人 CA TLS 憑證的伺服器。請僅對您自己掌控的伺服器啟用。此設定會停用所有連線的憑證驗證。';
-
-  @override
   String get settingsPrivacyAndSafetySection => '隱私與安全';
 
   @override
@@ -17596,12 +16178,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get settingsGeneralStyleSubtitle => '主題口音、背景、觀看指示器和主題音樂';
-
-  @override
-  String get settingsDetailsScreen => '詳細資料頁';
-
-  @override
-  String get settingsDetailsScreenSubtitle => '樣式、背景模糊與分頁行為';
 
   @override
   String get settingsHomePage => '首頁';
@@ -17629,12 +16205,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get settingsShowLibrariesButtonInNavigation => '在導覽列中顯示庫按鈕';
-
-  @override
-  String get settingsShowSeerrButtonInNavigation => '在導覽列中顯示 Seerr 按鈕';
-
-  @override
-  String get settingsAlwaysExpandNavbarLabels => '在頂端導覽列中一律顯示文字標籤';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -17699,7 +16269,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsSupportMoonfin => '支援Moonfin';
 
   @override
-  String get settingsSupportMoonfinSubtitle => '請開發者喝杯咖啡';
+  String get settingsSupportMoonfinSubtitle =>
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => '合法的';
@@ -17730,8 +16301,8 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# 則授權聲明',
-      one: '# 則授權聲明',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -17774,18 +16345,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsSkipIntrosAndOutros => '跳過片頭和片尾？';
 
   @override
-  String get settingsMediaSegmentCountdown => '媒體片段倒數';
-
-  @override
-  String get settingsProgressBar => '進度列';
-
-  @override
-  String get settingsTimer => '計時器';
-
-  @override
-  String get settingsNone => '無';
-
-  @override
   String get settingsPromptUser => '提示用戶';
 
   @override
@@ -17815,13 +16374,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3（建議）';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3（舊版）';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv（舊版）';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv（建議）';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision 後備';
@@ -17906,7 +16465,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String settingsMillisecondsValue(int value) {
-    return '$value 毫秒';
+    return '$value ms';
   }
 
   @override
@@ -17983,7 +16542,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String libraryNameWithServer(String libraryName, String serverName) {
-    return '$libraryName（$serverName）';
+    return '$libraryName ($serverName)';
   }
 
   @override
@@ -17992,705 +16551,622 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String recentlyReleasedLibraryName(String libraryName) {
-    return '最近上架的$libraryName';
-  }
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
-  String get autoplayNextEpisode => '自動播放下一集';
+  String get autoplayNextEpisodeSubtitle =>
+      'Automatically play the next episode when available.';
 
   @override
-  String get autoplayNextEpisodeSubtitle => '有下一集時自動播放。';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
-  String get skipSilenceTitle => '略過靜音';
+  String get skipSilenceSubtitle =>
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get skipSilenceSubtitle => '在串流支援時自動略過靜音片段。';
-
-  @override
-  String get allowExternalAudioEffectsTitle => '允許外部音效';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      '允許等化器與音效應用程式（例如 Wavelet）連接至 Media3 播放工作階段。';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => '停用穿隧';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
-  String get disableTunnelingSubtitle => '強制使用非穿隧播放。在穿隧會造成音訊／視訊不連續的裝置上相當實用。';
+  String get disableTunnelingSubtitle =>
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => '啟用穿隧';
-
-  @override
-  String get enableTunnelingSubtitle =>
-      '進階功能。將音訊與視訊透過耦合的硬體路徑傳送。預設為關閉，因為在部分裝置上會造成音訊／視訊中斷。';
-
-  @override
-  String get mapDolbyVisionP7Title => '將 Dolby Vision profile 7 對應至 HEVC';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      '在不支援 Dolby Vision 的裝置上，將 Dolby Vision profile 7 串流以 HDR10 相容的 HEVC 播放。';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => '使用內嵌的字幕樣式';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      '套用字幕軌中內嵌的顏色、字體與位置。停用後將改用您的字幕樣式偏好設定。';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
-  String get subtitlesUseEmbeddedFontSizes => '使用內嵌的字幕字體大小';
+  String get subtitlesUseEmbeddedFontSizes =>
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      '套用字幕軌中內嵌的字體大小提示。停用後將使用您樣式偏好設定中的字幕大小。';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => '顯示媒體詳細資料';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
-  String get showMediaDetailsOnLibraryPageDescription => '在媒體庫頁面頂端顯示所選項目的詳細資料。';
+  String get useDetailedSubHeadingsDescription =>
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get hideBackdropsInLibraries => '瀏覽時隱藏背景圖？';
-
-  @override
-  String get useDetailedSubHeadings => '使用詳細副標題';
-
-  @override
-  String get useDetailedSubHeadingsDescription => '在媒體庫頁面顯示詳細或簡潔的子列。';
-
-  @override
-  String get savedThemesDeleteDialogTitle => '要刪除已儲存的主題嗎？';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '要從此裝置的快取中移除「$themeName」嗎？';
-  }
-
-  @override
-  String get themeStore => '主題商店';
-
-  @override
-  String get themeStoreSubtitle => '瀏覽並儲存社群主題';
-
-  @override
-  String get themeStoreDescription => '儲存主題後，即可像使用其他已儲存的主題一樣使用它。';
-
-  @override
-  String get themeStoreEmpty => '目前沒有可用的主題。';
-
-  @override
-  String get themeStoreLoadFailed => '無法載入主題商店。請檢查您的連線後再試一次。';
-
-  @override
-  String get themeStoreSave => '儲存';
-
-  @override
-  String get themeStoreSaveAndApply => '儲存並套用';
-
-  @override
-  String get themeStoreSaved => '已儲存';
-
-  @override
-  String get themeStoreInvalidMessage => '無法載入此主題。';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return '已儲存「$themeName」。';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '已從此裝置刪除「$themeName」。';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '無法刪除「$themeName」。';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => '已儲存的主題';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      '這些是為目前伺服器從 Moonfin 外掛程式下載的主題。刪除僅會移除此本機副本。';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => '找不到此伺服器的已儲存主題。';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • 使用中';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => '刪除已儲存的主題';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
-  String get savedThemesManageSubtitle => '管理此裝置上已下載的外掛程式主題';
+  String get savedThemesManageSubtitle =>
+      'Manage downloaded plugin themes on this device';
 
   @override
-  String get themeEditor => '主題編輯器';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => '在您的瀏覽器中開啟 Moonfin 主題編輯器';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => '主畫面';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => '底部列';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => '經典';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
-  String get homeRowsStyleModern => '現代';
+  String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => '主畫面列';
-
-  @override
-  String get homeRowDisplay => '主畫面列顯示';
-
-  @override
-  String get homeRowSections => '主畫面列區段';
-
-  @override
-  String get homeRowToggles => '主畫面列開關';
-
-  @override
-  String get homeRowTogglesSubtitle => '啟用或停用以媒體庫為基礎的主畫面列類別';
-
-  @override
-  String get homeRowTogglesDescription => '啟用下列開關，即可在主畫面區段中顯示對應的列。';
+  String get homeRowsSection => 'Home Rows';
 
   @override
   String get rowsType => 'Rows Type';
 
   @override
-  String get rowsTypeDescription => '「經典」保留各列的圖片類型與資訊覆蓋層。「現代」使用直式轉背景圖的列。';
+  String get rowsTypeDescription =>
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => '顯示我的最愛列';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
-  String get displayFavoritesRowsSubtitle => '在主畫面區段中顯示最愛電影、影集及其他最愛列。';
+  String get displayFavoritesRowsSubtitle =>
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => '我的最愛列排序';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
-  String get favoritesRowSortingDescription => '依加入日期、上映日期、字母順序等方式排序我的最愛列。';
+  String get favoritesRowSortingDescription =>
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => '顯示合輯列';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
-  String get displayCollectionsRowsSubtitle => '在主畫面區段中顯示合輯列。';
+  String get displayCollectionsRowsSubtitle =>
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => '合輯列排序';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
-  String get collectionsRowSortingDescription => '依加入日期、上映日期、字母順序等方式排序合輯列。';
+  String get collectionsRowSortingDescription =>
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => '顯示類型列';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle => '在主畫面區段中顯示類型列。';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => '類型列排序';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
-  String get genresRowSortingDescription => '依加入日期、上映日期、字母順序等方式排序類型列。';
+  String get genresRowSortingDescription =>
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => '類型列項目';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
-  String get genresRowItemsDescription => '在類型列中顯示電影、影集或兩者。';
+  String get genresRowItemsDescription =>
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => '顯示播放清單列';
-
-  @override
-  String get displayPlaylistsRowsSubtitle => '在主畫面區段中顯示播放清單列。';
-
-  @override
-  String get playlistsRowSorting => '播放清單列排序';
-
-  @override
-  String get playlistsRowSortingDescription => '依加入日期、上映日期、字母順序等方式排序播放清單列。';
-
-  @override
-  String get displayAudioRows => '顯示音訊列';
-
-  @override
-  String get displayAudioRowsSubtitle => '在主畫面區段中顯示音訊列。';
-
-  @override
-  String get audioRowsSorting => '音訊列排序';
-
-  @override
-  String get audioRowsSortingDescription => '依加入日期、上映日期、字母順序等方式排序音訊列。';
-
-  @override
-  String get audioPlaylists => '音訊播放清單';
-
-  @override
-  String get appearance => '外觀';
-
-  @override
-  String get layout => '版面配置';
-
-  @override
-  String get theme => '主題';
-
-  @override
-  String get keyboard => '鍵盤';
-
-  @override
-  String get navButtons => '按鈕';
-
-  @override
-  String get rendering => '算圖';
-
-  @override
-  String get mpvConfiguration => 'MPV 設定';
+  String get appearance => 'Appearance';
 
   @override
   String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => '外部播放器應用程式';
+  String get externalPlayerApp => 'External player app';
 
   @override
-  String get externalPlayerAppDescription => '設定外部播放器後即可啟用長按播放選項';
+  String get externalPlayerAskEachTimeSubtitle =>
+      'Show app chooser when playback starts.';
 
   @override
-  String get externalPlayerAskEachTimeSubtitle => '開始播放時顯示應用程式選擇器。';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get loadingInstalledPlayers => '正在載入已安裝的播放器...';
+  String get connection => 'Connection';
 
   @override
-  String get connection => '連線';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get audioTranscodeTarget => '音訊轉碼目標';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get passthrough => '直通';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get supportedOnThisDevice => '此裝置支援';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => '此裝置不支援';
-
-  @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X（DTS UHD）直通';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      '將 DTS:X（DTS UHD）位元流傳送至外部解碼器。';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
-  String get settingsAudioTrueHdJocPassthrough => '含 Atmos（JOC）的 TrueHD 直通';
+  String get settingsAudioTrueHdJocPassthrough =>
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => '媒體播放器行為';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => '播放增強功能';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => '一律開啟。';
+  String get alwaysOn => 'Always on.';
 
   @override
-  String get replaceSkipOutroWithNextUpDisplay => '以「下一集」顯示取代「略過片尾」';
+  String get replaceSkipOutroWithNextUpDisplay =>
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '顯示「下一集」覆蓋層，而非「略過片尾」按鈕。';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => '播放器路由';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => '優先使用軟體解碼器';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      '在硬體解碼器之前優先使用 FFmpeg（音訊）與 libgav1（AV1）。若 HDMI 音訊直通發生問題請停用。';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
   String get useExternalPlayer => 'Use external player';
 
   @override
-  String get useExternalPlayerSubtitle => '在 Android TV 上使用您所選的外部應用程式播放影片。';
+  String get useExternalPlayerSubtitle =>
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => '自動排入佇列';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => '優先使用 SDH 字幕';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
-  String get preferSdhSubtitlesSubtitle => '自動選取字幕時優先選擇 SDH/CC 字幕軌。';
+  String get preferSdhSubtitlesSubtitle =>
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => '網頁診斷';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin 網頁診斷';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
-  String get webDiagnosticsIntro => '使用此頁面診斷瀏覽器連線問題（CORS、混合內容與探索設定）。';
+  String get webDiagnosticsIntro =>
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
-  String get webDiagnosticsDetectedMixedContentFailure => '偵測到混合內容失敗';
+  String get webDiagnosticsDetectedMixedContentFailure =>
+      'Detected Mixed-Content Failure';
 
   @override
-  String get webDiagnosticsDetectedCorsPreflightFailure => '偵測到 CORS／預檢失敗';
+  String get webDiagnosticsDetectedCorsPreflightFailure =>
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin 偵測到 HTTPS 頁面嘗試呼叫 HTTP 的伺服器 URL。瀏覽器會在要求送達您的伺服器之前將其封鎖。';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin 偵測到瀏覽器層級的要求失敗，這通常是因為媒體伺服器缺少 CORS 或預檢標頭所造成。';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return '目標 URL：$url';
+    return 'Target URL: $url';
   }
 
   @override
   String webDiagnosticsDetail(String detail) {
-    return '詳細資料：$detail';
+    return 'Detail: $detail';
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => '目前的執行階段環境';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => '來源';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => '通訊協定';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => '外掛程式模式';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC 掃描';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => '強制指定的伺服器 URL';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => '預設伺服器 URL';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => '探索代理 URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => '未設定';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => '混合內容';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      '此頁面透過 HTTPS 載入，但有一個或多個已設定的 URL 為 HTTP。瀏覽器會封鎖 HTTPS 頁面呼叫 HTTP API。';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      '解決方式：透過 HTTPS 提供您的媒體伺服器或代理端點，或僅在受信任的本地網路上以 HTTP 載入 Moonfin。';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      '從目前的執行階段設定中，未偵測到明顯的混合內容問題。';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS 檢查清單';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• 在 Access-Control-Allow-Origin 中允許瀏覽器的來源。';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• 在 Access-Control-Allow-Headers 中包含 Authorization、X-Emby-Authorization 與 X-Emby-Token。';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• 為串流與跳轉行為公開 Content-Range 與 Accept-Ranges。';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
-  String get webDiagnosticsCorsChecklistItem4 => '• 對 OPTIONS 預檢要求回傳 204。';
+  String get webDiagnosticsCorsChecklistItem4 =>
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
-  String get webDiagnosticsHeaderSnippetTitle => '標頭範例片段（nginx 風格）';
+  String get webDiagnosticsHeaderSnippetTitle =>
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => '注意';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      '此診斷路由是為網頁版建置而設計。若您在其他平台上看到此頁面，這些檢查可能不適用。';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => '返回伺服器選擇';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => '登出所有使用者';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
-  String get voiceSearchPermissionPermanentlyDenied => '麥克風權限已被永久拒絕。請至系統設定中啟用。';
+  String get voiceSearchPermissionPermanentlyDenied =>
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
-  String get voiceSearchPermissionRequired => '語音搜尋需要麥克風權限。';
+  String get voiceSearchPermissionRequired =>
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => '沒有聽清楚。請再試一次。';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => '未偵測到語音。';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => '麥克風錯誤。';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet => '語音搜尋需要網際網路連線。';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy => '語音服務忙碌中。請再試一次。';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
-  String get microphonePermissionPermanentlyDenied => '麥克風權限已被永久拒絕。';
+  String get microphonePermissionPermanentlyDenied =>
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => '麥克風權限遭拒。';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
-  String get speechRecognitionUnavailable => '此裝置無法使用語音辨識。';
+  String get speechRecognitionUnavailable =>
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => '開啟 iOS 路由選擇器';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
-  String get airPlayRoutePickerUnavailable => '此裝置無法使用 AirPlay 路由選擇器。';
+  String get airPlayRoutePickerUnavailable =>
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => '影片';
+  String get videos => 'Videos';
 
   @override
-  String get programs => '節目';
+  String get programs => 'Programs';
 
   @override
-  String get songs => '歌曲';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => '相簿';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => '相片';
+  String get photos => 'Photos';
 
   @override
-  String get people => '人物';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => '最近上架的集數';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => '再看一次';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => '客串演出';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => '演出（Seerr）';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get crewContributionsSeerr => '幕後參與（Seerr）';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get watchWithGroup => '與群組一起觀看';
+  String get errors => 'Errors';
 
   @override
-  String get errors => '錯誤';
+  String get warnings => 'Warnings';
 
   @override
-  String get warnings => '警告';
+  String get disk => 'Disk';
 
   @override
-  String get disk => '磁碟';
+  String get openInBrowser => 'Open in Browser';
 
   @override
-  String get openInBrowser => '在瀏覽器中開啟';
+  String get embeddedBrowserNotAvailable =>
+      'Embedded browser is not available on this platform.';
 
   @override
-  String get embeddedBrowserNotAvailable => '此平台無法使用內嵌瀏覽器。';
+  String get adminRestartServerConfirmation =>
+      'Are you sure you want to restart the server?';
 
   @override
-  String get adminRestartServerConfirmation => '您確定要重新啟動伺服器嗎？';
+  String get adminShutdownServerConfirmation =>
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get adminShutdownServerConfirmation => '您確定要關閉伺服器嗎？之後您需要手動重新啟動它。';
+  String get internal => 'Internal';
 
   @override
-  String get internal => '內部';
-
-  @override
-  String get idle => '閒置';
+  String get idle => 'Idle';
 
   @override
   String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => '找不到使用者';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch => '沒有使用者符合您的搜尋';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => '找不到裝置';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
-  String get adminNoDevicesMatchCurrentFilters => '沒有裝置符合目前的篩選條件';
+  String get adminNoDevicesMatchCurrentFilters =>
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => '已設定密碼';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => '未設定密碼';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => '遠端存取';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => '僅限本機';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => '無法載入媒體分析';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
-  String get analyticsCombinedAcrossLibraries => '所有媒體庫的綜合分析數據。';
+  String get analyticsCombinedAcrossLibraries =>
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => '熱門演出者';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => '熱門作者';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => '熱門貢獻者';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count 個媒體庫',
-      one: '1 個媒體庫',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
-  String get analyticsNoIndexedMediaTotals => '此選擇尚無可用的已建立索引媒體總數。';
+  String get analyticsNoIndexedMediaTotals =>
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => '媒體庫詳細資料';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => '媒體庫細目';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => '沒有可用的媒體庫。';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => '伺服器管理';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => '資料';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => '圖片快取';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => '快取';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => '紀錄';
+  String get adminServerPathLogs => 'Logs';
 
   @override
-  String get adminServerPathMetadata => '中繼資料';
+  String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => '轉碼';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
-  String get adminNoServerPathsReturned => '此伺服器並未回傳任何伺服器路徑。';
+  String get adminNoServerPathsReturned =>
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '已使用 $percent%';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => '使用者活動';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => '系統事件';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => '需要處理';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => '伺服器';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => '播放';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => '裝置';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => '進階';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
-  String get adminDrawerSectionPlugins => '外掛程式';
+  String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => '直播電視';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => '家庭影片';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => '混合內容';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => '家庭影片與相片';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => '電影與影集混合';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -18702,589 +17178,82 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => '找不到錄影';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '在 .$extension 封存檔中找不到圖片頁面。';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return '內嵌算圖器失敗（$code）：$description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB 算圖器失敗（$code）：$description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return '閱讀器找不到本機檔案：$uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '從 $uri 開啟書籍資料時發生 HTTP $status';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
-  String get noReadableBookEndpointAvailable => '沒有可讀取的書籍端點';
+  String get noReadableBookEndpointAvailable =>
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return '不支援的漫畫封存檔格式：.$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
-  String get cbrExtractionPluginUnavailable => '此平台無法使用 CBR 解壓縮外掛程式。';
+  String get cbrExtractionPluginUnavailable =>
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '無法解壓縮 .cbr 封存檔。';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
-  String get cb7ExtractionUnavailable => '此平台無法使用 CB7 解壓縮。';
+  String get cb7ExtractionUnavailable =>
+      'CB7 extraction is not available on this platform.';
 
   @override
-  String get cb7ExtractionPluginUnavailable => '此平台無法使用 CB7 解壓縮外掛程式。';
+  String get cb7ExtractionPluginUnavailable =>
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => '關閉類型面板';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => '正在載入隨機播放...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => '媒體庫隨機播放';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => '隨機播放';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => '類型隨機播放';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => '自動切換 HDR';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
-  String get autoHdrSwitchingDescription => '播放 HDR 影片時自動啟用 HDR，並在結束時還原顯示模式。';
+  String get autoHdrSwitchingDescription =>
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => '全螢幕時';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => '變更封面圖';
-
-  @override
-  String get missing => '缺少';
-
-  @override
-  String get transcodingLimits => '轉碼限制';
-
-  @override
-  String get clearAllArtworkButton => '要清除所有封面圖嗎？';
-
-  @override
-  String get clearAllArtworkWarning => '您確定要清除所有已下載的封面圖嗎？';
-
-  @override
-  String get confirmClear => '確認清除';
-
-  @override
-  String confirmClearMessage(String itemType) {
-    return '您確定要清除此$itemType嗎？';
-  }
-
-  @override
-  String get uploadButton => '要上傳嗎？';
-
-  @override
-  String get resolutionLabel => '解析度： ';
-
-  @override
-  String get onlyShowInterfaceLanguage => '僅顯示介面語言的封面圖';
-
-  @override
-  String get confirmClearAll => '確認全部清除';
-
-  @override
-  String get imageUploadSuccess => '圖片已成功上傳！';
-
-  @override
-  String imageUploadFailed(String error) {
-    return '無法上傳圖片：$error';
-  }
-
-  @override
-  String imageDownloadFailed(String error) {
-    return '無法設定圖片：$error';
-  }
-
-  @override
-  String imageDeleteFailed(String error) {
-    return '無法刪除圖片：$error';
-  }
-
-  @override
-  String clearAllArtworkFailed(String error) {
-    return '無法清除所有封面圖：$error';
-  }
-
-  @override
-  String get yes => '是';
-
-  @override
-  String get posterCategory => '海報';
-
-  @override
-  String get backdropsCategory => '背景圖';
-
-  @override
-  String get bannerCategory => '橫幅';
-
-  @override
-  String get logoCategory => '標誌';
-
-  @override
-  String get thumbnailCategory => '縮圖';
-
-  @override
-  String get artCategory => '美術圖';
-
-  @override
-  String get discArtCategory => '碟面圖';
-
-  @override
-  String get screenshotCategory => '螢幕擷圖';
-
-  @override
-  String get boxCoverCategory => '盒裝封面';
-
-  @override
-  String get boxRearCoverCategory => '盒裝背面';
-
-  @override
-  String get menuArtCategory => '選單美術圖';
-
-  @override
-  String get confirmItemPoster => '海報';
-
-  @override
-  String get confirmItemBackdrop => '背景圖';
-
-  @override
-  String get confirmItemBanner => '橫幅';
-
-  @override
-  String get confirmItemLogo => '標誌';
-
-  @override
-  String get confirmItemThumbnail => '縮圖';
-
-  @override
-  String get confirmItemArt => '美術圖';
-
-  @override
-  String get confirmItemDiscArt => '碟面圖';
-
-  @override
-  String get confirmItemScreenshot => '螢幕擷圖';
-
-  @override
-  String get confirmItemBoxCover => '盒裝封面';
-
-  @override
-  String get confirmItemBoxRearCover => '盒裝背面';
-
-  @override
-  String get confirmItemMenuArt => '選單美術圖';
-
-  @override
-  String get resolutionAll => '全部';
-
-  @override
-  String get resolutionHigh => '高（1080p+）';
-
-  @override
-  String get resolutionMedium => '中（720p）';
-
-  @override
-  String get resolutionLow => '低（<720p）';
-
-  @override
-  String get sources => '來源';
-
-  @override
-  String get audiobookChapters => '章節';
-
-  @override
-  String get audiobookBookmarks => '書籤';
-
-  @override
-  String get audiobookNotes => '筆記';
-
-  @override
-  String get audiobookQueue => '佇列';
-
-  @override
-  String get audiobookTimeline => '時間軸';
-
-  @override
-  String get audiobookTimelineEmpty => '時間軸是空的';
-
-  @override
-  String get audiobookWholeBook => '整本書';
-
-  @override
-  String get audiobookFocusedTimeline => '聚焦時間軸';
-
-  @override
-  String get audiobookExportBookmarks => '匯出書籤';
-
-  @override
-  String get audiobookExportNotes => '匯出筆記';
-
-  @override
-  String get audiobookExportAll => '全部匯出';
-
-  @override
-  String audiobookExportSuccess(String path) {
-    return '已匯出至 $path';
-  }
-
-  @override
-  String audiobookExportFailed(String error) {
-    return '匯出失敗：$error';
-  }
-
-  @override
-  String get audiobookLyrics => '歌詞';
-
-  @override
-  String get audiobookAddBookmark => '新增書籤';
-
-  @override
-  String get audiobookAddNote => '新增筆記';
-
-  @override
-  String get audiobookEditNote => '編輯筆記';
-
-  @override
-  String get audiobookNoteHint => '為此刻寫下筆記';
-
-  @override
-  String get audiobookSleepTimer => '睡眠計時器';
-
-  @override
-  String get audiobookSleepOff => '關閉';
-
-  @override
-  String get audiobookSleepEndOfChapter => '章節結束';
-
-  @override
-  String get audiobookSleepCustom => '自訂';
-
-  @override
-  String audiobookSleepRemaining(String remaining) {
-    return '還剩 $remaining';
-  }
-
-  @override
-  String audiobookSleepMinutes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '$count 分鐘',
-      one: '1 分鐘',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get audiobookPlaybackSpeed => '播放速度';
-
-  @override
-  String get audiobookRemainingTime => '剩餘';
-
-  @override
-  String get audiobookElapsedTime => '已播放';
-
-  @override
-  String audiobookSkipBackSeconds(int seconds) {
-    return '倒退 $seconds 秒';
-  }
-
-  @override
-  String audiobookSkipForwardSeconds(int seconds) {
-    return '快進 $seconds 秒';
-  }
-
-  @override
-  String get audiobookPreviousChapter => '上一章';
-
-  @override
-  String get audiobookNextChapter => '下一章';
-
-  @override
-  String audiobookChapterIndicator(int current, int total) {
-    return '第 $current 章，共 $total 章';
-  }
-
-  @override
-  String get audiobookNoChapters => '沒有章節';
-
-  @override
-  String get audiobookNoBookmarks => '尚無書籤';
-
-  @override
-  String get audiobookNoNotes => '尚無筆記';
-
-  @override
-  String audiobookBookmarkAdded(String position) {
-    return '已於 $position 新增書籤';
-  }
-
-  @override
-  String get audiobookSpeedReset => '重設為 1.0x';
-
-  @override
-  String audiobookSpeedCustomLabel(String value) {
-    return '${value}x';
-  }
-
-  @override
-  String get audiobookSave => '儲存';
-
-  @override
-  String get audiobookCancel => '取消';
-
-  @override
-  String get audiobookDelete => '刪除';
-
-  @override
-  String get subtitlePreferences => '字幕偏好設定';
-
-  @override
-  String get subtitlePreferencesDescription => '變更字幕模式、預設語言、外觀與算圖選項。';
-
-  @override
-  String get subtitleRendering => '字幕算圖';
-
-  @override
-  String get displayOptions => '顯示選項';
-
-  @override
-  String get releaseDateAscending => '上映日期（由舊到新）';
-
-  @override
-  String get releaseDateDescending => '上映日期（由新到舊）';
-
-  @override
-  String get groupContributions => '參與作品分組';
-
-  @override
-  String get groupMultipleRoles => '將多個角色分為一組';
-
-  @override
-  String get libraryWriteAccessWarningTitle => '媒體庫寫入權限警告';
-
-  @override
-  String get libraryWriteAccessHowToFix => '解決方式：';
-
-  @override
-  String get libraryWriteAccessFixSteps =>
-      '1. 在伺服器上，為您的媒體庫資料夾授予 Jellyfin 服務使用者（例如 jellyfin 或 Docker PUID/PGID）寫入權限。\n\n2. 或者前往您的 Jellyfin 儀表板 -> 媒體庫，編輯此媒體庫並停用「Save artwork into media folders」，將封面圖儲存於 Jellyfin 的內部資料庫中。';
-
-  @override
-  String get dismiss => '知道了';
-
-  @override
-  String libraryWriteAccessProactiveBody(
-    String libraryName,
-    String failedPath,
-  ) {
-    return '您的「$libraryName」媒體庫已設定為將封面圖直接儲存至媒體資料夾（「Save artwork into media folders」已啟用）。然而 Jellyfin 已測試寫入權限，發現沒有權限將檔案寫入此目錄：\n\n$failedPath';
-  }
-
-  @override
-  String get libraryWriteAccessReactiveBody =>
-      '看來 Jellyfin 無法更新封面圖。您的媒體庫已設定為將封面圖直接儲存至媒體資料夾（「Save artwork into media folders」已啟用）。此錯誤通常發生於 Jellyfin 伺服器程序沒有權限將檔案寫入您的媒體目錄時。';
-
-  @override
-  String get externalLists => '外部清單';
-
-  @override
-  String get replay => '重播';
-
-  @override
-  String get fileInformation => '檔案資訊';
-
-  @override
-  String fileSizeFormat(Object size, Object format) {
-    return '大小：$size  •  格式：$format';
-  }
-
-  @override
-  String showAllAudioTracks(int count) {
-    return '顯示全部（$count）音軌';
-  }
-
-  @override
-  String showAllSubtitleTracks(int count) {
-    return '顯示全部（$count）字幕軌';
-  }
-
-  @override
-  String get checkingDirectPlay => '正在檢查直接播放能力...';
-
-  @override
-  String get directPlayCapabilityLabel => '直接播放能力： ';
-
-  @override
-  String get forced => '強制';
-
-  @override
-  String get transcodeContainerNotSupported => '播放器不支援此容器格式。';
-
-  @override
-  String get transcodeVideoCodecNotSupported => '不支援此視訊編解碼器。';
-
-  @override
-  String get transcodeAudioCodecNotSupported => '不支援此音訊編解碼器。';
-
-  @override
-  String get transcodeSubtitleCodecNotSupported => '不支援此字幕格式（需要燒錄）。';
-
-  @override
-  String get transcodeAudioProfileNotSupported => '不支援此音訊設定檔。';
-
-  @override
-  String get transcodeVideoProfileNotSupported => '不支援此視訊設定檔。';
-
-  @override
-  String get transcodeVideoLevelNotSupported => '不支援此視訊等級。';
-
-  @override
-  String get transcodeVideoResolutionNotSupported => '此裝置不支援此視訊解析度。';
-
-  @override
-  String get transcodeVideoBitDepthNotSupported => '不支援此視訊位元深度。';
-
-  @override
-  String get transcodeVideoFramerateNotSupported => '不支援此視訊影格率。';
-
-  @override
-  String get transcodeContainerBitrateExceedsLimit => '檔案位元率超出播放器的串流上限。';
-
-  @override
-  String get transcodeVideoBitrateExceedsLimit => '視訊位元率超出串流上限。';
-
-  @override
-  String get transcodeAudioBitrateExceedsLimit => '音訊位元率超出串流上限。';
-
-  @override
-  String get transcodeAudioChannelsNotSupported => '不支援此音訊聲道數。';
-
-  @override
-  String get sortAlphabetical => '依字母順序';
-
-  @override
-  String get sortReleaseAscending => '上映順序（由舊到新）';
-
-  @override
-  String get sortReleaseDescending => '上映順序（由新到舊）';
-
-  @override
-  String get sortCustomDragDrop => '自訂（拖放）';
-
-  @override
-  String get playlistSortOptions => '播放清單排序選項';
-
-  @override
-  String get resetSort => '重設排序';
-
-  @override
-  String rewatchSeasonEpisode(int season, int episode) {
-    return '重看 第$season季第$episode集';
-  }
-
-  @override
-  String get rewatchPlaylist => '重看播放清單';
-
-  @override
-  String get noSubtitlesFound => '找不到字幕。';
-
-  @override
-  String get adminControls => '管理員控制';
-
-  @override
-  String get impellerRendering => '算圖引擎（Impeller）';
-
-  @override
-  String get impellerRenderingSubtitle =>
-      'Impeller 是 Flutter 新一代的 GPU 算圖器，可帶來更流暢的動畫並減少卡頓。在部分電視盒與較舊的 GPU 上可能造成畫面異常或黑畫面；若您遇到這些狀況請將其關閉。「自動」會為您的裝置選擇最合適的預設值。需重新啟動 Moonfin 才會生效。';
-
-  @override
-  String get impellerAuto => '自動';
-
-  @override
-  String get impellerOn => '開啟';
-
-  @override
-  String get impellerOff => '關閉';
-
-  @override
-  String get impellerRestartTitle => '需要重新啟動';
-
-  @override
-  String get impellerRestartMessage =>
-      'Moonfin 需要重新啟動才能變更算圖引擎。請立即關閉應用程式，再重新開啟以套用。';
-
-  @override
-  String get impellerCloseNow => '立即關閉應用程式';
-
-  @override
-  String get adminRefreshLibrary => '重新整理媒體庫';
-
-  @override
-  String get adminRefreshAllLibraries => '重新整理所有媒體庫';
-
-  @override
-  String get adminRepoSortDateOldest => '加入日期（由舊到新）';
-
-  @override
-  String get adminRepoSortDateNewest => '加入日期（由新到舊）';
-
-  @override
-  String get adminRepoSortNameAsc => '依字母順序（A 到 Z）';
-
-  @override
-  String get adminRepoSortNameDesc => '依字母順序（Z 到 A）';
-
-  @override
-  String adminAnalyticsLoadingProgress(int percentage) {
-    return '正在載入伺服器分析... $percentage%';
-  }
-
-  @override
-  String get adminLibChapterImageResolutionMatchSource => '與來源相符';
-
-  @override
-  String get imdbTop250Movies => 'IMDb 250 大電影';
-
-  @override
-  String get imdbTop250TvShows => 'IMDb 250 大電視劇';
-
-  @override
-  String get imdbMostPopularMovies => 'IMDb 最熱門電影';
-
-  @override
-  String get imdbMostPopularTvShows => 'IMDb 最熱門電視劇';
-
-  @override
-  String get imdbLowestRatedMovies => 'IMDb 評分最低電影';
-
-  @override
-  String get imdbTopEnglishMovies => 'IMDb 評分最高英語電影';
+  String get transcodingLimits => 'Transcoding Limits';
 }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -11,6 +11,7 @@ import 'package:server_core/server_core.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/models/home_row.dart';
 import '../../../data/repositories/multi_server_repository.dart';
+import '../../../data/repositories/user_views_repository.dart';
 import '../../../data/services/connectivity_service.dart';
 import '../../../data/services/home_row_cache_store.dart';
 import '../../../data/services/row_data_source.dart';
@@ -1315,37 +1316,32 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadLatestMediaRows() async {
-    final viewsFuture = _client.userViewsApi.getUserViews();
+    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
         .catchError((_) => const <String>{});
 
-    final viewsResponse = await viewsFuture;
-    final views = viewsResponse['Items'] as List? ?? [];
+    final views = await viewsFuture;
     final Set<String> latestExcludes = await configFuture;
 
-    final filteredViews = views.cast<Map<String, dynamic>>().where((data) {
-      final id = data['Id']?.toString() ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final filteredViews = views.where((lib) {
+      final collectionType = lib.collectionType.toLowerCase();
       if (collectionType == 'playlists' ||
           collectionType == 'boxsets' ||
           collectionType == 'livetv') {
         return false;
       }
-      return !latestExcludes.contains(id);
+      return !latestExcludes.contains(lib.id);
     }).toList();
 
-    final tasks = filteredViews.map((data) async {
-      final id = data['Id']?.toString() ?? '';
-      final name = data['Name'] as String? ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final tasks = filteredViews.map((lib) async {
       try {
         final row = await _dataSource.loadLatestMedia(
-          id,
-          name,
+          lib.id,
+          lib.name,
           _serverId,
-          collectionType,
+          lib.collectionType,
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {
@@ -1359,37 +1355,32 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadRecentlyReleasedRow() async {
-    final viewsFuture = _client.userViewsApi.getUserViews();
+    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
         .catchError((_) => const <String>{});
 
-    final viewsResponse = await viewsFuture;
-    final views = viewsResponse['Items'] as List? ?? [];
+    final views = await viewsFuture;
     final Set<String> latestExcludes = await configFuture;
 
-    final filteredViews = views.cast<Map<String, dynamic>>().where((data) {
-      final id = data['Id']?.toString() ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final filteredViews = views.where((lib) {
+      final collectionType = lib.collectionType.toLowerCase();
       if (collectionType == 'playlists' ||
           collectionType == 'boxsets' ||
           collectionType == 'livetv') {
         return false;
       }
-      return !latestExcludes.contains(id);
+      return !latestExcludes.contains(lib.id);
     }).toList();
 
-    final tasks = filteredViews.map((data) async {
-      final id = data['Id']?.toString() ?? '';
-      final name = data['Name'] as String? ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final tasks = filteredViews.map((lib) async {
       try {
         final row = await _dataSource.loadRecentlyReleased(
-          id,
-          name,
+          lib.id,
+          lib.name,
           _serverId,
-          collectionType,
+          lib.collectionType,
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {

--- a/packages/server_core/lib/src/models/system_models.dart
+++ b/packages/server_core/lib/src/models/system_models.dart
@@ -150,22 +150,22 @@ class UserConfiguration {
 
   factory UserConfiguration.fromJson(Map<String, dynamic> json) =>
       UserConfiguration(
-        orderedViews: _stringList(json['OrderedViews']),
-        latestItemsExcludes: _stringList(json['LatestItemsExcludes']),
-        myMediaExcludes: _stringList(json['MyMediaExcludes']),
-        groupedFolders: _stringList(json['GroupedFolders']),
-        hidePlayedInLatest: json['HidePlayedInLatest'] as bool? ?? true,
+        orderedViews: _stringList(json['OrderedViews'] ?? json['orderedViews']),
+        latestItemsExcludes: _stringList(json['LatestItemsExcludes'] ?? json['latestItemsExcludes']),
+        myMediaExcludes: _stringList(json['MyMediaExcludes'] ?? json['myMediaExcludes']),
+        groupedFolders: _stringList(json['GroupedFolders'] ?? json['groupedFolders']),
+        hidePlayedInLatest: (json['HidePlayedInLatest'] ?? json['hidePlayedInLatest']) as bool? ?? true,
         enableNextEpisodeAutoPlay:
-            json['EnableNextEpisodeAutoPlay'] as bool? ?? true,
+            (json['EnableNextEpisodeAutoPlay'] ?? json['enableNextEpisodeAutoPlay']) as bool? ?? true,
         playDefaultAudioTrack:
-            json['PlayDefaultAudioTrack'] as bool? ?? true,
+            (json['PlayDefaultAudioTrack'] ?? json['playDefaultAudioTrack']) as bool? ?? true,
         rememberAudioSelections:
-            json['RememberAudioSelections'] as bool? ?? true,
+            (json['RememberAudioSelections'] ?? json['rememberAudioSelections']) as bool? ?? true,
         rememberSubtitleSelections:
-            json['RememberSubtitleSelections'] as bool? ?? true,
-        audioLanguagePreference: _nonEmptyString(json['AudioLanguagePreference']),
-        subtitleLanguagePreference: _nonEmptyString(json['SubtitleLanguagePreference']),
-        subtitleMode: _subtitleModeString(json['SubtitleMode']),
+            (json['RememberSubtitleSelections'] ?? json['rememberSubtitleSelections']) as bool? ?? true,
+        audioLanguagePreference: _nonEmptyString(json['AudioLanguagePreference'] ?? json['audioLanguagePreference']),
+        subtitleLanguagePreference: _nonEmptyString(json['SubtitleLanguagePreference'] ?? json['subtitleLanguagePreference']),
+        subtitleMode: _subtitleModeString(json['SubtitleMode'] ?? json['subtitleMode']),
         raw: json,
       );
 
@@ -204,6 +204,7 @@ class UserConfiguration {
   UserConfiguration copyWith({
     List<String>? myMediaExcludes,
     List<String>? latestItemsExcludes,
+    String? subtitleMode,
   }) {
     return UserConfiguration(
       orderedViews: orderedViews,
@@ -217,6 +218,7 @@ class UserConfiguration {
       rememberSubtitleSelections: rememberSubtitleSelections,
       audioLanguagePreference: audioLanguagePreference,
       subtitleLanguagePreference: subtitleLanguagePreference,
+      subtitleMode: subtitleMode ?? this.subtitleMode,
       raw: _raw,
     );
   }
@@ -224,21 +226,36 @@ class UserConfiguration {
   Map<String, dynamic> toJson() {
     final json = Map<String, dynamic>.from(_raw);
     json['OrderedViews'] = orderedViews;
+    json['orderedViews'] = orderedViews;
     json['LatestItemsExcludes'] = latestItemsExcludes;
+    json['latestItemsExcludes'] = latestItemsExcludes;
     json['MyMediaExcludes'] = myMediaExcludes;
+    json['myMediaExcludes'] = myMediaExcludes;
     json['GroupedFolders'] = groupedFolders;
+    json['groupedFolders'] = groupedFolders;
     json['HidePlayedInLatest'] = hidePlayedInLatest;
+    json['hidePlayedInLatest'] = hidePlayedInLatest;
     json['EnableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
+    json['enableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
     json['PlayDefaultAudioTrack'] = playDefaultAudioTrack;
+    json['playDefaultAudioTrack'] = playDefaultAudioTrack;
     json['RememberAudioSelections'] = rememberAudioSelections;
+    json['rememberAudioSelections'] = rememberAudioSelections;
     json['RememberSubtitleSelections'] = rememberSubtitleSelections;
+    json['rememberSubtitleSelections'] = rememberSubtitleSelections;
 
     // key absence is used as a check, so only set if not null
     if (audioLanguagePreference != null) {
       json['AudioLanguagePreference'] = audioLanguagePreference;
+      json['audioLanguagePreference'] = audioLanguagePreference;
     }
     if (subtitleLanguagePreference != null) {
       json['SubtitleLanguagePreference'] = subtitleLanguagePreference;
+      json['subtitleLanguagePreference'] = subtitleLanguagePreference;
+    }
+    if (subtitleMode != null) {
+      json['SubtitleMode'] = subtitleMode;
+      json['subtitleMode'] = subtitleMode;
     }
     return json;
   }


### PR DESCRIPTION
This PR addresses issues where setting toggles for library visibility (Show in navigation) and Recently Added/Released media sections did not correctly reflect on the Home screen.

#### Changes
*   **Casing Normalization in User Configuration:** Modified **system_models.dart** to parse and serialize JSON keys using both `PascalCase` and `camelCase` (e.g. `MyMediaExcludes`/`myMediaExcludes` and `LatestItemsExcludes`/`latestItemsExcludes`). This ensures compatibility with any server version casing rules.
*   **My Media Filtering:** 
    *   Updated **row_data_source.dart** (`loadLibraryTiles`) and **multi_server_repository.dart** (`getAggregatedLibraries`) to load user configurations and filter out libraries that are configured to be hidden from navigation.
*   **Virtual Folders Integration:** Modified **user_views_repository.dart** (`getAllViewsIncludingHidden`) to map folders to matching user views (matching on collection type or name) to ensure dynamic views like **Playlists** use their user-specific view ID in the settings check-list.
*   **Recently Added Rows for Hidden Libraries:** Updated **home_view_model.dart** (`_loadLatestMediaRows` and `_loadRecentlyReleasedRow`) and **multi_server_repository.dart** (`getAggregatedLatestMediaRows`) to query views via the unified views list instead of the filtered `/UserViews` endpoint, ensuring "Recently Added" rows still show if enabled even when the library is hidden from navigation.
