### PR TITLE
bugfix-playback - Make sure preferred tracks are respected when starting playback

### DIFF
--- a/lib/playback/appletv_mpv_backend.dart
+++ b/lib/playback/appletv_mpv_backend.dart
@@ -243,10 +243,12 @@ class AppleTvMpvBackend implements PlayerBackend {
       'dolbyVisionFallbackBehavior':
           _prefs.get(UserPreferences.dolbyVisionFallbackBehavior).name,
       'preferredAudioLanguage': _normalizeTrackLanguagePref(
-        _prefs.get(UserPreferences.defaultAudioLanguage),
+        payload['preferredAudioLanguage']?.toString() ??
+            _prefs.get(UserPreferences.defaultAudioLanguage),
       ),
       'preferredTextLanguage': _normalizeTrackLanguagePref(
-        _prefs.get(UserPreferences.defaultSubtitleLanguage),
+        payload['preferredTextLanguage']?.toString() ??
+            _prefs.get(UserPreferences.defaultSubtitleLanguage),
       ),
       'speed': _playbackSpeed,
       'volume': _volume,

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -521,10 +521,12 @@ class Media3PlayerBackend extends PlayerBackend {
     _skipSilenceEnabled = _prefs.get(UserPreferences.media3SkipSilence);
     _volumeBoostLevel = 0;
     final preferredAudioLanguage = _normalizeTrackLanguagePref(
-      _prefs.get(UserPreferences.defaultAudioLanguage),
+      payload['preferredAudioLanguage']?.toString() ??
+          _prefs.get(UserPreferences.defaultAudioLanguage),
     );
     final preferredSubtitleLanguage = _normalizeTrackLanguagePref(
-      _prefs.get(UserPreferences.defaultSubtitleLanguage),
+      payload['preferredTextLanguage']?.toString() ??
+          _prefs.get(UserPreferences.defaultSubtitleLanguage),
     );
     final tunnelingDisabledByUser = _prefs.get(
       UserPreferences.media3TunnelingDisabled,

--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -3,7 +3,12 @@ import '../preference/preference_constants.dart';
 import 'language_matching.dart';
 
 bool isExternalSubtitleStream(Map<String, dynamic> stream) {
-  return stream['IsExternal'] == true;
+  if (stream['IsExternal'] == true) {
+    return true;
+  }
+  final deliveryMethod =
+      (stream['DeliveryMethod'] as String?)?.trim().toLowerCase();
+  return deliveryMethod == 'external';
 }
 
 bool isSdhSubtitleStream(Map<String, dynamic> stream) {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -272,24 +272,26 @@ class PlaybackManager implements AudioOwnable {
   }) {
     final resolvedMediaType = mediaType?.trim().toLowerCase();
 
-    final audio = mediaStreams.where((s) => s['Type'] == 'Audio').toList();
     final Map<String, dynamic>? audioStream;
     if (audioStreamIndex != null) {
-      audioStream = audio.firstWhere(
-        (s) => s['Index'] == audioStreamIndex,
-        orElse: () => _defaultAudioStream(mediaStreams) ?? const <String, dynamic>{},
+      final match = mediaStreams.firstWhere(
+        (s) => s['Type'] == 'Audio' && s['Index'] == audioStreamIndex,
+        orElse: () => const <String, dynamic>{},
       );
+      audioStream = match.isNotEmpty
+          ? match
+          : _defaultAudioStream(mediaStreams);
     } else {
       audioStream = _defaultAudioStream(mediaStreams);
     }
 
-    final subtitle = mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
     final Map<String, dynamic>? subtitleStream;
     if (subtitleStreamIndex != null && subtitleStreamIndex != -1) {
-      subtitleStream = subtitle.firstWhere(
-        (s) => s['Index'] == subtitleStreamIndex,
+      final match = mediaStreams.firstWhere(
+        (s) => s['Type'] == 'Subtitle' && s['Index'] == subtitleStreamIndex,
         orElse: () => const <String, dynamic>{},
       );
+      subtitleStream = match.isNotEmpty ? match : null;
     } else {
       subtitleStream = null;
     }
@@ -298,22 +300,23 @@ class PlaybackManager implements AudioOwnable {
         .where((s) => s['Type'] == 'Video')
         .firstOrNull;
 
-    final audioStreamLang = audioStream != null && audioStream.isNotEmpty ? _extractLanguage(audioStream) : null;
-    final subtitleStreamLang = subtitleStream != null && subtitleStream.isNotEmpty ? _extractLanguage(subtitleStream) : null;
+    final audioStreamLang = _extractLanguage(audioStream);
+    final subtitleStreamLang = _extractLanguage(subtitleStream);
 
     return <String, dynamic>{
       'url': url,
       if (container != null && container.isNotEmpty) 'container': container,
       if (videoRangeType != null && videoRangeType.isNotEmpty)
         'videoRangeType': videoRangeType,
-      if (audioStream != null && audioStream.isNotEmpty) ...{
+      if (audioStream != null) ...{
         'audioCodec': (audioStream['Codec'] ?? '').toString(),
         'audioProfile': (audioStream['Profile'] ?? '').toString(),
         if (audioStream['Channels'] is int) 'audioChannels': audioStream['Channels'],
         if (audioStream['Index'] is int) 'audioStreamIndex': audioStream['Index'],
       },
       if (audioStreamLang != null) 'preferredAudioLanguage': audioStreamLang,
-      if (subtitleStreamLang != null) 'preferredTextLanguage': subtitleStreamLang,
+      if (subtitleStreamLang != null)
+        'preferredTextLanguage': subtitleStreamLang,
       if (videoStream != null && videoStream['DvProfile'] is int)
         'videoDvProfile': videoStream['DvProfile'],
       if (videoStream != null && videoStream['RealFrameRate'] is num)

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -261,6 +261,8 @@ class PlaybackManager implements AudioOwnable {
   Map<String, dynamic> _buildBackendMediaPayload({
     required String url,
     List<Map<String, dynamic>> mediaStreams = const [],
+    int? audioStreamIndex,
+    int? subtitleStreamIndex,
     String? container,
     String? videoRangeType,
     String? mediaType,
@@ -269,21 +271,49 @@ class PlaybackManager implements AudioOwnable {
     String? hybridAudioUrl,
   }) {
     final resolvedMediaType = mediaType?.trim().toLowerCase();
-    final audioStream = _defaultAudioStream(mediaStreams);
+
+    final audio = mediaStreams.where((s) => s['Type'] == 'Audio').toList();
+    final Map<String, dynamic>? audioStream;
+    if (audioStreamIndex != null) {
+      audioStream = audio.firstWhere(
+        (s) => s['Index'] == audioStreamIndex,
+        orElse: () => _defaultAudioStream(mediaStreams) ?? const <String, dynamic>{},
+      );
+    } else {
+      audioStream = _defaultAudioStream(mediaStreams);
+    }
+
+    final subtitle = mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+    final Map<String, dynamic>? subtitleStream;
+    if (subtitleStreamIndex != null && subtitleStreamIndex != -1) {
+      subtitleStream = subtitle.firstWhere(
+        (s) => s['Index'] == subtitleStreamIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+    } else {
+      subtitleStream = null;
+    }
+
     final videoStream = mediaStreams
         .where((s) => s['Type'] == 'Video')
         .firstOrNull;
+
+    final audioStreamLang = audioStream != null && audioStream.isNotEmpty ? _extractLanguage(audioStream) : null;
+    final subtitleStreamLang = subtitleStream != null && subtitleStream.isNotEmpty ? _extractLanguage(subtitleStream) : null;
+
     return <String, dynamic>{
       'url': url,
       if (container != null && container.isNotEmpty) 'container': container,
       if (videoRangeType != null && videoRangeType.isNotEmpty)
         'videoRangeType': videoRangeType,
-      if (audioStream != null) ...{
+      if (audioStream != null && audioStream.isNotEmpty) ...{
         'audioCodec': (audioStream['Codec'] ?? '').toString(),
         'audioProfile': (audioStream['Profile'] ?? '').toString(),
         if (audioStream['Channels'] is int) 'audioChannels': audioStream['Channels'],
         if (audioStream['Index'] is int) 'audioStreamIndex': audioStream['Index'],
       },
+      if (audioStreamLang != null) 'preferredAudioLanguage': audioStreamLang,
+      if (subtitleStreamLang != null) 'preferredTextLanguage': subtitleStreamLang,
       if (videoStream != null && videoStream['DvProfile'] is int)
         'videoDvProfile': videoStream['DvProfile'],
       if (videoStream != null && videoStream['RealFrameRate'] is num)
@@ -1300,6 +1330,8 @@ class PlaybackManager implements AudioOwnable {
       final backendMediaPayload = _buildBackendMediaPayload(
         url: resolution.streamUrl,
         mediaStreams: resolution.mediaStreams,
+        audioStreamIndex: _audioStreamIndex,
+        subtitleStreamIndex: _subtitleStreamIndex,
         container: resolution.container,
         videoRangeType: resolution.videoRangeType,
         mediaType: resolution.mediaType,
@@ -2359,7 +2391,12 @@ class PlaybackManager implements AudioOwnable {
         const <Map<String, dynamic>>[];
     try {
       await _backend!.play(
-        _buildBackendMediaPayload(url: url, mediaStreams: offlineStreams),
+        _buildBackendMediaPayload(
+          url: url,
+          mediaStreams: offlineStreams,
+          audioStreamIndex: _audioStreamIndex,
+          subtitleStreamIndex: _subtitleStreamIndex,
+        ),
         startPosition: startPosition,
       );
       await _syncBackendRepeatModeIfSupported();


### PR DESCRIPTION
# Pull Request

## Summary
Pass preferred audio and subtitle languages to backends on initial payload resolution to resolve preferred audio track selection. Also fix `isExternalSubtitleStream` to respect the `DeliveryMethod == 'external'` attribute in shared track logic.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #863 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `_buildBackendMediaPayload` in `playback_manager.dart` to resolve preferred audio/subtitle languages from `_audioStreamIndex` and `_subtitleStreamIndex`, passing them in the payload.
- Modified `play()` in `media3_player_backend.dart` to check for `preferredAudioLanguage` and `preferredTextLanguage` from the payload before falling back to the default preferences.
- Fixed `isExternalSubtitleStream` in `subtitle_track_logic.dart` to verify `DeliveryMethod == 'external'` to match the test assertion expectations.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Set Moonfin preferred audio language to a different language (e.g. French)
2. Set fallback language for testing purposes
3. Find a film with multiple tracks and make sure the preferred track is used when present and the fallback language is used if it is not present.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_12-33-49" src="https://github.com/user-attachments/assets/57c75715-ab15-4515-8138-51e99dfe374e" />

With French preferred, it is chosen now in the Media Details page and during playback:

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_12-37-46" src="https://github.com/user-attachments/assets/9c34c801-3155-428e-bdb0-63d7bc140b82" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_12-38-40" src="https://github.com/user-attachments/assets/e08da3b5-e53a-47dd-aad5-d6ed39d3fe18" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
