### PR TITLE
bugfix-ui - Fix Classic Rows Homepage (banner media bar, focus expansion, My Media image type)

### DIFF
--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1799,8 +1799,8 @@ class UserPreferences extends ChangeNotifier {
   static ImageType _defaultHomeRowImageType(HomeSectionType sectionType) {
     return switch (sectionType) {
       HomeSectionType.resume ||
-      HomeSectionType.nextUp ||
-      HomeSectionType.libraryTilesSmall => ImageType.banner,
+      HomeSectionType.nextUp => ImageType.banner,
+      HomeSectionType.libraryTilesSmall => ImageType.thumb,
       _ => ImageType.poster,
     };
   }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -690,6 +690,10 @@ class _ContentRowsState extends State<_ContentRows>
   set _infoRevealed(bool value) {
     if (_infoRevealedNotifier.value != value) {
       _infoRevealedNotifier.value = value;
+      _updateOffsets();
+      if (mounted) {
+        setState(() {});
+      }
     }
   }
 
@@ -1095,7 +1099,9 @@ class _ContentRowsState extends State<_ContentRows>
 
     final rowExtents = _computeRowExtents(rows, posterSize, prefs);
     final rowTopOffsets = <double>[];
-    var currentTop = listTopPadding + (bannerMode ? 0.0 : infoOverlayPlaceholder);
+    var currentTop = listTopPadding + (bannerMode
+        ? (_infoRevealed ? infoOverlayPlaceholder : 0.0)
+        : infoOverlayPlaceholder);
     if (includeMediaBar) {
       currentTop += _mediaBarHeight();
     }
@@ -3926,6 +3932,7 @@ class _ContentRowsState extends State<_ContentRows>
           itemExtent: squarePosterSide,
           itemSpacing: 12,
           leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
+          clipBehavior: cardExpansion ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
           onIndexChanged: (_, _) {
             _onHomeRowTileFocused(null);
@@ -3987,6 +3994,7 @@ class _ContentRowsState extends State<_ContentRows>
           itemExtent: squarePosterSide,
           itemSpacing: 12,
           leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
+          clipBehavior: cardExpansion ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
           onIndexChanged: (_, item) {
             _onHomeRowTileFocused(item);
@@ -4144,7 +4152,7 @@ class _ContentRowsState extends State<_ContentRows>
           itemExtent: firstCardWidth,
           itemSpacing: 12,
           leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
-          clipBehavior: isRowsV2 ? Clip.none : Clip.hardEdge,
+          clipBehavior: (isRowsV2 || cardExpansion) ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
           onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
           onVerticalNavigation: (isUp) => _onRowVerticalNavigation(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1034,7 +1034,9 @@ class _ContentRowsState extends State<_ContentRows>
         ? (widget.mediaBarViewModel.state as MediaBarReady).items.length
         : 0;
     if (!_isMediaBarEnabledByMode()) {
-      _infoRevealed = true;
+      // Seed the revealed state directly. The setter recomputes offsets, which
+      // reads MediaQuery, and that is not available yet during initState.
+      _infoRevealedNotifier.value = true;
     }
   }
 
@@ -1099,9 +1101,11 @@ class _ContentRowsState extends State<_ContentRows>
 
     final rowExtents = _computeRowExtents(rows, posterSize, prefs);
     final rowTopOffsets = <double>[];
-    var currentTop = listTopPadding + (bannerMode
-        ? (_infoRevealed ? infoOverlayPlaceholder : 0.0)
-        : infoOverlayPlaceholder);
+    var currentTop =
+        listTopPadding +
+        (bannerMode
+            ? (_infoRevealed ? infoOverlayPlaceholder : 0.0)
+            : infoOverlayPlaceholder);
     if (includeMediaBar) {
       currentTop += _mediaBarHeight();
     }
@@ -2176,9 +2180,10 @@ class _ContentRowsState extends State<_ContentRows>
       widget.onItemSelected(null);
       if (mounted) {
         setState(() {
-          _infoRevealed = false;
+          _infoRevealedNotifier.value = false;
           _mediaBarVisible = true;
           _activeFocusedRowIndex = null;
+          _updateOffsets();
         });
       }
       if (!_isMediaBarIncluded()) {
@@ -2936,9 +2941,6 @@ class _ContentRowsState extends State<_ContentRows>
         if (_infoRevealed) {
           _infoRevealed = false;
           _scrollOffset = offset;
-          if (mounted) {
-            setState(() {});
-          }
         }
         return;
       }


### PR DESCRIPTION
# Pull Request

## Summary
1. Fixes rendering discrepancy where combining Classic Rows, Banner Media Bar, and Info Overlay caused the page layout calculations to break. This was because `_updateOffsets()` did not account for the dynamic height changes of `infoPlaceholderHeightBuilder` when the overlay state shifted.
2. Fixes clipping of the top edge of the focused card outline when Focus Expansion is enabled. This was caused by the horizontal list view (`LockedFocusRow`) using `Clip.hardEdge` by default.
3. Fixes default image type for the "My Media" row (`HomeSectionType.libraryTilesSmall`) from `ImageType.banner` to `ImageType.thumb` (thumbnail), since now that banners are included in the payload... they are showing up in unexpected places like here.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified **home_screen.dart** so that the `_infoRevealed` setter triggers `_updateOffsets()` and `setState()` synchronously to update calculated row positions immediately.
- Updated the offset calculation in `_updateOffsets()` to dynamically account for the `_infoRevealed` state in banner mode.
- Set `clipBehavior: Clip.none` on horizontal lists (`LockedFocusRow`) in **home_screen.dart** when focus expansion is active.
- Changed default home row image type fallback for `HomeSectionType.libraryTilesSmall` to `ImageType.thumb` in **user_preferences.dart**.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Set home row style to Classic.
2. Enable Banner Media Bar, Info Overlay, and Focus Expansion.
3. Navigate from the Media Bar down to the rows: verify the Info Overlay is shown and row positions shift correctly without any layout breaking.
4. Verify the top edge of the focused card's outline is not clipped.
5. Verify "My Media" row items render as thumbnails.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Classic w/Banner:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_13-54-18" src="https://github.com/user-attachments/assets/2921f139-1b17-418f-8bab-6e238c8534fe" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_13-54-29" src="https://github.com/user-attachments/assets/1230366a-ea2d-4b5c-80da-fe515ab8e0d4" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_13-54-39" src="https://github.com/user-attachments/assets/18d21ccc-7f09-49f0-9101-3a58c76a6eb8" />

## Clipping Issues:
<img width="706" height="687" alt="Shield_Screenshot_2026-07-19_13-58-05" src="https://github.com/user-attachments/assets/d3aed03e-3d32-404b-bb51-91e8a2e5924c" />
<img width="463" height="634" alt="Shield_Screenshot_2026-07-19_13-58-19" src="https://github.com/user-attachments/assets/94ffd21d-67c4-4082-9fbc-8a907e4415d2" />
<img width="999" height="696" alt="Shield_Screenshot_2026-07-19_14-02-57" src="https://github.com/user-attachments/assets/eb292307-83db-44bb-841c-6c8adaa9d2ad" />
<img width="775" height="762" alt="Shield_Screenshot_2026-07-19_14-03-06" src="https://github.com/user-attachments/assets/20ab3789-71ae-4c44-95ad-22fd95b199e2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
