### PR TITLE
enable external list rows when set in moonbase default row config

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1077,6 +1077,7 @@ class PluginSyncService extends ChangeNotifier {
               case prefs.HomeSectionType.tmdbTrendingAllWeekly: _prefs.set(UserPreferences.tmdbTrendingAllWeeklyEnabled, c.enabled);
               case prefs.HomeSectionType.radarrCalendar: _prefs.set(UserPreferences.enableRadarrCalendar, c.enabled);
               case prefs.HomeSectionType.sonarrCalendar: _prefs.set(UserPreferences.enableSonarrCalendar, c.enabled);
+              case prefs.HomeSectionType.rewatch: _prefs.set(UserPreferences.displayRewatchRow, c.enabled);
               default:
             }
 

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1055,32 +1055,12 @@ class PluginSyncService extends ChangeNotifier {
           var order = 0;
           for (final c in parsed) {
             sections.add(c.copyWith(order: order++));
-            switch (c.type) {
-              case prefs.HomeSectionType.imdbTop250Movies: _prefs.set(UserPreferences.imdbTop250MoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.imdbTop250TvShows: _prefs.set(UserPreferences.imdbTop250TvShowsEnabled, c.enabled);
-              case prefs.HomeSectionType.imdbMostPopularMovies: _prefs.set(UserPreferences.imdbMostPopularMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.imdbMostPopularTvShows: _prefs.set(UserPreferences.imdbMostPopularTvShowsEnabled, c.enabled);
-              case prefs.HomeSectionType.imdbLowestRatedMovies: _prefs.set(UserPreferences.imdbLowestRatedMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.imdbTopEnglishMovies: _prefs.set(UserPreferences.imdbTopEnglishMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbPopularMovies: _prefs.set(UserPreferences.tmdbPopularMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTopRatedMovies: _prefs.set(UserPreferences.tmdbTopRatedMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbNowPlayingMovies: _prefs.set(UserPreferences.tmdbNowPlayingMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbUpcomingMovies: _prefs.set(UserPreferences.tmdbUpcomingMoviesEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbPopularTv: _prefs.set(UserPreferences.tmdbPopularTvEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTopRatedTv: _prefs.set(UserPreferences.tmdbTopRatedTvEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbAiringTodayTv: _prefs.set(UserPreferences.tmdbAiringTodayTvEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbOnTheAirTv: _prefs.set(UserPreferences.tmdbOnTheAirTvEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTrendingMovieDaily: _prefs.set(UserPreferences.tmdbTrendingMovieDailyEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTrendingMovieWeekly: _prefs.set(UserPreferences.tmdbTrendingMovieWeeklyEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTrendingTvDaily: _prefs.set(UserPreferences.tmdbTrendingTvDailyEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTrendingTvWeekly: _prefs.set(UserPreferences.tmdbTrendingTvWeeklyEnabled, c.enabled);
-              case prefs.HomeSectionType.tmdbTrendingAllWeekly: _prefs.set(UserPreferences.tmdbTrendingAllWeeklyEnabled, c.enabled);
-              case prefs.HomeSectionType.radarrCalendar: _prefs.set(UserPreferences.enableRadarrCalendar, c.enabled);
-              case prefs.HomeSectionType.sonarrCalendar: _prefs.set(UserPreferences.enableSonarrCalendar, c.enabled);
-              case prefs.HomeSectionType.rewatch: _prefs.set(UserPreferences.displayRewatchRow, c.enabled);
-              default:
+            // External list and calendar rows are also gated by their own toggle, so
+            // flip it to match the layout moonbase pushed or the row stays hidden.
+            final toggle = _rowEnabledPreference(c.type);
+            if (toggle != null) {
+              _prefs.set(toggle, c.enabled);
             }
-
           }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);
@@ -1651,6 +1631,30 @@ class PluginSyncService extends ChangeNotifier {
       default:
         throw ArgumentError('Not a TMDB section type: $type');
     }
+  }
+
+  Preference<bool>? _rowEnabledPreference(prefs.HomeSectionType type) {
+    if (_isTmdbSectionType(type)) return _tmdbPrefForType(type);
+    return switch (type) {
+      prefs.HomeSectionType.imdbTop250Movies =>
+        UserPreferences.imdbTop250MoviesEnabled,
+      prefs.HomeSectionType.imdbTop250TvShows =>
+        UserPreferences.imdbTop250TvShowsEnabled,
+      prefs.HomeSectionType.imdbMostPopularMovies =>
+        UserPreferences.imdbMostPopularMoviesEnabled,
+      prefs.HomeSectionType.imdbMostPopularTvShows =>
+        UserPreferences.imdbMostPopularTvShowsEnabled,
+      prefs.HomeSectionType.imdbLowestRatedMovies =>
+        UserPreferences.imdbLowestRatedMoviesEnabled,
+      prefs.HomeSectionType.imdbTopEnglishMovies =>
+        UserPreferences.imdbTopEnglishMoviesEnabled,
+      prefs.HomeSectionType.radarrCalendar =>
+        UserPreferences.enableRadarrCalendar,
+      prefs.HomeSectionType.sonarrCalendar =>
+        UserPreferences.enableSonarrCalendar,
+      prefs.HomeSectionType.rewatch => UserPreferences.displayRewatchRow,
+      _ => null,
+    };
   }
 
   @override

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1055,6 +1055,31 @@ class PluginSyncService extends ChangeNotifier {
           var order = 0;
           for (final c in parsed) {
             sections.add(c.copyWith(order: order++));
+            switch (c.type) {
+              case prefs.HomeSectionType.imdbTop250Movies: _prefs.set(UserPreferences.imdbTop250MoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.imdbTop250TvShows: _prefs.set(UserPreferences.imdbTop250TvShowsEnabled, c.enabled);
+              case prefs.HomeSectionType.imdbMostPopularMovies: _prefs.set(UserPreferences.imdbMostPopularMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.imdbMostPopularTvShows: _prefs.set(UserPreferences.imdbMostPopularTvShowsEnabled, c.enabled);
+              case prefs.HomeSectionType.imdbLowestRatedMovies: _prefs.set(UserPreferences.imdbLowestRatedMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.imdbTopEnglishMovies: _prefs.set(UserPreferences.imdbTopEnglishMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbPopularMovies: _prefs.set(UserPreferences.tmdbPopularMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTopRatedMovies: _prefs.set(UserPreferences.tmdbTopRatedMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbNowPlayingMovies: _prefs.set(UserPreferences.tmdbNowPlayingMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbUpcomingMovies: _prefs.set(UserPreferences.tmdbUpcomingMoviesEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbPopularTv: _prefs.set(UserPreferences.tmdbPopularTvEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTopRatedTv: _prefs.set(UserPreferences.tmdbTopRatedTvEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbAiringTodayTv: _prefs.set(UserPreferences.tmdbAiringTodayTvEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbOnTheAirTv: _prefs.set(UserPreferences.tmdbOnTheAirTvEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTrendingMovieDaily: _prefs.set(UserPreferences.tmdbTrendingMovieDailyEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTrendingMovieWeekly: _prefs.set(UserPreferences.tmdbTrendingMovieWeeklyEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTrendingTvDaily: _prefs.set(UserPreferences.tmdbTrendingTvDailyEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTrendingTvWeekly: _prefs.set(UserPreferences.tmdbTrendingTvWeeklyEnabled, c.enabled);
+              case prefs.HomeSectionType.tmdbTrendingAllWeekly: _prefs.set(UserPreferences.tmdbTrendingAllWeeklyEnabled, c.enabled);
+              case prefs.HomeSectionType.radarrCalendar: _prefs.set(UserPreferences.enableRadarrCalendar, c.enabled);
+              case prefs.HomeSectionType.sonarrCalendar: _prefs.set(UserPreferences.enableSonarrCalendar, c.enabled);
+              default:
+            }
+
           }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);


### PR DESCRIPTION
# Pull Request

## Summary
If a external list (or sonarr/radarr) home row is pushed from moonbase default home row config, flip the toggles locally so the rows actually show up

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #822 #830
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- when loading moonbase home rows, flip toggles based on row enabled status from moonbase
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enabled row in moonbase - pushed
2. See toggle flipped on phone, row appears
3. Disable row in moonbase - pushed
4. See toggle flipped on phone, row is gone

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
