### PR TITLE
bugfix-ui - Fix library visibility and recently added toggles

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -155,9 +155,23 @@ class MultiServerRepository {
     final results = await Future.wait(
       sessions.map(
         (session) => _withTimeout(() async {
-          final response = await session.client.userViewsApi.getUserViews();
+          final viewsFuture = session.client.userViewsApi.getUserViews();
+          final configFuture = session.client.usersApi
+              .getUserConfiguration()
+              .then<Set<String>>((config) => config.myMediaExcludes.toSet())
+              .catchError((_) => const <String>{});
+
+          final response = await viewsFuture;
+          final Set<String> excludes = await configFuture;
           final items = response['Items'] as List? ?? [];
-          return items.map((item) {
+
+          final filteredItems = items.where((item) {
+            final data = item as Map<String, dynamic>;
+            final id = data['Id']?.toString() ?? '';
+            return !excludes.contains(id);
+          });
+
+          return filteredItems.map((item) {
             final data = item as Map<String, dynamic>;
             final name = data['Name'] as String? ?? '';
             return AggregatedLibrary(
@@ -898,6 +912,55 @@ class MultiServerRepository {
     );
   }
 
+  Future<List<Map<String, dynamic>>> _getAllViewsIncludingHidden(MediaServerClient client) async {
+    try {
+      final foldersFuture = client.adminLibraryApi.getMediaFolders();
+      final userViewsFuture = client.userViewsApi.getUserViews();
+
+      final folders = await foldersFuture;
+      final userViewsResponse = await userViewsFuture;
+      final userViews = userViewsResponse['Items'] as List? ?? [];
+
+      final List<Map<String, dynamic>> result = folders.map<Map<String, dynamic>>((folder) {
+        final matchingView = userViews.where((v) {
+          final data = v as Map<String, dynamic>;
+          final cType = data['CollectionType'] as String?;
+          final name = data['Name'] as String?;
+          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
+            return cType == folder.collectionType;
+          }
+          return name == folder.name;
+        }).firstOrNull;
+
+        final matchingData = matchingView as Map<String, dynamic>?;
+
+        return {
+          'Id': matchingData?['Id']?.toString() ?? folder.itemId,
+          'Name': folder.name,
+          'CollectionType': folder.collectionType ?? '',
+        };
+      }).toList();
+
+      final existingIds = result.map((l) => l['Id']?.toString() ?? '').toSet();
+      for (final view in userViews) {
+        final data = view as Map<String, dynamic>;
+        final id = data['Id']?.toString() ?? '';
+        if (!existingIds.contains(id)) {
+          result.add(data);
+        }
+      }
+      return result;
+    } catch (_) {
+      try {
+        final response = await client.userViewsApi.getUserViews();
+        final items = response['Items'] as List? ?? [];
+        return items.cast<Map<String, dynamic>>();
+      } catch (_) {
+        return const [];
+      }
+    }
+  }
+
   Future<List<HomeRow>> getAggregatedLatestMediaRows() async {
     final sessions = await getLoggedInServers();
     final hasMultiple = sessions.length > 1;
@@ -905,11 +968,10 @@ class MultiServerRepository {
 
     for (final session in sessions) {
       try {
-        final viewsResponse = await _withTimeout(
-          () => session.client.userViewsApi.getUserViews(),
+        final views = await _withTimeout(
+          () => _getAllViewsIncludingHidden(session.client),
           label: 'views from ${session.server.name}',
         );
-        final views = viewsResponse['Items'] as List? ?? [];
 
         Set<String> latestExcludes = const {};
         try {

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -19,6 +19,7 @@ import '../utils/genre_browse_utils.dart';
 import '../utils/latest_media_row_normalizer.dart';
 import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
+import 'user_views_repository.dart';
 import '../../l10n/app_localizations.dart';
 import '../../l10n/current_app_localizations.dart';
 
@@ -912,55 +913,6 @@ class MultiServerRepository {
     );
   }
 
-  Future<List<Map<String, dynamic>>> _getAllViewsIncludingHidden(MediaServerClient client) async {
-    try {
-      final foldersFuture = client.adminLibraryApi.getMediaFolders();
-      final userViewsFuture = client.userViewsApi.getUserViews();
-
-      final folders = await foldersFuture;
-      final userViewsResponse = await userViewsFuture;
-      final userViews = userViewsResponse['Items'] as List? ?? [];
-
-      final List<Map<String, dynamic>> result = folders.map<Map<String, dynamic>>((folder) {
-        final matchingView = userViews.where((v) {
-          final data = v as Map<String, dynamic>;
-          final cType = data['CollectionType'] as String?;
-          final name = data['Name'] as String?;
-          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
-            return cType == folder.collectionType;
-          }
-          return name == folder.name;
-        }).firstOrNull;
-
-        final matchingData = matchingView as Map<String, dynamic>?;
-
-        return {
-          'Id': matchingData?['Id']?.toString() ?? folder.itemId,
-          'Name': folder.name,
-          'CollectionType': folder.collectionType ?? '',
-        };
-      }).toList();
-
-      final existingIds = result.map((l) => l['Id']?.toString() ?? '').toSet();
-      for (final view in userViews) {
-        final data = view as Map<String, dynamic>;
-        final id = data['Id']?.toString() ?? '';
-        if (!existingIds.contains(id)) {
-          result.add(data);
-        }
-      }
-      return result;
-    } catch (_) {
-      try {
-        final response = await client.userViewsApi.getUserViews();
-        final items = response['Items'] as List? ?? [];
-        return items.cast<Map<String, dynamic>>();
-      } catch (_) {
-        return const [];
-      }
-    }
-  }
-
   Future<List<HomeRow>> getAggregatedLatestMediaRows() async {
     final sessions = await getLoggedInServers();
     final hasMultiple = sessions.length > 1;
@@ -969,7 +921,7 @@ class MultiServerRepository {
     for (final session in sessions) {
       try {
         final views = await _withTimeout(
-          () => _getAllViewsIncludingHidden(session.client),
+          () => loadAllViewsIncludingHidden(session.client),
           label: 'views from ${session.server.name}',
         );
 
@@ -980,10 +932,8 @@ class MultiServerRepository {
         } catch (_) {}
 
         for (final view in views) {
-          final data = view as Map<String, dynamic>;
-          final id = data['Id']?.toString() ?? '';
-          final collectionType = (data['CollectionType'] as String?)
-              ?.toLowerCase();
+          final id = view.id;
+          final collectionType = view.collectionType.toLowerCase();
           if (collectionType == 'playlists' ||
               collectionType == 'boxsets' ||
               collectionType == 'livetv') {
@@ -991,7 +941,7 @@ class MultiServerRepository {
           }
           if (latestExcludes.contains(id)) continue;
 
-          final name = data['Name'] as String? ?? '';
+          final name = view.name;
           final displayName = hasMultiple
               ? '$name (${session.server.name})'
               : name;

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -34,17 +34,35 @@ class UserViewsRepository extends ChangeNotifier {
 
   Future<List<AggregatedLibrary>> getAllViewsIncludingHidden() async {
     try {
-      final folders = await _client.adminLibraryApi.getMediaFolders();
-      return folders
-          .map(
-            (folder) => AggregatedLibrary(
-              id: folder.itemId,
-              name: folder.name,
-              collectionType: folder.collectionType ?? '',
-              serverId: '',
-            ),
-          )
-          .toList();
+      final foldersFuture = _client.adminLibraryApi.getMediaFolders();
+      final userViewsFuture = getAllViews();
+
+      final folders = await foldersFuture;
+      final userViews = await userViewsFuture;
+
+      final result = folders.map((folder) {
+        final matchingView = userViews.where((v) {
+          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
+            return v.collectionType == folder.collectionType;
+          }
+          return v.name == folder.name;
+        }).firstOrNull;
+
+        return AggregatedLibrary(
+          id: matchingView?.id ?? folder.itemId,
+          name: folder.name,
+          collectionType: folder.collectionType ?? '',
+          serverId: '',
+        );
+      }).toList();
+
+      final existingIds = result.map((l) => l.id).toSet();
+      for (final view in userViews) {
+        if (!existingIds.contains(view.id)) {
+          result.add(view);
+        }
+      }
+      return result;
     } catch (_) {
       return getAllViews();
     }

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -3,70 +3,83 @@ import 'package:server_core/server_core.dart';
 
 import '../models/aggregated_library.dart';
 
+/// The user's own views, which leave out anything hidden from My Media.
+Future<List<AggregatedLibrary>> loadUserViews(MediaServerClient client) async {
+  final response = await client.userViewsApi.getUserViews();
+  final items = response['Items'] as List? ?? [];
+
+  return items.map((item) {
+    final data = item as Map<String, dynamic>;
+    return AggregatedLibrary(
+      id: data['Id']?.toString() ?? '',
+      name: data['Name'] as String,
+      collectionType: data['CollectionType'] as String? ?? '',
+      serverId: data['ServerId']?.toString() ?? '',
+      primaryImageAspectRatio: (data['PrimaryImageAspectRatio'] as num?)
+          ?.toDouble(),
+      imageTags: data['ImageTags'] != null
+          ? Map<String, dynamic>.from(data['ImageTags'] as Map)
+          : null,
+      backdropImageTags: (data['BackdropImageTags'] as List?)
+          ?.map((e) => e.toString())
+          .toList(),
+    );
+  }).toList();
+}
+
+/// Every library the user can reach, including ones hidden from My Media, so
+/// the recently added rows stay independent of the navigation toggle.
+///
+/// Media folders come from an admin endpoint, so a regular user falls back to
+/// their own views and only sees libraries they haven't hidden. Folders match
+/// views by name, because a collection type is shared by every library of that
+/// kind and matching on it would give two movie libraries the same id.
+Future<List<AggregatedLibrary>> loadAllViewsIncludingHidden(
+  MediaServerClient client,
+) async {
+  final userViewsFuture = loadUserViews(client);
+  final foldersFuture = client.adminLibraryApi
+      .getMediaFolders()
+      .then<List<VirtualFolderInfo>?>((folders) => folders)
+      .catchError((_) => null);
+
+  final userViews = await userViewsFuture;
+  final folders = await foldersFuture;
+  if (folders == null) return userViews;
+
+  final viewsByName = <String, AggregatedLibrary>{
+    for (final view in userViews) view.name: view,
+  };
+
+  final result = folders.map((folder) {
+    final match = viewsByName[folder.name];
+    return AggregatedLibrary(
+      id: match?.id ?? folder.itemId,
+      name: folder.name,
+      collectionType: folder.collectionType ?? '',
+      serverId: match?.serverId ?? '',
+    );
+  }).toList();
+
+  // Virtual views such as Playlists have no media folder behind them, so they
+  // only arrive through the user's own views.
+  final seenIds = result.map((l) => l.id).toSet();
+  for (final view in userViews) {
+    if (seenIds.add(view.id)) result.add(view);
+  }
+  return result;
+}
+
 class UserViewsRepository extends ChangeNotifier {
   final MediaServerClient _client;
   UserConfiguration? _cachedConfig;
 
   UserViewsRepository(this._client);
 
-  Future<List<AggregatedLibrary>> getAllViews() async {
-    final response = await _client.userViewsApi.getUserViews();
-    final items = response['Items'] as List? ?? [];
+  Future<List<AggregatedLibrary>> getAllViews() => loadUserViews(_client);
 
-    return items.map((item) {
-      final data = item as Map<String, dynamic>;
-      return AggregatedLibrary(
-        id: data['Id']?.toString() ?? '',
-        name: data['Name'] as String,
-        collectionType: data['CollectionType'] as String? ?? '',
-        serverId: data['ServerId']?.toString() ?? '',
-        primaryImageAspectRatio: (data['PrimaryImageAspectRatio'] as num?)
-            ?.toDouble(),
-        imageTags: data['ImageTags'] != null
-            ? Map<String, dynamic>.from(data['ImageTags'] as Map)
-            : null,
-        backdropImageTags: (data['BackdropImageTags'] as List?)
-            ?.map((e) => e.toString())
-            .toList(),
-      );
-    }).toList();
-  }
-
-  Future<List<AggregatedLibrary>> getAllViewsIncludingHidden() async {
-    try {
-      final foldersFuture = _client.adminLibraryApi.getMediaFolders();
-      final userViewsFuture = getAllViews();
-
-      final folders = await foldersFuture;
-      final userViews = await userViewsFuture;
-
-      final result = folders.map((folder) {
-        final matchingView = userViews.where((v) {
-          if (folder.collectionType != null && folder.collectionType!.isNotEmpty) {
-            return v.collectionType == folder.collectionType;
-          }
-          return v.name == folder.name;
-        }).firstOrNull;
-
-        return AggregatedLibrary(
-          id: matchingView?.id ?? folder.itemId,
-          name: folder.name,
-          collectionType: folder.collectionType ?? '',
-          serverId: '',
-        );
-      }).toList();
-
-      final existingIds = result.map((l) => l.id).toSet();
-      for (final view in userViews) {
-        if (!existingIds.contains(view.id)) {
-          result.add(view);
-        }
-      }
-      return result;
-    } catch (_) {
-      return getAllViews();
-    }
-  }
+  Future<List<AggregatedLibrary>> getAllViewsIncludingHidden() =>
+      loadAllViewsIncludingHidden(_client);
 
   Future<List<AggregatedLibrary>> getUserViews() async {
     final views = await getAllViews();

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -644,13 +644,31 @@ class RowDataSource {
     String serverId, [
     HomeRowType rowType = HomeRowType.libraryTiles,
   ]) async {
-    final response = await _client.userViewsApi.getUserViews();
+    final viewsFuture = _client.userViewsApi.getUserViews();
+    final configFuture = _client.usersApi
+        .getUserConfiguration()
+        .then<Set<String>>((config) => config.myMediaExcludes.toSet())
+        .catchError((_) => const <String>{});
+
+    final response = await viewsFuture;
+    final Set<String> excludes = await configFuture;
+    final items = response['Items'] as List? ?? [];
+
+    final filteredItems = items.where((item) {
+      final data = item as Map<String, dynamic>;
+      final id = data['Id']?.toString() ?? '';
+      return !excludes.contains(id);
+    }).toList();
+
     return _buildRow(
       id: rowType == HomeRowType.libraryTilesSmall
           ? 'libraryTilesSmall'
           : 'libraryTiles',
       title: _l10n.myMedia,
-      response: response,
+      response: {
+        ...response,
+        'Items': filteredItems,
+      },
       serverId: serverId,
       rowType: rowType,
     );

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -665,10 +665,7 @@ class RowDataSource {
           ? 'libraryTilesSmall'
           : 'libraryTiles',
       title: _l10n.myMedia,
-      response: {
-        ...response,
-        'Items': filteredItems,
-      },
+      response: {...response, 'Items': filteredItems},
       serverId: serverId,
       rowType: rowType,
     );

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -11,6 +11,7 @@ import 'package:server_core/server_core.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/models/home_row.dart';
 import '../../../data/repositories/multi_server_repository.dart';
+import '../../../data/repositories/user_views_repository.dart';
 import '../../../data/services/connectivity_service.dart';
 import '../../../data/services/home_row_cache_store.dart';
 import '../../../data/services/row_data_source.dart';
@@ -1315,37 +1316,32 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadLatestMediaRows() async {
-    final viewsFuture = _client.userViewsApi.getUserViews();
+    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
         .catchError((_) => const <String>{});
 
-    final viewsResponse = await viewsFuture;
-    final views = viewsResponse['Items'] as List? ?? [];
+    final views = await viewsFuture;
     final Set<String> latestExcludes = await configFuture;
 
-    final filteredViews = views.cast<Map<String, dynamic>>().where((data) {
-      final id = data['Id']?.toString() ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final filteredViews = views.where((lib) {
+      final collectionType = lib.collectionType.toLowerCase();
       if (collectionType == 'playlists' ||
           collectionType == 'boxsets' ||
           collectionType == 'livetv') {
         return false;
       }
-      return !latestExcludes.contains(id);
+      return !latestExcludes.contains(lib.id);
     }).toList();
 
-    final tasks = filteredViews.map((data) async {
-      final id = data['Id']?.toString() ?? '';
-      final name = data['Name'] as String? ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final tasks = filteredViews.map((lib) async {
       try {
         final row = await _dataSource.loadLatestMedia(
-          id,
-          name,
+          lib.id,
+          lib.name,
           _serverId,
-          collectionType,
+          lib.collectionType,
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {
@@ -1359,37 +1355,32 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadRecentlyReleasedRow() async {
-    final viewsFuture = _client.userViewsApi.getUserViews();
+    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
         .catchError((_) => const <String>{});
 
-    final viewsResponse = await viewsFuture;
-    final views = viewsResponse['Items'] as List? ?? [];
+    final views = await viewsFuture;
     final Set<String> latestExcludes = await configFuture;
 
-    final filteredViews = views.cast<Map<String, dynamic>>().where((data) {
-      final id = data['Id']?.toString() ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final filteredViews = views.where((lib) {
+      final collectionType = lib.collectionType.toLowerCase();
       if (collectionType == 'playlists' ||
           collectionType == 'boxsets' ||
           collectionType == 'livetv') {
         return false;
       }
-      return !latestExcludes.contains(id);
+      return !latestExcludes.contains(lib.id);
     }).toList();
 
-    final tasks = filteredViews.map((data) async {
-      final id = data['Id']?.toString() ?? '';
-      final name = data['Name'] as String? ?? '';
-      final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+    final tasks = filteredViews.map((lib) async {
       try {
         final row = await _dataSource.loadRecentlyReleased(
-          id,
-          name,
+          lib.id,
+          lib.name,
           _serverId,
-          collectionType,
+          lib.collectionType,
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -1316,7 +1316,8 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadLatestMediaRows() async {
-    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
+    final viewsFuture = GetIt.instance<UserViewsRepository>()
+        .getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
@@ -1341,7 +1342,7 @@ class HomeViewModel extends ChangeNotifier {
           lib.id,
           lib.name,
           _serverId,
-          lib.collectionType,
+          lib.collectionType.toLowerCase(),
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {
@@ -1355,7 +1356,8 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadRecentlyReleasedRow() async {
-    final viewsFuture = GetIt.instance<UserViewsRepository>().getAllViewsIncludingHidden();
+    final viewsFuture = GetIt.instance<UserViewsRepository>()
+        .getAllViewsIncludingHidden();
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.latestItemsExcludes.toSet())
@@ -1380,7 +1382,7 @@ class HomeViewModel extends ChangeNotifier {
           lib.id,
           lib.name,
           _serverId,
-          lib.collectionType,
+          lib.collectionType.toLowerCase(),
         );
         return row.items.isNotEmpty ? row : null;
       } catch (_) {

--- a/packages/server_core/lib/src/models/system_models.dart
+++ b/packages/server_core/lib/src/models/system_models.dart
@@ -150,22 +150,22 @@ class UserConfiguration {
 
   factory UserConfiguration.fromJson(Map<String, dynamic> json) =>
       UserConfiguration(
-        orderedViews: _stringList(json['OrderedViews']),
-        latestItemsExcludes: _stringList(json['LatestItemsExcludes']),
-        myMediaExcludes: _stringList(json['MyMediaExcludes']),
-        groupedFolders: _stringList(json['GroupedFolders']),
-        hidePlayedInLatest: json['HidePlayedInLatest'] as bool? ?? true,
+        orderedViews: _stringList(json['OrderedViews'] ?? json['orderedViews']),
+        latestItemsExcludes: _stringList(json['LatestItemsExcludes'] ?? json['latestItemsExcludes']),
+        myMediaExcludes: _stringList(json['MyMediaExcludes'] ?? json['myMediaExcludes']),
+        groupedFolders: _stringList(json['GroupedFolders'] ?? json['groupedFolders']),
+        hidePlayedInLatest: (json['HidePlayedInLatest'] ?? json['hidePlayedInLatest']) as bool? ?? true,
         enableNextEpisodeAutoPlay:
-            json['EnableNextEpisodeAutoPlay'] as bool? ?? true,
+            (json['EnableNextEpisodeAutoPlay'] ?? json['enableNextEpisodeAutoPlay']) as bool? ?? true,
         playDefaultAudioTrack:
-            json['PlayDefaultAudioTrack'] as bool? ?? true,
+            (json['PlayDefaultAudioTrack'] ?? json['playDefaultAudioTrack']) as bool? ?? true,
         rememberAudioSelections:
-            json['RememberAudioSelections'] as bool? ?? true,
+            (json['RememberAudioSelections'] ?? json['rememberAudioSelections']) as bool? ?? true,
         rememberSubtitleSelections:
-            json['RememberSubtitleSelections'] as bool? ?? true,
-        audioLanguagePreference: _nonEmptyString(json['AudioLanguagePreference']),
-        subtitleLanguagePreference: _nonEmptyString(json['SubtitleLanguagePreference']),
-        subtitleMode: _subtitleModeString(json['SubtitleMode']),
+            (json['RememberSubtitleSelections'] ?? json['rememberSubtitleSelections']) as bool? ?? true,
+        audioLanguagePreference: _nonEmptyString(json['AudioLanguagePreference'] ?? json['audioLanguagePreference']),
+        subtitleLanguagePreference: _nonEmptyString(json['SubtitleLanguagePreference'] ?? json['subtitleLanguagePreference']),
+        subtitleMode: _subtitleModeString(json['SubtitleMode'] ?? json['subtitleMode']),
         raw: json,
       );
 
@@ -204,6 +204,7 @@ class UserConfiguration {
   UserConfiguration copyWith({
     List<String>? myMediaExcludes,
     List<String>? latestItemsExcludes,
+    String? subtitleMode,
   }) {
     return UserConfiguration(
       orderedViews: orderedViews,
@@ -217,6 +218,7 @@ class UserConfiguration {
       rememberSubtitleSelections: rememberSubtitleSelections,
       audioLanguagePreference: audioLanguagePreference,
       subtitleLanguagePreference: subtitleLanguagePreference,
+      subtitleMode: subtitleMode ?? this.subtitleMode,
       raw: _raw,
     );
   }
@@ -224,21 +226,36 @@ class UserConfiguration {
   Map<String, dynamic> toJson() {
     final json = Map<String, dynamic>.from(_raw);
     json['OrderedViews'] = orderedViews;
+    json['orderedViews'] = orderedViews;
     json['LatestItemsExcludes'] = latestItemsExcludes;
+    json['latestItemsExcludes'] = latestItemsExcludes;
     json['MyMediaExcludes'] = myMediaExcludes;
+    json['myMediaExcludes'] = myMediaExcludes;
     json['GroupedFolders'] = groupedFolders;
+    json['groupedFolders'] = groupedFolders;
     json['HidePlayedInLatest'] = hidePlayedInLatest;
+    json['hidePlayedInLatest'] = hidePlayedInLatest;
     json['EnableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
+    json['enableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
     json['PlayDefaultAudioTrack'] = playDefaultAudioTrack;
+    json['playDefaultAudioTrack'] = playDefaultAudioTrack;
     json['RememberAudioSelections'] = rememberAudioSelections;
+    json['rememberAudioSelections'] = rememberAudioSelections;
     json['RememberSubtitleSelections'] = rememberSubtitleSelections;
+    json['rememberSubtitleSelections'] = rememberSubtitleSelections;
 
     // key absence is used as a check, so only set if not null
     if (audioLanguagePreference != null) {
       json['AudioLanguagePreference'] = audioLanguagePreference;
+      json['audioLanguagePreference'] = audioLanguagePreference;
     }
     if (subtitleLanguagePreference != null) {
       json['SubtitleLanguagePreference'] = subtitleLanguagePreference;
+      json['subtitleLanguagePreference'] = subtitleLanguagePreference;
+    }
+    if (subtitleMode != null) {
+      json['SubtitleMode'] = subtitleMode;
+      json['subtitleMode'] = subtitleMode;
     }
     return json;
   }

--- a/packages/server_core/lib/src/models/system_models.dart
+++ b/packages/server_core/lib/src/models/system_models.dart
@@ -148,26 +148,33 @@ class UserConfiguration {
     Map<String, dynamic> raw = const {},
   }) : _raw = raw;
 
-  factory UserConfiguration.fromJson(Map<String, dynamic> json) =>
-      UserConfiguration(
-        orderedViews: _stringList(json['OrderedViews'] ?? json['orderedViews']),
-        latestItemsExcludes: _stringList(json['LatestItemsExcludes'] ?? json['latestItemsExcludes']),
-        myMediaExcludes: _stringList(json['MyMediaExcludes'] ?? json['myMediaExcludes']),
-        groupedFolders: _stringList(json['GroupedFolders'] ?? json['groupedFolders']),
-        hidePlayedInLatest: (json['HidePlayedInLatest'] ?? json['hidePlayedInLatest']) as bool? ?? true,
-        enableNextEpisodeAutoPlay:
-            (json['EnableNextEpisodeAutoPlay'] ?? json['enableNextEpisodeAutoPlay']) as bool? ?? true,
-        playDefaultAudioTrack:
-            (json['PlayDefaultAudioTrack'] ?? json['playDefaultAudioTrack']) as bool? ?? true,
-        rememberAudioSelections:
-            (json['RememberAudioSelections'] ?? json['rememberAudioSelections']) as bool? ?? true,
-        rememberSubtitleSelections:
-            (json['RememberSubtitleSelections'] ?? json['rememberSubtitleSelections']) as bool? ?? true,
-        audioLanguagePreference: _nonEmptyString(json['AudioLanguagePreference'] ?? json['audioLanguagePreference']),
-        subtitleLanguagePreference: _nonEmptyString(json['SubtitleLanguagePreference'] ?? json['subtitleLanguagePreference']),
-        subtitleMode: _subtitleModeString(json['SubtitleMode'] ?? json['subtitleMode']),
-        raw: json,
-      );
+  factory UserConfiguration.fromJson(Map<String, dynamic> json) {
+    // Servers differ on casing, so read either spelling of each key.
+    Object? read(String key) => json[key] ?? json[_camelOf(key)];
+
+    return UserConfiguration(
+      orderedViews: _stringList(read('OrderedViews')),
+      latestItemsExcludes: _stringList(read('LatestItemsExcludes')),
+      myMediaExcludes: _stringList(read('MyMediaExcludes')),
+      groupedFolders: _stringList(read('GroupedFolders')),
+      hidePlayedInLatest: read('HidePlayedInLatest') as bool? ?? true,
+      enableNextEpisodeAutoPlay:
+          read('EnableNextEpisodeAutoPlay') as bool? ?? true,
+      playDefaultAudioTrack: read('PlayDefaultAudioTrack') as bool? ?? true,
+      rememberAudioSelections: read('RememberAudioSelections') as bool? ?? true,
+      rememberSubtitleSelections:
+          read('RememberSubtitleSelections') as bool? ?? true,
+      audioLanguagePreference: _nonEmptyString(read('AudioLanguagePreference')),
+      subtitleLanguagePreference: _nonEmptyString(
+        read('SubtitleLanguagePreference'),
+      ),
+      subtitleMode: _subtitleModeString(read('SubtitleMode')),
+      raw: json,
+    );
+  }
+
+  static String _camelOf(String pascal) =>
+      pascal[0].toLowerCase() + pascal.substring(1);
 
   static List<String> _stringList(dynamic value) {
     if (value is List) return value.cast<String>();
@@ -223,39 +230,48 @@ class UserConfiguration {
     );
   }
 
+  /// Every key this class owns, in the casing it writes back.
+  static const _ownedKeys = [
+    'OrderedViews',
+    'LatestItemsExcludes',
+    'MyMediaExcludes',
+    'GroupedFolders',
+    'HidePlayedInLatest',
+    'EnableNextEpisodeAutoPlay',
+    'PlayDefaultAudioTrack',
+    'RememberAudioSelections',
+    'RememberSubtitleSelections',
+    'AudioLanguagePreference',
+    'SubtitleLanguagePreference',
+    'SubtitleMode',
+  ];
+
   Map<String, dynamic> toJson() {
     final json = Map<String, dynamic>.from(_raw);
+    // The raw payload is the base, so drop any camel spelling that came in
+    // with it or a stale copy rides along beside the fresh value.
+    for (final key in _ownedKeys) {
+      json.remove(_camelOf(key));
+    }
     json['OrderedViews'] = orderedViews;
-    json['orderedViews'] = orderedViews;
     json['LatestItemsExcludes'] = latestItemsExcludes;
-    json['latestItemsExcludes'] = latestItemsExcludes;
     json['MyMediaExcludes'] = myMediaExcludes;
-    json['myMediaExcludes'] = myMediaExcludes;
     json['GroupedFolders'] = groupedFolders;
-    json['groupedFolders'] = groupedFolders;
     json['HidePlayedInLatest'] = hidePlayedInLatest;
-    json['hidePlayedInLatest'] = hidePlayedInLatest;
     json['EnableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
-    json['enableNextEpisodeAutoPlay'] = enableNextEpisodeAutoPlay;
     json['PlayDefaultAudioTrack'] = playDefaultAudioTrack;
-    json['playDefaultAudioTrack'] = playDefaultAudioTrack;
     json['RememberAudioSelections'] = rememberAudioSelections;
-    json['rememberAudioSelections'] = rememberAudioSelections;
     json['RememberSubtitleSelections'] = rememberSubtitleSelections;
-    json['rememberSubtitleSelections'] = rememberSubtitleSelections;
 
     // key absence is used as a check, so only set if not null
     if (audioLanguagePreference != null) {
       json['AudioLanguagePreference'] = audioLanguagePreference;
-      json['audioLanguagePreference'] = audioLanguagePreference;
     }
     if (subtitleLanguagePreference != null) {
       json['SubtitleLanguagePreference'] = subtitleLanguagePreference;
-      json['subtitleLanguagePreference'] = subtitleLanguagePreference;
     }
     if (subtitleMode != null) {
       json['SubtitleMode'] = subtitleMode;
-      json['subtitleMode'] = subtitleMode;
     }
     return json;
   }


### PR DESCRIPTION
# Pull Request

## Summary
Resolve issues where library visibility toggles (Show in navigation) and Recently Added/Released toggles did not apply correctly on the Home Screen, and ensure dynamic virtual folders (like Playlists) are togglable in settings. Prior to this PR, some of the library toggles for hiding/showing an item in My Media were not functional; further, if an item was hidden in My Media, it couldn't be used as a Recently Added... row despite the UI showing them as independent. This PR properly makes them independent.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified **system_models.dart**: Standardized casing of `UserConfiguration` fields to handle both `PascalCase` and `camelCase` keys (e.g. `MyMediaExcludes`/`myMediaExcludes` and `LatestItemsExcludes`/`latestItemsExcludes`) for cross-version server compatibility.
- Modified **row_data_source.dart**: Added `myMediaExcludes` navigation visibility filtering in `loadLibraryTiles`.
- Modified **multi_server_repository.dart**: Added `myMediaExcludes` filtering in `getAggregatedLibraries` and added a helper `_getAllViewsIncludingHidden` to load hidden libraries for `getAggregatedLatestMediaRows`.
- Modified **user_views_repository.dart**: Updated `getAllViewsIncludingHidden` to merge folders and user views (mapping virtual collections like Playlists to user-specific view IDs) to fix settings toggle mapping.
- Modified **home_view_model.dart**: Updated `_loadLatestMediaRows` and `_loadRecentlyReleasedRow` to fetch views via the unified `getAllViewsIncludingHidden()` helper so recently added rows display correctly for hidden libraries.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Configure dynamic libraries (e.g., Playlists) and standard libraries (e.g., Movies).
2. Toggle "Show in navigation" OFF for Movies and Playlists in settings.
3. Verify they are hidden from "My Media" library row on the Home Screen and sidebar.
4. Toggle "Show in recently added/released media" ON for Movies, and verify "Recently Added in Movies" is still visible on the Home Screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## The problem:
<img width="2454" height="1475" alt="2026-07-18_13-12-53_moonfin" src="https://github.com/user-attachments/assets/85a8ef3d-1198-4092-9a2b-85f7d05e4627" />

## Fixed:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_13-55-20" src="https://github.com/user-attachments/assets/38574200-306d-49b7-a7cd-447db7c9cfbf" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_13-31-32" src="https://github.com/user-attachments/assets/1625bf66-c3a5-4348-871a-1395b9591167" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
