### PR TITLE
general-ui - Move Since You Watched section below Rewatch for alpha ordering

### DIFF
--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -377,65 +377,6 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                 ],
               ),
 
-              _SectionHeader('SINCE YOU WATCHED'),
-              adaptiveListSection(
-                children: [
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.displaySinceYouWatchedRows,
-                    title: 'Display Since You Watched Rows',
-                    subtitle: 'Show and customize Since You Watched rows in Home Sections.',
-                    icon: Icons.recommend,
-                    onChanged: _onSinceYouWatchedRowsToggleChanged,
-                  ),
-                  if (showSinceYouWatchedRows) ...[
-                    EnumPreferenceTile<SinceYouWatchedSource>(
-                      preference: UserPreferences.sinceYouWatchedSource,
-                      title: 'Source',
-                      description: "Choose recommendation source (the local-content-only Moonfin special or TMDB's similarity metric. Note: Online recommendations require Seerr integration).",
-                      icon: Icons.source,
-                      values: SinceYouWatchedSource.values,
-                      labelOf: (v) => v.displayName,
-                      onChanged: _onSinceYouWatchedConfigChanged,
-                    ),
-                    EnumPreferenceTile<SinceYouWatchedSourceType>(
-                      preference: UserPreferences.sinceYouWatchedSourceType,
-                      title: 'Source Type',
-                      description: 'Choose type of items to recommend',
-                      icon: Icons.merge_type,
-                      values: SinceYouWatchedSourceType.values,
-                      labelOf: (v) => v.displayName,
-                      onChanged: _onSinceYouWatchedConfigChanged,
-                    ),
-                    EnumPreferenceTile<SinceYouWatchedSourceItem>(
-                      preference: UserPreferences.sinceYouWatchedSourceItem,
-                      title: 'Source Item',
-                      description: 'Choose which source item to base recommendations on',
-                      icon: Icons.play_circle_filled,
-                      values: SinceYouWatchedSourceItem.values,
-                      labelOf: (v) => v.displayName,
-                      onChanged: _onSinceYouWatchedConfigChanged,
-                    ),
-                    EnumPreferenceTile<SinceYouWatchedNumRows>(
-                      preference: UserPreferences.sinceYouWatchedNumRows,
-                      title: 'Number of Rows to Add',
-                      description: 'Choose how many Since You Watched rows to display (1-5)',
-                      icon: Icons.format_list_numbered,
-                      values: SinceYouWatchedNumRows.values,
-                      labelOf: (v) => v.displayName,
-                      onChanged: _onSinceYouWatchedConfigChanged,
-                    ),
-                    if (sinceYouWatchedSource != SinceYouWatchedSource.online)
-                      SwitchPreferenceTile(
-                        preference: UserPreferences.sinceYouWatchedIncludeWatched,
-                        title: 'Include Previously Watched',
-                        subtitle: 'Include watched items in recommendations',
-                        icon: Icons.history,
-                        onChanged: _onSinceYouWatchedConfigChanged,
-                      ),
-                  ],
-                ],
-              ),
-
               _SectionHeader(l10n.collections),
               adaptiveListSection(
                 children: [
@@ -532,6 +473,7 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                     ),
                 ],
               ),
+
               _SectionHeader('REWATCH'),
               adaptiveListSection(
                 children: [
@@ -573,6 +515,65 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                       icon: Icons.collections,
                       onChanged: _onRewatchConfigChanged,
                     ),
+                  ],
+                ],
+              ),
+
+              _SectionHeader('SINCE YOU WATCHED'),
+              adaptiveListSection(
+                children: [
+                  SwitchPreferenceTile(
+                    preference: UserPreferences.displaySinceYouWatchedRows,
+                    title: 'Display Since You Watched Rows',
+                    subtitle: 'Show and customize Since You Watched rows in Home Sections.',
+                    icon: Icons.recommend,
+                    onChanged: _onSinceYouWatchedRowsToggleChanged,
+                  ),
+                  if (showSinceYouWatchedRows) ...[
+                    EnumPreferenceTile<SinceYouWatchedSource>(
+                      preference: UserPreferences.sinceYouWatchedSource,
+                      title: 'Source',
+                      description: "Choose recommendation source (the local-content-only Moonfin special or TMDB's similarity metric. Note: Online recommendations require Seerr integration).",
+                      icon: Icons.source,
+                      values: SinceYouWatchedSource.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedSourceType>(
+                      preference: UserPreferences.sinceYouWatchedSourceType,
+                      title: 'Source Type',
+                      description: 'Choose type of items to recommend',
+                      icon: Icons.merge_type,
+                      values: SinceYouWatchedSourceType.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedSourceItem>(
+                      preference: UserPreferences.sinceYouWatchedSourceItem,
+                      title: 'Source Item',
+                      description: 'Choose which source item to base recommendations on',
+                      icon: Icons.play_circle_filled,
+                      values: SinceYouWatchedSourceItem.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedNumRows>(
+                      preference: UserPreferences.sinceYouWatchedNumRows,
+                      title: 'Number of Rows to Add',
+                      description: 'Choose how many Since You Watched rows to display (1-5)',
+                      icon: Icons.format_list_numbered,
+                      values: SinceYouWatchedNumRows.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    if (sinceYouWatchedSource != SinceYouWatchedSource.online)
+                      SwitchPreferenceTile(
+                        preference: UserPreferences.sinceYouWatchedIncludeWatched,
+                        title: 'Include Previously Watched',
+                        subtitle: 'Include watched items in recommendations',
+                        icon: Icons.history,
+                        onChanged: _onSinceYouWatchedConfigChanged,
+                      ),
                   ],
                 ],
               ),


### PR DESCRIPTION
# Pull Request

## Summary
Least exciting PR of the day: Move the "Since You Watched" settings section to the bottom of the Home Row Toggles settings screen to restore alphabetical order. Yup. That's it.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified **home_row_toggles_screen.dart**: Moved the "SINCE YOU WATCHED" settings section header and its adaptive list section child below the "REWATCH" settings section block.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to settings -> Home Row Toggles.
2. Verify that the "Since You Watched" settings section appears below the "Rewatch" section.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_14-14-18" src="https://github.com/user-attachments/assets/3f878b96-6a95-44ef-b069-bd8f899b43f8" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
