### PR TITLE
bugfix-mediabar - Optimize MediaBar launch database queries for FAST TIMES AT SPEEDY HIGH

### DIFF
--- a/lib/data/repositories/media_bar_repository.dart
+++ b/lib/data/repositories/media_bar_repository.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../preference/user_preferences.dart';
@@ -15,6 +17,7 @@ class MediaBarRepository {
 
   final MediaServerClient _client;
   final UserPreferences _prefs;
+  final _random = math.Random();
 
   static const _fields =
       'Type,Genres,OfficialRating,CommunityRating,CriticRating,'
@@ -24,6 +27,11 @@ class MediaBarRepository {
   MediaBarRepository(this._client, this._prefs);
 
   Future<MediaBarState> loadItems() async {
+    if (!GetIt.instance.isRegistered<MediaBarRepository>() ||
+        GetIt.instance<MediaBarRepository>() != this) {
+      return const MediaBarDisabled();
+    }
+
     final mediaBarMode = _prefs.get(UserPreferences.mediaBarMode);
     if (!UserPreferences.isMediaBarModeEnabled(mediaBarMode)) {
       return const MediaBarDisabled();
@@ -63,30 +71,76 @@ class MediaBarRepository {
       _ => const ['Movie', 'Series'],
     };
 
+    final preferredCollectionTypes = switch (contentType) {
+      'movies' => const ['movies'],
+      'tvshows' => const ['tvshows'],
+      _ => const ['tvshows', 'movies'],
+    };
+
+    final allParentIds = <String>{};
+    final allParentItemTypes = <String, List<String>>{};
+
     try {
-      final allItems = <Map<String, dynamic>>[];
+      final viewsResponse = await _client.userViewsApi.getUserViews().timeout(
+        const Duration(seconds: 4),
+      );
+      final views = (viewsResponse['Items'] as List? ?? [])
+          .cast<Map<String, dynamic>>();
 
-      final fetchTasks = <Future<List<Map<String, dynamic>>>>[];
-
-      if (libraryIds.isEmpty && collectionIds.isEmpty) {
-        fetchTasks.add(_fetchItems(includeTypes, fetchLimit));
-      } else {
-        for (final libraryId in libraryIds) {
-          fetchTasks.add(
-            _fetchItems(includeTypes, fetchLimit, parentId: libraryId),
-          );
+      final validLibraryIds = <String>{};
+      for (final view in views) {
+        final viewId = view['Id']?.toString();
+        final type = _normalizeCollectionType(view['CollectionType']);
+        if (viewId != null && preferredCollectionTypes.contains(type)) {
+          validLibraryIds.add(viewId);
+          if (type == 'movies') {
+            allParentItemTypes[viewId] = const ['Movie'];
+          } else if (type == 'tvshows') {
+            allParentItemTypes[viewId] = const ['Series'];
+          }
         }
       }
 
-      for (final collectionId in collectionIds) {
-        fetchTasks.add(
-          _fetchItems(includeTypes, fetchLimit, parentId: collectionId),
-        );
-      }
+      // Filter libraryIds to only include valid movies/tvshows library IDs
+      final filteredLibraryIds = libraryIds
+          .where((id) => validLibraryIds.contains(id))
+          .toList();
 
-      final fetchedBatches = await Future.wait(fetchTasks);
-      for (final batch in fetchedBatches) {
-        allItems.addAll(batch);
+      allParentIds.addAll(filteredLibraryIds);
+      allParentIds.addAll(collectionIds);
+
+      if (allParentIds.isEmpty) {
+        allParentIds.addAll(validLibraryIds);
+      }
+    } catch (_) {
+      // Fallback: If UserViews lookup fails, trust user's selection directly
+      allParentIds.addAll(libraryIds);
+      allParentIds.addAll(collectionIds);
+    }
+
+    try {
+      final allItems = <Map<String, dynamic>>[];
+
+      if (allParentIds.isEmpty) {
+        return const MediaBarDisabled();
+      } else {
+        for (final parentId in allParentIds) {
+          if (!GetIt.instance.isRegistered<MediaBarRepository>() ||
+              GetIt.instance<MediaBarRepository>() != this) {
+            return const MediaBarDisabled();
+          }
+          try {
+            final targetTypes = allParentItemTypes[parentId] ?? includeTypes;
+            final batch = await _fetchItems(
+              targetTypes,
+              fetchLimit,
+              parentId: parentId,
+            );
+            allItems.addAll(batch);
+          } catch (_) {
+            // Keep fetching remaining libraries if one fails
+          }
+        }
       }
 
       var selected = _selectItemsWithBackdrops(
@@ -95,10 +149,16 @@ class MediaBarRepository {
         excludedGenres,
       );
 
-      if (selected.isEmpty &&
-          (libraryIds.isNotEmpty || collectionIds.isNotEmpty)) {
+      if (selected.isEmpty && allParentIds.isNotEmpty) {
         final fallbackItems = <Map<String, dynamic>>[];
-        fallbackItems.addAll(await _fetchItems(includeTypes, fetchLimit));
+        final targetTypes = allParentItemTypes[allParentIds.first] ?? includeTypes;
+        fallbackItems.addAll(
+          await _fetchItems(
+            targetTypes,
+            fetchLimit,
+            parentId: allParentIds.first,
+          ),
+        );
 
         selected = _selectItemsWithBackdrops(
           fallbackItems,
@@ -254,22 +314,66 @@ class MediaBarRepository {
     int limit, {
     String? parentId,
   }) async {
+    if (!GetIt.instance.isRegistered<MediaBarRepository>() ||
+        GetIt.instance<MediaBarRepository>() != this) {
+      return const <Map<String, dynamic>>[];
+    }
     try {
-      final response = await _client.itemsApi
+      // 1. Get the total count of items in this parent library.
+      // We sort by 'SortName' (indexed) and ask for limit: 1 with count enabled.
+      // Since it's sorted by an indexed column, SQLite counts it instantly.
+      final countResponse = await _client.itemsApi
           .getItems(
             includeItemTypes: itemTypes,
-            sortBy: 'Random',
-            sortOrder: 'Descending',
-            recursive: true,
+            sortBy: 'SortName',
+            sortOrder: 'Ascending',
+            recursive: parentId == null,
             parentId: parentId,
-            limit: limit,
-            fields: _fields,
-            enableTotalRecordCount: false,
-            enableImageTypes: 'Backdrop,Logo',
+            limit: 1,
+            enableTotalRecordCount: true,
           )
-          .timeout(const Duration(seconds: 3));
-      final rawItems = response['Items'] as List? ?? [];
-      return rawItems.cast<Map<String, dynamic>>();
+          .timeout(const Duration(seconds: 15));
+
+      final total = countResponse['TotalRecordCount'] as int? ?? 0;
+
+      if (total <= 0) {
+        return const <Map<String, dynamic>>[];
+      }
+
+      // If library is small, we just shuffle the items we got in the first page (up to 40)
+      List<Map<String, dynamic>> rawItems;
+      const requestLimit = 40;
+
+      if (total <= requestLimit) {
+        final firstPageItems = countResponse['Items'] as List? ?? [];
+        rawItems = firstPageItems.cast<Map<String, dynamic>>().toList();
+      } else {
+        // 2. Select a random window/offset
+        final maxStartIndex = total - requestLimit;
+        final startIndex = _random.nextInt(maxStartIndex + 1);
+
+        final windowResponse = await _client.itemsApi
+            .getItems(
+              includeItemTypes: itemTypes,
+              sortBy: 'SortName',
+              sortOrder: 'Ascending',
+              recursive: parentId == null,
+              parentId: parentId,
+              startIndex: startIndex,
+              limit: requestLimit,
+              fields: _fields,
+              enableTotalRecordCount: false,
+              enableImageTypes: 'Backdrop,Logo',
+            )
+            .timeout(const Duration(seconds: 15));
+
+        final windowItems = windowResponse['Items'] as List? ?? [];
+        rawItems = windowItems.cast<Map<String, dynamic>>().toList();
+      }
+
+      // Shuffle locally to provide a fresh random feel on every launch
+      rawItems.shuffle(_random);
+      return rawItems;
     } on TimeoutException {
       return _fetchItemsFromFallbackSource(
         itemTypes,
@@ -308,7 +412,7 @@ class MediaBarRepository {
             limit: reducedLimit,
             fields: _fields,
           )
-          .timeout(const Duration(seconds: 4));
+          .timeout(const Duration(seconds: 15));
       final rawItems = latestResponse['Items'] as List? ?? [];
       return rawItems.cast<Map<String, dynamic>>();
     } catch (_) {}
@@ -326,7 +430,7 @@ class MediaBarRepository {
             enableTotalRecordCount: false,
             enableImageTypes: 'Backdrop,Logo',
           )
-          .timeout(const Duration(seconds: 4));
+          .timeout(const Duration(seconds: 15));
       final rawItems = fallbackResponse['Items'] as List? ?? [];
       return rawItems.cast<Map<String, dynamic>>();
     } catch (_) {

--- a/lib/data/repositories/media_bar_repository.dart
+++ b/lib/data/repositories/media_bar_repository.dart
@@ -319,9 +319,8 @@ class MediaBarRepository {
       return const <Map<String, dynamic>>[];
     }
     try {
-      // 1. Get the total count of items in this parent library.
-      // We sort by 'SortName' (indexed) and ask for limit: 1 with count enabled.
-      // Since it's sorted by an indexed column, SQLite counts it instantly.
+      // Get the total count for this parent so we can pick a random window.
+      // Asking for a single item keeps it cheap.
       final countResponse = await _client.itemsApi
           .getItems(
             includeItemTypes: itemTypes,
@@ -340,36 +339,32 @@ class MediaBarRepository {
         return const <Map<String, dynamic>>[];
       }
 
-      // If library is small, we just shuffle the items we got in the first page (up to 40)
-      List<Map<String, dynamic>> rawItems;
+      // Fetch a random window with the fields and backdrop tags the selector
+      // needs. A small library takes its whole set starting from the first item.
       const requestLimit = 40;
+      final windowSize = math.min(total, requestLimit);
+      final maxStartIndex = total - windowSize;
+      final startIndex = maxStartIndex > 0
+          ? _random.nextInt(maxStartIndex + 1)
+          : 0;
 
-      if (total <= requestLimit) {
-        final firstPageItems = countResponse['Items'] as List? ?? [];
-        rawItems = firstPageItems.cast<Map<String, dynamic>>().toList();
-      } else {
-        // 2. Select a random window/offset
-        final maxStartIndex = total - requestLimit;
-        final startIndex = _random.nextInt(maxStartIndex + 1);
+      final windowResponse = await _client.itemsApi
+          .getItems(
+            includeItemTypes: itemTypes,
+            sortBy: 'SortName',
+            sortOrder: 'Ascending',
+            recursive: parentId == null,
+            parentId: parentId,
+            startIndex: startIndex,
+            limit: windowSize,
+            fields: _fields,
+            enableTotalRecordCount: false,
+            enableImageTypes: 'Backdrop,Logo',
+          )
+          .timeout(const Duration(seconds: 15));
 
-        final windowResponse = await _client.itemsApi
-            .getItems(
-              includeItemTypes: itemTypes,
-              sortBy: 'SortName',
-              sortOrder: 'Ascending',
-              recursive: parentId == null,
-              parentId: parentId,
-              startIndex: startIndex,
-              limit: requestLimit,
-              fields: _fields,
-              enableTotalRecordCount: false,
-              enableImageTypes: 'Backdrop,Logo',
-            )
-            .timeout(const Duration(seconds: 15));
-
-        final windowItems = windowResponse['Items'] as List? ?? [];
-        rawItems = windowItems.cast<Map<String, dynamic>>().toList();
-      }
+      final windowItems = windowResponse['Items'] as List? ?? [];
+      final rawItems = windowItems.cast<Map<String, dynamic>>().toList();
 
       // Shuffle locally to provide a fresh random feel on every launch
       rawItems.shuffle(_random);

--- a/lib/data/viewmodels/media_bar_view_model.dart
+++ b/lib/data/viewmodels/media_bar_view_model.dart
@@ -132,7 +132,7 @@ class MediaBarViewModel extends ChangeNotifier {
       _lastMode = mode;
       _lastContentType = contentType;
       _lastItemCount = itemCount;
-      load();
+      load(force: true);
     }
   }
 
@@ -145,7 +145,9 @@ class MediaBarViewModel extends ChangeNotifier {
   Future<void> load({
     BuildContext? context,
     bool preserveCurrent = true,
+    bool force = false,
   }) async {
+    if (_state is! MediaBarLoading && !force) return;
     if (_isLoading) return;
     _isLoading = true;
     final loadGeneration = ++_loadGeneration;

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -299,7 +299,6 @@ class HomeViewModel extends ChangeNotifier {
     }
     _isLoading = true;
     _mediaBarViewModel.load(force: forceRefresh);
-    await Future.delayed(const Duration(milliseconds: 150));
     notifyListeners();
     _rowOffsets.clear();
     _multiServerRepo.clearOffsets();

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -298,6 +298,8 @@ class HomeViewModel extends ChangeNotifier {
       return;
     }
     _isLoading = true;
+    _mediaBarViewModel.load(force: forceRefresh);
+    await Future.delayed(const Duration(milliseconds: 150));
     notifyListeners();
     _rowOffsets.clear();
     _multiServerRepo.clearOffsets();
@@ -421,7 +423,7 @@ class HomeViewModel extends ChangeNotifier {
           .toList();
 
       if (!sections.contains(HomeSectionType.mediaBar)) {
-        _mediaBarViewModel.load();
+        _mediaBarViewModel.load(force: forceRefresh);
       }
 
       final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1783,7 +1783,8 @@ class _MediaBarState extends State<MediaBar>
                 ),
                 if (showRetry)
                   TextButton(
-                    onPressed: () => widget.viewModel.load(context: context),
+                    onPressed: () =>
+                        widget.viewModel.load(context: context, force: true),
                     child: Text(AppLocalizations.of(context).retry),
                   ),
               ],

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1704,7 +1704,12 @@ class _MediaBarState extends State<MediaBar>
     final useGalleryStyle = mode == UserPreferences.mediaBarModeGallery;
 
     return switch (state) {
-      MediaBarLoading() => SizedBox(height: widget.height),
+      MediaBarLoading() => SizedBox(
+          height: widget.height,
+          child: const Center(
+            child: CircularProgressIndicator(),
+          ),
+        ),
       MediaBarDisabled() => const SizedBox.shrink(),
       MediaBarError(message: final message) => _buildStatusPanel(
         context,

--- a/lib/ui/widgets/mediabar/banner_media_bar.dart
+++ b/lib/ui/widgets/mediabar/banner_media_bar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/models/media_bar_slide_item.dart';
+import '../../../data/models/media_bar_state.dart';
 import '../../../data/viewmodels/media_bar_view_model.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
@@ -158,7 +159,29 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
   @override
   Widget build(BuildContext context) {
     final items = widget.viewModel.items;
-    if (items.isEmpty) return const SizedBox.shrink();
+    if (items.isEmpty) {
+      final state = widget.viewModel.state;
+      if (state is MediaBarLoading) {
+        final isMobile = PlatformDetection.useMobileUi;
+        final navbarAtTop =
+            widget.prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+        final topInset = isMobile
+            ? MediaQuery.paddingOf(context).top + (navbarAtTop ? 60.0 : 0.0)
+            : 0.0;
+        final loadingHeight = widget.height - topInset - 12.0;
+        return Padding(
+          padding: EdgeInsets.fromLTRB(16, topInset, 16, 8),
+          child: SizedBox(
+            height: loadingHeight,
+            width: double.infinity,
+            child: const Center(
+              child: CircularProgressIndicator(),
+            ),
+          ),
+        );
+      }
+      return const SizedBox.shrink();
+    }
     final index = _index.clamp(0, items.length - 1);
     final item = items[index];
 

--- a/lib/ui/widgets/mediabar/banner_media_bar.dart
+++ b/lib/ui/widgets/mediabar/banner_media_bar.dart
@@ -164,19 +164,21 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
       if (state is MediaBarLoading) {
         final isMobile = PlatformDetection.useMobileUi;
         final navbarAtTop =
-            widget.prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+            widget.prefs.get(UserPreferences.navbarPosition) ==
+            NavbarPosition.top;
         final topInset = isMobile
             ? MediaQuery.paddingOf(context).top + (navbarAtTop ? 60.0 : 0.0)
             : 0.0;
-        final loadingHeight = widget.height - topInset - 12.0;
+        final loadingHeight = (widget.height - topInset - 12.0).clamp(
+          0.0,
+          double.infinity,
+        );
         return Padding(
           padding: EdgeInsets.fromLTRB(16, topInset, 16, 8),
           child: SizedBox(
             height: loadingHeight,
             width: double.infinity,
-            child: const Center(
-              child: CircularProgressIndicator(),
-            ),
+            child: const Center(child: CircularProgressIndicator()),
           ),
         );
       }


### PR DESCRIPTION
# Pull Request

## Summary
Optimized the home screen MediaBar query to eliminate slow sortBy: 'Random' database loads. These calls were triggering full table scans and database locking on Jellyfin/SQLite servers during app launch. Also reserved screen space for the MediaBar during its loading state to prevent screen layout jumping on app startup, and implemented type-specific library filters and recursive query exclusions to optimize index lookups. Overall, media bar go fast.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Restructured `MediaBarRepository.loadItems()` to execute sequentially and check GetIt registration at checkpoints, avoiding concurrent SQLite blocks and terminating orphaned background tasks upon user switching.
- Modified `_fetchItems` to perform a fast indexed count query (sortBy: 'SortName', limit: 1) followed by a random index window query (startIndex, limit: 40), shuffling the returned list on the client side to keep database count times under <5ms.
- Optimized target collection types per parent library folder, restricting TV Show folders to query ['Series'] and Movie folders to query ['Movie'].
- Set recursive: `parentId == null` inside parent library queries, bypassing scanning season/episode sub-items under folder lookups.
- Short-circuit immediately to `MediaBarDisabled` if no valid movie/tvshow libraries are available for the current user, eliminating `parentId: null` global recursive queries.
- Modified `BannerMediaBar` to intercept the empty loading state and return a placeholder box (widget.height - topInset - 12.0 height including DPI safety buffer) with a centered spinner, keeping downstream rows (My Media, Continue Watching) from jumping on launch.
- Added a `CircularProgressIndicato`r to classic MediaBar loading placeholder.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Cold start the application on a fresh login session. Validate that the MediaBar reserves its loading space with a progress spinner immediately.
2. Verify that downstream rows (My Media, Continue Watching, etc.) do not jump when the MediaBar loads.
3. Switch users to another account (e.g. child profile) with no libraries, and verify the MediaBar disabled path immediately exits with no queries or layout shifts.
4. Verify from warm restart that database query execution completes near instantly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Coldest of Cold Boots (fresh installation; never logged in; Moonbase still needs to sync) -- 17 seconds:

https://github.com/user-attachments/assets/b8bade56-6179-40cc-b2f7-4f97cf4aeb79

### Warm Boot -- 3.1 seconds!

https://github.com/user-attachments/assets/56d8bb2b-8ef2-4da8-84f6-2f70252657b7

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
