### PR TITLE
bugfix-ui - Prioritize banner and backdrop fallback images for library banner views

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,6 +10,8 @@ PODS:
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 6.0.3)
+  - gamepads_ios (0.1.1):
+    - Flutter
   - google-cast-sdk-no-bluetooth-xcframework (4.8.0):
     - Protobuf (~> 3.13)
   - LzmaSDK-ObjC (2.1.1)
@@ -30,6 +32,7 @@ DEPENDENCIES:
   - archive_extract (from `.symlinks/plugins/archive_extract/ios`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
+  - gamepads_ios (from `.symlinks/plugins/gamepads_ios/ios`)
   - google-cast-sdk-no-bluetooth-xcframework (~> 4.8.0)
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
@@ -50,6 +53,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_inappwebview_ios:
     :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
+  gamepads_ios:
+    :path: ".symlinks/plugins/gamepads_ios/ios"
   media_kit_libs_ios_video:
     :path: ".symlinks/plugins/media_kit_libs_ios_video/ios"
   media_kit_video:
@@ -61,6 +66,7 @@ SPEC CHECKSUMS:
   archive_extract: acd7ac4b098e5adc7af644e1d70e6df4ff6f9a28
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  gamepads_ios: c75c6d31377d275b0effb9174c619e2705678c09
   google-cast-sdk-no-bluetooth-xcframework: 1783f52a1b2dc0293ac3ae995db5435989a87da7
   LzmaSDK-ObjC: 6c68c37743a658fc9a4c7b70f7d6045b587aa42b
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854

--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -60,6 +60,9 @@ class AggregatedItem {
   String? get thumbImageTag =>
       (rawData['ImageTags'] as Map?)?['Thumb'] as String?;
 
+  String? get bannerImageTag =>
+      (rawData['ImageTags'] as Map?)?['Banner'] as String?;
+
   String? get primaryImageTagField => rawData['PrimaryImageTag'] as String?;
 
   String? get primaryImageItemId => rawData['PrimaryImageItemId']?.toString();

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -52,7 +52,7 @@ class MultiServerRepository {
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
       'ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio';
   // Cap image tags to one per type (server returns all by default)
-  static const _imageTypes = 'Primary,Backdrop,Thumb';
+  static const _imageTypes = 'Primary,Backdrop,Thumb,Banner';
   static const _imageTypeLimit = 1;
   static const _defaultLimit = 15;
   static const _maxItems = 100;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -68,7 +68,7 @@ class RowDataSource {
   }
 
   // Cap image tags to one per type (server returns all by default)
-  static const _imageTypes = 'Primary,Backdrop,Thumb';
+  static const _imageTypes = 'Primary,Backdrop,Thumb,Banner';
   static const _imageTypeLimit = 1;
 
   // ParentIds that returned 401/403 (no library access) this session. They are

--- a/lib/data/viewmodels/folder_browse_view_model.dart
+++ b/lib/data/viewmodels/folder_browse_view_model.dart
@@ -23,7 +23,7 @@ class FolderBrowseViewModel extends ChangeNotifier {
   static const _fields =
       'Type,ProductionYear,ImageTags,BackdropImageTags,ChildCount,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag';
   // Cap image tags to one per type (server returns all by default)
-  static const _imageTypes = 'Primary,Backdrop,Thumb';
+  static const _imageTypes = 'Primary,Backdrop,Thumb,Banner';
   static const _imageTypeLimit = 1;
 
   FolderBrowseViewModel(this._client, {String? serverId})

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -35,7 +35,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   static const _browseFields =
       'PrimaryImageAspectRatio,SortName,Type,IsFolder,UserData,CommunityRating,OfficialRating,RunTimeTicks,ProductionYear,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag';
   // Cap image tags to one per type (server returns all by default)
-  static const _imageTypes = 'Primary,Backdrop,Thumb';
+  static const _imageTypes = 'Primary,Backdrop,Thumb,Banner';
   static const _imageTypeLimit = 1;
 
   LibraryBrowseState _state = LibraryBrowseState.loading;

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -253,6 +253,15 @@ enum MediaSegmentCountdown {
   none,
 }
 
+/// Banner artwork is authored at 1000x185. Card geometry and image requests
+/// both use this so the artwork that comes back matches what gets drawn.
+const double kBannerAspectRatio = 1000 / 185;
+
+/// Card height for banner mode. Banner mode hides the poster size control, so
+/// it reads this instead of PosterSize.landscapeHeight, which would otherwise
+/// keep resizing banners with no way to change them.
+const double kBannerCardHeight = 110;
+
 enum ImageType {
   poster,
   thumb,

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -260,7 +260,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
     final posterSize = _posterSize;
     final baseWidth = switch (_imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
+      ImageType.banner => kBannerCardHeight * kBannerAspectRatio,
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * _desktopUiScaleFactor();
@@ -269,7 +269,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   double _cardAspectRatio() {
     return switch (_imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => 2 / 3,
     };
   }

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -260,7 +260,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
     final posterSize = _posterSize;
     final baseWidth = switch (_imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (16 / 9),
+      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * _desktopUiScaleFactor();
@@ -269,7 +269,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   double _cardAspectRatio() {
     return switch (_imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => 2 / 3,
     };
   }
@@ -402,7 +402,9 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
         final desktopScale = _desktopUiScaleFactor();
         final hPad = isMobile ? 16.0 : _horizontalPadding * desktopScale;
         final spacing = 16.0 * desktopScale;
-        final minColumns = isMobile ? 1 : 2;
+        final minColumns = _imageType == ImageType.banner
+            ? (constraints.maxWidth < 600 ? 1 : 2)
+            : (isMobile ? 1 : 2);
         final maxColumns = isMobile ? 4 : 8;
         final crossAxisCount =
             ((constraints.maxWidth - hPad * 2 + spacing) /

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -155,7 +155,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
     final posterSize = _vm.posterSize;
     final baseWidth = switch (_vm.imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (16 / 9),
+      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -164,7 +164,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
   double _gridBaseAspectRatio() {
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => 2 / 3,
     };
   }
@@ -179,7 +179,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
         'Person' => 1.0,
         _ => 16 / 9,
       },
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -480,9 +480,12 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
       builder: (context, constraints) {
         const spacing = 12.0;
         final available = constraints.maxWidth - horizontalPadding * 2;
+        final minClamp = _vm.imageType == ImageType.banner
+            ? (constraints.maxWidth < 600 ? 1 : 2)
+            : 2;
         final columns = ((available + spacing) / (cardWidth + spacing))
             .floor()
-            .clamp(2, 20);
+            .clamp(minClamp, 20);
         final cellWidth = (available - (columns - 1) * spacing) / columns;
         final ar = _gridBaseAspectRatio();
         final hasSubtitles = items.any(
@@ -605,11 +608,14 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
       builder: (context, constraints) {
         final isMobile = _isCompact(context);
         final gridPadding = isMobile ? 16.0 : _horizontalPadding;
+        final minClamp = _vm.imageType == ImageType.banner
+            ? (constraints.maxWidth < 600 ? 1 : 2)
+            : 2;
         final crossAxisCount =
             ((constraints.maxWidth - gridPadding * 2 + spacing) /
                     (cardWidth + spacing))
                 .floor()
-                .clamp(2, 20);
+                .clamp(minClamp, 20);
 
         final cellWidth =
             (constraints.maxWidth -
@@ -1283,10 +1289,12 @@ class _DisplaySettingsDialogState extends State<_DisplaySettingsDialog> {
             Divider(color: dividerColor),
             _sectionHeader(AppLocalizations.of(context).imageType),
             for (final type in ImageType.values) _imageTypeRadioTile(vm, type),
-            Divider(color: dividerColor),
-            _sectionHeader(AppLocalizations.of(context).posterSize),
-            for (final size in PosterSize.values)
-              _posterSizeRadioTile(vm, size),
+            if (vm.imageType != ImageType.banner) ...[
+              Divider(color: dividerColor),
+              _sectionHeader(AppLocalizations.of(context).posterSize),
+              for (final size in PosterSize.values)
+                _posterSizeRadioTile(vm, size),
+            ],
           ],
         ),
       ),

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -155,7 +155,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
     final posterSize = _vm.posterSize;
     final baseWidth = switch (_vm.imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
+      ImageType.banner => kBannerCardHeight * kBannerAspectRatio,
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -164,7 +164,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
   double _gridBaseAspectRatio() {
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => 2 / 3,
     };
   }
@@ -179,7 +179,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
         'Person' => 1.0,
         _ => 16 / 9,
       },
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -310,6 +310,29 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
     int? maxHeight,
   }) {
     final api = _vm.imageApi;
+    if (_vm.imageType == ImageType.banner) {
+      // Same order library browse uses. The portrait primary comes last
+      // because a banner card crops it down to a sliver.
+      final bannerTag = item.bannerImageTag;
+      if (bannerTag != null) {
+        return api.getBannerImageUrl(
+          item.id,
+          maxWidth: maxWidth,
+          tag: bannerTag,
+        );
+      }
+      if (item.backdropImageTags.isNotEmpty) {
+        return api.getBackdropImageUrl(
+          item.id,
+          maxWidth: maxWidth,
+          tag: item.backdropImageTags.first,
+        );
+      }
+      final thumbTag = item.thumbImageTag;
+      if (thumbTag != null) {
+        return api.getThumbImageUrl(item.id, maxWidth: maxWidth, tag: thumbTag);
+      }
+    }
     if (_vm.imageType == ImageType.thumb && item.backdropImageTags.isNotEmpty) {
       return api.getBackdropImageUrl(item.id, maxWidth: maxWidth);
     }
@@ -551,6 +574,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
       ),
       width: double.infinity,
       aspectRatio: itemAspectRatio,
+      isBanner: _vm.imageType == ImageType.banner,
       focusColor: focusColor,
       focusNode: _usesDpad ? getGridItemFocusNode(index) : null,
       cardFocusExpansion: focusExpansion,
@@ -661,6 +685,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
                     ),
                     width: double.infinity,
                     aspectRatio: itemAspectRatio,
+                    isBanner: _vm.imageType == ImageType.banner,
                     focusColor: focusColor,
                     focusNode: getGridItemFocusNode(index),
                     cardFocusExpansion: focusExpansion,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -245,7 +245,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     final posterSize = _vm.posterSize;
     final baseWidth = switch (_vm.imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (16 / 9),
+      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -254,7 +254,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   double _selectedImageAspectRatio() {
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => 2 / 3,
     };
   }
@@ -265,11 +265,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (_vm.imageType != ImageType.poster &&
         _vm.items.isNotEmpty &&
         _vm.items.every(_vm.isNavigableFolder)) {
-      return 16 / 9;
+      return _vm.imageType == ImageType.banner ? 1000 / 185 : 16 / 9;
     }
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => 2 / 3,
     };
   }
@@ -278,7 +278,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (_vm.isMusicBrowse || _vm.isPlaylistBrowse) return 1.0;
     if (_vm.isFilterBrowse) return _selectedImageAspectRatio();
     if (_vm.isNavigableFolder(item) && _vm.imageType != ImageType.poster) {
-      return 16 / 9;
+      return _vm.imageType == ImageType.banner ? 1000 / 185 : 16 / 9;
     }
     return switch (_vm.imageType) {
       ImageType.thumb => switch (item.type) {
@@ -289,7 +289,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         'Person' => 1.0,
         _ => 16 / 9,
       },
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -348,6 +348,37 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         }
         return null;
       }
+      if (_vm.imageType == ImageType.banner) {
+        if (itemBannerTag != null) {
+          return api.getBannerImageUrl(
+            item.id,
+            maxWidth: landscapeMaxW,
+            tag: itemBannerTag,
+          );
+        }
+        if (item.backdropImageTags.isNotEmpty) {
+          return api.getBackdropImageUrl(
+            item.id,
+            maxWidth: landscapeMaxW,
+            tag: item.backdropImageTags.first,
+          );
+        }
+        if (itemThumbTag != null) {
+          return api.getThumbImageUrl(
+            item.id,
+            maxWidth: landscapeMaxW,
+            tag: itemThumbTag,
+          );
+        }
+        if (item.primaryImageTag != null) {
+          return api.getPrimaryImageUrl(
+            item.id,
+            maxWidth: posterMaxW,
+            tag: item.primaryImageTag,
+          );
+        }
+        return null;
+      }
       if (itemThumbTag != null) {
         return api.getThumbImageUrl(
           item.id,
@@ -400,18 +431,18 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           tag: itemBannerTag,
         );
       }
-      if (item.primaryImageTag != null) {
-        return api.getPrimaryImageUrl(
-          item.id,
-          maxWidth: posterMaxW,
-          tag: item.primaryImageTag,
-        );
-      }
       if (item.backdropImageTags.isNotEmpty) {
         return api.getBackdropImageUrl(
           item.id,
           maxWidth: landscapeMaxW,
           tag: item.backdropImageTags.first,
+        );
+      }
+      if (item.primaryImageTag != null) {
+        return api.getPrimaryImageUrl(
+          item.id,
+          maxWidth: posterMaxW,
+          tag: item.primaryImageTag,
         );
       }
       return null;
@@ -670,11 +701,14 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       builder: (context, constraints) {
         final isMobile = _isCompact(context);
         final gridPadding = isMobile ? 16.0 : _horizontalPadding;
+        final minClamp = _vm.imageType == ImageType.banner
+            ? (constraints.maxWidth < 600 ? 1 : 2)
+            : 2;
         final crossAxisCount =
             ((constraints.maxWidth - gridPadding * 2 + spacing) /
                     (cardWidth + spacing))
                 .floor()
-                .clamp(2, 20);
+                .clamp(minClamp, 20);
 
         final cellWidth =
             (constraints.maxWidth -
@@ -1811,19 +1845,21 @@ class _SettingsDialogState extends State<_SettingsDialog> {
               for (final type in ImageType.values) _settingsRadioTile(vm, type),
               Divider(color: dividerColor),
             ],
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
-              child: Text(
-                l10n.posterSize,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w500,
-                  color: sectionColor,
+            if (vm.imageType != ImageType.banner) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+                child: Text(
+                  l10n.posterSize,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: sectionColor,
+                  ),
                 ),
               ),
-            ),
-            for (final size in PosterSize.values)
-              _posterSizeRadioTile(vm, size),
+              for (final size in PosterSize.values)
+                _posterSizeRadioTile(vm, size),
+            ],
           ],
         ),
       ),

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -245,7 +245,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     final posterSize = _vm.posterSize;
     final baseWidth = switch (_vm.imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
+      ImageType.banner => kBannerCardHeight * kBannerAspectRatio,
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -254,7 +254,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   double _selectedImageAspectRatio() {
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => 2 / 3,
     };
   }
@@ -265,11 +265,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (_vm.imageType != ImageType.poster &&
         _vm.items.isNotEmpty &&
         _vm.items.every(_vm.isNavigableFolder)) {
-      return _vm.imageType == ImageType.banner ? 1000 / 185 : 16 / 9;
+      return _vm.imageType == ImageType.banner ? kBannerAspectRatio : 16 / 9;
     }
     return switch (_vm.imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => 2 / 3,
     };
   }
@@ -278,7 +278,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (_vm.isMusicBrowse || _vm.isPlaylistBrowse) return 1.0;
     if (_vm.isFilterBrowse) return _selectedImageAspectRatio();
     if (_vm.isNavigableFolder(item) && _vm.imageType != ImageType.poster) {
-      return _vm.imageType == ImageType.banner ? 1000 / 185 : 16 / 9;
+      return _vm.imageType == ImageType.banner ? kBannerAspectRatio : 16 / 9;
     }
     return switch (_vm.imageType) {
       ImageType.thumb => switch (item.type) {
@@ -289,7 +289,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         'Person' => 1.0,
         _ => 16 / 9,
       },
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -436,6 +436,22 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           item.id,
           maxWidth: landscapeMaxW,
           tag: item.backdropImageTags.first,
+        );
+      }
+      // A landscape thumb beats the portrait primary here, since cropping a
+      // poster down to banner shape loses far more of the image.
+      if (itemThumbTag != null) {
+        return api.getThumbImageUrl(
+          item.id,
+          maxWidth: landscapeMaxW,
+          tag: itemThumbTag,
+        );
+      }
+      if (parentThumbItemId != null && parentThumbTag != null) {
+        return api.getThumbImageUrl(
+          parentThumbItemId,
+          maxWidth: landscapeMaxW,
+          tag: parentThumbTag,
         );
       }
       if (item.primaryImageTag != null) {
@@ -748,6 +764,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     imageUrl: _imageUrl(item),
                     width: double.infinity,
                     aspectRatio: itemAspectRatio,
+                    isBanner: _vm.imageType == ImageType.banner,
                     focusColor: focusColor,
                     focusNode: getGridItemFocusNode(index),
                     cardFocusExpansion: _prefs.get(

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -297,7 +297,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
     final posterSize = _posterSize;
     final baseWidth = switch (_imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
+      ImageType.banner => kBannerCardHeight * kBannerAspectRatio,
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -310,7 +310,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
     return switch (_imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => 2 / 3,
     };
   }

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -297,7 +297,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
     final posterSize = _posterSize;
     final baseWidth = switch (_imageType) {
       ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
-      ImageType.banner => posterSize.landscapeHeight * (16 / 9),
+      ImageType.banner => posterSize.landscapeHeight * (1000 / 185),
       ImageType.poster => posterSize.portraitHeight * (2 / 3),
     };
     return baseWidth * desktopScale;
@@ -310,7 +310,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
     return switch (_imageType) {
       ImageType.thumb => 16 / 9,
-      ImageType.banner => 16 / 9,
+      ImageType.banner => 1000 / 185,
       ImageType.poster => 2 / 3,
     };
   }
@@ -400,7 +400,9 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
             ? _mobileHorizontalPadding
             : _horizontalPadding * desktopScale;
         final spacing = 16.0 * desktopScale;
-        final minColumns = isMobile ? 1 : 2;
+        final minColumns = _imageType == ImageType.banner
+            ? (constraints.maxWidth < 600 ? 1 : 2)
+            : (isMobile ? 1 : 2);
         final maxColumns = isMobile ? 4 : 8;
         final crossAxisCount =
             ((constraints.maxWidth - horizontalPadding * 2 + spacing) /

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5198,7 +5198,8 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
     return switch (imageType) {
-      ImageType.thumb || ImageType.banner => thumbAspectRatio(),
+      ImageType.thumb => thumbAspectRatio(),
+      ImageType.banner => 1000 / 185,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -5253,6 +5254,20 @@ class _ContentRowsState extends State<_ContentRows>
 
     if (imageType == ImageType.banner) {
       final maxW = (height * 16 / 9 * requestScale).toInt();
+      if (itemBannerTag != null) {
+        return imageApi.getBannerImageUrl(
+          item.id,
+          maxWidth: maxW,
+          tag: itemBannerTag,
+        );
+      }
+      if (item.backdropImageTags.isNotEmpty) {
+        return imageApi.getBackdropImageUrl(
+          item.id,
+          maxWidth: maxW,
+          tag: item.backdropImageTags.first,
+        );
+      }
       if (isMyMediaRow) {
         final myMediaPrimary = _resolvePrimaryImageUrl(
           item,
@@ -5263,25 +5278,11 @@ class _ContentRowsState extends State<_ContentRows>
           return myMediaPrimary;
         }
       }
-      if (itemBannerTag != null) {
-        return imageApi.getBannerImageUrl(
-          item.id,
-          maxWidth: maxW,
-          tag: itemBannerTag,
-        );
-      }
       if (itemThumbTag != null) {
         return imageApi.getThumbImageUrl(
           item.id,
           maxWidth: maxW,
           tag: itemThumbTag,
-        );
-      }
-      if (item.backdropImageTags.isNotEmpty) {
-        return imageApi.getBackdropImageUrl(
-          item.id,
-          maxWidth: maxW,
-          tag: item.backdropImageTags.first,
         );
       }
       return _resolveImageUrl(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4443,6 +4443,10 @@ class _ContentRowsState extends State<_ContentRows>
                     imageUrl: imageUrl,
                     width: width,
                     aspectRatio: ar,
+                    // Safe to compare doubles here, since ar is assigned
+                    // this same constant and audio and Seerr filter rows
+                    // already get a different ratio.
+                    isBanner: ar == kBannerAspectRatio,
                     isFavorite: item.isFavorite,
                     isPlayed: item.isPlayed,
                     unplayedCount: item.unplayedItemCount,
@@ -5199,7 +5203,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     return switch (imageType) {
       ImageType.thumb => thumbAspectRatio(),
-      ImageType.banner => 1000 / 185,
+      ImageType.banner => kBannerAspectRatio,
       ImageType.poster => MediaCard.aspectRatioForType(item.type),
     };
   }
@@ -5253,7 +5257,9 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
     if (imageType == ImageType.banner) {
-      final maxW = (height * 16 / 9 * requestScale).toInt();
+      // Ask for the banner ratio. At 16/9 the artwork comes back about three
+      // times too narrow for the card and has to be upscaled.
+      final maxW = (height * kBannerAspectRatio * requestScale).toInt();
       if (itemBannerTag != null) {
         return imageApi.getBannerImageUrl(
           item.id,
@@ -5376,7 +5382,13 @@ class _ContentRowsState extends State<_ContentRows>
     ImageType imageType,
     double requestScale,
   ) {
-    final maxW = (height * 16 / 9 * requestScale).toInt();
+    // The banner branch below shares this width, so it has to account for the
+    // banner ratio or that artwork comes back too narrow.
+    final maxW =
+        (height *
+                (imageType == ImageType.banner ? kBannerAspectRatio : 16 / 9) *
+                requestScale)
+            .toInt();
     final maxH = (height * requestScale).toInt();
     final seriesId = item.seriesId;
     final seriesPrimaryTag = item.seriesPrimaryImageTag;

--- a/lib/ui/widgets/marquee_text.dart
+++ b/lib/ui/widgets/marquee_text.dart
@@ -3,6 +3,13 @@ import 'package:flutter/material.dart';
 class MarqueeText extends StatefulWidget {
   final String text;
   final TextStyle style;
+
+  /// Optional rich content rendered in place of [text], so one scrolling line
+  /// can mix styles, such as a bold title followed by a dimmer subtitle.
+  /// [style] still applies as the root, and [text] stays as the plain text
+  /// equivalent used to spot content changes.
+  final List<InlineSpan>? spans;
+
   final int minDurationMs;
   final int maxDurationMs;
   final double millisPerPixel;
@@ -13,6 +20,7 @@ class MarqueeText extends StatefulWidget {
     super.key,
     required this.text,
     required this.style,
+    this.spans,
     this.minDurationMs = 2200,
     this.maxDurationMs = 12000,
     this.millisPerPixel = 50,
@@ -29,7 +37,11 @@ class _MarqueeTextState extends State<MarqueeText>
   late final ScrollController _controller;
   late final AnimationController _anim;
   double _lastTextWidth = 0.0;
-  double _lastParentWidth = 0.0;
+
+  /// What gets painted and measured, the spans when given, otherwise [text].
+  TextSpan get _span => widget.spans != null
+      ? TextSpan(style: widget.style, children: widget.spans)
+      : TextSpan(text: widget.text, style: widget.style);
 
   @override
   void initState() {
@@ -80,7 +92,6 @@ class _MarqueeTextState extends State<MarqueeText>
     if (!mounted) return;
 
     _lastTextWidth = textWidth;
-    _lastParentWidth = parentWidth;
 
     final overflows = textWidth > parentWidth;
     if (!overflows) {
@@ -112,8 +123,9 @@ class _MarqueeTextState extends State<MarqueeText>
 
   @override
   Widget build(BuildContext context) {
+    final span = _span;
     final textPainter = TextPainter(
-      text: TextSpan(text: widget.text, style: widget.style),
+      text: span,
       textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
       maxLines: 1,
       textScaler: MediaQuery.textScalerOf(context),
@@ -131,12 +143,7 @@ class _MarqueeTextState extends State<MarqueeText>
         final overflows = textWidth > parentWidth;
 
         if (!overflows) {
-          return Text(
-            widget.text,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: widget.style,
-          );
+          return Text.rich(span, maxLines: 1, overflow: TextOverflow.ellipsis);
         }
 
         return SingleChildScrollView(
@@ -145,9 +152,9 @@ class _MarqueeTextState extends State<MarqueeText>
           physics: const NeverScrollableScrollPhysics(),
           child: Row(
             children: [
-              Text(widget.text, maxLines: 1, style: widget.style),
+              Text.rich(span, maxLines: 1),
               SizedBox(width: widget.gap),
-              Text(widget.text, maxLines: 1, style: widget.style),
+              Text.rich(span, maxLines: 1),
             ],
           ),
         );

--- a/lib/ui/widgets/marquee_text.dart
+++ b/lib/ui/widgets/marquee_text.dart
@@ -116,6 +116,7 @@ class _MarqueeTextState extends State<MarqueeText>
       text: TextSpan(text: widget.text, style: widget.style),
       textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
       maxLines: 1,
+      textScaler: MediaQuery.textScalerOf(context),
     )..layout();
     final textWidth = textPainter.width;
 

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -48,6 +48,11 @@ class MediaCard extends StatefulWidget {
   final Color? subtitleColor;
   final bool isGenreFallback;
 
+  /// Puts the title and subtitle on one line, which is what the very wide
+  /// banner artwork has room for. The caller sets this rather than having the
+  /// card guess from [aspectRatio].
+  final bool isBanner;
+
   /// Extra widgets layered over the poster image (inside its clip), e.g.
   /// format badges. Position each with [Positioned].
   final List<Widget> imageOverlays;
@@ -93,6 +98,7 @@ class MediaCard extends StatefulWidget {
     this.imageOverlays = const [],
     this.overlayOccupiesTopLeft = false,
     this.isGenreFallback = false,
+    this.isBanner = false,
   });
 
   static IconData iconForType(String? type) {
@@ -199,6 +205,45 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
     }
   }
 
+  /// Title and subtitle on one line, which is the shape banner artwork wants.
+  /// A rich [MediaCard.subtitleWidget] can't be inlined here, so the caller
+  /// renders it below instead, the same precedence the taller cards use.
+  Widget _bannerLabel({
+    required TextStyle titleStyle,
+    required TextStyle subtitleStyle,
+    required bool showMarquee,
+  }) {
+    const separator = '  •  ';
+    final inlineSubtitle =
+        widget.subtitleWidget == null &&
+            widget.subtitle != null &&
+            widget.subtitle!.isNotEmpty
+        ? widget.subtitle
+        : null;
+    // Both branches share these spans so the subtitle keeps its own style
+    // once the card is focused and the text starts scrolling.
+    final spans = <InlineSpan>[
+      TextSpan(text: widget.title!),
+      if (inlineSubtitle != null) ...[
+        TextSpan(text: separator, style: subtitleStyle),
+        TextSpan(text: inlineSubtitle, style: subtitleStyle),
+      ],
+    ];
+    return showMarquee
+        ? MarqueeText(
+            text: inlineSubtitle != null
+                ? '${widget.title}$separator$inlineSubtitle'
+                : widget.title!,
+            style: titleStyle,
+            spans: spans,
+          )
+        : Text.rich(
+            TextSpan(style: titleStyle, children: spans),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
@@ -295,33 +340,22 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
                       overlayOccupiesTopLeft: widget.overlayOccupiesTopLeft,
                       isGenreFallback: widget.isGenreFallback,
                     ),
-                    if ((widget.aspectRatio - (1000 / 185)).abs() < 0.01) ...[
+                    if (widget.isBanner) ...[
                       if (widget.title != null) ...[
                         const SizedBox(height: 6),
                         SizedBox(
                           height: titleLineHeight,
                           width: cardWidth,
-                          child: () {
-                            final combinedText = widget.subtitle != null && widget.subtitle!.isNotEmpty
-                                ? '${widget.title}  •  ${widget.subtitle}'
-                                : widget.title!;
-                            return showMarquee
-                                ? MarqueeText(text: combinedText, style: titleStyle)
-                                : Text.rich(
-                                    TextSpan(
-                                      children: [
-                                        TextSpan(text: widget.title!, style: titleStyle),
-                                        if (widget.subtitle != null && widget.subtitle!.isNotEmpty) ...[
-                                          TextSpan(text: '  •  ', style: subtitleStyle),
-                                          TextSpan(text: widget.subtitle!, style: subtitleStyle),
-                                        ],
-                                      ],
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  );
-                          }(),
+                          child: _bannerLabel(
+                            titleStyle: titleStyle,
+                            subtitleStyle: subtitleStyle,
+                            showMarquee: showMarquee,
+                          ),
                         ),
+                      ],
+                      if (widget.subtitleWidget != null) ...[
+                        SizedBox(height: widget.title != null ? 2 : 6),
+                        widget.subtitleWidget!,
                       ],
                     ] else ...[
                       if (widget.title != null) ...[

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -164,9 +164,39 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
   final _selectKeyHandler = LongPressSelectKeyHandler();
 
   @override
+  void initState() {
+    super.initState();
+    _addFocusListener();
+  }
+
+  @override
+  void didUpdateWidget(covariant MediaCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      _removeFocusListener(oldWidget.focusNode);
+      _addFocusListener();
+    }
+  }
+
+  @override
   void dispose() {
+    _removeFocusListener(widget.focusNode);
     _selectKeyHandler.dispose();
     super.dispose();
+  }
+
+  void _addFocusListener() {
+    widget.focusNode?.addListener(_onFocusNodeChanged);
+  }
+
+  void _removeFocusListener(FocusNode? node) {
+    node?.removeListener(_onFocusNodeChanged);
+  }
+
+  void _onFocusNodeChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -234,66 +264,105 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
             curve: PlatformDetection.isAppleTV
                 ? Curves.easeOutCubic
                 : Curves.linear,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _CardImage(
-                  imageUrl: widget.imageUrl,
-                  title: widget.title,
-                  aspectRatio: widget.aspectRatio,
-                  isFavorite: widget.isFavorite,
-                  isPlayed: widget.isPlayed,
-                  unplayedCount: widget.unplayedCount,
-                  playedPercentage: widget.playedPercentage,
-                  watchedBehavior: widget.watchedBehavior,
-                  focused: effectiveFocused,
-                  hovered: hovered,
-                  focusColor: widget.focusColor,
-                  suppressFocusBorder: widget.suppressImageFocusBorder,
-                  suppressFocusGlow: widget.suppressFocusGlow,
-                  isCircular: widget.itemType == 'Person',
-                  itemType: widget.itemType,
-                  seerrMediaType: widget.seerrMediaType,
-                  seerrStatus: widget.seerrStatus,
-                  imageOverlays: widget.imageOverlays,
-                  overlayOccupiesTopLeft: widget.overlayOccupiesTopLeft,
-                  isGenreFallback: widget.isGenreFallback,
-                ),
-                if (widget.title != null) ...[
-                  const SizedBox(height: 6),
-                  SizedBox(
-                    height: titleLineHeight,
-                    child: showMarquee
-                        ? MarqueeText(text: widget.title!, style: titleStyle)
-                        : Text(
-                            widget.title!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: titleStyle,
-                          ),
-                  ),
-                ],
-                if (widget.subtitleWidget != null) ...[
-                  SizedBox(height: widget.title != null ? 2 : 6),
-                  widget.subtitleWidget!,
-                ] else if (widget.subtitle != null &&
-                    widget.subtitle!.isNotEmpty)
-                  SizedBox(
-                    height: subtitleLineHeight,
-                    child: showMarquee
-                        ? MarqueeText(
-                            text: widget.subtitle!,
-                            style: subtitleStyle,
-                          )
-                        : Text(
-                            widget.subtitle!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: subtitleStyle,
-                          ),
-                  ),
-              ],
+            child: LayoutBuilder(
+              builder: (context, cardConstraints) {
+                final cardWidth = cardConstraints.maxWidth.isFinite
+                    ? cardConstraints.maxWidth
+                    : (widget.width.isFinite ? widget.width : 150.0);
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _CardImage(
+                      imageUrl: widget.imageUrl,
+                      title: widget.title,
+                      aspectRatio: widget.aspectRatio,
+                      isFavorite: widget.isFavorite,
+                      isPlayed: widget.isPlayed,
+                      unplayedCount: widget.unplayedCount,
+                      playedPercentage: widget.playedPercentage,
+                      watchedBehavior: widget.watchedBehavior,
+                      focused: effectiveFocused,
+                      hovered: hovered,
+                      focusColor: widget.focusColor,
+                      suppressFocusBorder: widget.suppressImageFocusBorder,
+                      suppressFocusGlow: widget.suppressFocusGlow,
+                      isCircular: widget.itemType == 'Person',
+                      itemType: widget.itemType,
+                      seerrMediaType: widget.seerrMediaType,
+                      seerrStatus: widget.seerrStatus,
+                      imageOverlays: widget.imageOverlays,
+                      overlayOccupiesTopLeft: widget.overlayOccupiesTopLeft,
+                      isGenreFallback: widget.isGenreFallback,
+                    ),
+                    if ((widget.aspectRatio - (1000 / 185)).abs() < 0.01) ...[
+                      if (widget.title != null) ...[
+                        const SizedBox(height: 6),
+                        SizedBox(
+                          height: titleLineHeight,
+                          width: cardWidth,
+                          child: () {
+                            final combinedText = widget.subtitle != null && widget.subtitle!.isNotEmpty
+                                ? '${widget.title}  •  ${widget.subtitle}'
+                                : widget.title!;
+                            return showMarquee
+                                ? MarqueeText(text: combinedText, style: titleStyle)
+                                : Text.rich(
+                                    TextSpan(
+                                      children: [
+                                        TextSpan(text: widget.title!, style: titleStyle),
+                                        if (widget.subtitle != null && widget.subtitle!.isNotEmpty) ...[
+                                          TextSpan(text: '  •  ', style: subtitleStyle),
+                                          TextSpan(text: widget.subtitle!, style: subtitleStyle),
+                                        ],
+                                      ],
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  );
+                          }(),
+                        ),
+                      ],
+                    ] else ...[
+                      if (widget.title != null) ...[
+                        const SizedBox(height: 6),
+                        SizedBox(
+                          height: titleLineHeight,
+                          width: cardWidth,
+                          child: showMarquee
+                              ? MarqueeText(text: widget.title!, style: titleStyle)
+                              : Text(
+                                  widget.title!,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: titleStyle,
+                                ),
+                        ),
+                      ],
+                      if (widget.subtitleWidget != null) ...[
+                        SizedBox(height: widget.title != null ? 2 : 6),
+                        widget.subtitleWidget!,
+                      ] else if (widget.subtitle != null &&
+                          widget.subtitle!.isNotEmpty)
+                        SizedBox(
+                          height: subtitleLineHeight,
+                          width: cardWidth,
+                          child: showMarquee
+                              ? MarqueeText(
+                                  text: widget.subtitle!,
+                                  style: subtitleStyle,
+                                )
+                              : Text(
+                                  widget.subtitle!,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: subtitleStyle,
+                                ),
+                        ),
+                    ],
+                  ],
+                );
+              },
             ),
           ),
         ),

--- a/lib/ui/widgets/poster_size_settings_dialog.dart
+++ b/lib/ui/widgets/poster_size_settings_dialog.dart
@@ -80,19 +80,21 @@ class _PosterSizeSettingsDialogState extends State<PosterSizeSettingsDialog> {
                 _imageTypeTile(type, currentImageType == type),
               Divider(color: dividerColor),
             ],
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
-              child: Text(
-                l10n.posterSize,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w500,
-                  color: sectionColor,
+            if (currentImageType != ImageType.banner) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+                child: Text(
+                  l10n.posterSize,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: sectionColor,
+                  ),
                 ),
               ),
-            ),
-            for (final size in PosterSize.values)
-              _posterSizeTile(size, currentSize == size),
+              for (final size in PosterSize.values)
+                _posterSizeTile(size, currentSize == size),
+            ],
           ],
         ),
       ),

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
     - FlutterMacOS
     - OrderedSet (~> 6.0.3)
   - FlutterMacOS (1.0.0)
+  - gamepads_darwin (0.1.1):
+    - FlutterMacOS
   - LzmaSDK-ObjC (2.1.1)
   - media_kit_libs_macos_video (1.0.4):
     - FlutterMacOS
@@ -25,6 +27,7 @@ DEPENDENCIES:
   - archive_extract (from `Flutter/ephemeral/.symlinks/plugins/archive_extract/macos`)
   - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - gamepads_darwin (from `Flutter/ephemeral/.symlinks/plugins/gamepads_darwin/macos`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
   - rar (from `Flutter/ephemeral/.symlinks/plugins/rar/macos`)
@@ -43,6 +46,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  gamepads_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/gamepads_darwin/macos
   media_kit_libs_macos_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos
   media_kit_video:
@@ -56,6 +61,7 @@ SPEC CHECKSUMS:
   archive_extract: fa02419dff51d40b97c25de265b5db2357a4162d
   flutter_inappwebview_macos: c2d68649f9f8f1831bfcd98d73fd6256366d9d1d
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  gamepads_darwin: 643b6a69e20ca678fae83781b7f7fc8f15f5d710
   LzmaSDK-ObjC: 6c68c37743a658fc9a4c7b70f7d6045b587aa42b
   media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
   media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758


### PR DESCRIPTION
# Pull Request

## Summary
Prioritize banner and backdrop fallback images for library banner views. When "Banner" is selected as the view style, display banner images. If a banner is not set, use the backdrop image (which is also landscape) as a fallback before falling back to portrait/primary/thumb options.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #856 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

 **home_screen.dart**:
  - Prioritized `itemBannerTag` first and `item.backdropImageTags` second when `imageType == ImageType.banner`, checking them before falling back to `myMediaPrimary` or `itemThumbTag` for the library rows.
- **library_browse_screen.dart**:
  - Added an explicit `_vm.imageType == ImageType.banner` block for navigable folders to resolve banner tags first, then backdrop tags, then thumbs/primary images, instead of falling back straight to thumb first.
  - Updated standard list items resolving to prioritize `item.backdropImageTags` over `item.primaryImageTag` when the banner view style is selected.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Select the **Banner** view option on a library view or folder grid.
2. Verify that items with banner tags render banner images.
3. Verify that items without banner tags render their backdrop images as the landscape fallback.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_21-54-25" src="https://github.com/user-attachments/assets/7cc5560a-11dc-4944-a11f-cba6ade777fd" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_21-54-53" src="https://github.com/user-attachments/assets/a4ecdb4d-e983-48f2-a3d4-c5bd6f400281" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
