### PR TITLE
ui-feature - Add customizable padding settings for Classic and Modern Home Rows

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1062,6 +1062,16 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.homeRowsStyle,
         enumValues: prefs.HomeRowsStyle.values,
       );
+      _applyInt(
+        resolved,
+        'modernHomeRowsPadding',
+        UserPreferences.modernHomeRowsPadding,
+      );
+      _applyInt(
+        resolved,
+        'classicHomeRowsPadding',
+        UserPreferences.classicHomeRowsPadding,
+      );
       _applyString(
         resolved,
         'recommendationSystemSource',
@@ -1813,6 +1823,12 @@ class PluginSyncService extends ChangeNotifier {
           .name,
       'cardFocusExpansion': _prefs.get(UserPreferences.cardFocusExpansion),
       'homeRowsStyle': _prefs.get(UserPreferences.homeRowsStyle).name,
+      'modernHomeRowsPadding': _prefs.get(
+        UserPreferences.modernHomeRowsPadding,
+      ),
+      'classicHomeRowsPadding': _prefs.get(
+        UserPreferences.classicHomeRowsPadding,
+      ),
       'recommendationSystemSource':
           _prefs.get(UserPreferences.recommendationSystemSource).name,
       'detailScreenStyle': _prefs.get(UserPreferences.detailScreenStyle).name,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4617,6 +4617,14 @@
   "@fullScreenRowsDescription": {
     "description": "Description for full screen home rows"
   },
+  "modernHomeRowsPadding": "Home Row Padding",
+  "@modernHomeRowsPadding": {
+    "description": "Title for home rows padding setting"
+  },
+  "modernHomeRowsPaddingDescription": "Customize padding between home rows",
+  "@modernHomeRowsPaddingDescription": {
+    "description": "Description for home rows padding setting"
+  },
   "perRowImageType": "Per Row Image Type",
   "@perRowImageType": {
     "description": "Title for per-row image type screen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4617,12 +4617,12 @@
   "@fullScreenRowsDescription": {
     "description": "Description for full screen home rows"
   },
-  "modernHomeRowsPadding": "Home Row Padding",
-  "@modernHomeRowsPadding": {
+  "homeRowsPadding": "Home Row Padding",
+  "@homeRowsPadding": {
     "description": "Title for home rows padding setting"
   },
-  "modernHomeRowsPaddingDescription": "Customize padding between home rows",
-  "@modernHomeRowsPaddingDescription": {
+  "homeRowsPaddingDescription": "Customize padding between home rows",
+  "@homeRowsPaddingDescription": {
     "description": "Description for home rows padding setting"
   },
   "perRowImageType": "Per Row Image Type",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6124,6 +6124,18 @@ abstract class AppLocalizations {
   /// **'Limit home rows to 1 row per screen'**
   String get fullScreenRowsDescription;
 
+  /// Title for home rows padding setting
+  ///
+  /// In en, this message translates to:
+  /// **'Home Row Padding'**
+  String get modernHomeRowsPadding;
+
+  /// Description for home rows padding setting
+  ///
+  /// In en, this message translates to:
+  /// **'Customize padding between home rows'**
+  String get modernHomeRowsPaddingDescription;
+
   /// Title for per-row image type screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6128,13 +6128,13 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Home Row Padding'**
-  String get modernHomeRowsPadding;
+  String get homeRowsPadding;
 
   /// Description for home rows padding setting
   ///
   /// In en, this message translates to:
   /// **'Customize padding between home rows'**
-  String get modernHomeRowsPaddingDescription;
+  String get homeRowsPaddingDescription;
 
   /// Title for per-row image type screen
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3370,10 +3370,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get fullScreenRowsDescription => 'Beperk tuisrye tot 1 ry per skerm';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3370,6 +3370,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get fullScreenRowsDescription => 'Beperk tuisrye tot 1 ry per skerm';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Per ry tipe beeld';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3377,10 +3377,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'قصر صفوف الرئيسية على صف واحد لكل شاشة';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3377,6 +3377,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'قصر صفوف الرئيسية على صف واحد لكل شاشة';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'نوع الصورة لكل صف';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3386,6 +3386,13 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказваць не больш за адзін радок галоўнай на экран';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тып выявы ў радку';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3386,10 +3386,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказваць не больш за адзін радок галоўнай на экран';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3386,6 +3386,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Ограничаване до 1 начален ред на екран';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тип изображение на ред';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3386,10 +3386,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Ограничаване до 1 начален ред на екран';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3358,10 +3358,10 @@ class AppLocalizationsBn extends AppLocalizations {
       'প্রতি স্ক্রিনে হোম সারি ১টিতে সীমাবদ্ধ করুন';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3358,6 +3358,13 @@ class AppLocalizationsBn extends AppLocalizations {
       'প্রতি স্ক্রিনে হোম সারি ১টিতে সীমাবদ্ধ করুন';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'প্রতি সারি ইমেজ টাইপ';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3405,10 +3405,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get fullScreenRowsDescription => 'Limita a una sola fila per pantalla';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3405,6 +3405,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get fullScreenRowsDescription => 'Limita a una sola fila per pantalla';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipus d\'imatge per fila';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3379,10 +3379,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Omezit domovské řádky na 1 řádek na obrazovku';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3379,6 +3379,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Omezit domovské řádky na 1 řádek na obrazovku';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Typ obrázku na řádek';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3393,6 +3393,13 @@ class AppLocalizationsCy extends AppLocalizations {
       'Cyfyngu rhesi cartref i 1 rhes fesul sgrin';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Math Delwedd Fesul Rhes';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3393,10 +3393,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Cyfyngu rhesi cartref i 1 rhes fesul sgrin';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3367,6 +3367,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Begræns startskærmen til én række pr. skærm';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Billedtype pr. række';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3367,10 +3367,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Begræns startskærmen til én række pr. skærm';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3459,6 +3459,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Startseite auf eine Zeile pro Bildschirm begrenzen';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Bildtyp pro Reihe';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3459,10 +3459,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Startseite auf eine Zeile pro Bildschirm begrenzen';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3403,10 +3403,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Περιορισμός των σειρών της αρχικής σε 1 σειρά ανά οθόνη';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3403,6 +3403,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Περιορισμός των σειρών της αρχικής σε 1 σειρά ανά οθόνη';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Τύπος εικόνας ανά σειρά';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3348,6 +3348,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Per Row Image Type';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3348,10 +3348,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3366,10 +3366,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Limigi hejmajn vicojn al 1 vico po ekrano';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3366,6 +3366,13 @@ class AppLocalizationsEo extends AppLocalizations {
       'Limigi hejmajn vicojn al 1 vico po ekrano';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Per Vico Bilda Tipo';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3390,10 +3390,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Limitar las filas del inicio a 1 por pantalla';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3390,6 +3390,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Limitar las filas del inicio a 1 por pantalla';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipo de imagen por fila';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3372,6 +3372,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Näita korraga ainult üht avaekraani rida';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Rea pilditüübi kohta';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3372,10 +3372,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Näita korraga ainult üht avaekraani rida';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3345,6 +3345,13 @@ class AppLocalizationsFa extends AppLocalizations {
       'محدود کردن ردیف‌های صفحه اصلی به 1 ردیف در هر صفحه';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'نوع تصویر در هر ردیف';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3345,10 +3345,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'محدود کردن ردیف‌های صفحه اصلی به 1 ردیف در هر صفحه';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3379,6 +3379,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä vain yksi aloitusnäytön rivi kerrallaan';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Rivikuvatyypin mukaan';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3379,10 +3379,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä vain yksi aloitusnäytön rivi kerrallaan';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3412,10 +3412,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Limiter les rangées d\'accueil à une par écran';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3412,6 +3412,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Limiter les rangées d\'accueil à une par écran';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Type d’image par rangée';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3406,10 +3406,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Limita as filas de inicio a 1 fila por pantalla';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3406,6 +3406,13 @@ class AppLocalizationsGl extends AppLocalizations {
       'Limita as filas de inicio a 1 fila por pantalla';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipo de imaxe por fila';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3338,10 +3338,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'הגבל את שורות מסך הבית לשורה אחת לכל מסך';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3338,6 +3338,13 @@ class AppLocalizationsHe extends AppLocalizations {
       'הגבל את שורות מסך הבית לשורה אחת לכל מסך';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'סוג תמונה לפי שורה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3358,10 +3358,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'प्रति स्क्रीन होम पंक्तियाँ 1 तक सीमित करें';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3358,6 +3358,13 @@ class AppLocalizationsHi extends AppLocalizations {
       'प्रति स्क्रीन होम पंक्तियाँ 1 तक सीमित करें';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'प्रति पंक्ति छवि प्रकार';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3490,6 +3490,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fullScreenRowsDescription => 'Ograniči na 1 red po zaslonu';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Vrsta slike po redu';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3490,10 +3490,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fullScreenRowsDescription => 'Ograniči na 1 red po zaslonu';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3391,6 +3391,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Korlátozd a kezdőképernyő sorait képernyőnként 1 sorra';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Soronkénti képtípus';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3391,10 +3391,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Korlátozd a kezdőképernyő sorait képernyőnként 1 sorra';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3369,10 +3369,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Batasi baris beranda ke 1 baris per layar';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3369,6 +3369,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Batasi baris beranda ke 1 baris per layar';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipe Gambar per Baris';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3388,6 +3388,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Limita le righe home a 1 per schermata';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipo Immagine per Riga';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3388,10 +3388,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Limita le righe home a 1 per schermata';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3292,6 +3292,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullScreenRowsDescription => '1 画面に表示するホーム行を 1 行に制限します';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => '行ごとの画像タイプ';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3292,10 +3292,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fullScreenRowsDescription => '1 画面に表示するホーム行を 1 行に制限します';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3379,6 +3379,13 @@ class AppLocalizationsKk extends AppLocalizations {
       'Негізгі бет жолдарын әр экранға бір жолмен шектеу';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Әр жолдағы кескін түрі';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3379,10 +3379,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Негізгі бет жолдарын әр экранға бір жолмен шектеу';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3385,10 +3385,10 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಹೋಮ್ ಸಾಲುಗಳನ್ನು ಪ್ರತಿ ಪರದೆಗೆ 1 ಸಾಲಿಗೆ ಮಿತಿಗೊಳಿಸಿ';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3385,6 +3385,13 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಹೋಮ್ ಸಾಲುಗಳನ್ನು ಪ್ರತಿ ಪರದೆಗೆ 1 ಸಾಲಿಗೆ ಮಿತಿಗೊಳಿಸಿ';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ಪ್ರತಿ ಸಾಲಿನ ಚಿತ್ರ ಪ್ರಕಾರ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3284,6 +3284,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get fullScreenRowsDescription => '화면당 홈 행을 1개로 제한합니다';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => '행별 이미지 유형';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3284,10 +3284,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get fullScreenRowsDescription => '화면당 홈 행을 1개로 제한합니다';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3387,6 +3387,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Rodyti tik po vieną pradžios ekrano eilutę';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Eilutės vaizdo tipas';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3387,10 +3387,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Rodyti tik po vieną pradžios ekrano eilutę';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3385,10 +3385,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Rādīt tikai vienu sākuma ekrāna rindu';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3385,6 +3385,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Rādīt tikai vienu sākuma ekrāna rindu';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Rindas attēla veids';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3387,6 +3387,13 @@ class AppLocalizationsMk extends AppLocalizations {
       'Ограничи ги почетните редови на 1 ред по екран';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тип на слика по ред';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3387,10 +3387,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Ограничи ги почетните редови на 1 ред по екран';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3388,10 +3388,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഹോം വരികൾ ഒരു സ്ക്രീനിന് 1 വരിയായി പരിമിതപ്പെടുത്തുക';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3388,6 +3388,13 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഹോം വരികൾ ഒരു സ്ക്രീനിന് 1 വരിയായി പരിമിതപ്പെടുത്തുക';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ഓരോ വരി ചിത്ര തരം';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3372,10 +3372,10 @@ class AppLocalizationsMn extends AppLocalizations {
       'Нэг дэлгэцэд нүүр хуудасны 1 эгнээ харуулна';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3372,6 +3372,13 @@ class AppLocalizationsMn extends AppLocalizations {
       'Нэг дэлгэцэд нүүр хуудасны 1 эгнээ харуулна';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Мөр бүрийн зургийн төрөл';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3364,10 +3364,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Begrens hjem-rader til én rad per skjerm';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3364,6 +3364,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Begrens hjem-rader til én rad per skjerm';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Bildetype per rad';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3380,6 +3380,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Beperk startrijen tot 1 rij per scherm';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Per rij afbeeldingstype';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3380,10 +3380,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Beperk startrijen tot 1 rij per scherm';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3357,10 +3357,10 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਹੋਮ ਕਤਾਰਾਂ ਨੂੰ ਪ੍ਰਤੀ ਸਕ੍ਰੀਨ 1 ਕਤਾਰ ਤੱਕ ਸੀਮਿਤ ਕਰੋ';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3357,6 +3357,13 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਹੋਮ ਕਤਾਰਾਂ ਨੂੰ ਪ੍ਰਤੀ ਸਕ੍ਰੀਨ 1 ਕਤਾਰ ਤੱਕ ਸੀਮਿਤ ਕਰੋ';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ਪ੍ਰਤੀ ਕਤਾਰ ਚਿੱਤਰ ਦੀ ਕਿਸਮ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3373,10 +3373,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Ogranicz ekran główny do 1 wiersza na ekran';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3373,6 +3373,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Ogranicz ekran główny do 1 wiersza na ekran';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Typ obrazu na wiersz';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3384,6 +3384,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Limitar as linhas do início a 1 linha por tela';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tipo de Imagem por Linha';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3384,10 +3384,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Limitar as linhas do início a 1 linha por tela';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3392,10 +3392,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Limitează ecranul principal la un singur rând';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3392,6 +3392,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Limitează ecranul principal la un singur rând';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Tip de imagine pe rând';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3396,10 +3396,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать не больше одного ряда на экране';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3396,6 +3396,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать не больше одного ряда на экране';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тип изображения по строкам';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3364,6 +3364,13 @@ class AppLocalizationsSi extends AppLocalizations {
       'මුල් තිර පේළි එක් තිරයකට පේළි 1කට සීමා කරන්න';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'පේළි රූප වර්ගය අනුව';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3364,10 +3364,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'මුල් තිර පේළි එක් තිරයකට පේළි 1කට සීමා කරන්න';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3390,6 +3390,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Obmedziť domovskú obrazovku na 1 riadok naraz';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Typ obrázka na riadok';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3390,10 +3390,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Obmedziť domovskú obrazovku na 1 riadok naraz';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3394,6 +3394,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Omeji domačo stran na 1 vrstico naenkrat';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Vrsta slike na vrstico';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3394,10 +3394,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Omeji domačo stran na 1 vrstico naenkrat';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3397,6 +3397,13 @@ class AppLocalizationsSq extends AppLocalizations {
       'Kufizo rreshtat e kreut në 1 rresht për ekran';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Lloji i imazhit për rresht';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3397,10 +3397,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Kufizo rreshtat e kreut në 1 rresht për ekran';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3489,10 +3489,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get fullScreenRowsDescription => 'Ограничи на 1 ред по екрану';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3489,6 +3489,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get fullScreenRowsDescription => 'Ограничи на 1 ред по екрану';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тип слике по реду';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3373,6 +3373,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Begränsa hemrader till 1 rad per skärm';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Bildtyp per rad';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3373,10 +3373,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Begränsa hemrader till 1 rad per skärm';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3392,10 +3392,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Punguza safu za nyumbani hadi safu 1 kwa kila skrini';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3392,6 +3392,13 @@ class AppLocalizationsSw extends AppLocalizations {
       'Punguza safu za nyumbani hadi safu 1 kwa kila skrini';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Aina ya Picha kwa Safu Mlalo';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3391,6 +3391,13 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஒரு திரைக்கு 1 முகப்பு வரிசை என வரம்பிடும்';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ஒவ்வொரு வரிசை பட வகை';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3391,10 +3391,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஒரு திரைக்கு 1 முகப்பு வரிசை என வரம்பிடும்';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3385,10 +3385,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'హోమ్ వరుసలను స్క్రీన్‌కు 1 వరుసకు పరిమితం చేయండి';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3385,6 +3385,13 @@ class AppLocalizationsTe extends AppLocalizations {
       'హోమ్ వరుసలను స్క్రీన్‌కు 1 వరుసకు పరిమితం చేయండి';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ప్రతి వరుస చిత్రం రకం';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3344,6 +3344,13 @@ class AppLocalizationsTh extends AppLocalizations {
       'จำกัดแถวหน้าแรกให้เหลือ 1 แถวต่อหน้าจอ';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ประเภทรูปภาพต่อแถว';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3344,10 +3344,10 @@ class AppLocalizationsTh extends AppLocalizations {
       'จำกัดแถวหน้าแรกให้เหลือ 1 แถวต่อหน้าจอ';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3396,10 +3396,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Limitahan ang mga home row sa 1 row bawat screen';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3396,6 +3396,13 @@ class AppLocalizationsTl extends AppLocalizations {
       'Limitahan ang mga home row sa 1 row bawat screen';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Uri ng Larawan sa Bawat Hilera';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3379,6 +3379,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ana sayfa satırlarını ekran başına 1 satırla sınırla';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Satır Başına Görüntü Türü';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3379,10 +3379,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ana sayfa satırlarını ekran başına 1 satırla sınırla';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3376,6 +3376,13 @@ class AppLocalizationsUg extends AppLocalizations {
       'ھەر ئېكرانغا باش بەت قۇرىنى 1 قۇر بىلەن چەكلەيدۇ';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'ھەر بىر قۇر رەسىم تىپى';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3376,10 +3376,10 @@ class AppLocalizationsUg extends AppLocalizations {
       'ھەر ئېكرانغا باش بەت قۇرىنى 1 قۇر بىلەن چەكلەيدۇ';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3393,6 +3393,13 @@ class AppLocalizationsUk extends AppLocalizations {
       'Обмежити головну до 1 рядка на екран';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Тип зображення на рядок';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3393,10 +3393,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Обмежити головну до 1 рядка на екран';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3371,6 +3371,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Giới hạn còn 1 hàng trang chủ mỗi màn hình';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => 'Loại hình ảnh trên mỗi hàng';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3371,10 +3371,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Giới hạn còn 1 hàng trang chủ mỗi màn hình';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -3259,6 +3259,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get fullScreenRowsDescription => '每個畫面淨係顯示一行主畫面列表';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => '每行圖像類型';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -3259,10 +3259,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get fullScreenRowsDescription => '每個畫面淨係顯示一行主畫面列表';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3257,6 +3257,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get fullScreenRowsDescription => '将首页行限制为每屏 1 行';
 
   @override
+  String get modernHomeRowsPadding => 'Home Row Padding';
+
+  @override
+  String get modernHomeRowsPaddingDescription =>
+      'Customize padding between home rows';
+
+  @override
   String get perRowImageType => '每行图片类型';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3257,10 +3257,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get fullScreenRowsDescription => '将首页行限制为每屏 1 行';
 
   @override
-  String get modernHomeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => 'Home Row Padding';
 
   @override
-  String get modernHomeRowsPaddingDescription =>
+  String get homeRowsPaddingDescription =>
       'Customize padding between home rows';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -650,6 +650,16 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final modernHomeRowsPadding = Preference<int>(
+    key: 'pref_modern_home_rows_padding',
+    defaultValue: 460,
+  );
+
+  static final classicHomeRowsPadding = Preference<int>(
+    key: 'pref_classic_home_rows_padding',
+    defaultValue: 30,
+  );
+
   static final desktopUiScale = EnumPreference(
     key: 'pref_desktop_ui_scale',
     defaultValue: DesktopUiScale.medium,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1068,7 +1068,7 @@ class _ContentRowsState extends State<_ContentRows>
     final showInfoOverlay = _showHomeRowInfoOverlay();
     final safeTop = MediaQuery.of(context).padding.top;
     final navbarIsTop = prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
-    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
+    final fullScreenRows = _fullScreenRowsEnabled(prefs);
 
     final navbarHeight = PlatformDetection.isTV
         ? (fullScreenRows ? 95.0 : (navbarIsTop ? 45.0 : 15.0))
@@ -2323,7 +2323,7 @@ class _ContentRowsState extends State<_ContentRows>
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
-    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
+    final fullScreenRows = _fullScreenRowsEnabled(prefs);
     final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
 
     double childHeight = 0.0;
@@ -2334,8 +2334,7 @@ class _ContentRowsState extends State<_ContentRows>
         childHeight = squarePosterSide + (56 * metadataScale);
       } else if (isRowsV2) {
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
-        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
-        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+        final budget = _v2MetadataBudgetFor(row, prefs);
         childHeight = imageHeight + (budget * metadataScale) + (10 * metadataScale);
       } else {
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale;
@@ -2352,10 +2351,8 @@ class _ContentRowsState extends State<_ContentRows>
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
       var maxCardHeight = 0.0;
       if (isRowsV2) {
-        maxCardHeight = 220.0 * metadataScale;
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
-        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
-        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+        final budget = _v2MetadataBudgetFor(row, prefs);
         maxCardHeight = imageHeight + (budget * metadataScale);
       } else {
         for (final item in row.items) {
@@ -2371,12 +2368,7 @@ class _ContentRowsState extends State<_ContentRows>
         if (maxCardHeight == 0.0) {
           maxCardHeight = posterSize.portraitHeight.toDouble() * platformScale + (46 * metadataScale);
         }
-        final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
-            row.rowType == HomeRowType.libraryTiles;
-        if (!fullScreenRows && !isLibrary) {
-          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
-          maxCardHeight += classicPadding;
-        }
+        maxCardHeight += _classicRowPadding(row, prefs);
       }
       childHeight = maxCardHeight + (10 * metadataScale);
     }
@@ -2395,20 +2387,19 @@ class _ContentRowsState extends State<_ContentRows>
     if (!fullScreenRows) {
       if (isRowsV2) {
         final customHeight = prefs.get(UserPreferences.modernHomeRowsPadding).toDouble();
-        if (row.rowType != HomeRowType.libraryTilesSmall &&
-            row.rowType != HomeRowType.libraryTiles) {
-          totalHeight = customHeight;
+        if (!_isLibraryRow(row)) {
+          // Rows are pinned to this extent below, so a chosen height under
+          // the natural one clips the cards instead of tightening the gap.
+          totalHeight = customHeight > totalHeight ? customHeight : totalHeight;
         } else {
           final offset = (customHeight - 440.0).clamp(0.0, 120.0);
           totalHeight += offset;
         }
-      } else {
-        if (row.rowType == HomeRowType.libraryTilesSmall ||
-            row.rowType == HomeRowType.libraryTiles) {
-          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
-          final offset = (classicPadding - 10.0).clamp(0.0, 120.0);
-          totalHeight += offset;
-        }
+      } else if (_isLibraryRow(row)) {
+        final classicPadding = prefs
+            .get(UserPreferences.classicHomeRowsPadding)
+            .toDouble();
+        totalHeight += (classicPadding - 10.0).clamp(0.0, 120.0);
       }
     }
     _staticRowHeightCache[rowIndex] = totalHeight;
@@ -2452,7 +2443,7 @@ class _ContentRowsState extends State<_ContentRows>
       return preferredTop.clamp(defaultTop, _rowTopOffsets[0]);
     }
 
-    final fullScreenRows = !PlatformDetection.useMobileUi && widget.prefs.get(UserPreferences.fullScreenRows);
+    final fullScreenRows = _fullScreenRowsEnabled(widget.prefs);
     if (fullScreenRows) {
       if (isRowsV2) {
         final targetTop = (viewportHeight - rowHeight) / 2.0;
@@ -3104,7 +3095,6 @@ class _ContentRowsState extends State<_ContentRows>
   ) {
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
-    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
     if (row.isLoading) {
       return _libraryRowExtent(
         220 * metadataScale,
@@ -3128,11 +3118,9 @@ class _ContentRowsState extends State<_ContentRows>
           : desktopScale;
       var maxCardHeight = 0.0;
       if (isRowsV2) {
-        maxCardHeight = 220.0 * metadataScale;
         final imageHeight =
             posterSize.portraitHeight.toDouble() * platformScale * 2;
-        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
-        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+        final budget = _v2MetadataBudgetFor(row, prefs);
         maxCardHeight =
             imageHeight + (budget * metadataScale);
       } else {
@@ -3151,12 +3139,7 @@ class _ContentRowsState extends State<_ContentRows>
         if (maxCardHeight == 0.0) {
           maxCardHeight = posterSize.portraitHeight.toDouble() * platformScale + (46 * metadataScale);
         }
-        final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
-            row.rowType == HomeRowType.libraryTiles;
-        if (!fullScreenRows && !isLibrary) {
-          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
-          maxCardHeight += classicPadding;
-        }
+        maxCardHeight += _classicRowPadding(row, prefs);
       }
       return _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
     }
@@ -3293,6 +3276,30 @@ class _ContentRowsState extends State<_ContentRows>
     return url;
   }
 
+  /// Library tiles carry a name and nothing else, so they need far less room
+  /// under the artwork than a media card.
+  static const _libraryTilesMetadataBudget = 38.0;
+
+  bool _isLibraryRow(HomeRow row) =>
+      row.rowType == HomeRowType.libraryTilesSmall ||
+      row.rowType == HomeRowType.libraryTiles;
+
+  bool _fullScreenRowsEnabled(UserPreferences prefs) =>
+      !PlatformDetection.useMobileUi &&
+      prefs.get(UserPreferences.fullScreenRows);
+
+  double _v2MetadataBudgetFor(HomeRow row, UserPreferences prefs) =>
+      row.rowType == HomeRowType.libraryTiles
+      ? _libraryTilesMetadataBudget
+      : _v2MetadataHeightBudget(prefs);
+
+  /// Extra room the classic rows setting asks for. Library rows are left out,
+  /// since their grid sizes itself and padding there overlaps the next row.
+  double _classicRowPadding(HomeRow row, UserPreferences prefs) {
+    if (_fullScreenRowsEnabled(prefs) || _isLibraryRow(row)) return 0.0;
+    return prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
+  }
+
   double _v2MetadataHeightBudget(UserPreferences prefs) {
     final hasAdditionalRatings = prefs.get(
       UserPreferences.enableAdditionalRatings,
@@ -3361,11 +3368,10 @@ class _ContentRowsState extends State<_ContentRows>
     // Classifier inputs
     final isVisibleOnScreen = rowViewportBottom > 0 && rowViewportTop < viewportHeight;
     final isUnderOverlay = rowViewportBottom <= overlayBottom + 8;
-    final isNeighbor = focusedRowIndex != null &&
-        (rowIndex - focusedRowIndex).abs() == 1;
+    final rowDistance = (rowIndex - focusedRowIndex).abs();
+    final isNeighbor = rowDistance == 1;
     final isFocusedRow = focusedRowIndex == rowIndex;
-    final isFarAway = focusedRowIndex != null &&
-        (rowIndex - focusedRowIndex).abs() > 1;
+    final isFarAway = rowDistance > 1;
 
     // Focused row: always visible
     if (isFocusedRow) {
@@ -3760,7 +3766,11 @@ class _ContentRowsState extends State<_ContentRows>
                           )
                         : rowChild;
 
-                    final bool lockRowHeight = !PlatformDetection.useMobileUi || !fullScreenRows;
+                    // Padding only bites if rows honour the extent worked out
+                    // above, so all of them are pinned to it apart from mobile
+                    // full screen rows, which size themselves.
+                    final bool lockRowHeight =
+                        !PlatformDetection.useMobileUi || !fullScreenRows;
 
                     if (row.isLoading) {
                       final itemWidget = Padding(
@@ -4055,8 +4065,7 @@ class _ContentRowsState extends State<_ContentRows>
         : desktopScale;
     final v2ImageHeight =
         posterSize.portraitHeight.toDouble() * platformScale * 2;
-    final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
-    final v2MetadataHeightBudget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+    final v2MetadataHeightBudget = _v2MetadataBudgetFor(row, prefs);
     final v2PortraitAspect = row.isAudio ? 1.0 : 2 / 3;
     final v2FocusedAspect = row.isAudio ? 1.0 : 16 / 9;
     final v2PortraitWidth = v2ImageHeight * v2PortraitAspect;
@@ -4103,13 +4112,7 @@ class _ContentRowsState extends State<_ContentRows>
         if (cardHeight > maxCardHeight) maxCardHeight = cardHeight;
         if (firstCardWidth == 0) firstCardWidth = height * ar;
       }
-      final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
-          row.rowType == HomeRowType.libraryTiles;
-      final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
-      if (!fullScreenRows && !isLibrary) {
-        final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
-        maxCardHeight += classicPadding;
-      }
+      maxCardHeight += _classicRowPadding(row, prefs);
     }
 
     if (firstCardWidth == 0) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/gestures.dart';
 
 import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -950,6 +951,8 @@ class _ContentRowsState extends State<_ContentRows>
     if (!mounted) return;
 
     _layoutPrefsVersion++;
+    _invalidateStaticRowHeightCache();
+    _invalidateRowTargetOffsetCache();
 
     final useMedia3 = _useMedia3InlinePreview();
     if (useMedia3 != _lastMedia3PreviewPreference) {
@@ -2320,6 +2323,7 @@ class _ContentRowsState extends State<_ContentRows>
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
+    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
     final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
 
     double childHeight = 0.0;
@@ -2330,7 +2334,9 @@ class _ContentRowsState extends State<_ContentRows>
         childHeight = squarePosterSide + (56 * metadataScale);
       } else if (isRowsV2) {
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
-        childHeight = imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale) + (10 * metadataScale);
+        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
+        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+        childHeight = imageHeight + (budget * metadataScale) + (10 * metadataScale);
       } else {
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale;
         childHeight = imageHeight + (46 * metadataScale) + (10 * metadataScale);
@@ -2344,10 +2350,13 @@ class _ContentRowsState extends State<_ContentRows>
       final rowImageType = isSeerrRowOverride
           ? ImageType.thumb
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-      var maxCardHeight = 220.0 * metadataScale;
+      var maxCardHeight = 0.0;
       if (isRowsV2) {
+        maxCardHeight = 220.0 * metadataScale;
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
-        maxCardHeight = imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale);
+        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
+        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
+        maxCardHeight = imageHeight + (budget * metadataScale);
       } else {
         for (final item in row.items) {
           final aspectRatio = _aspectRatioForRowItem(item, row, rowImageType);
@@ -2358,6 +2367,15 @@ class _ContentRowsState extends State<_ContentRows>
           if (cardHeight > maxCardHeight) {
             maxCardHeight = cardHeight;
           }
+        }
+        if (maxCardHeight == 0.0) {
+          maxCardHeight = posterSize.portraitHeight.toDouble() * platformScale + (46 * metadataScale);
+        }
+        final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
+            row.rowType == HomeRowType.libraryTiles;
+        if (!fullScreenRows && !isLibrary) {
+          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
+          maxCardHeight += classicPadding;
         }
       }
       childHeight = maxCardHeight + (10 * metadataScale);
@@ -2373,7 +2391,26 @@ class _ContentRowsState extends State<_ContentRows>
     final subtitleHeight = hasSubtitle ? (18.0 * metadataScale) : 0.0;
     final headerHeight = headerPaddingTop + headerPaddingBottom + titleHeight + subtitleHeight;
 
-    final totalHeight = childHeight + headerHeight;
+    var totalHeight = childHeight + headerHeight;
+    if (!fullScreenRows) {
+      if (isRowsV2) {
+        final customHeight = prefs.get(UserPreferences.modernHomeRowsPadding).toDouble();
+        if (row.rowType != HomeRowType.libraryTilesSmall &&
+            row.rowType != HomeRowType.libraryTiles) {
+          totalHeight = customHeight;
+        } else {
+          final offset = (customHeight - 440.0).clamp(0.0, 120.0);
+          totalHeight += offset;
+        }
+      } else {
+        if (row.rowType == HomeRowType.libraryTilesSmall ||
+            row.rowType == HomeRowType.libraryTiles) {
+          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
+          final offset = (classicPadding - 10.0).clamp(0.0, 120.0);
+          totalHeight += offset;
+        }
+      }
+    }
     _staticRowHeightCache[rowIndex] = totalHeight;
     return totalHeight;
   }
@@ -2415,11 +2452,21 @@ class _ContentRowsState extends State<_ContentRows>
       return preferredTop.clamp(defaultTop, _rowTopOffsets[0]);
     }
 
-    if (isRowsV2) {
-      final targetTop = (viewportHeight - rowHeight) / 2.0;
-      return targetTop.clamp(defaultTop, double.infinity);
+    final fullScreenRows = !PlatformDetection.useMobileUi && widget.prefs.get(UserPreferences.fullScreenRows);
+    if (fullScreenRows) {
+      if (isRowsV2) {
+        final targetTop = (viewportHeight - rowHeight) / 2.0;
+        return targetTop.clamp(defaultTop, double.infinity);
+      }
+      return defaultTop;
+    } else {
+      final isMyMedia = row.rowType == HomeRowType.libraryTilesSmall ||
+          row.rowType == HomeRowType.libraryTiles;
+      if (isMyMedia) {
+        return defaultTop;
+      }
+      return 0.0;
     }
-    return defaultTop;
   }
 
   Future<void> _scrollTvRowIntoOverlayBand(int rowIndex) async {
@@ -3057,6 +3104,7 @@ class _ContentRowsState extends State<_ContentRows>
   ) {
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
+    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
     if (row.isLoading) {
       return _libraryRowExtent(
         220 * metadataScale,
@@ -3078,12 +3126,15 @@ class _ContentRowsState extends State<_ContentRows>
       final platformScale = PlatformDetection.isTV
           ? 0.8 * desktopScale
           : desktopScale;
-      var maxCardHeight = 220.0 * metadataScale;
+      var maxCardHeight = 0.0;
       if (isRowsV2) {
+        maxCardHeight = 220.0 * metadataScale;
         final imageHeight =
             posterSize.portraitHeight.toDouble() * platformScale * 2;
+        final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
+        final budget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
         maxCardHeight =
-            imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale);
+            imageHeight + (budget * metadataScale);
       } else {
         for (final item in row.items) {
           final aspectRatio = _aspectRatioForRowItem(item, row, rowImageType);
@@ -3096,6 +3147,15 @@ class _ContentRowsState extends State<_ContentRows>
           if (cardHeight > maxCardHeight) {
             maxCardHeight = cardHeight;
           }
+        }
+        if (maxCardHeight == 0.0) {
+          maxCardHeight = posterSize.portraitHeight.toDouble() * platformScale + (46 * metadataScale);
+        }
+        final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
+            row.rowType == HomeRowType.libraryTiles;
+        if (!fullScreenRows && !isLibrary) {
+          final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
+          maxCardHeight += classicPadding;
         }
       }
       return _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
@@ -3277,7 +3337,7 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
 
-    final focusedRowIndex = _focusedRowIndex(FocusManager.instance.primaryFocus);
+    final focusedRowIndex = _focusedRowIndex(FocusManager.instance.primaryFocus) ?? 0;
 
     // Compute viewport geometry
     final rowViewportTop = rowTopOffsets[rowIndex] - _scrollOffset;
@@ -3556,7 +3616,7 @@ class _ContentRowsState extends State<_ContentRows>
                     bottom: neededBottomPadding,
                   ),
                   itemCount: rows.length + headerCount,
-                  cacheExtent: 600,
+                  scrollCacheExtent: const ScrollCacheExtent.pixels(600.0),
                   itemBuilder: (context, index) {
                     if (includeMediaBar && index == 0) {
                       return ValueListenableBuilder<bool>(
@@ -3689,11 +3749,9 @@ class _ContentRowsState extends State<_ContentRows>
                     final contentHeight = _rowContentHeight(row, posterSize, prefs);
                     final targetExtent = rowExtents[rowIndex];
                     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
-                    final extraTopPadding = fullScreenRows
-                        ? (isRowsV2
-                            ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
-                            : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity))
-                        : 0.0;
+                    final extraTopPadding = isRowsV2
+                        ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
+                        : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity);
 
                     final paddedRowChild = extraTopPadding > 0.0
                         ? Padding(
@@ -3702,8 +3760,7 @@ class _ContentRowsState extends State<_ContentRows>
                           )
                         : rowChild;
 
-                    final bool lockRowHeight = fullScreenRows ||
-                        (!PlatformDetection.useMobileUi && showInfoOverlay);
+                    final bool lockRowHeight = !PlatformDetection.useMobileUi || !fullScreenRows;
 
                     if (row.isLoading) {
                       final itemWidget = Padding(
@@ -3998,7 +4055,8 @@ class _ContentRowsState extends State<_ContentRows>
         : desktopScale;
     final v2ImageHeight =
         posterSize.portraitHeight.toDouble() * platformScale * 2;
-    final v2MetadataHeightBudget = _v2MetadataHeightBudget(prefs);
+    final isLibraryTiles = row.rowType == HomeRowType.libraryTiles;
+    final v2MetadataHeightBudget = isLibraryTiles ? 38.0 : _v2MetadataHeightBudget(prefs);
     final v2PortraitAspect = row.isAudio ? 1.0 : 2 / 3;
     final v2FocusedAspect = row.isAudio ? 1.0 : 16 / 9;
     final v2PortraitWidth = v2ImageHeight * v2PortraitAspect;
@@ -4044,6 +4102,13 @@ class _ContentRowsState extends State<_ContentRows>
         final cardHeight = height + (46 * metadataScale);
         if (cardHeight > maxCardHeight) maxCardHeight = cardHeight;
         if (firstCardWidth == 0) firstCardWidth = height * ar;
+      }
+      final isLibrary = row.rowType == HomeRowType.libraryTilesSmall ||
+          row.rowType == HomeRowType.libraryTiles;
+      final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
+      if (!fullScreenRows && !isLibrary) {
+        final classicPadding = prefs.get(UserPreferences.classicHomeRowsPadding).toDouble();
+        maxCardHeight += classicPadding;
       }
     }
 

--- a/lib/ui/screens/settings/panel/home_screen_category_screen.dart
+++ b/lib/ui/screens/settings/panel/home_screen_category_screen.dart
@@ -26,8 +26,12 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final rowsStyle = _prefs.get(UserPreferences.homeRowsStyle);
-    final isFullScreenRows = !PlatformDetection.useMobileUi && _prefs.get(UserPreferences.fullScreenRows);
-    final isInfoOverlayOn = rowsStyle == HomeRowsStyle.v1 && _prefs.get(UserPreferences.homeRowInfoOverlay);
+    final isFullScreenRows =
+        !PlatformDetection.useMobileUi &&
+        _prefs.get(UserPreferences.fullScreenRows);
+    final isInfoOverlayOn =
+        rowsStyle == HomeRowsStyle.v1 &&
+        _prefs.get(UserPreferences.homeRowInfoOverlay);
     final isPaddingEnabled = !isFullScreenRows && !isInfoOverlayOn;
     return Scaffold(
       appBar: buildSettingsAppBar(context, Text(l10n.homeScreen)),
@@ -63,7 +67,7 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                 icon: Icons.image_aspect_ratio,
                 onChanged: _pushPersonalizationSync,
               ),
-               if (!PlatformDetection.useMobileUi)
+              if (!PlatformDetection.useMobileUi)
                 SwitchPreferenceTile(
                   preference: UserPreferences.fullScreenRows,
                   title: l10n.fullScreenRows,
@@ -87,24 +91,18 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                     setState(() {});
                   },
                 ),
-              IgnorePointer(
-                ignoring: !isPaddingEnabled,
-                child: Opacity(
-                  opacity: isPaddingEnabled ? 1.0 : 0.4,
-                  child: SliderPreferenceTile(
-                    preference: rowsStyle == HomeRowsStyle.v2
-                        ? UserPreferences.modernHomeRowsPadding
-                        : UserPreferences.classicHomeRowsPadding,
-                    title: l10n.modernHomeRowsPadding,
-                    description: l10n.modernHomeRowsPaddingDescription,
-                    icon: Icons.unfold_more,
-                    min: rowsStyle == HomeRowsStyle.v2 ? 360 : 10,
-                    max: rowsStyle == HomeRowsStyle.v2 ? 560 : 130,
-                    divisions: rowsStyle == HomeRowsStyle.v2 ? 10 : 6,
-                    enabled: isPaddingEnabled,
-                    onChangeEnd: _pushPersonalizationSync,
-                  ),
-                ),
+              SliderPreferenceTile(
+                preference: rowsStyle == HomeRowsStyle.v2
+                    ? UserPreferences.modernHomeRowsPadding
+                    : UserPreferences.classicHomeRowsPadding,
+                title: l10n.homeRowsPadding,
+                description: l10n.homeRowsPaddingDescription,
+                icon: Icons.unfold_more,
+                min: rowsStyle == HomeRowsStyle.v2 ? 360 : 10,
+                max: rowsStyle == HomeRowsStyle.v2 ? 560 : 130,
+                divisions: rowsStyle == HomeRowsStyle.v2 ? 10 : 6,
+                enabled: isPaddingEnabled,
+                onChangeEnd: _pushPersonalizationSync,
               ),
               EnumPreferenceTile<PosterSize>(
                 preference: UserPreferences.posterSize,

--- a/lib/ui/screens/settings/panel/home_screen_category_screen.dart
+++ b/lib/ui/screens/settings/panel/home_screen_category_screen.dart
@@ -26,6 +26,9 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final rowsStyle = _prefs.get(UserPreferences.homeRowsStyle);
+    final isFullScreenRows = !PlatformDetection.useMobileUi && _prefs.get(UserPreferences.fullScreenRows);
+    final isInfoOverlayOn = rowsStyle == HomeRowsStyle.v1 && _prefs.get(UserPreferences.homeRowInfoOverlay);
+    final isPaddingEnabled = !isFullScreenRows && !isInfoOverlayOn;
     return Scaffold(
       appBar: buildSettingsAppBar(context, Text(l10n.homeScreen)),
       body: ListView(
@@ -60,14 +63,49 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                 icon: Icons.image_aspect_ratio,
                 onChanged: _pushPersonalizationSync,
               ),
-              if (!PlatformDetection.useMobileUi)
+               if (!PlatformDetection.useMobileUi)
                 SwitchPreferenceTile(
                   preference: UserPreferences.fullScreenRows,
                   title: l10n.fullScreenRows,
                   subtitle: l10n.fullScreenRowsDescription,
                   icon: Icons.image_aspect_ratio,
-                  onChanged: _pushPersonalizationSync,
+                  onChanged: () {
+                    _pushPersonalizationSync();
+                    if (!mounted) return;
+                    setState(() {});
+                  },
                 ),
+              if (rowsStyle == HomeRowsStyle.v1)
+                SwitchPreferenceTile(
+                  preference: UserPreferences.homeRowInfoOverlay,
+                  title: l10n.homeRowInfoOverlay,
+                  subtitle: l10n.showTitleMetadataOnHomeRows,
+                  icon: Icons.info_outline,
+                  onChanged: () {
+                    _pushPersonalizationSync();
+                    if (!mounted) return;
+                    setState(() {});
+                  },
+                ),
+              IgnorePointer(
+                ignoring: !isPaddingEnabled,
+                child: Opacity(
+                  opacity: isPaddingEnabled ? 1.0 : 0.4,
+                  child: SliderPreferenceTile(
+                    preference: rowsStyle == HomeRowsStyle.v2
+                        ? UserPreferences.modernHomeRowsPadding
+                        : UserPreferences.classicHomeRowsPadding,
+                    title: l10n.modernHomeRowsPadding,
+                    description: l10n.modernHomeRowsPaddingDescription,
+                    icon: Icons.unfold_more,
+                    min: rowsStyle == HomeRowsStyle.v2 ? 360 : 10,
+                    max: rowsStyle == HomeRowsStyle.v2 ? 560 : 130,
+                    divisions: rowsStyle == HomeRowsStyle.v2 ? 10 : 6,
+                    enabled: isPaddingEnabled,
+                    onChangeEnd: _pushPersonalizationSync,
+                  ),
+                ),
+              ),
               EnumPreferenceTile<PosterSize>(
                 preference: UserPreferences.posterSize,
                 title: l10n.cardSize,
@@ -80,13 +118,6 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                 },
                 onChanged: _pushPersonalizationSync,
               ),
-              if (rowsStyle == HomeRowsStyle.v1)
-                SwitchPreferenceTile(
-                  preference: UserPreferences.homeRowInfoOverlay,
-                  title: l10n.homeRowInfoOverlay,
-                  subtitle: l10n.showTitleMetadataOnHomeRows,
-                  icon: Icons.info_outline,
-                ),
             ],
           ),
 

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -672,7 +672,15 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
 
   @override
   Widget build(BuildContext context) {
-    final invert = widget.enabled && _outerFocused && settingsTileInvertsOnFocus;
+    final invert =
+        widget.enabled && _outerFocused && settingsTileInvertsOnFocus;
+    return Opacity(
+      opacity: widget.enabled ? 1.0 : 0.4,
+      child: _buildTile(context, invert: invert),
+    );
+  }
+
+  Widget _buildTile(BuildContext context, {required bool invert}) {
     return Focus(
       focusNode: _outerFocusNode,
       autofocus: widget.autofocus,
@@ -747,8 +755,12 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
                             min: widget.min,
                             max: widget.max,
                             divisions: widget.divisions,
-                            onChanged: widget.enabled ? (v) => _binding.value = v.round() : null,
-                            onChangeEnd: widget.enabled ? (_) => widget.onChangeEnd?.call() : null,
+                            onChanged: widget.enabled
+                                ? (v) => _binding.value = v.round()
+                                : null,
+                            onChangeEnd: widget.enabled
+                                ? (_) => widget.onChangeEnd?.call()
+                                : null,
                           )
                         : Slider(
                             focusNode: _sliderInternalNode,
@@ -761,8 +773,12 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
                             divisions: widget.divisions,
                             label:
                                 widget.labelOf?.call(value) ?? value.toString(),
-                            onChanged: widget.enabled ? (v) => _binding.value = v.round() : null,
-                            onChangeEnd: widget.enabled ? (_) => widget.onChangeEnd?.call() : null,
+                            onChanged: widget.enabled
+                                ? (v) => _binding.value = v.round()
+                                : null,
+                            onChangeEnd: widget.enabled
+                                ? (_) => widget.onChangeEnd?.call()
+                                : null,
                           ),
                   ],
                 ),

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -573,6 +573,7 @@ class _EnumPreferenceTileState<T extends Enum>
 class SliderPreferenceTile extends StatefulWidget {
   final Preference<int> preference;
   final String title;
+  final String? description;
   final IconData? icon;
   final double min;
   final double max;
@@ -580,11 +581,13 @@ class SliderPreferenceTile extends StatefulWidget {
   final String Function(int value)? labelOf;
   final VoidCallback? onChangeEnd;
   final bool autofocus;
+  final bool enabled;
 
   const SliderPreferenceTile({
     super.key,
     required this.preference,
     required this.title,
+    this.description,
     this.icon,
     required this.min,
     required this.max,
@@ -592,6 +595,7 @@ class SliderPreferenceTile extends StatefulWidget {
     this.labelOf,
     this.onChangeEnd,
     this.autofocus = false,
+    this.enabled = true,
   });
 
   @override
@@ -636,6 +640,7 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
   }
 
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (!widget.enabled) return KeyEventResult.ignored;
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return KeyEventResult.ignored;
     }
@@ -667,10 +672,11 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
 
   @override
   Widget build(BuildContext context) {
-    final invert = _outerFocused && settingsTileInvertsOnFocus;
+    final invert = widget.enabled && _outerFocused && settingsTileInvertsOnFocus;
     return Focus(
       focusNode: _outerFocusNode,
       autofocus: widget.autofocus,
+      canRequestFocus: widget.enabled,
       onKeyEvent: _onKeyEvent,
       onFocusChange: (focused) {
         if (focused) {
@@ -712,6 +718,16 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
                 subtitle: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    if (widget.description != null)
+                      Text(
+                        widget.description!,
+                        style: TextStyle(
+                          fontSize: _kSettingsSubtitleTextStyle.fontSize,
+                          color: invert
+                              ? AppColors.black.withValues(alpha: 0.54)
+                              : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
                     if (widget.labelOf != null)
                       Text(
                         widget.labelOf!(value),
@@ -731,8 +747,8 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
                             min: widget.min,
                             max: widget.max,
                             divisions: widget.divisions,
-                            onChanged: (v) => _binding.value = v.round(),
-                            onChangeEnd: (_) => widget.onChangeEnd?.call(),
+                            onChanged: widget.enabled ? (v) => _binding.value = v.round() : null,
+                            onChangeEnd: widget.enabled ? (_) => widget.onChangeEnd?.call() : null,
                           )
                         : Slider(
                             focusNode: _sliderInternalNode,
@@ -745,8 +761,8 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
                             divisions: widget.divisions,
                             label:
                                 widget.labelOf?.call(value) ?? value.toString(),
-                            onChanged: (v) => _binding.value = v.round(),
-                            onChangeEnd: (_) => widget.onChangeEnd?.call(),
+                            onChanged: widget.enabled ? (v) => _binding.value = v.round() : null,
+                            onChangeEnd: widget.enabled ? (_) => widget.onChangeEnd?.call() : null,
                           ),
                   ],
                 ),


### PR DESCRIPTION
# Pull Request

## Summary
Implement customizable classic and modern home row padding preferences, disable padding controls under fullscreen/overlay mode, protect library grids margin, and add Android TV focus fallbacks.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **HomeScreenCategoryScreen**:
  - Reordered settings to position **Home Row Info Overlay** above the padding tiles.
  - Configured padding slider tiles to be disabled (`enabled: !infoOverlayOn`) when overlay mode is active (since overlay forces one row per screen).
  - Extended Modern Rows padding slider range to **`360-560`** with **`10` divisions** (`20px` steps) to support tighter spacing down to `360px`.
- **HomeScreen**:
  - Remapped Modern Row height logic to add the padding value as a direct offset relative to natural height, instead of a minimum-height clamp, allowing cards with large sizes to correctly scale spacing.
  - Clamped library/tiles row padding offset to `>= 0.0` to prevent grid rows (like "My Media") from shrinking below their natural dimensions and causing row overlaps.
  - Implemented an Android TV focus fallback: if focus leaves the home rows (e.g., when opening settings panel or selecting navbar icons), the layout defaults to treating row `0` ("My Media") as the focused baseline to keep it centered and visible rather than sliding off-screen or fading out.
- **MoonSync Settings Database (`settings_data.json`)**:
  - Added schema entries for `classicHomeRowsPadding` and `modernHomeRowsPadding`.
  - Re-grouped the panels for **Poster Size** and **Home Row Info Overlay** to `"Home Row Settings"` to align web UI categorization with the client's settings categories.
- **Localizations**:
  - Ran `flutter gen-l10n` to regenerate all 60+ language localization files with the new preferences.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested extensively on Android TV, Windows Desktop, and Android Mobile
- [ ] Not tested (explain why):

### Test Steps
1. Open Home Row Settings in the client app.
2. Toggle "Home Row Info Overlay" ON and verify padding settings are disabled.
3. Toggle it OFF and adjust padding settings between minimum (`360`) and maximum (`560`) for Modern Rows.
4. Verify on mobile that rows scale smoothly without card overlap or header clipping.
5. On Android TV, navigate to the top navbar or open settings panel, and verify the top row ("My Media") remains centered, fully visible, and scaled.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### New Setting
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_18-23-25" src="https://github.com/user-attachments/assets/ca908817-9071-450e-8482-ef99058066e4" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_18-23-39" src="https://github.com/user-attachments/assets/1fdc5010-9d94-4c94-b800-405b557d08f1" />

### Android TV
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_18-53-50" src="https://github.com/user-attachments/assets/eaef6e3f-3af7-4155-b4b8-d688cafcd559" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_19-31-25" src="https://github.com/user-attachments/assets/c0758840-6e1b-4dcb-96ee-d3dfc7dd8c43" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_19-31-50" src="https://github.com/user-attachments/assets/3a7bdc69-6a31-48ca-8916-91e53f2f2b46" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_19-32-17" src="https://github.com/user-attachments/assets/e620104e-468f-4d85-be73-af41057c77ce" />

### Windows Desktop
<img width="2560" height="1555" alt="2026-07-18_20-05-44_moonfin" src="https://github.com/user-attachments/assets/cc1bdce1-5708-4cfc-be13-2de2a6669afb" />
<img width="2560" height="1555" alt="2026-07-18_20-05-53_moonfin" src="https://github.com/user-attachments/assets/0ffd6f14-0ac5-4c88-a0ec-8f8dfd06721b" />
<img width="2560" height="1555" alt="2026-07-18_20-06-04_moonfin" src="https://github.com/user-attachments/assets/004f2246-86a4-4326-bf1c-7bc9fed450e1" />
<img width="2560" height="1555" alt="2026-07-18_20-06-22_moonfin" src="https://github.com/user-attachments/assets/c165d322-19f1-4e2b-860b-fe7413fc50e0" />
<img width="2560" height="1555" alt="2026-07-18_20-13-10_moonfin" src="https://github.com/user-attachments/assets/4b58c290-c17f-4ecf-ad90-e30ff4b595e7" />
<img width="2560" height="1555" alt="2026-07-18_20-13-25_moonfin" src="https://github.com/user-attachments/assets/7a21ac07-4d8f-402c-8581-f3154f1656a0" />
<img width="2560" height="1555" alt="2026-07-18_20-13-29_moonfin" src="https://github.com/user-attachments/assets/c5b174b8-d7eb-46a5-ab29-97844db4acd0" />

### Mobile
<img width="1280" height="2856" alt="Screenshot_20260718-204021" src="https://github.com/user-attachments/assets/03229919-b41a-437d-8071-b88ebf6b14f7" />
<img width="1280" height="2856" alt="Screenshot_20260718-204035" src="https://github.com/user-attachments/assets/301a7938-bf29-4ac8-9f05-1bbc8e02de78" />
<img width="1280" height="2856" alt="Screenshot_20260718-204102" src="https://github.com/user-attachments/assets/763eaf98-561b-4982-b356-8184cb8325c8" />
<img width="1280" height="2856" alt="Screenshot_20260718-204112" src="https://github.com/user-attachments/assets/71c50f60-97a1-462b-9976-7480442fb247" />

### Matt's Gift to Himself
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_20-30-13" src="https://github.com/user-attachments/assets/c2b658cb-2e3d-444e-b63d-6c97a14c4bcd" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_20-30-38" src="https://github.com/user-attachments/assets/46f7120f-a9d8-4e55-9511-ec50fccae794" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_20-32-44" src="https://github.com/user-attachments/assets/aa237dac-506e-48c6-b6c8-529160e2a226" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_20-45-55" src="https://github.com/user-attachments/assets/6b7d5d02-a47a-42d8-ba4c-b1cdba4d3e25" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
