### PR TITLE
bug-playback - Fix Web UI subtitle rendering and OSD track sorting

### DIFF
--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -119,6 +119,8 @@ class DeviceProfileBuilder {
     MaxVideoResolution maxResolution = MaxVideoResolution.auto,
     bool pgsDirectPlay = true,
     bool assDirectPlay = true,
+    bool supportsEmbeddedTextSubtitles = true,
+    bool supportsExternalTextSubtitles = true,
     bool supportsAvc = false,
     bool supportsAvcHigh10 = false,
     int avcMainLevel = 0,
@@ -397,6 +399,8 @@ class DeviceProfileBuilder {
       'SubtitleProfiles': _subtitleProfiles(
         pgsDirectPlay: pgsDirectPlay,
         assDirectPlay: assDirectPlay,
+        supportsEmbeddedTextSubtitles: supportsEmbeddedTextSubtitles,
+        supportsExternalTextSubtitles: supportsExternalTextSubtitles,
       ),
     };
   }
@@ -1574,6 +1578,8 @@ class DeviceProfileBuilder {
   static List<Map<String, dynamic>> _subtitleProfiles({
     required bool pgsDirectPlay,
     required bool assDirectPlay,
+    bool supportsEmbeddedTextSubtitles = true,
+    bool supportsExternalTextSubtitles = true,
   }) {
     final profiles = <Map<String, dynamic>>[];
 
@@ -1588,25 +1594,33 @@ class DeviceProfileBuilder {
     }
 
     for (final format in const <String>['srt', 'subrip', 'ttml']) {
-      add(format, 'Embed');
-      add(format, 'External');
+      if (supportsEmbeddedTextSubtitles) {
+        add(format, 'Embed');
+      }
+      if (supportsExternalTextSubtitles) {
+        add(format, 'External');
+      }
     }
 
     for (final format in const <String>['dvbsub', 'dvdsub', 'idx']) {
-      add(format, 'Embed');
+      if (supportsEmbeddedTextSubtitles) {
+        add(format, 'Embed');
+      }
       add(format, 'Encode');
     }
 
     for (final format in const <String>['pgs', 'pgssub']) {
-      if (pgsDirectPlay) {
+      if (pgsDirectPlay && supportsEmbeddedTextSubtitles) {
         add(format, 'Embed');
       }
       add(format, 'Encode');
     }
 
     for (final format in const <String>['ass', 'ssa']) {
-      if (assDirectPlay) {
+      if (assDirectPlay && supportsEmbeddedTextSubtitles) {
         add(format, 'Embed');
+        add(format, 'External');
+      } else if (assDirectPlay) {
         add(format, 'External');
       }
       add(format, 'Encode');

--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -119,7 +119,7 @@ class DeviceProfileBuilder {
     MaxVideoResolution maxResolution = MaxVideoResolution.auto,
     bool pgsDirectPlay = true,
     bool assDirectPlay = true,
-    bool supportsEmbeddedTextSubtitles = true,
+    bool supportsEmbeddedSubtitles = true,
     bool supportsExternalTextSubtitles = true,
     bool supportsAvc = false,
     bool supportsAvcHigh10 = false,
@@ -399,7 +399,7 @@ class DeviceProfileBuilder {
       'SubtitleProfiles': _subtitleProfiles(
         pgsDirectPlay: pgsDirectPlay,
         assDirectPlay: assDirectPlay,
-        supportsEmbeddedTextSubtitles: supportsEmbeddedTextSubtitles,
+        supportsEmbeddedSubtitles: supportsEmbeddedSubtitles,
         supportsExternalTextSubtitles: supportsExternalTextSubtitles,
       ),
     };
@@ -1575,10 +1575,14 @@ class DeviceProfileBuilder {
     };
   }
 
+  /// [supportsEmbeddedSubtitles] covers embedded streams of every kind, image
+  /// formats included, so a player that can't read them leaves the server to
+  /// burn them in. [supportsExternalTextSubtitles] is narrower and only covers
+  /// the plain text formats, which is why ass and ssa still offer External.
   static List<Map<String, dynamic>> _subtitleProfiles({
     required bool pgsDirectPlay,
     required bool assDirectPlay,
-    bool supportsEmbeddedTextSubtitles = true,
+    bool supportsEmbeddedSubtitles = true,
     bool supportsExternalTextSubtitles = true,
   }) {
     final profiles = <Map<String, dynamic>>[];
@@ -1594,7 +1598,7 @@ class DeviceProfileBuilder {
     }
 
     for (final format in const <String>['srt', 'subrip', 'ttml']) {
-      if (supportsEmbeddedTextSubtitles) {
+      if (supportsEmbeddedSubtitles) {
         add(format, 'Embed');
       }
       if (supportsExternalTextSubtitles) {
@@ -1603,21 +1607,21 @@ class DeviceProfileBuilder {
     }
 
     for (final format in const <String>['dvbsub', 'dvdsub', 'idx']) {
-      if (supportsEmbeddedTextSubtitles) {
+      if (supportsEmbeddedSubtitles) {
         add(format, 'Embed');
       }
       add(format, 'Encode');
     }
 
     for (final format in const <String>['pgs', 'pgssub']) {
-      if (pgsDirectPlay && supportsEmbeddedTextSubtitles) {
+      if (pgsDirectPlay && supportsEmbeddedSubtitles) {
         add(format, 'Embed');
       }
       add(format, 'Encode');
     }
 
     for (final format in const <String>['ass', 'ssa']) {
-      if (assDirectPlay && supportsEmbeddedTextSubtitles) {
+      if (assDirectPlay && supportsEmbeddedSubtitles) {
         add(format, 'Embed');
         add(format, 'External');
       } else if (assDirectPlay) {

--- a/lib/playback/html_video_backend_profile.dart
+++ b/lib/playback/html_video_backend_profile.dart
@@ -31,6 +31,8 @@ Map<String, dynamic> buildHtmlVideoBackendDeviceProfile(
     maxResolution: maxResolution,
     pgsDirectPlay: prefs.get(UserPreferences.pgsDirectPlay),
     assDirectPlay: prefs.get(UserPreferences.assDirectPlay),
+    supportsEmbeddedTextSubtitles: false,
+    supportsExternalTextSubtitles: false,
     supportsAvc: PlatformDetection.supportsAvc,
     supportsAvcHigh10: PlatformDetection.supportsAvcHigh10,
     avcMainLevel: PlatformDetection.avcMainLevel,

--- a/lib/playback/html_video_backend_profile.dart
+++ b/lib/playback/html_video_backend_profile.dart
@@ -31,7 +31,7 @@ Map<String, dynamic> buildHtmlVideoBackendDeviceProfile(
     maxResolution: maxResolution,
     pgsDirectPlay: prefs.get(UserPreferences.pgsDirectPlay),
     assDirectPlay: prefs.get(UserPreferences.assDirectPlay),
-    supportsEmbeddedTextSubtitles: false,
+    supportsEmbeddedSubtitles: false,
     supportsExternalTextSubtitles: false,
     supportsAvc: PlatformDetection.supportsAvc,
     supportsAvcHigh10: PlatformDetection.supportsAvcHigh10,

--- a/lib/playback/html_video_backend_web.dart
+++ b/lib/playback/html_video_backend_web.dart
@@ -75,7 +75,6 @@ class HtmlVideoBackend extends PlayerBackend {
       ..autoplay = false
       ..controls = false
       ..preload = 'auto'
-      ..crossOrigin = 'anonymous'
       ..style.border = '0'
       ..style.width = '100%'
       ..style.height = '100%'
@@ -251,7 +250,25 @@ class HtmlVideoBackend extends PlayerBackend {
     } catch (_) {}
   }
 
+  static bool _isCrossOrigin(String url) {
+    final target = Uri.tryParse(url);
+    if (target == null || !target.hasAuthority) return false;
+    final page = Uri.base;
+    return target.scheme != page.scheme ||
+        target.host != page.host ||
+        target.port != page.port;
+  }
+
   void _applyNativeSource(String url) {
+    // Subtitle tracks are fetched in whatever CORS mode the video element is
+    // in, so a remote server needs this. Asking for CORS on a same origin
+    // stream only gives playback another way to fail, and the element outlives
+    // the source, so it comes back off again.
+    if (_isCrossOrigin(url)) {
+      _videoElement.crossOrigin = 'anonymous';
+    } else {
+      _videoElement.removeAttribute('crossorigin');
+    }
     _videoElement.src = url;
     _videoElement.load();
   }
@@ -546,7 +563,6 @@ class HtmlVideoBackend extends PlayerBackend {
       ..src = url
       ..label = title ?? language ?? 'External Subtitle'
       ..srclang = language ?? 'en';
-    track.setAttribute('default', '');
 
     if (codec != null && codec.isNotEmpty) {
       track.setAttribute('data-codec', codec);
@@ -554,10 +570,6 @@ class HtmlVideoBackend extends PlayerBackend {
 
     _videoElement.appendChild(track);
     _externalTracks.add(track);
-
-    try {
-      (track as dynamic).track.mode = 'showing';
-    } catch (_) {}
 
     await setSubtitleTrack(_externalTracks.length - 1);
   }

--- a/lib/playback/html_video_backend_web.dart
+++ b/lib/playback/html_video_backend_web.dart
@@ -75,6 +75,7 @@ class HtmlVideoBackend extends PlayerBackend {
       ..autoplay = false
       ..controls = false
       ..preload = 'auto'
+      ..crossOrigin = 'anonymous'
       ..style.border = '0'
       ..style.width = '100%'
       ..style.height = '100%'
@@ -463,9 +464,21 @@ class HtmlVideoBackend extends PlayerBackend {
     try {
       final dynamic tracks = (_videoElement as dynamic).textTracks;
       final length = (tracks.length as num?)?.toInt() ?? 0;
+
+      dynamic targetTrackObj;
+      if (index >= 0 && index < _externalTracks.length) {
+        targetTrackObj = (_externalTracks[index] as dynamic).track;
+      } else {
+        targetTrackObj = index >= 0 && index < length ? tracks[index] : null;
+      }
+
       for (var i = 0; i < length; i++) {
         final dynamic track = tracks[i];
-        track.mode = i == index ? 'showing' : 'disabled';
+        track.mode = 'disabled';
+      }
+
+      if (targetTrackObj != null) {
+        targetTrackObj.mode = 'showing';
       }
     } catch (_) {}
   }
@@ -533,6 +546,7 @@ class HtmlVideoBackend extends PlayerBackend {
       ..src = url
       ..label = title ?? language ?? 'External Subtitle'
       ..srclang = language ?? 'en';
+    track.setAttribute('default', '');
 
     if (codec != null && codec.isNotEmpty) {
       track.setAttribute('data-codec', codec);
@@ -540,6 +554,10 @@ class HtmlVideoBackend extends PlayerBackend {
 
     _videoElement.appendChild(track);
     _externalTracks.add(track);
+
+    try {
+      (track as dynamic).track.mode = 'showing';
+    } catch (_) {}
 
     await setSubtitleTrack(_externalTracks.length - 1);
   }

--- a/lib/playback/web_subtitle_overlay_web.dart
+++ b/lib/playback/web_subtitle_overlay_web.dart
@@ -68,10 +68,7 @@ class WebSubtitleOverlay {
 
   static bool _isAssCodec(String? codec) {
     final c = codec?.toLowerCase() ?? '';
-    return c.contains('ass') ||
-        c.contains('ssa') ||
-        c.contains('subrip') ||
-        c == 'srt';
+    return c.contains('ass') || c.contains('ssa');
   }
 
   static bool _isPgsCodec(String? codec) {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -5938,10 +5938,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final streams = allStreams.where((s) => s['Type'] == streamType).toList();
     final displaySubtitleStreams = audio
         ? const <Map<String, dynamic>>[]
-        : [
-            ...streams.where((s) => !_isExternalSubtitleStream(s)),
-            ...streams.where(_isExternalSubtitleStream),
-          ];
+        : sortedSubtitleStreams(streams);
     final optionStreams = audio ? streams : displaySubtitleStreams;
     final audioStreams = allStreams.where((s) => s['Type'] == 'Audio').toList();
     final canDownloadRemote =
@@ -6087,15 +6084,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _showControls();
   }
 
-  bool _isExternalSubtitleStream(Map<String, dynamic> stream) {
-    if (stream['IsExternal'] == true) {
-      return true;
-    }
-    final deliveryMethod = (stream['DeliveryMethod'] as String?)
-        ?.trim()
-        .toLowerCase();
-    return deliveryMethod == 'external';
-  }
+
 
   Widget _buildZoomButton({
     double size = 24,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -6084,8 +6084,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _showControls();
   }
 
-
-
   Widget _buildZoomButton({
     double size = 24,
     double extent = 48,

--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -3,10 +3,7 @@ import '../preference/preference_constants.dart';
 import 'language_matching.dart';
 
 bool isExternalSubtitleStream(Map<String, dynamic> stream) {
-  if (stream['IsExternal'] == true) return true;
-  final deliveryMethod =
-      (stream['DeliveryMethod'] as String?)?.trim().toLowerCase();
-  return deliveryMethod == 'external';
+  return stream['IsExternal'] == true;
 }
 
 bool isSdhSubtitleStream(Map<String, dynamic> stream) {


### PR DESCRIPTION
# Pull Request

## Summary
Resolve subtitle track ordering inconsistencies between the OSD and details page, and fix subtitle playback failures in the HTML5 Web UI player.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **video_player_screen.dart**: Replaced private ad-hoc sorting logic with the shared **subtitle_track_logic.dart** helper. Removed the unused private helper.
- **subtitle_track_logic.dart**: Updated external stream checking to determine externality solely by source metadata (`IsExternal == true`) rather than transient session-level delivery methods. This ensures sorting parity across the details and playback OSD screens.
- **web_subtitle_overlay_web.dart**: Excluded `srt` and `subrip` from the WASM Jassub overlay renderer, routing them dynamically to native browser text tracks.
- **device_profile_builder.dart**: Added `supportsEmbeddedTextSubtitles` and `supportsExternalTextSubtitles` parameters to omit `Embed`/`External` methods for text subtitle formats.
- **html_video_backend_profile.dart**: Disabled embedded and external text subtitle capabilities in the browser profile, forcing the Jellyfin server to dynamically transcode/extract them as native WebVTT files instead of raw SRT/SubRip.
- **html_video_backend_web.dart**: Added `crossOrigin = 'anonymous'` and set the `default` attribute on dynamically created track elements. Re-implemented track activation by reference matching rather than index lookup to prevent conflicts with HLS/manifest-injected streams.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [X] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch local dev server and connect to Jellyfin.
2. Select internal and external subtitle tracks.
3. Verify that both render successfully on screen and the OSD track order matches the media details page.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## External sub-track:
<img width="1309" height="1195" alt="2026-07-18_16-35-55_brave" src="https://github.com/user-attachments/assets/2cec0734-b689-4249-9d6f-93f13a7e25c5" />

## Internal sub-track
<img width="1302" height="1189" alt="2026-07-18_16-35-38_brave" src="https://github.com/user-attachments/assets/95c83fd1-c66a-4f3f-b2a1-914e3158c7a5" />

## Media Info ordering vs. In-Player
<img width="796" height="735" alt="2026-07-18_16-50-27_brave" src="https://github.com/user-attachments/assets/c562a112-7e1f-441d-b453-46fe9c0265b4" />
<img width="1803" height="1169" alt="2026-07-18_16-50-45_brave" src="https://github.com/user-attachments/assets/fc9d11be-e8da-4fd8-9395-110cf7e9bea7" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
